### PR TITLE
Add fix for find_transpose_contiguous_reshaper_unary in simplify_reshapes pass

### DIFF
--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -678,12 +678,10 @@ struct find_transpose_contiguous_reshaper_unary
         auto trans_ins     = r.instructions["trans_ins"];
         auto cont_ins      = r.instructions["cont_ins"];
         auto unary_op_name = ins->get_operator().name();
-        if(unary_op_name != "convert")
-        {
-            auto unary_ins = m.insert_instruction(cont_ins, make_op(unary_op_name), trans_ins);
-            // older cont and reshape are removed by deadcode elimination
-            m.replace_instruction(ins, reshaper_ins->get_operator(), unary_ins);
-        }
+        auto unary_ins     = m.insert_instruction(
+            cont_ins, make_op(unary_op_name, ins->get_operator().to_value()), trans_ins);
+        // older cont and reshape are removed by deadcode elimination
+        m.replace_instruction(ins, reshaper_ins->get_operator(), unary_ins);
     }
 };
 

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -678,9 +678,12 @@ struct find_transpose_contiguous_reshaper_unary
         auto trans_ins     = r.instructions["trans_ins"];
         auto cont_ins      = r.instructions["cont_ins"];
         auto unary_op_name = ins->get_operator().name();
-        auto unary_ins     = m.insert_instruction(cont_ins, make_op(unary_op_name), trans_ins);
-        // older cont and reshape are removed by deadcode elimination
-        m.replace_instruction(ins, reshaper_ins->get_operator(), unary_ins);
+        if(unary_op_name != "convert")
+        {
+            auto unary_ins = m.insert_instruction(cont_ins, make_op(unary_op_name), trans_ins);
+            // older cont and reshape are removed by deadcode elimination
+            m.replace_instruction(ins, reshaper_ins->get_operator(), unary_ins);
+        }
     }
 };
 

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -677,9 +677,7 @@ struct find_transpose_contiguous_reshaper_unary
         auto reshaper_ins  = r.instructions["reshaper_ins"];
         auto trans_ins     = r.instructions["trans_ins"];
         auto cont_ins      = r.instructions["cont_ins"];
-        auto unary_op_name = ins->get_operator().name();
-        auto unary_ins     = m.insert_instruction(
-            cont_ins, make_op(unary_op_name, ins->get_operator().to_value()), trans_ins);
+        auto unary_ins     = m.insert_instruction(cont_ins, ins->get_operator(), trans_ins);
         // older cont and reshape are removed by deadcode elimination
         m.replace_instruction(ins, reshaper_ins->get_operator(), unary_ins);
     }


### PR DESCRIPTION
Expand unary make_op function in find_transpose_contiguous_reshaper_unary to include original unary operator attributes.

Resolves https://github.com/migraphx-benchmark/AMDMIGraphX/issues/166 https://github.com/ROCm/AMDMIGraphX/issues/2706