### PR TITLE
Keep output shape from pointwise instruction after fusing with concat

### DIFF
--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -842,7 +842,9 @@ struct find_concat_pointwise
         inputs.insert(inputs.end(), ins->inputs().begin() + 1, ins->inputs().end());
 
         auto op = concat->get_operator();
-        op.from_value({{"additional_args", ins->inputs().size() - 1}, {"ignore_modules", true}});
+        op.from_value({{"additional_args", ins->inputs().size() - 1},
+                       {"ignore_modules", true},
+                       {"output_shape", to_value(ins->get_shape())}});
 
         m.replace_instruction(ins, op, inputs, {pm});
     }

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -767,7 +767,7 @@ struct find_contiguous
     }
 };
 
-struct find_contiguous_pointwise
+struct find_pointwise_contiguous
 {
     auto matcher() const
     {
@@ -852,7 +852,7 @@ struct find_concat_pointwise
 
 void fuse_ops::apply(module& m) const
 {
-    match::find_matches(m, find_contiguous_pointwise{});
+    match::find_matches(m, find_pointwise_contiguous{});
     run_passes(m, {dead_code_elimination{}});
     match::find_matches(m, find_conv_pointwise{ctx}, find_conv_bias_relu{ctx}, find_conv_bias{ctx});
     run_passes(m, {dead_code_elimination{}});

--- a/test/gpu/fuse_ops.cpp
+++ b/test/gpu/fuse_ops.cpp
@@ -104,7 +104,7 @@ TEST_CASE(layernorm_pointwise)
     }
 }
 
-TEST_CASE(contiguous_pointwise)
+TEST_CASE(pointwise_contiguous)
 {
     migraphx::shape s1{migraphx::shape::float_type, {128, 4, 196, 32}};
     migraphx::shape s2{migraphx::shape::float_type, {128, 196, 4, 32}};


### PR DESCRIPTION
`fuse_ops.cpp` pass is running `find_contiguous_pointwise` first which folds contiguous inside pointwise. 

Later, `fuse_concat_pointwise` runs which is not maintaining the standard output shape while folding pointwise inside concat.  

This leads to errors when trying to use `reshape_lazy`. 

Renaming `find_contiguous_pointwise` to `find_pointwise_contiguous`.  Many of the matchers have names such that operations appear in order they appear in graph. 
E.g. 
`find_concat_pointwise` means output of the concat is feeding into pointwise. 
`find_layernorm_pointwise` means output of layernorm is going into pointwise. 
Therefore `find_pointwise_contiguous` makes more sense. 