### PR TITLE
Fixing export API symbols from dynamic library

### DIFF
--- a/src/include/migraphx/pass.hpp
+++ b/src/include/migraphx/pass.hpp
@@ -332,7 +332,7 @@ inline const ValueType& any_cast(const pass& x)
 #endif
 
 /// Used in the targets to enable/disable compiler passes
-pass enable_pass(bool enabled, pass p);
+MIGRAPHX_EXPORT pass enable_pass(bool enabled, pass p);
 
 #endif
 

--- a/tools/include/pass.hpp
+++ b/tools/include/pass.hpp
@@ -90,7 +90,7 @@ interface('pass',
 %>
 
 /// Used in the targets to enable/disable compiler passes
-pass enable_pass(bool enabled, pass p);
+MIGRAPHX_EXPORT pass enable_pass(bool enabled, pass p);
 
 #endif
 


### PR DESCRIPTION
Export API symbol for `migraphx`. API symbol exporting affects only Windows. It is transparent on Linux.

@pfultz2 @apwojcik 