### PR TITLE
Fixed iterator_out_of_range error in test_op_shape

### DIFF
--- a/src/include/migraphx/op/scatternd_op.hpp
+++ b/src/include/migraphx/op/scatternd_op.hpp
@@ -91,11 +91,10 @@ struct scatternd_op : op_name<Derived>
         auto data_dims = data_shape.to_dynamic().dyn_dims();
 
         // Check that corresponding portions of tensor shapes match.
-        if(not(std::equal(
-                   ind_dims.begin(), std::next(ind_dims.begin(), q - 1), upd_dims.begin()) and
-               std::equal(std::next(data_dims.begin(), k),
-                          data_dims.end(),
-                          std::next(upd_dims.begin(), q - 1))))
+        // Brackets around q - 1 are placed for safeguarding against the breaking iterator out of
+        // vector range.
+        if(not(std::equal(ind_dims.begin(), ind_dims.begin() + (q - 1), upd_dims.begin()) and
+               std::equal(data_dims.begin() + k, data_dims.end(), upd_dims.begin() + (q - 1))))
             MIGRAPHX_THROW("ScatterND: incorrect update shape. Update dimensions must match "
                            "indices and data.");
 

--- a/src/include/migraphx/op/scatternd_op.hpp
+++ b/src/include/migraphx/op/scatternd_op.hpp
@@ -91,8 +91,8 @@ struct scatternd_op : op_name<Derived>
         auto data_dims = data_shape.to_dynamic().dyn_dims();
 
         // Check that corresponding portions of tensor shapes match.
-        if(not(std::equal(ind_dims.begin(), ind_dims.begin() + q - 1, upd_dims.begin()) and
-               std::equal(data_dims.begin() + k, data_dims.end(), upd_dims.begin() + q - 1)))
+        if(not(std::equal(ind_dims.begin(), std::next(ind_dims.begin(), q - 1), upd_dims.begin()) and
+               std::equal(std::next(data_dims.begin(), k), data_dims.end(), std::next(upd_dims.begin(), q - 1))))
             MIGRAPHX_THROW("ScatterND: incorrect update shape. Update dimensions must match "
                            "indices and data.");
 

--- a/src/include/migraphx/op/scatternd_op.hpp
+++ b/src/include/migraphx/op/scatternd_op.hpp
@@ -91,8 +91,11 @@ struct scatternd_op : op_name<Derived>
         auto data_dims = data_shape.to_dynamic().dyn_dims();
 
         // Check that corresponding portions of tensor shapes match.
-        if(not(std::equal(ind_dims.begin(), std::next(ind_dims.begin(), q - 1), upd_dims.begin()) and
-               std::equal(std::next(data_dims.begin(), k), data_dims.end(), std::next(upd_dims.begin(), q - 1))))
+        if(not(std::equal(
+                   ind_dims.begin(), std::next(ind_dims.begin(), q - 1), upd_dims.begin()) and
+               std::equal(std::next(data_dims.begin(), k),
+                          data_dims.end(),
+                          std::next(upd_dims.begin(), q - 1))))
             MIGRAPHX_THROW("ScatterND: incorrect update shape. Update dimensions must match "
                            "indices and data.");
 


### PR DESCRIPTION
Fixed error iterator_out_of_range in test_op_shape using `std::next(data_dims.begin(), k)` function in if condition where the test was falling instead of operator+ `data_dims.begin() + k`. Similar changes are made on two more operator+ places in the same if condition, `std::next(ind_dims.begin(), q - 1)` instead of `ind_dims.begin() + q - 1` and `std::next(upd_dims.begin(), q - 1)` instead of `upd_dims.begin() + q - 1`.