### PR TITLE
Add vim syntax file for MIGX IR

### DIFF
--- a/tools/syntax/migx.vim
+++ b/tools/syntax/migx.vim
@@ -1,0 +1,30 @@
+" Vim syntax file
+" Language: MIGraphX Intermediate Representation
+" Current Maintainer: Charlie Lin (https://github.com/CharlieL7)
+" Previous Maintainer:
+" Last Change: 14 Feb 2024
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+syn keyword migx_keyword param
+syn keyword migx_keyword return
+syn keyword migx_keyword target_id
+syn match migx_ins_number "@\d\+"
+syn match migx_instruction "\s=\s\zs.\+\ze\[" nextgroup=migx_attributes
+syn match migx_attributes "\(\[.\{-}\]\)"
+syn match migx_output_type "\s->\s\zs.\{-}\ze," nextgroup=migx_output_dims
+syn match migx_output_dims "\s\zs{.\{-}}\ze,\starget_id"
+syn match migx_exec_time ":\s\zs.\{-}ms\ze"
+
+let b:current_syntax = "migx"
+
+hi def link migx_keyword NonText
+hi def link migx_ins_number Number
+hi def link migx_instruction Operator
+hi def link migx_attributes Comment
+hi def link migx_output_type Type
+hi def link migx_output_dims Normal
+hi def link migx_exec_time NonText

--- a/tools/syntax/migx.vim
+++ b/tools/syntax/migx.vim
@@ -14,8 +14,8 @@ syn keyword migx_keyword return
 syn keyword migx_keyword target_id
 syn keyword migx_keyword literal
 syn match migx_ins_number "@\d\+"
-syn match migx_instruction "\s=\s\zs.\+\ze\[" nextgroup=migx_attributes
-syn region migx_attributes start="\[" end="\]" fold contains=migx_keyword
+syn match migx_instruction "\s=\s\zs.\+\ze(" contains=migx_attributes 
+syn region migx_attributes start="\[" end="\]" contains=migx_keyword
 syn match migx_output_type "\s->\s\zs.\{-}\ze," nextgroup=migx_output_dims
 syn match migx_output_dims "\s\zs{.\{-}}\ze,\starget_id"
 syn match migx_exec_time ":\s\zs\d\{-}\.\d\{-}ms\ze"

--- a/tools/syntax/migx.vim
+++ b/tools/syntax/migx.vim
@@ -2,7 +2,7 @@
 " Language: MIGraphX Intermediate Representation
 " Current Maintainer: Charlie Lin (https://github.com/CharlieL7)
 " Previous Maintainer:
-" Last Change: 14 Feb 2024
+" Last Change: 15 Feb 2024
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -12,12 +12,13 @@ endif
 syn keyword migx_keyword param
 syn keyword migx_keyword return
 syn keyword migx_keyword target_id
+syn keyword migx_keyword literal
 syn match migx_ins_number "@\d\+"
 syn match migx_instruction "\s=\s\zs.\+\ze\[" nextgroup=migx_attributes
-syn match migx_attributes "\(\[.\{-}\]\)"
+syn region migx_attributes start="\[" end="\]" fold contains=migx_keyword
 syn match migx_output_type "\s->\s\zs.\{-}\ze," nextgroup=migx_output_dims
 syn match migx_output_dims "\s\zs{.\{-}}\ze,\starget_id"
-syn match migx_exec_time ":\s\zs.\{-}ms\ze"
+syn match migx_exec_time ":\s\zs\d\{-}\.\d\{-}ms\ze"
 
 let b:current_syntax = "migx"
 


### PR DESCRIPTION
* I created a syntax highlighting file for vim for the MIGX IR
* You can add the syntax file to your syntax directory for vim or neovim to install
* Here is an example of the highlighting:
![2024-02-14-191219_1276x1381_scrot](https://github.com/ROCm/AMDMIGraphX/assets/11913076/fe4d2e6a-a6a5-4275-9f58-b18501689059)
