### PR TITLE
Update license stamper to only update the year for files changed

### DIFF
--- a/tools/license_stamper.py
+++ b/tools/license_stamper.py
@@ -231,7 +231,9 @@ def openAndWriteFile(rfile, message, commentChar, useLastCommitYear=False):
                     save, "Advanced Micro Devices, Inc. All rights reserved")
                 hasOtherLic = hasKeySequence(save, "Software License")
 
-                # Check if we have a licence stamp already and the latest commit year matches license year (unless commit year is pre-2023, which case its ignored)
+                # Check if we have a licence stamp already and the latest
+                # commit year matches license year (unless commit year is
+                # pre-2023, which case its ignored)
                 if hasAmdLic or hasOtherLic is True:
                     contents.close()
 

--- a/tools/license_stamper.py
+++ b/tools/license_stamper.py
@@ -335,6 +335,5 @@ def main():
             print(f"No valid delimeter for file: {rfile}")
 
 
-
 if __name__ == "__main__":
     main()

--- a/tools/license_stamper.py
+++ b/tools/license_stamper.py
@@ -82,13 +82,13 @@ def get_merge_base(branch):
 def get_files_changed(against):
     files = eval(f"git diff-index --cached --name-only {against}",
                  cwd=__repo_dir__).splitlines()
-    return (f for f in files if getDelimiter(f))
+    return [f for f in files if getDelimiter(f)]
 
 
 def get_all_files():
     files = eval("git ls-files --exclude-standard",
                  cwd=__repo_dir__).splitlines()
-    return (f for f in files if getDelimiter(f))
+    return [f for f in files if getDelimiter(f)]
 
 
 # Markdown code blob we should use to insert into notebook files
@@ -331,6 +331,9 @@ def main():
                              commentDelim,
                              useLastCommitYear=args.all,
                              debug=args.debug)
+        elif args.debug:
+            print(f"No valid delimeter for file: {rfile}")
+
 
 
 if __name__ == "__main__":

--- a/tools/license_stamper.py
+++ b/tools/license_stamper.py
@@ -185,7 +185,11 @@ def bottomFooter(commentChar):
 
 
 # Simple just open and write stuff to each file with the license stamp
-def openAndWriteFile(rfile, message, commentChar, useLastCommitYear=False, debug=False):
+def openAndWriteFile(rfile,
+                     message,
+                     commentChar,
+                     useLastCommitYear=False,
+                     debug=False):
 
     filename = os.path.join(__repo_dir__, rfile)
     add_shebang = False
@@ -325,7 +329,8 @@ def main():
             openAndWriteFile(rfile,
                              message,
                              commentDelim,
-                             useLastCommitYear=args.all, debug=args.debug)
+                             useLastCommitYear=args.all,
+                             debug=args.debug)
 
 
 if __name__ == "__main__":

--- a/tools/license_stamper.py
+++ b/tools/license_stamper.py
@@ -71,8 +71,10 @@ def eval(cmd, **kwargs):
                           check=True,
                           **kwargs).stdout.decode('utf-8').strip()
 
+
 def get_head():
     return eval("git rev-parse --abbrev-ref HEAD")
+
 
 def get_merge_base(branch):
     head = get_head()
@@ -185,11 +187,8 @@ def bottomFooter(commentChar):
 
 
 # Simple just open and write stuff to each file with the license stamp
-def openAndWriteFile(rfile,
-                     message,
-                     commentChar,
-                     useLastCommitYear=False):
-    
+def openAndWriteFile(rfile, message, commentChar, useLastCommitYear=False):
+
     filename = os.path.join(__repo_dir__, rfile)
     add_shebang = False
     #markdown file stamping for .ipynb

--- a/tools/license_stamper.py
+++ b/tools/license_stamper.py
@@ -30,7 +30,7 @@
 # commit year (which is found via GIT LOG). It then updates the year if needed. If a license stamp is not found, then
 # it will add a stamp at the begenning of the file with the year set to the current year.
 #####################################################################################
-import subprocess, os, datetime, re
+import subprocess, os, datetime, re, argparse
 
 debug = False
 
@@ -38,6 +38,59 @@ current_year = datetime.date.today().year
 
 __repo_dir__ = os.path.normpath(
     os.path.join(os.path.realpath(__file__), '..', '..'))
+
+delimiters = {
+    ".cpp": "*",
+    ".hpp": "*",
+    ".h": "*",
+    ".ipynb": "//",
+    ".py": "#",
+    ".txt": "#",
+    ".bsh": "#",
+    ".sh": "#",
+    ".cmake": "#"
+}
+extensions = delimiters.keys()
+
+# Get the delimiter from the file type based on what we care about to tag with our licence
+# file. Otherwise return None for the delimiter and skip the file
+def getDelimiter(filename):
+    delimiter = None
+    for extension in extensions:
+        if extension in filename:
+            delimiter = delimiters[extension]
+            break
+    return delimiter
+
+def eval(cmd, **kwargs):
+    return subprocess.run(cmd,
+                          capture_output=True,
+                          shell=True,
+                          check=True,
+                          **kwargs).stdout.decode('utf-8').strip()
+
+
+# def get_top():
+#     return eval("git rev-parse --show-toplevel")
+
+
+# def get_head():
+#     return eval("git rev-parse --abbrev-ref HEAD")
+
+
+def get_merge_base(branch):
+    head = get_head()
+    return eval(f"git merge-base {branch} {head}")
+
+def get_files_changed(against):
+    files = eval(f"git diff-index --cached --name-only {against}",
+                 cwd=__repo_dir__).splitlines()
+    return (f for f in files if getDelimiter(f))
+
+def get_all_files():
+    files = eval("git ls-files --exclude-standard",
+                 cwd=__repo_dir__).splitlines()
+    return (f for f in files if getDelimiter(f))
 
 
 # Markdown code blob we should use to insert into notebook files
@@ -78,7 +131,7 @@ def hasKeySequence(inputfile, key_message):
     return result
 
 
-def getYearOfLatestCommit(rfile: str) -> datetime:
+def getYearOfLatestCommit(rfile: str) -> int:
     proc2 = subprocess.run(f"git log -1 --format=%cd --date=short {rfile}",
                            shell=True,
                            stdout=subprocess.PIPE,
@@ -87,8 +140,10 @@ def getYearOfLatestCommit(rfile: str) -> datetime:
                                       '%Y-%m-%d').year
     return year
 
+def currentYear() -> int:
+    return datetime.datetime.now().date().year
 
-def updateYear(filename: str, lastCommitYear: str) -> None:
+def updateYear(filename: str, lastCommitYear: int) -> None:
     with open(filename, 'r') as f:
         newfileContent = re.sub(
             "2015-\d+ Advanced Micro Devices",
@@ -129,8 +184,8 @@ def bottomFooter(commentChar):
     return delim
 
 
-#Simple just open and write stuff to each file with the license stamp
-def openAndWriteFile(filename, message, commentChar, rfile):
+# Simple just open and write stuff to each file with the license stamp
+def openAndWriteFile(filename, message, commentChar, rfile, useLastCommitYear=False):
     add_shebang = False
     #markdown file stamping for .ipynb
     save_markdown_lines = []
@@ -172,21 +227,21 @@ def openAndWriteFile(filename, message, commentChar, rfile):
                     save, "Advanced Micro Devices, Inc. All rights reserved")
                 hasOtherLic = hasKeySequence(save, "Software License")
 
-                #Check if we have a licence stamp already and the latest commit year matches license year (unless commit year is pre-2023, which case its ignored)
+                # Check if we have a licence stamp already and the latest commit year matches license year (unless commit year is pre-2023, which case its ignored)
                 if hasAmdLic or hasOtherLic is True:
                     contents.close()
 
-                    lastCommitYear = getYearOfLatestCommit(rfile)
+                    year = getYearOfLatestCommit(rfile) if useLastCommitYear else currentYear()
 
                     if not hasKeySequence(
                             save,
-                            f'2015-{lastCommitYear} Advanced Micro Devices'
-                    ) and lastCommitYear > 2022:
+                            f'2015-{year} Advanced Micro Devices'
+                    ) and year > 2022:
                         if debug:
                             print(
-                                f"....Already stamped but wrong year: Updating the year to {lastCommitYear}"
+                                f"....Already stamped but wrong year: Updating the year to {year}"
                             )
-                        return updateYear(filename, lastCommitYear)
+                        return updateYear(filename, year)
 
                     if debug:
                         print("....Already Stamped: Skipping file ")
@@ -233,45 +288,22 @@ def openAndWriteFile(filename, message, commentChar, rfile):
     if debug is True:
         print("...done")
 
-
-# Get the file type based on what we care about to tag with our licence
-# file. Otherwise return None for the delimiter and skip the file
-
-
-def getDelimiter(filename):
-
-    delimiterDict = {
-        ".cpp": "*",
-        ".hpp": "*",
-        ".h": "*",
-        ".ipynb": "//",
-        ".py": "#",
-        ".txt": "#",
-        ".bsh": "#",
-        ".sh": "#",
-        ".cmake": "#"
-    }
-    listOfKeys = delimiterDict.keys()
-    delimiter = None
-
-    for extension in listOfKeys:
-        if extension in filename:
-            delimiter = delimiterDict[extension]
-            break
-
-    return delimiter
-
-
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('against', default='develop', nargs='?')
+    parser.add_argument('-a', '--all', action='store_true', help='Update all files')
+    parser.add_argument('--dry-run', action='store_true')
+    args = parser.parse_args()
 
     message = open(os.path.join(__repo_dir__, 'LICENSE')).read()
 
-    #Get a list of all the files in our git repo
-    proc = subprocess.run("git ls-files --exclude-standard",
-                          shell=True,
-                          stdout=subprocess.PIPE,
-                          cwd=__repo_dir__)
-    fileList = proc.stdout.decode().split('\n')
+    # Get a list of all the files in our git repo
+    fileList = None
+    if args.all:
+        fileList = get_all_files()
+    else:
+        fileList = get_files_changed(args.against)
+
     message = message.split('\n')
 
     if debug is True:
@@ -282,7 +314,10 @@ def main():
         file = os.path.join(__repo_dir__, rfile)
         commentDelim = getDelimiter(file)
         if commentDelim is not None:
-            openAndWriteFile(file, message, commentDelim, rfile)
+            if args.dry_run:
+                print(f"Updating file: {file}")
+            else:
+                openAndWriteFile(file, message, commentDelim, rfile, useLastCommitYear=args.all)
 
 
 if __name__ == "__main__":

--- a/tools/license_stamper.py
+++ b/tools/license_stamper.py
@@ -52,6 +52,7 @@ delimiters = {
 }
 extensions = delimiters.keys()
 
+
 # Get the delimiter from the file type based on what we care about to tag with our licence
 # file. Otherwise return None for the delimiter and skip the file
 def getDelimiter(filename):
@@ -61,6 +62,7 @@ def getDelimiter(filename):
             delimiter = delimiters[extension]
             break
     return delimiter
+
 
 def eval(cmd, **kwargs):
     return subprocess.run(cmd,
@@ -73,7 +75,6 @@ def eval(cmd, **kwargs):
 # def get_top():
 #     return eval("git rev-parse --show-toplevel")
 
-
 # def get_head():
 #     return eval("git rev-parse --abbrev-ref HEAD")
 
@@ -82,10 +83,12 @@ def get_merge_base(branch):
     head = get_head()
     return eval(f"git merge-base {branch} {head}")
 
+
 def get_files_changed(against):
     files = eval(f"git diff-index --cached --name-only {against}",
                  cwd=__repo_dir__).splitlines()
     return (f for f in files if getDelimiter(f))
+
 
 def get_all_files():
     files = eval("git ls-files --exclude-standard",
@@ -140,8 +143,10 @@ def getYearOfLatestCommit(rfile: str) -> int:
                                       '%Y-%m-%d').year
     return year
 
+
 def currentYear() -> int:
     return datetime.datetime.now().date().year
+
 
 def updateYear(filename: str, lastCommitYear: int) -> None:
     with open(filename, 'r') as f:
@@ -185,7 +190,11 @@ def bottomFooter(commentChar):
 
 
 # Simple just open and write stuff to each file with the license stamp
-def openAndWriteFile(filename, message, commentChar, rfile, useLastCommitYear=False):
+def openAndWriteFile(filename,
+                     message,
+                     commentChar,
+                     rfile,
+                     useLastCommitYear=False):
     add_shebang = False
     #markdown file stamping for .ipynb
     save_markdown_lines = []
@@ -231,11 +240,11 @@ def openAndWriteFile(filename, message, commentChar, rfile, useLastCommitYear=Fa
                 if hasAmdLic or hasOtherLic is True:
                     contents.close()
 
-                    year = getYearOfLatestCommit(rfile) if useLastCommitYear else currentYear()
+                    year = getYearOfLatestCommit(
+                        rfile) if useLastCommitYear else currentYear()
 
                     if not hasKeySequence(
-                            save,
-                            f'2015-{year} Advanced Micro Devices'
+                            save, f'2015-{year} Advanced Micro Devices'
                     ) and year > 2022:
                         if debug:
                             print(
@@ -288,10 +297,14 @@ def openAndWriteFile(filename, message, commentChar, rfile, useLastCommitYear=Fa
     if debug is True:
         print("...done")
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('against', default='develop', nargs='?')
-    parser.add_argument('-a', '--all', action='store_true', help='Update all files')
+    parser.add_argument('-a',
+                        '--all',
+                        action='store_true',
+                        help='Update all files')
     parser.add_argument('--dry-run', action='store_true')
     args = parser.parse_args()
 
@@ -317,7 +330,11 @@ def main():
             if args.dry_run:
                 print(f"Updating file: {file}")
             else:
-                openAndWriteFile(file, message, commentDelim, rfile, useLastCommitYear=args.all)
+                openAndWriteFile(file,
+                                 message,
+                                 commentDelim,
+                                 rfile,
+                                 useLastCommitYear=args.all)
 
 
 if __name__ == "__main__":

--- a/tools/license_stamper.py
+++ b/tools/license_stamper.py
@@ -32,8 +32,6 @@
 #####################################################################################
 import subprocess, os, datetime, re, argparse
 
-debug = False
-
 current_year = datetime.date.today().year
 
 __repo_dir__ = os.path.normpath(
@@ -187,7 +185,7 @@ def bottomFooter(commentChar):
 
 
 # Simple just open and write stuff to each file with the license stamp
-def openAndWriteFile(rfile, message, commentChar, useLastCommitYear=False):
+def openAndWriteFile(rfile, message, commentChar, useLastCommitYear=False, debug=False):
 
     filename = os.path.join(__repo_dir__, rfile)
     add_shebang = False
@@ -302,6 +300,9 @@ def main():
                         '--all',
                         action='store_true',
                         help='Update all files')
+    parser.add_argument('--debug',
+                        action='store_true',
+                        help='Enable debug output')
     args = parser.parse_args()
 
     message = open(os.path.join(__repo_dir__, 'LICENSE')).read().split('\n')
@@ -313,9 +314,9 @@ def main():
     else:
         fileList = get_files_changed(get_merge_base(args.against))
 
-    if debug is True:
-        print("Target file list:\n" + str(fileList))
-        print("Output Message:\n" + str(message))
+    if args.debug is True:
+        print("Target file list:\n" + '\n'.join(fileList))
+        print("Output Message:\n" + '\n'.join(message))
 
     for rfile in fileList:
         commentDelim = getDelimiter(rfile)
@@ -324,7 +325,7 @@ def main():
             openAndWriteFile(rfile,
                              message,
                              commentDelim,
-                             useLastCommitYear=args.all)
+                             useLastCommitYear=args.all, debug=args.debug)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For files changed it will update the year to the current year. This much faster than the older version. You can also invoke the old behavior with `--all` if we need it again in the future.