### PR TITLE
replace scaler multibroadcast + unsqueeze with just a multibroadcast

### DIFF
--- a/src/include/migraphx/matcher.hpp
+++ b/src/include/migraphx/matcher.hpp
@@ -578,6 +578,8 @@ MIGRAPHX_PRED_MATCHER(broadcast_shape, instruction_ref ins)
     return ins->get_shape().broadcasted();
 }
 
+MIGRAPHX_PRED_MATCHER(scalar_shape, instruction_ref ins) { return ins->get_shape().scalar(); }
+
 MIGRAPHX_PRED_MATCHER(transpose_shape, instruction_ref ins)
 {
     return ins->get_shape().transposed();

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -784,6 +784,27 @@ TEST_CASE(multibroadcast_simplify)
     EXPECT(std::distance(m.begin(), m.end()) == n - 1);
 }
 
+TEST_CASE(multibroadcast_unsqueeze_scalar)
+{
+    migraphx::module m1;
+    {
+        auto l  = m1.add_parameter("x", {migraphx::shape::float_type, {1}, {0}});
+        auto mb = m1.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2}}}), l);
+        auto t1 = m1.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1}}}), mb);
+        m1.add_return({t1});
+    }
+    run_pass(m1);
+    migraphx::module m2;
+    {
+        auto l = m2.add_parameter("x", {migraphx::shape::float_type, {1}, {0}});
+        auto mb =
+            m2.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 1}}}), l);
+        m2.add_return({mb});
+    }
+
+    EXPECT(m1 == m2);
+}
+
 TEST_CASE(double_slice1)
 {
     migraphx::module m1;


### PR DESCRIPTION
Simplify scalar multibroadcast+unsqueeze, to eliminate unsqueeze.