### PR TITLE
Fixes a Doxygen syntax error

### DIFF
--- a/docs/dev/data.rst
+++ b/docs/dev/data.rst
@@ -29,8 +29,9 @@ raw_data
    :members:
    :undoc-members:
 
-.. doxygenfunction:: template<class T, class ...Ts> auto migraphx::internal::visit_all(T &&x, Ts&&... xs)
-
+.. doxygenfunction:: migraphx::internal::visit_all(T&& x, Ts&&... xs)
+   
+.. doxygenfunction:: migraphx::internal::visit_all(const std::vector<T>& x)
 
 tensor_view
 -----------

--- a/src/include/migraphx/raw_data.hpp
+++ b/src/include/migraphx/raw_data.hpp
@@ -220,12 +220,12 @@ auto visit_all_pack(const shape& s, V1&& v1)
 /**
  * @brief Visits every object together
  * @details This will visit every object, but assumes each object is the same type. This can reduce
- * the deeply nested visit calls. This will return a function that will take the visitor callback.
- * So it will be called with `visit_all(xs...)([](auto... ys) {})` where `xs...` and `ys...` are the
+ * the deeply nested visit calls. Returns a function that takes the visitor callback.
+ * Calling syntax is `visit_all(xs...)([](auto... ys) {})` where `xs...` and `ys...` are the
  * same number of parameters.
  *
  * @param x A raw data object
- * @param xs Many raw data objects
+ * @param xs Many raw data objects.  All must be the same type as x.
  * @return A function to be called with the visitor
  */
 template <class T, class... Ts>
@@ -238,6 +238,14 @@ auto visit_all(T&& x, Ts&&... xs)
     return [&](auto... vs) { detail::visit_all_pack(s, vs...)(x, xs...); };
 }
 
+/**
+ * @brief Visits every object together
+ * @details This will visit every object, but assumes each object is the same type. This can reduce
+ * the deeply nested visit calls. Returns a function that takes the visitor callback.
+ *
+ * @param x A vector of raw data objects.  Types must all be the same.
+ * @return A function to be called with the visitor
+ */
 template <class T>
 auto visit_all(const std::vector<T>& x)
 {


### PR DESCRIPTION
… that caused the function `visit_all()` not to appear in online documentation.  The correct listing in a *.rst file for a templated function is a qualified function name with argument list, but without template or return type, eg. `.. doxygenfunction:: migraphx::internal::visit_all(T&& x, Ts&&... xs)`.  Note the space before "migraphx".  Also changed some doc wording and added doxygen code for a second overload of the same function.

To check results for yourself , use `build-j22 doc`  then open the generated file `<path-to-docs>/docs/html/dev/data.html` in a Web browser.  If you want to copy the generated documentation to another location for viewing, you should transfer the entire `docs/html` directory. 