### PR TITLE
Fix compute shape for the fused_concat

### DIFF
--- a/src/fuse_concat.cpp
+++ b/src/fuse_concat.cpp
@@ -50,10 +50,10 @@ struct fused_concat
     shape compute_shape(std::vector<shape> inputs, const std::vector<module_ref>& mods) const
     {
         check_shapes{inputs, *this}.same_ndims();
-        // original concat can have multiple inputs. Let's say it has `n` input args. 
-        // Each of those `n` input args are converted into pointwise modules that take atleast 1 input parameter. 
-        // Fused concat will have `n+1` module arguments. 
-        // `n+1`th module is the post pointwise module which can take 0 or more input arguments.  
+        // original concat can have multiple inputs. Let's say it has `n` input args.
+        // Each of those `n` input args are converted into pointwise modules that take atleast 1
+        // input parameter. Fused concat will have `n+1` module arguments. `n+1`th module is the
+        // post pointwise module which can take 0 or more input arguments.
         if((inputs.size() + 1) < mods.size())
             MIGRAPHX_THROW("FUSED_CONCAT: Missing fused modules inputs parameters");
         auto input_iter = inputs.begin();

--- a/src/fuse_concat.cpp
+++ b/src/fuse_concat.cpp
@@ -64,6 +64,7 @@ struct fused_concat
             input_iter += mod->get_parameter_names().size();
         }
         module_ref post_mod          = mods.back();
+        assert(input_iter + post_mod->get_parameter_shapes().size() == inputs.end());
         auto type                    = std::prev(post_mod->end())->get_shape().type();
         const auto& first_shape_lens = concat_inputs.front().lens();
         auto mismatch_it =

--- a/src/fuse_concat.cpp
+++ b/src/fuse_concat.cpp
@@ -50,8 +50,12 @@ struct fused_concat
     shape compute_shape(std::vector<shape> inputs, const std::vector<module_ref>& mods) const
     {
         check_shapes{inputs, *this}.same_ndims();
-        if((inputs.size() + 1) == mods.size())
-            MIGRAPHX_THROW("FUSED_CONCAT: Missing fused modules");
+        // original concat can have multiple inputs. Let's say it has `n` input args. 
+        // Each of those `n` input args are converted into pointwise modules that take atleast 1 input parameter. 
+        // Fused concat will have `n+1` module arguments. 
+        // `n+1`th module is the post pointwise module which can take 0 or more input arguments.  
+        if((inputs.size() + 1) < mods.size())
+            MIGRAPHX_THROW("FUSED_CONCAT: Missing fused modules inputs parameters");
         auto input_iter = inputs.begin();
         std::vector<shape> concat_inputs;
         for(module_ref mod : range(mods.begin(), mods.end() - 1))

--- a/src/fuse_concat.cpp
+++ b/src/fuse_concat.cpp
@@ -63,6 +63,7 @@ struct fused_concat
             concat_inputs.push_back(*input_iter);
             input_iter += mod->get_parameter_names().size();
         }
+        assert(input_iter == inputs.end());
         module_ref post_mod          = mods.back();
         auto type                    = std::prev(post_mod->end())->get_shape().type();
         const auto& first_shape_lens = concat_inputs.front().lens();

--- a/src/fuse_concat.cpp
+++ b/src/fuse_concat.cpp
@@ -61,7 +61,6 @@ struct fused_concat
         for(module_ref mod : range(mods.begin(), mods.end() - 1))
         {
             concat_inputs.push_back(*input_iter);
-            std::cout << "addign size: " << mod->get_parameter_names().size() << std::endl;
             input_iter += mod->get_parameter_names().size();
         }
         module_ref post_mod          = mods.back();

--- a/src/fuse_concat.cpp
+++ b/src/fuse_concat.cpp
@@ -61,10 +61,13 @@ struct fused_concat
         for(module_ref mod : range(mods.begin(), mods.end() - 1))
         {
             concat_inputs.push_back(*input_iter);
+            std::cout << "addign size: " << mod->get_parameter_names().size() << std::endl;
             input_iter += mod->get_parameter_names().size();
         }
         module_ref post_mod          = mods.back();
-        assert(input_iter + post_mod->get_parameter_shapes().size() == inputs.end());
+        // post_mod has one input argument that is result of concat and will get generated from
+        // pre-mods internally. Therefore deduct 1 from post_mod params while asserting.
+        assert(input_iter + post_mod->get_parameter_names().size() - 1 == inputs.end());
         auto type                    = std::prev(post_mod->end())->get_shape().type();
         const auto& first_shape_lens = concat_inputs.front().lens();
         auto mismatch_it =

--- a/src/fuse_concat.cpp
+++ b/src/fuse_concat.cpp
@@ -63,7 +63,6 @@ struct fused_concat
             concat_inputs.push_back(*input_iter);
             input_iter += mod->get_parameter_names().size();
         }
-        assert(input_iter == inputs.end());
         module_ref post_mod          = mods.back();
         auto type                    = std::prev(post_mod->end())->get_shape().type();
         const auto& first_shape_lens = concat_inputs.front().lens();

--- a/test/fuse_concat.cpp
+++ b/test/fuse_concat.cpp
@@ -149,4 +149,36 @@ TEST_CASE(partial_pointwise_concat)
     EXPECT(p1 == p2);
 }
 
+TEST_CASE(pointwise_concat_fusion) {
+    migraphx::shape s1{migraphx::shape::half_type, {2, 3}};
+    migraphx::shape s2{migraphx::shape::half_type, {2, 3}, {1, 2}}; 
+    migraphx::program p1;
+    {
+        auto* mm    = p1.get_main_module();
+        auto x      = mm->add_parameter("x", s1);
+        auto y      = mm->add_parameter("y", s2);
+        auto yc = mm->add_instruction(migraphx::make_op("contiguous"), y);
+        auto sins    = add_pointwise(p1, "main:pointwise0", {x}, single_pointwise("sigmoid"));
+        auto concat = mm->add_instruction(migraphx::make_op("concat", {{"axis", 1}}), sins, yc);
+        auto relu   = add_pointwise(p1, "main:pointwise2", {concat}, single_pointwise("relu"));
+        mm->add_return({relu});
+    }
+    run_pass(p1);
+    migraphx::program p2;
+    {
+        auto* mm = p2.get_main_module();
+        auto x   = mm->add_parameter("x", s1);
+        auto y   = mm->add_parameter("y", s2);
+        auto yc = mm->add_instruction(migraphx::make_op("contiguous"), y);
+        auto fused_concat =
+            add_concat(p2,
+                       1,
+                       arg("main:pointwise2:concat", {}, single_pointwise("relu")),
+                       arg("concat:main:pointwise0", {x}, single_pointwise("sigmoid")),
+                       arg("concat:identity1", {yc}, single_pointwise("identity")));
+        mm->add_return({fused_concat});
+    }
+    EXPECT(p1 == p2);
+}
+
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/fuse_concat.cpp
+++ b/test/fuse_concat.cpp
@@ -149,16 +149,17 @@ TEST_CASE(partial_pointwise_concat)
     EXPECT(p1 == p2);
 }
 
-TEST_CASE(pointwise_concat_fusion) {
+TEST_CASE(pointwise_concat_fusion)
+{
     migraphx::shape s1{migraphx::shape::half_type, {2, 3}};
-    migraphx::shape s2{migraphx::shape::half_type, {2, 3}, {1, 2}}; 
+    migraphx::shape s2{migraphx::shape::half_type, {2, 3}, {1, 2}};
     migraphx::program p1;
     {
         auto* mm    = p1.get_main_module();
         auto x      = mm->add_parameter("x", s1);
         auto y      = mm->add_parameter("y", s2);
-        auto yc = mm->add_instruction(migraphx::make_op("contiguous"), y);
-        auto sins    = add_pointwise(p1, "main:pointwise0", {x}, single_pointwise("sigmoid"));
+        auto yc     = mm->add_instruction(migraphx::make_op("contiguous"), y);
+        auto sins   = add_pointwise(p1, "main:pointwise0", {x}, single_pointwise("sigmoid"));
         auto concat = mm->add_instruction(migraphx::make_op("concat", {{"axis", 1}}), sins, yc);
         auto relu   = add_pointwise(p1, "main:pointwise2", {concat}, single_pointwise("relu"));
         mm->add_return({relu});
@@ -169,7 +170,7 @@ TEST_CASE(pointwise_concat_fusion) {
         auto* mm = p2.get_main_module();
         auto x   = mm->add_parameter("x", s1);
         auto y   = mm->add_parameter("y", s2);
-        auto yc = mm->add_instruction(migraphx::make_op("contiguous"), y);
+        auto yc  = mm->add_instruction(migraphx::make_op("contiguous"), y);
         auto fused_concat =
             add_concat(p2,
                        1,


### PR DESCRIPTION
Fixes compilation for the `migraphx-driver yolov4.onnx --fp16`
```
Running [ MIGraphX Version: 2.9.0.538ffcce ]: ./migraphx-driver perf yolov4.onnx --fp16
Compiling ...
Reading: yolov4.onnx
terminate called after throwing an instance of 'migraphx::version_2_9_0::exception'
  what():  /long_pathname_so_that_rpms_can_package_the_debug_info/src/extlibs/AMDMIGraphX/src/fuse_concat.cpp:54: compute_shape: FUSED_CONCAT: Missing fused modules

```
