### PR TITLE
Add dilation to ref convolution

### DIFF
--- a/src/include/migraphx/op/convolution.hpp
+++ b/src/include/migraphx/op/convolution.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -229,7 +229,7 @@ struct convolution
 
         argument result{output_shape};
         visit_all(result, args[0], args[1])([&](auto output, auto input, auto weights) {
-            migraphx::convolution(output, input, weights, new_padding, stride, group);
+            migraphx::convolution(output, input, weights, new_padding, stride, dilation, group);
         });
         return result;
     }

--- a/src/include/migraphx/op/quant_convolution.hpp
+++ b/src/include/migraphx/op/quant_convolution.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -128,7 +128,7 @@ struct quant_convolution
         argument result{output_shape};
         result.visit([&](auto output) {
             visit_all(args[0], args[1])([&](auto input, auto weights) {
-                migraphx::convolution(output, input, weights, padding, stride, group);
+                migraphx::convolution(output, input, weights, padding, stride, dilation, group);
             });
         });
         return result;


### PR DESCRIPTION
Fixes: https://github.com/ROCm/AMDMIGraphX/issues/2708, https://github.com/ROCm/AMDMIGraphX/issues/2701

Dilation was not included in the reference convolution logic. The shapes were calculated correctly, but the compute was missing it.
The GPU version works correctly.