### PR TITLE
Place gemm_pointwise at a higher priority than layernorm_pointwise

### DIFF
--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -851,9 +851,9 @@ void fuse_ops::apply(module& m) const
     match::find_matches(m, find_conv_pointwise{ctx}, find_conv_bias_relu{ctx}, find_conv_bias{ctx});
     run_passes(m, {dead_code_elimination{}});
     match::find_matches(m,
+                        find_gemm_pointwise{},
                         find_layernorm_pointwise{},
                         find_concat_pointwise{},
-                        find_gemm_pointwise{},
                         find_contiguous_tranpose_gemm{},
                         find_commutative_broadcast{});
     match::find_matches(m, find_contiguous{});


### PR DESCRIPTION
Bert Based Case add operator needs to be fused with a gemm.