### PR TITLE
Check Gather output bounds

### DIFF
--- a/src/include/migraphx/op/gather.hpp
+++ b/src/include/migraphx/op/gather.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/op/gather.hpp
+++ b/src/include/migraphx/op/gather.hpp
@@ -129,6 +129,8 @@ struct gather
                         auto data_idx   = out_idx_v;
                         auto in_index   = indices[data_idx[axis]];
                         in_index        = (in_index < 0) ? in_index + axis_dim_size : in_index;
+                        // don't go out of bounds: https://github.com/ROCm/AMDMIGraphX/issues/2838
+                        assert(in_index >= 0 and in_index < axis_dim_size);
                         data_idx[axis]  = in_index;
                         output[out_idx] = data(data_idx.begin(), data_idx.end());
                     });


### PR DESCRIPTION
This PR fixes: https://github.com/ROCm/AMDMIGraphX/issues/2838
Short summary: when the `input-dim` is not properly set Gather output idx can go out of bounds for some models.
I've added an assert to catch this beahviour, so the next dev running into this don't have to waste as much time on this as I did :D.