### PR TITLE
fix test_ref makelist

### DIFF
--- a/test/ref/CMakeLists.txt
+++ b/test/ref/CMakeLists.txt
@@ -26,5 +26,6 @@ file(GLOB REF CONFIGURE_DEPENDS *.cpp)
 
 rocm_add_test_executable(test_ref ${REF})
 target_include_directories(test_ref PUBLIC ../include)
+target_link_libraries(test_ref migraphx migraphx_ref)
 rocm_clang_tidy_check(test_ref)
 


### PR DESCRIPTION
One-line bug fix.  Adds a `target_link_libraries` statement to the CMakeLists file for the test_ref target.

Without this, trying to make `test_ref` without building any other targets leads to runtime error because a needed library `libmigraphx_ref.so` isn't created.  The problem can be worked around by making nearly any other Migraphx target program.