### PR TITLE
Update URLs and Update deprecated actions/checkout version

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -17,7 +17,7 @@ This workflow adds pull requests and issues to a specific GitHub project board w
     The workflow has a single job named `add-to-project`. The following step is executed in this job:
      - The `add-to-project` job uses the `actions/add-to-project@v0.4.0` action to add pull requests and issues to a specific project board. The `with` parameters are `project-url` and `github-token`, which specify the URL of the project board and the GitHub token used to authenticate the action.
 
-    For more details, please refer to the [add-to-project.yaml](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/add-to-project.yaml) file in the repository.
+    For more details, please refer to the [add-to-project.yaml](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/add-to-project.yaml) file in the repository.
 
 ---
 ## `benchmark.yaml`
@@ -41,7 +41,7 @@ This workflow runs the `MiGraphX performance benchmarks` and generates reports b
 
      - `result_repo`: the repository where the benchmark results will be pushed for comparison.
 
-    For more details, please refer to the [benchmark.yaml](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/benchmark.yaml) file in the repository.
+    For more details, please refer to the [benchmark.yaml](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/benchmark.yaml) file in the repository.
 
 ---
 
@@ -80,7 +80,7 @@ Overall, this workflow automates the process of building and testing the AMDMIGr
 
      - `linux-fpga`: this job builds and tests AMDMIGraphX on a Linux operating system with support for FPGA acceleration. It includes additional steps to verify FPGA functionality and performance.
 
-    For more details, please refer to the [ci.yaml](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/ci.yaml) file in the repository.
+    For more details, please refer to the [ci.yaml](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/ci.yaml) file in the repository.
 
 ---
 ## `clean-closed-pr-caches.yaml`
@@ -100,7 +100,7 @@ This workflow has purpose to clean up any cached data related to the pull reques
 
      - `Cleanup`: step performs the actual cache cleanup using a series of commands.
 
-    For more details, please refer to the [clean-closed-pr-caches.yaml](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/clean-closed-pr-caches.yaml) file in the repository.
+    For more details, please refer to the [clean-closed-pr-caches.yaml](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/clean-closed-pr-caches.yaml) file in the repository.
 
 ---
 
@@ -111,7 +111,7 @@ This workflow generates a report of the MiGraphX benchmark results between two d
 </p>
 
 - ## Trigger
-     - The workflow is triggered manually through the "Run workflow" button in the Actions tab of the repository and it will run reusable workflow [history.yml](https://github.com/ROCmSoftwarePlatform/migraphx-benchmark/blob/main/.github/workflows/history.yml)
+     - The workflow is triggered manually through the "Run workflow" button in the Actions tab of the repository and it will run reusable workflow [history.yml](https://github.com/ROCm/migraphx-benchmark/blob/main/.github/workflows/history.yml)
 
 - ## Input Parameters
     The workflow requires the following inputs:
@@ -126,7 +126,7 @@ This workflow generates a report of the MiGraphX benchmark results between two d
 
      - `organization`: Organization based on which location of files will be different.
 
-    For more details, please refer to the [history.yaml](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/history.yaml) file in the repository.
+    For more details, please refer to the [history.yaml](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/history.yaml) file in the repository.
 
 ---
 ## `performance.yaml`
@@ -136,7 +136,7 @@ This workflow runs performance tests on the MIGraphX repository and generates a 
 </p>
 
 - ## Trigger
-    The workflow will run reusable workflow [perf-test.yml](https://github.com/ROCmSoftwarePlatform/migraphx-benchmark/blob/main/.github/workflows/perf-test.yml) by the following events:
+    The workflow will run reusable workflow [perf-test.yml](https://github.com/ROCm/migraphx-benchmark/blob/main/.github/workflows/perf-test.yml) by the following events:
 
      - Pull requests opened, synchronized or closed on the `develop` branch.
 
@@ -161,7 +161,7 @@ This workflow runs performance tests on the MIGraphX repository and generates a 
 
      - `flags`: Command line arguments to be passed to the performance test script. Default is `-r`.
 
-    For more details, please refer to the [performance.yaml](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/performance.yaml) file in the repository.
+    For more details, please refer to the [performance.yaml](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/performance.yaml) file in the repository.
 
 ---
 ## `rocm-image-release.yaml`
@@ -171,7 +171,7 @@ This workflow builds a Docker image for a specified ROCm release version and pus
 </p>
 
 - ## Trigger
-     - The workflow is triggered manually through the "Run workflow" button in the Actions tab of the repository and it will run reusable workflow [rocm-release.yml](https://github.com/ROCmSoftwarePlatform/migraphx-benchmark/blob/main/.github/workflows/rocm-release.yml)
+     - The workflow is triggered manually through the "Run workflow" button in the Actions tab of the repository and it will run reusable workflow [rocm-release.yml](https://github.com/ROCm/migraphx-benchmark/blob/main/.github/workflows/rocm-release.yml)
 
 - ## Input Parameters
     The workflow requires the following inputs:
@@ -190,7 +190,7 @@ This workflow builds a Docker image for a specified ROCm release version and pus
 
      - `overwrite`: Specify whether to overwrite the Docker image if it already exists.
 
-    For more details, please refer to the [rocm-image-release.yaml](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/rocm-image-release.yaml) file in the repository.
+    For more details, please refer to the [rocm-image-release.yaml](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/rocm-image-release.yaml) file in the repository.
 
 ---
 
@@ -219,6 +219,6 @@ This workflow updates a file with the latest commit hash then creates a pull req
 
      - `Make changes to pull request`: step uses the `peter-evans/create-pull-request` action to create a pull request.
 
-    For more details, please refer to the [sync-onnxrt-main.yaml](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/sync-onnxrt-main.yaml) file in the repository.
+    For more details, please refer to the [sync-onnxrt-main.yaml](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/sync-onnxrt-main.yaml) file in the repository.
 
 ---

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -213,7 +213,7 @@ This workflow updates a file with the latest commit hash then creates a pull req
 
      - `echo_sha1`: step prints the SHA1 commit hash set in step `extract_sha1`.
 
-     - `actions/checkout@v3`: step checks out the codebase from the repository.
+     - `actions/checkout@v4.1.1`: step checks out the codebase from the repository.
 
      - `update_file`: step updates a file in the repository with the SHA1 commit hash fetched in step `extract_sha1`.
 

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -10,6 +10,6 @@ jobs:
       rocm_version: 5.7
       script_repo: migraphx-benchmark/benchmark-utils
       result_path: /usr/share/migraphx/test-results
-      result_repo: ROCmSoftwarePlatform/comparison-results
+      result_repo: ROCm/comparison-results
     secrets:
       gh_token: ${{ secrets.MIGRAPHX_BOT_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps: 
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Create Image Tag
         id: image_hash
@@ -72,7 +72,7 @@ jobs:
     needs: check_image
     if: ${{ needs.check_image.outputs.imageexists != 'true' }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
 
     - name: Build and publish 
       env:            
@@ -94,7 +94,7 @@ jobs:
     needs: check_image
     if: ${{ needs.check_image.outputs.imageexists_sles != 'true' }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
     - name: Build and publish SLES
       env:            
         DOCKER_TAG_SLES: ${{ needs.check_image.outputs.imagetag_sles }}
@@ -118,7 +118,7 @@ jobs:
 
     if: ${{ !cancelled() && (needs.build_image.result == 'success' || needs.build_image.result == 'skipped') }}
     steps: 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
 
     - name: Restore cache files for tidy
       uses: actions/cache/restore@v3 
@@ -172,7 +172,7 @@ jobs:
 
     if: ${{ !cancelled() && (needs.build_image.result == 'success' || needs.build_image.result == 'skipped') }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
 
     - name: Restore cache files for cppcheck
       id: cppcheck_restore
@@ -222,7 +222,7 @@ jobs:
 
     if: ${{ !cancelled() && (needs.build_image.result == 'success' || needs.build_image.result == 'skipped') }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
       with:
         fetch-depth: 0
 
@@ -253,7 +253,7 @@ jobs:
     
     if: ${{ !cancelled() && (needs.build_SLES_image.result == 'success' || needs.build_SLES_image.result == 'skipped') }}      
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
       with:
         fetch-depth: 0
 
@@ -319,7 +319,7 @@ jobs:
         swap-storage: true
         docker-images: true
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -350,7 +350,7 @@ jobs:
         swap-storage: true
         docker-images: true
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -397,7 +397,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install https://github.com/RadeonOpenCompute/rbuild/archive/master.tar.gz
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -510,7 +510,7 @@ jobs:
         swap-storage: true
         docker-images: true
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/clean-closed-pr-caches.yaml
+++ b/.github/workflows/clean-closed-pr-caches.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         
       - name: Cleanup
         run: |

--- a/.github/workflows/history.yaml
+++ b/.github/workflows/history.yaml
@@ -15,11 +15,11 @@ on:
       history_repo:
         description: Repository for history results between dates
         required: true
-        default: 'ROCmSoftwarePlatform/migraphx-reports'
+        default: 'ROCm/migraphx-reports'
       benchmark_utils_repo:
         description: Repository where benchmark utils are stored
         required: true
-        default: "ROCmSoftwarePlatform/migraphx-benchmark-utils"
+        default: "ROCm/migraphx-benchmark-utils"
       organization:
         description: Organization based on which location of files will be different
         required: true
@@ -27,12 +27,12 @@ on:
 
 jobs:
   release:
-    uses: ROCmSoftwarePlatform/migraphx-benchmark/.github/workflows/history.yml@main
+    uses: ROCm/migraphx-benchmark/.github/workflows/history.yml@main
     with:
       start_date: ${{ github.event.inputs.start_date || 'yyyy-mm-dd' }}
       end_date: ${{ github.event.inputs.end_date || 'yyyy-mm-dd' }}
-      history_repo: ${{ github.event.inputs.history_repo || 'ROCmSoftwarePlatform/migraphx-reports' }}
-      benchmark_utils_repo: ${{ github.event.inputs.benchmark_utils_repo || 'ROCmSoftwarePlatform/migraphx-benchmark-utils' }}
+      history_repo: ${{ github.event.inputs.history_repo || 'ROCm/migraphx-reports' }}
+      benchmark_utils_repo: ${{ github.event.inputs.benchmark_utils_repo || 'ROCm/migraphx-benchmark-utils' }}
       organization: ${{ github.event.inputs.organization || 'AMD' }}
     secrets:
       gh_token: ${{ secrets.MIGRAPHX_BOT_TOKEN }}

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -16,11 +16,11 @@ on:
       performance_reports_repo:
         description: Repository where performance reports are stored
         required: true
-        default: 'ROCmSoftwarePlatform/migraphx-reports'
+        default: 'ROCm/migraphx-reports'
       benchmark_utils_repo:
         description: Repository where benchmark utils are stored
         required: true
-        default: "ROCmSoftwarePlatform/migraphx-benchmark-utils"
+        default: "ROCm/migraphx-benchmark-utils"
       organization:
         description: Organization based on which location of files will be different
         required: true
@@ -48,14 +48,14 @@ concurrency:
 
 jobs:
   release:
-    uses: ROCmSoftwarePlatform/migraphx-benchmark/.github/workflows/perf-test.yml@main
+    uses: ROCm/migraphx-benchmark/.github/workflows/perf-test.yml@main
     with:
       rocm_release: ${{ github.event.inputs.rocm_release || '5.7' }}
       result_number: ${{ github.event.inputs.result_number || '10' }}
       flags: ${{ github.event.inputs.flags || '-r' }}
-      performance_reports_repo: ${{ github.event.inputs.performance_reports_repo || 'ROCmSoftwarePlatform/migraphx-reports' }}
+      performance_reports_repo: ${{ github.event.inputs.performance_reports_repo || 'ROCm/migraphx-reports' }}
       performance_backup_repo: ${{ github.event.inputs.performance_backup_repo || 'migraphx-benchmark/performance-backup' }}
-      benchmark_utils_repo: ${{ github.event.inputs.benchmark_utils_repo || 'ROCmSoftwarePlatform/migraphx-benchmark-utils' }}
+      benchmark_utils_repo: ${{ github.event.inputs.benchmark_utils_repo || 'ROCm/migraphx-benchmark-utils' }}
       organization: ${{ github.event.inputs.organization || 'AMD' }}
       model_timeout: ${{ github.event.inputs.model_timeout || '30m' }}
     secrets:

--- a/.github/workflows/rocm-image-release.yaml
+++ b/.github/workflows/rocm-image-release.yaml
@@ -9,7 +9,7 @@ on:
       benchmark-utils_repo:
         description: Repository for benchmark utils
         required: true
-        default: 'ROCmSoftwarePlatform/migraphx-benchmark-utils'
+        default: 'ROCm/migraphx-benchmark-utils'
       base_image:
         description: Base image for rocm Docker build
         required: true
@@ -29,10 +29,10 @@ on:
 
 jobs:
   release:
-    uses: ROCmSoftwarePlatform/migraphx-benchmark/.github/workflows/rocm-release.yml@main
+    uses: ROCm/migraphx-benchmark/.github/workflows/rocm-release.yml@main
     with:
       rocm_release: ${{ github.event.inputs.rocm_release || '5.1' }}
-      benchmark-utils_repo: ${{ github.event.inputs.benchmark-utils_repo || 'ROCmSoftwarePlatform/migraphx-benchmark-utils' }}
+      benchmark-utils_repo: ${{ github.event.inputs.benchmark-utils_repo || 'ROCm/migraphx-benchmark-utils' }}
       base_image: ${{ github.event.inputs.base_image || 'rocm/dev-ubuntu-20.04' }}
       docker_image: ${{ github.event.inputs.docker_image || 'rocm-migraphx' }}
       build_navi: ${{ github.event.inputs.build_navi || '0' }}

--- a/.github/workflows/sync-onnxrt-main.yaml
+++ b/.github/workflows/sync-onnxrt-main.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: echo_sha1
         run: echo ${{ env.onnxsha }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         with: 
           ref: develop
 


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Node.js 16 is deprecated and versions of actions using those need to be upgraded. 

`actions/checkout@v3` was using node.js 16. upgrading it to v4.1.1