### PR TITLE
tests: sort programs before compaing content

### DIFF
--- a/test/quantization.cpp
+++ b/test/quantization.cpp
@@ -436,7 +436,7 @@ TEST_CASE(fp16_subgraph)
 
     auto p2 = create_fp16_program();
 
-    EXPECT(p1 == p2);
+    EXPECT(p1.sort() == p2.sort());
 }
 
 TEST_CASE(topk)

--- a/test/split_single_dyn_dim_test.cpp
+++ b/test/split_single_dyn_dim_test.cpp
@@ -158,7 +158,7 @@ TEST_CASE(dynamic_batch_multiple_input)
     }
     run_pass(p1);
 
-    EXPECT(p0 == p1);
+    EXPECT(p0.sort() == p1.sort());
 }
 
 TEST_CASE(multiple_outputs)


### PR DESCRIPTION
With sorting the programs/modules, the comparison is working on Windows.