### PR TITLE
Revert "Add Dot, Convolution, and Fused as default options in fuse_mlir"

### DIFF
--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -61,20 +61,12 @@ bool mlir_enabled()
 #endif
 }
 
-const std::vector<std::string>& get_default_options()
-{
-    static std::vector<std::string> default_options{"dot", "convolution", "fused"};
-    return default_options;
-}
-
-static bool is_requested(std::string_view option)
+static bool is_requested(std::string_view option, bool fallback = false)
 {
     auto string_value = string_value_of(MIGRAPHX_MLIR_USE_SPECIFIC_OPS{}, "");
     if(string_value.empty())
-        return contains(get_default_options(), option);
-    auto options = split_string(string_value, ',');
-    if(contains(options, "none"))
-        return false;
+        return fallback;
+    const auto options = split_string(string_value, ',');
     return contains(options, option);
 }
 


### PR DESCRIPTION
Reverts ROCm/AMDMIGraphX#2669
I shouldn't have merged this as is.  More work needs to be done to control this since there are certain conditions (gfx#) in the current release where not using MLIR for everything is still the fastest solution