### PR TITLE
Suppress compilation warning about result not read

### DIFF
--- a/test/ref/resize.cpp
+++ b/test/ref/resize.cpp
@@ -421,7 +421,7 @@ TEST_CASE(resize_fail_test_4)
                                            {"coordinate_transformation_mode", "invalid"}}),
                         {a0});
     p.compile(migraphx::make_target("ref"));
-    EXPECT(test::throws([&] { std::ignore = p.eval({}); }));
+    EXPECT(test::throws([&] { p.eval({}); }));
 }
 
 TEST_CASE(resize_fail_test_5)
@@ -444,7 +444,7 @@ TEST_CASE(resize_fail_test_5)
                            {"coordinate_transformation_mode", "pytorch_half_pixel"}}),
         {a0});
     p.compile(migraphx::make_target("ref"));
-    EXPECT(test::throws([&] { std::ignore = p.eval({}); }));
+    EXPECT(test::throws([&] { p.eval({}); }));
 }
 
 TEST_CASE(resize_fail_test_6)

--- a/test/ref/resize.cpp
+++ b/test/ref/resize.cpp
@@ -421,7 +421,7 @@ TEST_CASE(resize_fail_test_4)
                                            {"coordinate_transformation_mode", "invalid"}}),
                         {a0});
     p.compile(migraphx::make_target("ref"));
-    EXPECT(test::throws([&] { p.eval({}).back(); }));
+    EXPECT(test::throws([&] { std::ignore = p.eval({}).back(); }));
 }
 
 TEST_CASE(resize_fail_test_5)
@@ -444,7 +444,7 @@ TEST_CASE(resize_fail_test_5)
                            {"coordinate_transformation_mode", "pytorch_half_pixel"}}),
         {a0});
     p.compile(migraphx::make_target("ref"));
-    EXPECT(test::throws([&] { p.eval({}).back(); }));
+    EXPECT(test::throws([&] { std::ignore = p.eval({}).back(); }));
 }
 
 TEST_CASE(resize_fail_test_6)

--- a/test/ref/resize.cpp
+++ b/test/ref/resize.cpp
@@ -421,7 +421,7 @@ TEST_CASE(resize_fail_test_4)
                                            {"coordinate_transformation_mode", "invalid"}}),
                         {a0});
     p.compile(migraphx::make_target("ref"));
-    EXPECT(test::throws([&] { std::ignore = p.eval({}).back(); }));
+    EXPECT(test::throws([&] { std::ignore = p.eval({}); }));
 }
 
 TEST_CASE(resize_fail_test_5)
@@ -444,7 +444,7 @@ TEST_CASE(resize_fail_test_5)
                            {"coordinate_transformation_mode", "pytorch_half_pixel"}}),
         {a0});
     p.compile(migraphx::make_target("ref"));
-    EXPECT(test::throws([&] { std::ignore = p.eval({}).back(); }));
+    EXPECT(test::throws([&] { std::ignore = p.eval({}); }));
 }
 
 TEST_CASE(resize_fail_test_6)


### PR DESCRIPTION
The official documentation allows us to use `std::ignore` for suppressing compilation warnings about return values not being read (even originally, it was designed to be used together with `std::tie`).
See more info here: https://en.cppreference.com/w/cpp/utility/tuple/ignore.