### PR TITLE
Fix resetting rounding mode for nearbyint

### DIFF
--- a/src/include/migraphx/op/nearbyint.hpp
+++ b/src/include/migraphx/op/nearbyint.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,8 +38,9 @@ struct nearbyint : unary<nearbyint>
         return [](auto x) {
             auto rounding_mode = fegetround();
             fesetround(FE_TONEAREST);
-            return std::nearbyint(x);
+            auto result = std::nearbyint(x);
             fesetround(rounding_mode);
+            return result;
         };
     }
 };


### PR DESCRIPTION
Rounding mode was not reset after nearbyint because of the `return` before ` fesetround(rounding_mode);`:
https://github.com/ROCm/AMDMIGraphX/blob/9d8dc8696b457efcdc578111f0963df3c0b85c38/src/include/migraphx/op/nearbyint.hpp#L39-L42