### PR TITLE
Mlir disable specific ops

### DIFF
--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -28,6 +28,7 @@
 #include <migraphx/make_op.hpp>
 #include <migraphx/register_op.hpp>
 #include <migraphx/env.hpp>
+#include <migraphx/algorithm.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -61,12 +62,36 @@ bool mlir_enabled()
 #endif
 }
 
-static bool is_requested(std::string_view option, bool fallback = false)
+namespace {
+struct requested {};
+struct rejected {};
+}
+
+template<class Action>
+static std::vector<std::string> get_usage()
 {
-    auto string_value = string_value_of(MIGRAPHX_MLIR_USE_SPECIFIC_OPS{}, "");
-    if(string_value.empty())
+    static const auto options = split_string(string_value_of(MIGRAPHX_MLIR_USE_SPECIFIC_OPS{}, ""), ',');
+    static const auto enabled = std::is_same<Action, requested>{};
+    std::vector<std::string> result;
+    auto remove_not_symbol = [&](const std::string& s) {
+        if (starts_with(s, "!"))
+            return s.substr(1);
+        return s;
+    };
+    transform_if(options.begin(), options.end(), std::back_inserter(result), [&](const std::string& option) {
+        if (starts_with(option, "!"))
+            return not enabled;
+        return enabled;
+    }, remove_not_symbol);
+    return result;
+}
+
+template<class Action>
+static bool specific_op(std::string_view option, bool fallback = false)
+{
+    static const auto options = get_usage<Action>();
+    if(options.empty())
         return fallback;
-    const auto options = split_string(string_value, ',');
     if(contains(option, "fused") and contains(options, "fused"))
         return true;
     return contains(options, option);
@@ -77,7 +102,7 @@ bool mlir_attention_enabled()
 #ifdef MIGRAPHX_MLIR
     if(not mlir_enabled())
         return false;
-    return is_requested("attention");
+    return specific_op<requested>("attention");
 #else
     return false;
 #endif
@@ -550,7 +575,9 @@ void fuse_mlir::apply(module_pass_manager& mpm) const
     const bool is_navi      = starts_with(device_name, "gfx110");
 
     auto get_mode = [&](std::string_view option, mlir_mode m1, mlir_mode m2 = mlir_mode::fast) {
-        if(is_requested(option))
+        if(specific_op<rejected>(option))
+            return mlir_mode::none;
+        if(specific_op<requested>(option))
             return mlir_mode::all;
         if(is_navi)
             return mlir_mode::all;

--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -63,30 +63,40 @@ bool mlir_enabled()
 }
 
 namespace {
-struct requested {};
-struct rejected {};
-}
+struct requested
+{
+};
+struct rejected
+{
+};
+} // namespace
 
-template<class Action>
+template <class Action>
 static std::vector<std::string> get_usage()
 {
-    static const auto options = split_string(string_value_of(MIGRAPHX_MLIR_USE_SPECIFIC_OPS{}, ""), ',');
+    static const auto options =
+        split_string(string_value_of(MIGRAPHX_MLIR_USE_SPECIFIC_OPS{}, ""), ',');
     static const auto enabled = std::is_same<Action, requested>{};
     std::vector<std::string> result;
     auto remove_not_symbol = [&](const std::string& s) {
-        if (starts_with(s, "!"))
+        if(starts_with(s, "!"))
             return s.substr(1);
         return s;
     };
-    transform_if(options.begin(), options.end(), std::back_inserter(result), [&](const std::string& option) {
-        if (starts_with(option, "!"))
-            return not enabled;
-        return enabled;
-    }, remove_not_symbol);
+    transform_if(
+        options.begin(),
+        options.end(),
+        std::back_inserter(result),
+        [&](const std::string& option) {
+            if(starts_with(option, "!"))
+                return not enabled;
+            return enabled;
+        },
+        remove_not_symbol);
     return result;
 }
 
-template<class Action>
+template <class Action>
 static bool specific_op(std::string_view option, bool fallback = false)
 {
     static const auto options = get_usage<Action>();

--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -63,9 +63,13 @@ bool mlir_enabled()
 }
 
 namespace {
-struct requested {};
-struct rejected {};
-}
+struct requested
+{
+};
+struct rejected
+{
+};
+} // namespace
 
 static bool is_negated_op(const std::string& s)
 {
@@ -74,28 +78,34 @@ static bool is_negated_op(const std::string& s)
     return contains({'!', '~'}, s[0]);
 }
 
-template<class Action>
+template <class Action>
 static std::vector<std::string> get_usage()
 {
-    static const auto options = split_string(string_value_of(MIGRAPHX_MLIR_USE_SPECIFIC_OPS{}, ""), ',');
+    static const auto options =
+        split_string(string_value_of(MIGRAPHX_MLIR_USE_SPECIFIC_OPS{}, ""), ',');
     static const bool enabled = std::is_same<Action, requested>{};
     std::vector<std::string> result;
     auto remove_not_symbol = [&](const std::string& s) {
-        if (is_negated_op(s))
+        if(is_negated_op(s))
             return s.substr(1);
         return s;
     };
-    transform_if(options.begin(), options.end(), std::back_inserter(result), [&](const std::string& option) {
-        if (option.empty())
-            return false;
-        if (is_negated_op(option))
-            return not enabled;
-        return enabled;
-    }, remove_not_symbol);
+    transform_if(
+        options.begin(),
+        options.end(),
+        std::back_inserter(result),
+        [&](const std::string& option) {
+            if(option.empty())
+                return false;
+            if(is_negated_op(option))
+                return not enabled;
+            return enabled;
+        },
+        remove_not_symbol);
     return result;
 }
 
-template<class Action>
+template <class Action>
 static bool specific_op(std::string_view option, bool fallback = false)
 {
     static const auto options = get_usage<Action>();


### PR DESCRIPTION
Specific ops can be disabled using the `!` or `~` prefix to disable it.