### PR TITLE
Temporarily disable parallel executors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,9 +111,10 @@ set(MIGRAPHX_ENABLE_FPGA Off CACHE BOOL "")
 
 set(MIGRAPHX_HAS_EXECUTORS_DEFAULT Off)
 find_package(ParallelSTL)
-if(ParallelSTL_FOUND)
-    set(MIGRAPHX_HAS_EXECUTORS_DEFAULT On)
-endif()
+# TODO: resolve parallism issue
+# if(ParallelSTL_FOUND)
+# set(MIGRAPHX_HAS_EXECUTORS_DEFAULT On)
+# endif()
 option(MIGRAPHX_HAS_EXECUTORS "C++ supports parallel executors" ${MIGRAPHX_HAS_EXECUTORS_DEFAULT})
 if(MIGRAPHX_HAS_EXECUTORS AND ParallelSTL_USES_TBB)
     list(APPEND PACKAGE_DEPENDS libtbb2)


### PR DESCRIPTION
The introduction of 2618 caused a significant slow down in graph compile times. Running resnet50 went from 50 seconds to 5 minutes between https://github.com/ROCm/AMDMIGraphX/commit/538ffcce339ec76c06ffa703cf3368fddad21c95 and https://github.com/ROCm/AMDMIGraphX/commit/733bd87bb547a35b68ad89ad338d0b1bede98503.