### PR TITLE
use eliminate_convert for the fp8 JIT compilation 

### DIFF
--- a/src/include/migraphx/op/quantizelinear.hpp
+++ b/src/include/migraphx/op/quantizelinear.hpp
@@ -77,7 +77,7 @@ struct quantizelinear
         visit_all(result, y_zero_point)([&](auto output, auto zero_pts) {
             visit_all(x, y_scale)([&](auto input, auto scales) {
                 using quant_type = typename decltype(output)::value_type;
-                auto min_value   = std::numeric_limits<quant_type>::min();
+                auto min_value   = std::numeric_limits<quant_type>::lowest();
                 auto max_value   = std::numeric_limits<quant_type>::max();
                 par_for(output_shape.elements(), [&](auto i) {
                     double quantized = static_cast<double>(std::nearbyint(input[i] / scales[i])) +

--- a/src/targets/gpu/compile_gen.cpp
+++ b/src/targets/gpu/compile_gen.cpp
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <migraphx/eliminate_convert.hpp>
 #include <migraphx/gpu/compile_gen.hpp>
 #include <migraphx/gpu/context.hpp>
 #include <migraphx/shape.hpp>
@@ -183,7 +184,10 @@ void generate_pointwise(cpp_generator& gg, const module& pm, const std::string& 
 {
     module m = pm;
     run_passes(m,
-               {rewrite_quantization{}, eliminate_common_subexpression{}, dead_code_elimination{}});
+               {rewrite_quantization{},
+                eliminate_convert{},
+                eliminate_common_subexpression{},
+                dead_code_elimination{}});
     cpp_generator g;
     g.fmap([](const std::string& fname) { return "migraphx::" + fname; });
     g.add_point_op("where", "${function:where}(${0}, ${1}, ${2})");

--- a/test/ref/quantizelinear.cpp
+++ b/test/ref/quantizelinear.cpp
@@ -83,3 +83,29 @@ TEST_CASE(quantizelinear_2)
     std::vector<float> gold{0, 255, 64, 0, 2, 2, 0, 255, 255, 0, 255, 64, 0, 2, 2, 0, 255, 255};
     EXPECT(results_vector == gold);
 }
+
+TEST_CASE(quantizelinear_3)
+{
+    migraphx::shape xs{migraphx::shape::float_type, {2, 2, 2}};
+    migraphx::shape zs{migraphx::shape::fp8e4m3fnuz_type, {2, 2, 2}};
+    std::vector<float> xv = {0.5, 0.75, -0.4375, 0.6875, -0.9375, -0.9375, 0.625, -0.5625};
+    std::vector<float> sv = {0.25, 0.75, 0.5625, 0.4375, 0.8125, -0.6875, 0.875, -0.0625};
+    std::vector<float> zv{0.6875, 0.75, -0.75, 0.5, -0.0625, 0.0625, -0.375, 0.25};
+    auto create_program = [&]() {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        auto x   = mm->add_literal(xs, xv);
+        auto s   = mm->add_literal(xs, sv);
+        auto z   = mm->add_literal(zs, zv);
+        mm->add_instruction(migraphx::make_op("quantizelinear"), x, s, z);
+        return p;
+    };
+
+    migraphx::program p1 = create_program();
+    p1.compile(migraphx::make_target("ref"));
+    auto result = p1.eval({}).back();
+    std::vector<float> results_vector(8);
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    std::vector<float> gold{2.75, 1.75, -1.75, 2.5, -1, 1, 0.625, 9};
+    EXPECT(results_vector == gold);
+}

--- a/test/verify/main.cpp
+++ b/test/verify/main.cpp
@@ -89,5 +89,6 @@ int main(int argc, const char* argv[])
                          "batch_quant_dot_1<migraphx::fp8::fp8e4m3fnuz, float>",
                          "quant_dot_3args_4<migraphx::fp8::fp8e4m3fnuz, float>",
                          "quant_dot_3args_5<migraphx::fp8::fp8e4m3fnuz, float>"});
+    rv.change_tolerance_for("test_quantizelinear_convert", 100000);
     rv.run(argc, argv);
 }

--- a/test/verify/run_verify.hpp
+++ b/test/verify/run_verify.hpp
@@ -27,6 +27,7 @@
 #include <migraphx/program.hpp>
 #include <functional>
 #include <map>
+#include <unordered_map>
 
 struct target_info
 {
@@ -54,16 +55,19 @@ struct run_verify
                   const migraphx::parameter_map& m) const;
     void verify(const std::string& name,
                 const migraphx::program& p,
-                const migraphx::compile_options& c_opts) const;
+                const migraphx::compile_options& c_opts,
+                size_t tolerance = 80) const;
     void run(int argc, const char* argv[]) const;
 
     target_info get_target_info(const std::string& name) const;
     void disable_parallel_for(const std::string& name);
     void add_validation_for(const std::string& name, target_info::validation_function v);
     void disable_test_for(const std::string& name, const std::vector<std::string>& tests);
+    void change_tolerance_for(const std::string& test_name, size_t tolerance);
 
     private:
     std::map<std::string, target_info> info{};
+    std::unordered_map<std::string, size_t> tolerances;
 };
 
 #endif

--- a/test/verify/test_quantizelinear.cpp
+++ b/test/verify/test_quantizelinear.cpp
@@ -45,3 +45,24 @@ struct test_quantizelinear : verify_program<test_quantizelinear>
         return p;
     };
 };
+
+struct test_quantizelinear_convert : verify_program<test_quantizelinear_convert>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+
+        migraphx::shape sx{migraphx::shape::float_type, {2, 2, 2}};
+        migraphx::shape ss{migraphx::shape::float_type, {2, 2, 2}};
+        migraphx::shape sz{migraphx::shape::fp8e4m3fnuz_type, {2, 2, 2}};
+        auto input1 = mm->add_parameter("x", sx);
+        auto input2 = mm->add_parameter("y_scale", ss);
+        auto input3 = mm->add_parameter("y_zero_point", sz);
+        auto r  = mm->add_instruction(migraphx::make_op("quantizelinear"), input1, input2, input3);
+        auto rf = mm->add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), r);
+        mm->add_return({rf});
+        return p;
+    };
+};


### PR DESCRIPTION
This PR fixes two things and adds one feature.

1.  Compilation of FP8 on non-MI300 machines. 
2.  Bug in quantizelinear which uses `min()` for the FP8. For the floating points it should use `lowest()`

- Adds capibility to set tolerances case by case basis for the verify tests. 

On non-MI300 machines when compiling model using `--fp8` flag, it generates following kind of JIT kernel. Notice it has quantizelinear + convert as the pattern. This pattern generates two redundant converts. One of the convert is coming from `rewrite_quantization`. https://github.com/ROCm/AMDMIGraphX/blob/3fd8abf5c383cae44bea27a93b72c1c7c90ef3d3/src/targets/gpu/compile_gen.cpp#L186

```
template<class Tx0, class Tx1>
__device__ __attribute__((const)) auto inner_pointwise(Tx0 x0,Tx1 x1) {
// @literal -> float_type, {1}, {0}
auto z0 = float(240);
// @literal -> float_type, {1}, {0}
auto z1 = float(-240);
// @literal -> fp8e4m3fnuz_type, {1}, {0}
auto z2 = migraphx::fp8::fp8e4m3fnuz(0);
// @literal -> float_type, {1}, {0}
auto z3 = float(0.19705340266227722);
// @param:x1 -> float_type, {1}, {0}
// @literal -> float_type, {1}, {0}
auto z5 = float(0.00023211138613987714);
// @param:x0 -> float_type, {1}, {0}
// convert[target_type=2] -> float_type, {1}, {0}
......
// add -> float_type, {1}, {0}
auto z14 = migraphx::convert<float>(z12 + z13);
// clip -> float_type, {1}, {0}
auto z15 = migraphx::convert<float>(migraphx::min(migraphx::max(z1, z14), z0));
// convert[target_type=12] -> fp8e4m3fnuz_type, {1}, {0}
auto z16 = migraphx::convert<migraphx::fp8::fp8e4m3fnuz>(migraphx::convert<migraphx::fp8::fp8e4m3fnuz>(z15));
// convert[target_type=2] -> float_type, {1}, {0}
auto z17 = migraphx::convert<float>(migraphx::convert<float>(z16));
// @return -> float_type, {1}, {0}
return z17;

}
```

This can't be compiled as MIGraphX would try to vectorize based on input and output types of the kernel which is Float but internally it uses FP8.  FP8 can't be vectorized. 

Converts can be eliminated in such cases as they are redundant. 

