### PR TITLE
Print Ref compiled program in verify tests

### DIFF
--- a/test/verify/run_verify.cpp
+++ b/test/verify/run_verify.cpp
@@ -136,16 +136,18 @@ void run_verify::validate(const migraphx::target& t,
         ti.validate(p, m);
 }
 
-std::vector<migraphx::argument> run_verify::run_ref(migraphx::program p,
-                                                    migraphx::parameter_map inputs,
-                                                    const migraphx::compile_options& c_opts) const
+std::pair<migraphx::program, std::vector<migraphx::argument>>
+run_verify::run_ref(migraphx::program p,
+                    migraphx::parameter_map inputs,
+                    const migraphx::compile_options& c_opts) const
 {
     migraphx::target t = migraphx::make_target("ref");
     auto_print pp{p, t.name()};
     auto trace_target = migraphx::string_value_of(MIGRAPHX_TRACE_TEST_COMPILE{});
     compile_check(p, t, c_opts, (trace_target == "ref"));
-    return p.eval(std::move(inputs));
+    return std::make_pair(std::move(p), p.eval(std::move(inputs)));
 }
+
 std::pair<migraphx::program, std::vector<migraphx::argument>>
 run_verify::run_target(const migraphx::target& t,
                        migraphx::program p,
@@ -226,7 +228,7 @@ void run_verify::verify(const std::string& name,
             }
         }
 
-        auto gold_f = detach_async([=] { return run_ref(p, m, c_opts); });
+        auto ref_f = detach_async([=] { return run_ref(p, m, c_opts); });
         for(const auto& tname : target_names)
         {
             target_info ti = get_target_info(tname);
@@ -235,8 +237,8 @@ void run_verify::verify(const std::string& name,
                 tname, detach_async([=] { return run_target(t, p, m, c_opts); }, ti.parallel));
         }
 
-        assert(gold_f.valid());
-        auto gold = gold_f.get();
+        assert(ref_f.valid());
+        auto ref_results = ref_f.get();
 
         for(auto&& pp : results)
         {
@@ -245,7 +247,7 @@ void run_verify::verify(const std::string& name,
             auto x      = pp.second.get();
             auto cp     = x.first;
             auto result = x.second;
-
+            auto gold   = ref_results.second;
             bool passed = true;
             passed &= (gold.size() == result.size());
             std::size_t num = gold.size();
@@ -258,7 +260,7 @@ void run_verify::verify(const std::string& name,
             if(not passed or migraphx::enabled(MIGRAPHX_TRACE_TEST{}))
             {
                 std::cout << p << std::endl;
-                std::cout << "ref:\n" << p << std::endl;
+                std::cout << "ref:\n" << ref_results.first << std::endl;
                 std::cout << tname << ":\n" << cp << std::endl;
                 std::cout << std::endl;
             }

--- a/test/verify/run_verify.hpp
+++ b/test/verify/run_verify.hpp
@@ -39,9 +39,11 @@ struct target_info
 
 struct run_verify
 {
-    std::vector<migraphx::argument> run_ref(migraphx::program p,
-                                            migraphx::parameter_map inputs,
-                                            const migraphx::compile_options& c_opts) const;
+    std::pair<migraphx::program, std::vector<migraphx::argument>>
+    run_ref(migraphx::program p,
+            migraphx::parameter_map inputs,
+            const migraphx::compile_options& c_opts) const;
+
     std::pair<migraphx::program, std::vector<migraphx::argument>>
     run_target(const migraphx::target& t,
                migraphx::program p,


### PR DESCRIPTION
Solution to #2525  and #2520 would mean changing compilation pipeline for ref program. 
It is easier for debug purpose to print compiled ref program for comparison. 

This PR allows to print it. Previously verify test printed uncompiled program for "ref". 