### PR TITLE
Buffer read/write: use fs::path instead of std::string for filenames

### DIFF
--- a/src/compile_src.cpp
+++ b/src/compile_src.cpp
@@ -47,7 +47,7 @@ std::vector<char> src_compiler::compile(const std::vector<src_file>& srcs) const
         fs::path full_path   = td.path / src.path;
         fs::path parent_path = full_path.parent_path();
         fs::create_directories(parent_path);
-        write_buffer(full_path.string(), src.content.data(), src.content.size());
+        write_buffer(full_path, src.content.data(), src.content.size());
         if(src.path.extension().string() == ".cpp")
         {
             params += " " + src.path.filename().string();

--- a/src/compile_src.cpp
+++ b/src/compile_src.cpp
@@ -71,7 +71,7 @@ std::vector<char> src_compiler::compile(const std::vector<src_file>& srcs) const
     if(not fs::exists(out_path))
         MIGRAPHX_THROW("Output file missing: " + out);
 
-    return read_buffer(out_path.string());
+    return read_buffer(out_path);
 }
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/dynamic_loader.cpp
+++ b/src/dynamic_loader.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/dynamic_loader.cpp
+++ b/src/dynamic_loader.cpp
@@ -72,7 +72,7 @@ struct dynamic_loader_impl
     {
         auto t = std::make_shared<tmp_dir>("dloader");
         auto f = t->path / "libtmp.so";
-        write_buffer(f.string(), image, size);
+        write_buffer(f, image, size);
         return std::make_shared<dynamic_loader_impl>(f, t);
     }
 
@@ -122,7 +122,7 @@ struct dynamic_loader_impl
     {
         auto t = tmp_dir{"migx-dynload"};
         auto f = t.path / "tmp.dll";
-        write_buffer(f.string(), image, size);
+        write_buffer(f, image, size);
         return std::make_shared<dynamic_loader_impl>(f, std::move(t));
     }
 

--- a/src/file_buffer.cpp
+++ b/src/file_buffer.cpp
@@ -34,6 +34,8 @@ template <class T>
 T generic_read_file(const fs::path& filename, size_t offset = 0, size_t nbytes = 0)
 {
     std::ifstream is(filename, std::ios::binary | std::ios::ate);
+    if(not is.is_open())
+        MIGRAPHX_THROW("Failure opening file: " + filename);
     if(nbytes == 0)
     {
         // if there is a non-zero offset and nbytes is not set,
@@ -68,6 +70,7 @@ void write_buffer(const fs::path& filename, const char* buffer, std::size_t size
     std::ofstream os(filename, std::ios::out | std::ios::binary);
     os.write(buffer, size);
 }
+
 void write_buffer(const fs::path& filename, const std::vector<char>& buffer)
 {
     write_buffer(filename, buffer.data(), buffer.size());

--- a/src/file_buffer.cpp
+++ b/src/file_buffer.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,7 @@
  */
 #include <migraphx/file_buffer.hpp>
 #include <migraphx/errors.hpp>
+#include <migraphx/fileutils.hpp>
 #include <fstream>
 #include <iostream>
 
@@ -30,7 +31,7 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
 template <class T>
-T generic_read_file(const std::string& filename, size_t offset = 0, size_t nbytes = 0)
+T generic_read_file(const fs::path& filename, size_t offset = 0, size_t nbytes = 0)
 {
     std::ifstream is(filename, std::ios::binary | std::ios::ate);
     if(nbytes == 0)
@@ -52,22 +53,22 @@ T generic_read_file(const std::string& filename, size_t offset = 0, size_t nbyte
     return buffer;
 }
 
-std::vector<char> read_buffer(const std::string& filename, size_t offset, size_t nbytes)
+std::vector<char> read_buffer(const fs::path& filename, size_t offset, size_t nbytes)
 {
     return generic_read_file<std::vector<char>>(filename, offset, nbytes);
 }
 
-std::string read_string(const std::string& filename)
+std::string read_string(const fs::path& filename)
 {
     return generic_read_file<std::string>(filename);
 }
 
-void write_buffer(const std::string& filename, const char* buffer, std::size_t size)
+void write_buffer(const fs::path& filename, const char* buffer, std::size_t size)
 {
-    std::ofstream os(filename);
+    std::ofstream os(filename, std::ios::out | std::ios::binary);
     os.write(buffer, size);
 }
-void write_buffer(const std::string& filename, const std::vector<char>& buffer)
+void write_buffer(const fs::path& filename, const std::vector<char>& buffer)
 {
     write_buffer(filename, buffer.data(), buffer.size());
 }

--- a/src/include/migraphx/file_buffer.hpp
+++ b/src/include/migraphx/file_buffer.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@
 #define MIGRAPHX_GUARD_RTGLIB_FILE_BUFFER_HPP
 
 #include <migraphx/config.hpp>
+#include <migraphx/filesystem.hpp>
 #include <string>
 #include <vector>
 
@@ -32,12 +33,11 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
 MIGRAPHX_EXPORT std::vector<char>
-read_buffer(const std::string& filename, size_t offset = 0, size_t nbytes = 0);
-MIGRAPHX_EXPORT std::string read_string(const std::string& filename);
+read_buffer(const fs::path& filename, size_t offset = 0, size_t nbytes = 0);
+MIGRAPHX_EXPORT std::string read_string(const fs::path& filename);
 
-MIGRAPHX_EXPORT void
-write_buffer(const std::string& filename, const char* buffer, std::size_t size);
-MIGRAPHX_EXPORT void write_buffer(const std::string& filename, const std::vector<char>& buffer);
+MIGRAPHX_EXPORT void write_buffer(const fs::path& filename, const char* buffer, std::size_t size);
+MIGRAPHX_EXPORT void write_buffer(const fs::path& filename, const std::vector<char>& buffer);
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/onnx/include/migraphx/onnx/onnx_parser.hpp
+++ b/src/onnx/include/migraphx/onnx/onnx_parser.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/onnx/include/migraphx/onnx/onnx_parser.hpp
+++ b/src/onnx/include/migraphx/onnx/onnx_parser.hpp
@@ -25,6 +25,7 @@
 #define MIGRAPHX_GUARD_AMDMIGRAPHX_ONNX_PARSER_HPP
 
 #include <migraphx/config.hpp>
+#include <migraphx/filesystem.hpp>
 #include <migraphx/program.hpp>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
@@ -43,7 +44,7 @@ namespace onnx = onnx_for_migraphx;
 struct onnx_parser
 {
     std::string filename;
-    std::string path    = ".";
+    fs::path path;
     using attribute_map = std::unordered_map<std::string, onnx::AttributeProto>;
     struct node_info
     {

--- a/src/onnx/onnx_parser.cpp
+++ b/src/onnx/onnx_parser.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/onnx/onnx_parser.cpp
+++ b/src/onnx/onnx_parser.cpp
@@ -514,7 +514,7 @@ literal onnx_parser::parse_tensor(const onnx::TensorProto& t) const
         {
             nbytes = std::stoul(t.external_data().at(2).value());
         }
-        auto raw_buffer = read_buffer(path + "/" + data_file, offset, nbytes);
+        auto raw_buffer = read_buffer(path / data_file, offset, nbytes);
         std::string s(raw_buffer.begin(), raw_buffer.end());
         return create_literal(type, dims, s.data());
     }

--- a/src/targets/gpu/compile_hip.cpp
+++ b/src/targets/gpu/compile_hip.cpp
@@ -275,11 +275,9 @@ std::vector<std::vector<char>> compile_hip_src(const std::vector<src_file>& srcs
         tmp_dir td{};
         auto out = td.path / "output";
 
-        process(driver.string() + " " + out.string()).write([&](auto writer) {
-            to_msgpack(v, writer);
-        });
+        process(driver + " " + out).write([&](auto writer) { to_msgpack(v, writer); });
         if(fs::exists(out))
-            return {read_buffer(out.string())};
+            return {read_buffer(out)};
     }
     return compile_hip_src_with_hiprtc(std::move(hsrcs), params, arch);
 }

--- a/test/fileutils.cpp
+++ b/test/fileutils.cpp
@@ -79,7 +79,7 @@ TEST_CASE(append_to_string)
     std::string prefix{baze_name};
     auto s1 = prefix + separator + cwd;
     EXPECT(s1 == prefix + separator + cwd.string());
-    auto s2 = cwd + separator + prefix;
+    auto s2 = cwd + std::string{separator} + prefix;
     EXPECT(s2 == cwd.string() + separator + prefix);
 }
 


### PR DESCRIPTION
It is extracted from #2469.