### PR TITLE
Add optional fp16 rmsnorm conversion pass to fix fp16 accuracy

### DIFF
--- a/docs/dev/env_vars.rst
+++ b/docs/dev/env_vars.rst
@@ -131,6 +131,10 @@ Enables additional opportunities to use MLIR that may improve performance.
 Set to "1", "enable", "enabled", "yes", or "true" to use.
 Use ``hip_copy_to_gpu`` with a new ``literal`` instruction rather than use ``hip_copy_literal{}``.
 
+.. envvar:: MIGRAPHX_ENABLE_RMSNORM_FP16_REWRITE
+Set to "1", "enable", "enabled", "yes", or "true" to use.
+Enables RMSNorm to be converted to fp32 precision to handle large numbers.
+
 Compilation traces
 ----------------------
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(migraphx
     rewrite_gelu.cpp
     rewrite_pooling.cpp
     rewrite_quantization.cpp
+    rewrite_rmsnorm.cpp
     rewrite_rnn.cpp
     schedule.cpp
     serialize.cpp

--- a/src/driver/passes.cpp
+++ b/src/driver/passes.cpp
@@ -42,6 +42,7 @@
 #include <migraphx/promote_literals.hpp>
 #include <migraphx/propagate_constant.hpp>
 #include <migraphx/rewrite_gelu.hpp>
+#include <migraphx/rewrite_rmsnorm.hpp>
 #include <migraphx/rewrite_pooling.hpp>
 #include <migraphx/rewrite_quantization.hpp>
 #include <migraphx/rewrite_rnn.hpp>
@@ -80,6 +81,7 @@ std::unordered_map<std::string, pass> create_passes_lookup()
         promote_literals{},
         propagate_constant{},
         rewrite_gelu{},
+        rewrite_rmsnorm{},
         rewrite_pooling{},
         rewrite_quantization{},
         rewrite_rnn{},

--- a/src/include/migraphx/match/rmsnorm.hpp
+++ b/src/include/migraphx/match/rmsnorm.hpp
@@ -1,0 +1,100 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MIGRAPHX_GUARD_AMDMIGRAPHX_MATCH_RMSNORM_HPP
+#define MIGRAPHX_GUARD_AMDMIGRAPHX_MATCH_RMSNORM_HPP
+
+#include <migraphx/config.hpp>
+#include <migraphx/matcher.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace match {
+
+namespace detail {
+template <class F>
+struct rmsnorm_matcher
+{
+    F f;
+
+    auto last_axis() const
+    {
+        return make_basic_pred_matcher([](instruction_ref ins) {
+            auto v = ins->get_operator().to_value();
+            if(not v.contains("axes"))
+                return false;
+            auto axes = v["axes"].to_vector<std::size_t>();
+            if(axes.size() != 1)
+                return false;
+            return (axes.front() == -1) or
+                   (axes.front() == ins->inputs().front()->get_shape().lens().size() - 1);
+        });
+    }
+
+    auto reduce_op() const
+    {
+        return any(any_of(f("reduce_mean")(last_axis()), f("reduce_sum")(last_axis())));
+    }
+
+    auto variance() const
+    {
+        return reduce_op()(
+                   arg(0)(f("pow")(arg(0)(any().bind("x")), arg(1)(has_value(2.0f)).bind("pow"))))
+            .bind("reduce_op");
+    }
+
+    auto sqrt_add_eps(const std::string& name) const
+    {
+        auto add_eps =
+            f("add")(either_arg(0, 1)(variance(), is_constant().bind("eps"))).bind("add");
+        auto sqrt = f(name)(arg(0)(any_of(add_eps, variance()))).bind("sqrt");
+        return any_of(sqrt, f("multibroadcast")(arg(0)(sqrt)).bind("mbcast"));
+    }
+
+    auto rmsnorm() const
+    {
+        auto div_sqrt  = f("div")(arg(0)(any()), arg(1)(sqrt_add_eps("sqrt"))).bind("div");
+        auto mul_rsqrt = f("mul")(either_arg(0, 1)(any(), sqrt_add_eps("rsqrt"))).bind("mul");
+        return any(any_of(div_sqrt, mul_rsqrt).bind("div_mul"));
+    }
+
+    auto matcher() const { return rmsnorm(); }
+};
+} // namespace detail
+
+template <class F>
+auto rmsnorm(F f)
+{
+    return detail::rmsnorm_matcher<F>{f}.matcher();
+}
+
+inline auto rmsnorm()
+{
+    return rmsnorm([](auto x) { return name(x); });
+}
+
+} // namespace match
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+
+#endif

--- a/src/include/migraphx/rewrite_rmsnorm.hpp
+++ b/src/include/migraphx/rewrite_rmsnorm.hpp
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MIGRAPHX_GUARD_RTGLIB_REWRITE_RMSNORM_HPP
+#define MIGRAPHX_GUARD_RTGLIB_REWRITE_RMSNORM_HPP
+
+#include <string>
+#include <migraphx/instruction_ref.hpp>
+#include <migraphx/config.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+
+struct module;
+
+/**
+ * Rewrite RMSNorm to improve fp16 accuracy
+ * eq1: x * rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+ * eq2: x / sqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+ * eq3: x * rsqrt((x/sqrt(n)).pow(2).sum(-1, keepdim=True) + eps)
+ * eq4: x / sqrt((x/sqrt(n)).pow(2).sum(-1, keepdim=True) + eps)
+ * where n=x.shape[-1]
+ *
+ * If this does not resolve the accuracy issue, it can be forced
+ * to convert the original eq to use fp32
+ */
+struct MIGRAPHX_EXPORT rewrite_rmsnorm
+{
+    std::string name() const { return "rewrite_rmsnorm"; }
+    void apply(module& m) const;
+};
+
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+
+#endif

--- a/src/rewrite_rmsnorm.cpp
+++ b/src/rewrite_rmsnorm.cpp
@@ -1,0 +1,123 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <migraphx/dead_code_elimination.hpp>
+#include <migraphx/pass_manager.hpp>
+#include <migraphx/rewrite_rmsnorm.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/matcher.hpp>
+#include <migraphx/match/rmsnorm.hpp>
+#include <migraphx/common.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+
+struct rewrite_rmsnorm_dtype
+{
+    auto matcher() const { return match::rmsnorm(); }
+
+    void apply(module& m, const match::matcher_result& r) const
+    {
+        // We only need to run when fp16 is used
+        auto x = r.instructions["x"];
+        if(x->get_shape().type() != migraphx::shape::half_type)
+            return;
+
+        auto pow = r.instructions["pow"];
+        std::vector<instruction_ref> pow_inputs;
+        pow_inputs.emplace_back(m.insert_instruction(
+            pow, make_op("convert", {{"target_type", shape::float_type}}), pow->inputs().at(0)));
+        pow_inputs.emplace_back(m.insert_instruction(
+            pow, make_op("convert", {{"target_type", shape::float_type}}), pow->inputs().at(1)));
+        auto converted_pow = m.insert_instruction(pow, pow->get_operator(), pow_inputs);
+
+        auto reduce_op = r.instructions["reduce_op"];
+        auto converted_reduce_op =
+            m.insert_instruction(reduce_op, reduce_op->get_operator(), converted_pow);
+
+        // NOTE: Eps (and add) will be optimized out, revisit after issue #2659 is resolved
+        auto variance = converted_reduce_op;
+        if(r.instructions.find("add") != r.instructions.end())
+        {
+            auto add = r.instructions["add"];
+            std::vector<instruction_ref> add_inputs;
+            add_inputs.emplace_back(converted_reduce_op);
+            add_inputs.emplace_back(
+                m.insert_instruction(add,
+                                     make_op("convert", {{"target_type", shape::float_type}}),
+                                     add->inputs().at(1)));
+            variance = m.insert_instruction(add, add->get_operator(), add_inputs);
+        }
+
+        auto sqrt           = r.instructions["sqrt"];
+        auto converted_sqrt = m.insert_instruction(sqrt, sqrt->get_operator(), variance);
+
+        instruction_ref prev_input;
+        instruction_ref converted_input;
+
+        if(r.instructions.find("mbcast") != r.instructions.end())
+        {
+            // mul -- mbcast -- rsqrt path
+            prev_input = r.instructions["mbcast"];
+            converted_input =
+                m.insert_instruction(prev_input, prev_input->get_operator(), converted_sqrt);
+        }
+        else
+        {
+            // 1/div -- sqrt path
+            prev_input = r.instructions["div"];
+            std::vector<instruction_ref> prev_input_inputs;
+            prev_input_inputs.emplace_back(
+                m.insert_instruction(prev_input,
+                                     make_op("convert", {{"target_type", shape::float_type}}),
+                                     prev_input->inputs().at(0)));
+            prev_input_inputs.emplace_back(converted_sqrt);
+            converted_input =
+                m.insert_instruction(prev_input, prev_input->get_operator(), prev_input_inputs);
+        }
+
+        auto y = prev_input->outputs().at(0);
+        std::vector<instruction_ref> y_inputs;
+        if(y->inputs().size() > 1)
+        {
+            auto other_input =
+                y->inputs().at(0) == prev_input ? y->inputs().at(1) : y->inputs().at(0);
+            y_inputs.emplace_back(other_input);
+        }
+        y_inputs.emplace_back(m.insert_instruction(
+            y, make_op("convert", {{"target_type", shape::half_type}}), converted_input));
+        auto converted_y = m.insert_instruction(y, y->get_operator(), y_inputs);
+
+        m.replace_instruction(y, converted_y);
+    }
+};
+
+void rewrite_rmsnorm::apply(module& m) const
+{
+    match::find_matches(m, rewrite_rmsnorm_dtype{});
+    run_passes(m, {dead_code_elimination{}});
+}
+
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx

--- a/src/targets/cpu/target.cpp
+++ b/src/targets/cpu/target.cpp
@@ -38,6 +38,7 @@
 #include <migraphx/propagate_constant.hpp>
 #include <migraphx/register_target.hpp>
 #include <migraphx/replace_allocate.hpp>
+#include <migraphx/rewrite_rmsnorm.hpp>
 #include <migraphx/rewrite_pooling.hpp>
 #include <migraphx/rewrite_quantization.hpp>
 #include <migraphx/rewrite_rnn.hpp>
@@ -60,6 +61,8 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace cpu {
 
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_RMSNORM_FP16_REWRITE)
+
 std::string target::name() const { return "cpu"; }
 
 // cppcheck-suppress constParameterReference
@@ -80,6 +83,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
             dead_code_elimination{},
             rewrite_rnn{},
             dead_code_elimination{},
+            enable_pass(enabled(MIGRAPHX_ENABLE_RMSNORM_FP16_REWRITE{}), rewrite_rmsnorm{}),
             eliminate_common_subexpression{},
             dead_code_elimination{},
             simplify_algebra{},

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -45,6 +45,7 @@
 #include <migraphx/register_target.hpp>
 #include <migraphx/replace_allocate.hpp>
 #include <migraphx/rewrite_gelu.hpp>
+#include <migraphx/rewrite_rmsnorm.hpp>
 #include <migraphx/rewrite_pooling.hpp>
 #include <migraphx/rewrite_quantization.hpp>
 #include <migraphx/rewrite_rnn.hpp>
@@ -76,6 +77,7 @@ namespace gpu {
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_DISABLE_SCHEDULE_PASS)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_DISABLE_REDUCE_FUSION)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_NHWC)
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_RMSNORM_FP16_REWRITE)
 #ifndef _WIN32
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_CK)
 #endif
@@ -144,6 +146,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
         rewrite_pooling{},
         dead_code_elimination{},
         rewrite_gelu{options.fast_math},
+        enable_pass(enabled(MIGRAPHX_ENABLE_RMSNORM_FP16_REWRITE{}), rewrite_rmsnorm{}),
         optimize_module{},
         enable_pass(enabled(MIGRAPHX_ENABLE_NHWC{}), layout_nhwc{}),
         dead_code_elimination{},

--- a/src/targets/ref/target.cpp
+++ b/src/targets/ref/target.cpp
@@ -28,6 +28,7 @@
 #include <migraphx/pass.hpp>
 #include <migraphx/auto_contiguous.hpp>
 #include <migraphx/rewrite_rnn.hpp>
+#include <migraphx/rewrite_rmsnorm.hpp>
 #include <migraphx/eliminate_convert.hpp>
 #include <migraphx/eliminate_pad.hpp>
 #include <migraphx/insert_pad.hpp>
@@ -40,6 +41,8 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace ref {
 
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_RMSNORM_FP16_REWRITE)
+
 std::string target::name() const { return "ref"; }
 
 std::vector<pass> target::get_passes(migraphx::context&, const compile_options&) const
@@ -51,6 +54,7 @@ std::vector<pass> target::get_passes(migraphx::context&, const compile_options&)
             dead_code_elimination{},
             rewrite_rnn{},
             dead_code_elimination{},
+            enable_pass(enabled(MIGRAPHX_ENABLE_RMSNORM_FP16_REWRITE{}), rewrite_rmsnorm{}),
             auto_contiguous{},
             dead_code_elimination{},
             lowering{},

--- a/test/rewrite_rmsnorm_test.cpp
+++ b/test/rewrite_rmsnorm_test.cpp
@@ -1,0 +1,232 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/rewrite_rmsnorm.hpp>
+#include <migraphx/program.hpp>
+#include <migraphx/register_target.hpp>
+#include <migraphx/common.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/verify.hpp>
+
+#include <test.hpp>
+
+void create_rmsnorm_fp16_div_sqrt(migraphx::module& m, const std::vector<std::size_t>& input_lens)
+{
+    migraphx::shape s_input{migraphx::shape::half_type, input_lens};
+    migraphx::shape s_lit{migraphx::shape::half_type, {1}};
+    auto l_pow_2     = m.add_literal(migraphx::literal{s_lit, {2.0f}});
+    auto l_eps       = m.add_literal(migraphx::literal{s_lit, {1e-05}});
+    auto l_div_1     = m.add_literal(migraphx::literal{s_lit, {1.0f}});
+    auto input       = m.add_parameter("input", s_input);
+    auto pow         = add_common_op(m, migraphx::make_op("pow"), {input, l_pow_2});
+    auto reduce_mean = m.add_instruction(migraphx::make_op("reduce_mean", {{"axes", {-1}}}), pow);
+    auto add         = add_common_op(m, migraphx::make_op("add"), {reduce_mean, l_eps});
+    auto sqrt        = m.add_instruction(migraphx::make_op("sqrt"), add);
+    auto div         = add_common_op(m, migraphx::make_op("div"), {l_div_1, sqrt});
+    auto mul         = add_common_op(m, migraphx::make_op("mul"), {input, div});
+    m.add_return({mul});
+}
+
+void create_rmsnorm_fp16_mul_rsqrt(migraphx::module& m, const std::vector<std::size_t>& input_lens)
+{
+    migraphx::shape s_input{migraphx::shape::half_type, input_lens};
+    migraphx::shape s_lit{migraphx::shape::half_type, {1}};
+    auto l_pow_2     = m.add_literal(migraphx::literal{s_lit, {2.0f}});
+    auto l_eps       = m.add_literal(migraphx::literal{s_lit, {1e-05}});
+    auto input       = m.add_parameter("input", s_input);
+    auto pow         = add_common_op(m, migraphx::make_op("pow"), {input, l_pow_2});
+    auto reduce_mean = m.add_instruction(migraphx::make_op("reduce_mean", {{"axes", {-1}}}), pow);
+    auto add         = add_common_op(m, migraphx::make_op("add"), {reduce_mean, l_eps});
+    auto rsqrt       = m.add_instruction(migraphx::make_op("rsqrt"), add);
+    auto mul         = add_common_op(m, migraphx::make_op("mul"), {input, rsqrt});
+    m.add_return({mul});
+}
+
+TEST_CASE(rewrite_rmsnorm_fp16_to_fp32_div_sqrt_test)
+{
+    migraphx::shape s_input{migraphx::shape::half_type, {1, 256, 4096}};
+    migraphx::shape s_lit{migraphx::shape::half_type, {1}};
+    migraphx::module m1;
+    create_rmsnorm_fp16_div_sqrt(m1, s_input.lens());
+    migraphx::rewrite_rmsnorm pass{};
+    pass.apply(m1);
+
+    migraphx::module m2;
+    {
+        auto l_pow_2      = m2.add_literal(migraphx::literal{s_lit, {2.0f}});
+        auto l_eps        = m2.add_literal(migraphx::literal{s_lit, {1e-05}});
+        auto l_div_1      = m2.add_literal(migraphx::literal{s_lit, {1.0f}});
+        auto input        = m2.add_parameter("input", s_input);
+        auto pow_2_mbcast = m2.add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", s_input.lens()}}), l_pow_2);
+        auto input_f = m2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), input);
+        auto pow_2_mbcast_f = m2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}),
+            pow_2_mbcast);
+        auto pow = m2.add_instruction(migraphx::make_op("pow"), {input_f, pow_2_mbcast_f});
+        auto reduce_mean =
+            m2.add_instruction(migraphx::make_op("reduce_mean", {{"axes", {-1}}}), pow);
+        auto add   = add_common_op(m2, migraphx::make_op("add"), {reduce_mean, l_eps});
+        auto sqrt  = m2.add_instruction(migraphx::make_op("sqrt"), add);
+        auto div   = add_common_op(m2, migraphx::make_op("div"), {l_div_1, sqrt});
+        auto div_h = m2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), div);
+        auto mul = add_common_op(m2, migraphx::make_op("mul"), {input, div_h});
+        m2.add_return({mul});
+    }
+
+    EXPECT(m1 == m2);
+}
+
+TEST_CASE(rewrite_rmsnorm_fp16_to_fp32_mul_rsqrt_test)
+{
+    migraphx::shape s_input{migraphx::shape::half_type, {1, 256, 4096}};
+    migraphx::shape s_lit{migraphx::shape::half_type, {1}};
+    migraphx::module m1;
+    create_rmsnorm_fp16_mul_rsqrt(m1, s_input.lens());
+    migraphx::rewrite_rmsnorm pass{};
+    pass.apply(m1);
+
+    migraphx::module m2;
+    {
+        auto l_pow_2      = m2.add_literal(migraphx::literal{s_lit, {2.0f}});
+        auto l_eps        = m2.add_literal(migraphx::literal{s_lit, {1e-05}});
+        auto input        = m2.add_parameter("input", s_input);
+        auto pow_2_mbcast = m2.add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", s_input.lens()}}), l_pow_2);
+        auto input_f = m2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), input);
+        auto pow_2_mbcast_f = m2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}),
+            pow_2_mbcast);
+        auto pow = m2.add_instruction(migraphx::make_op("pow"), {input_f, pow_2_mbcast_f});
+        auto reduce_mean =
+            m2.add_instruction(migraphx::make_op("reduce_mean", {{"axes", {-1}}}), pow);
+        auto add          = add_common_op(m2, migraphx::make_op("add"), {reduce_mean, l_eps});
+        auto rsqrt        = add_common_op(m2, migraphx::make_op("rsqrt"), {add});
+        auto rsqrt_mbcast = m2.add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", s_input.lens()}}), rsqrt);
+        auto rsqrt_mbcast_h = m2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}),
+            rsqrt_mbcast);
+        auto mul = m2.add_instruction(migraphx::make_op("mul"), input, rsqrt_mbcast_h);
+        m2.add_return({mul});
+    }
+
+    EXPECT(m1 == m2);
+}
+
+TEST_CASE(rewrite_rmsnorm_fp16_to_fp32_div_sqrt_accuracy_test)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+
+    migraphx::shape s_input{migraphx::shape::half_type, {1, 3, 9}};
+    create_rmsnorm_fp16_div_sqrt(*mm, s_input.lens());
+    migraphx::rewrite_rmsnorm pass{};
+    pass.apply(*mm);
+    p.compile(migraphx::make_target("ref"));
+
+    // Note: converting the calculation to fp32 can handle half::max numbers
+    std::vector<migraphx::half> data{
+        migraphx::half{-2446.96233826},  migraphx::half{-37347.03145467},
+        migraphx::half{-1829.02050925},  migraphx::half{10155.3566038},
+        migraphx::half{-11032.43548165}, migraphx::half{-215.74688557},
+        migraphx::half{5642.95552563},   migraphx::half{31193.5484022},
+        migraphx::half{-12379.14968852}, migraphx::half{3876.8102353},
+        migraphx::half{5228.56319534},   migraphx::half{4017.52134421},
+        migraphx::half{-41109.51403055}, migraphx::half{-13427.75230111},
+        migraphx::half{17637.85685999},  migraphx::half{13903.10580781},
+        migraphx::half{-6630.92344508},  migraphx::half{-36526.86578131},
+        migraphx::half{-18907.53509807}, migraphx::half{-7211.00914282},
+        migraphx::half{-33006.71807566}, migraphx::half{8259.18826548},
+        migraphx::half{-9487.80837355},  migraphx::half{-2824.52207497},
+        migraphx::half{24448.37690028},  migraphx::half{-770.63316253},
+        migraphx::half{310.0554823}};
+    migraphx::parameter_map params;
+    params["input"] = migraphx::argument(s_input, data.data());
+    auto result     = p.eval(params).back();
+
+    std::vector<migraphx::half> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    std::vector<migraphx::half> gold{
+        migraphx::half{-0.13904916}, migraphx::half{-2.12225311}, migraphx::half{-0.10393448},
+        migraphx::half{0.57708033},  migraphx::half{-0.62692052}, migraphx::half{-0.01225986},
+        migraphx::half{0.32066216},  migraphx::half{1.77258011},  migraphx::half{-0.70344785},
+        migraphx::half{0.18838872},  migraphx::half{0.25407546},  migraphx::half{0.1952264},
+        migraphx::half{-1.99766516}, migraphx::half{-0.65250474}, migraphx::half{0.85708948},
+        migraphx::half{0.67560395},  migraphx::half{-0.32222139}, migraphx::half{-1.77497712},
+        migraphx::half{-1.19223013}, migraphx::half{-0.4546961},  migraphx::half{-2.08126568},
+        migraphx::half{0.52078989},  migraphx::half{-0.59826154}, migraphx::half{-0.17810256},
+        migraphx::half{1.54161245},  migraphx::half{-0.04859291}, migraphx::half{0.0195508}};
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+}
+
+TEST_CASE(rewrite_rmsnorm_fp16_to_fp32_mul_rsqrt_accuracy_test)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+
+    migraphx::shape s_input{migraphx::shape::half_type, {1, 3, 9}};
+    create_rmsnorm_fp16_mul_rsqrt(*mm, s_input.lens());
+    migraphx::rewrite_rmsnorm pass{};
+    pass.apply(*mm);
+    p.compile(migraphx::make_target("ref"));
+
+    // Note: converting the calculation to fp32 can handle half::max numbers
+    std::vector<migraphx::half> data{
+        migraphx::half{-2446.96233826},  migraphx::half{-37347.03145467},
+        migraphx::half{-1829.02050925},  migraphx::half{10155.3566038},
+        migraphx::half{-11032.43548165}, migraphx::half{-215.74688557},
+        migraphx::half{5642.95552563},   migraphx::half{31193.5484022},
+        migraphx::half{-12379.14968852}, migraphx::half{3876.8102353},
+        migraphx::half{5228.56319534},   migraphx::half{4017.52134421},
+        migraphx::half{-41109.51403055}, migraphx::half{-13427.75230111},
+        migraphx::half{17637.85685999},  migraphx::half{13903.10580781},
+        migraphx::half{-6630.92344508},  migraphx::half{-36526.86578131},
+        migraphx::half{-18907.53509807}, migraphx::half{-7211.00914282},
+        migraphx::half{-33006.71807566}, migraphx::half{8259.18826548},
+        migraphx::half{-9487.80837355},  migraphx::half{-2824.52207497},
+        migraphx::half{24448.37690028},  migraphx::half{-770.63316253},
+        migraphx::half{310.0554823}};
+    migraphx::parameter_map params;
+    params["input"] = migraphx::argument(s_input, data.data());
+    auto result     = p.eval(params).back();
+
+    std::vector<migraphx::half> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    std::vector<migraphx::half> gold{
+        migraphx::half{-0.13904916}, migraphx::half{-2.12225311}, migraphx::half{-0.10393448},
+        migraphx::half{0.57708033},  migraphx::half{-0.62692052}, migraphx::half{-0.01225986},
+        migraphx::half{0.32066216},  migraphx::half{1.77258011},  migraphx::half{-0.70344785},
+        migraphx::half{0.18838872},  migraphx::half{0.25407546},  migraphx::half{0.1952264},
+        migraphx::half{-1.99766516}, migraphx::half{-0.65250474}, migraphx::half{0.85708948},
+        migraphx::half{0.67560395},  migraphx::half{-0.32222139}, migraphx::half{-1.77497712},
+        migraphx::half{-1.19223013}, migraphx::half{-0.4546961},  migraphx::half{-2.08126568},
+        migraphx::half{0.52078989},  migraphx::half{-0.59826154}, migraphx::half{-0.17810256},
+        migraphx::half{1.54161245},  migraphx::half{-0.04859291}, migraphx::half{0.0195508}};
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
Fixes https://github.com/ROCm/AMDMIGraphX/issues/2556
RMSNorm is used in LLMs like Llama2. Currently the fp16 version can overflow during normalization. This change try to addess it byconvert normalization to fp32.