### PR TITLE
Add warnings for FP8 onnx

### DIFF
--- a/src/onnx/onnx_parser.cpp
+++ b/src/onnx/onnx_parser.cpp
@@ -625,7 +625,11 @@ shape::type_t get_type(int dtype)
     case 11: return shape::double_type;
     case 12: return shape::uint32_type;
     case 13: return shape::uint64_type;
-    case 18: return shape::fp8e4m3fnuz_type;
+    case 18: {
+        std::cout << "[Warning] : MIGraphX has BETA support for FP8. Using FP8 may result in "
+                     "incorrect final outputs\n";
+        return shape::fp8e4m3fnuz_type;
+    }
     case 14:
     case 15:
     case 16:


### PR DESCRIPTION
Need to put some warnings. 

Can't find a better place other than parser to put these warnings. Ideally warnings should come from API side. 

This would work for both C/C++ and Python. 

But this wouldn't work if users were to create python or C program themselves. I assume it is not a usecase other than for testing purpose. 