### PR TITLE
Fix parsing of MatMulInteger

### DIFF
--- a/src/onnx/parse_matmul.cpp
+++ b/src/onnx/parse_matmul.cpp
@@ -91,46 +91,101 @@ struct parse_matmul : op_parser<parse_matmul>
             auto s1_lens        = a1->get_shape().lens();
             instruction_ref ba0 = a0;
             instruction_ref ba1 = a1;
-            // try broadcasting if dimensions other than last two do not match
-            if(not std::equal(
-                   s0_lens.rbegin() + 2, s0_lens.rend(), s1_lens.rbegin() + 2, s1_lens.rend()))
-            {
-                auto l0_it = s0_lens.begin() + s0_lens.size() - 2;
-                std::vector<std::size_t> l0_broadcasted_lens(s0_lens.begin(), l0_it);
-                auto l1_it = s1_lens.begin() + s1_lens.size() - 2;
-                std::vector<std::size_t> l1_broadcasted_lens(s1_lens.begin(), l1_it);
-                auto output_lens =
-                    compute_broadcasted_lens(l0_broadcasted_lens, l1_broadcasted_lens);
-                l0_broadcasted_lens = output_lens;
-                l0_broadcasted_lens.insert(l0_broadcasted_lens.end(), l0_it, s0_lens.end());
-                l1_broadcasted_lens = output_lens;
-                l1_broadcasted_lens.insert(l1_broadcasted_lens.end(), l1_it, s1_lens.end());
-                if(s0_lens != l0_broadcasted_lens)
-                {
-                    ba0 = info.add_instruction(
-                        make_op("multibroadcast", {{"out_lens", l0_broadcasted_lens}}), a0);
-                }
-                if(s1_lens != l1_broadcasted_lens)
-                {
-                    ba1 = info.add_instruction(
-                        make_op("multibroadcast", {{"out_lens", l1_broadcasted_lens}}), a1);
-                }
-            }
 
             // parse a_zero_point and b_zero_point values
             if(args.size() > 2)
             {
-                ba0 = info.add_instruction(
-                    make_op("convert", {{"target_type", migraphx::shape::float_type}}), ba0);
+                if(args[2]->get_shape().type() != a0->get_shape().type())
+                {
+                    MIGRAPHX_THROW("PARSE_QUANT_DOT: A zero point must be the same type as A data");
+                }
 
-                ba0 = info.add_common_op("sub", ba0, args[2]);
+                ba0 = args[2];
+                ba0 = info.add_common_op("sub", a0, ba0);
+
                 if(args.size() > 3)
                 {
-                    ba1 = info.add_instruction(
-                        make_op("convert", {{"target_type", migraphx::shape::float_type}}), ba1);
-                    ba1 = info.add_common_op("sub", ba1, args[3]);
+                    if(args[3]->get_shape().type() != a1->get_shape().type())
+                    {
+                        MIGRAPHX_THROW(
+                            "PARSE_QUANT_DOT: B zero point must be the same type as B data");
+                    }
+
+                    ba1 = args[3];
+                    ba1 = info.add_common_op("sub", a1, ba1);
                 }
-                dot_res = info.add_instruction(make_op("dot"), ba0, ba1);
+
+                auto ba0_type = ba0->get_shape().type();
+                auto ba1_type = ba1->get_shape().type();
+
+                // determine if we need to add a shift to ensure items get shifted to the same int8
+                // type if we see uint8/int8 mismatches
+                if(ba0_type != ba1_type)
+                {
+                    instruction_ref unshifted_input;
+                    if(ba0_type == migraphx::shape::int8_type)
+                    {
+                        unshifted_input = ba1;
+                    }
+                    if(ba1_type == migraphx::shape::int8_type)
+                    {
+                        unshifted_input = ba0;
+                    }
+
+                    // Convert to fp16 prior to a shift to ensure we preserve accuracy here then
+                    // convert back to int8
+                    auto int8_shift = info.add_literal(
+                        migraphx::literal{migraphx::shape{migraphx::shape::int16_type}, {-128}});
+
+                    auto unshifted_input_int16 = info.add_instruction(
+                        migraphx::make_op("convert",
+                                          {{"target_type", migraphx::shape::int16_type}}),
+                        unshifted_input);
+
+                    auto input_shifted_int16 =
+                        info.add_common_op("add", unshifted_input_int16, int8_shift);
+
+                    auto shifted_input = info.add_instruction(
+                        migraphx::make_op("convert", {{"target_type", migraphx::shape::int8_type}}),
+                        input_shifted_int16);
+
+                    if(ba0_type == migraphx::shape::int8_type)
+                    {
+                        ba1 = shifted_input;
+                    }
+                    if(ba1_type == migraphx::shape::int8_type)
+                    {
+                        ba0 = shifted_input;
+                    }
+                }
+
+                // try broadcasting if dimensions other than last two do not match
+                if(not std::equal(
+                       s0_lens.rbegin() + 2, s0_lens.rend(), s1_lens.rbegin() + 2, s1_lens.rend()))
+                {
+                    auto l0_it = s0_lens.begin() + s0_lens.size() - 2;
+                    std::vector<std::size_t> l0_broadcasted_lens(s0_lens.begin(), l0_it);
+                    auto l1_it = s1_lens.begin() + s1_lens.size() - 2;
+                    std::vector<std::size_t> l1_broadcasted_lens(s1_lens.begin(), l1_it);
+                    auto output_lens =
+                        compute_broadcasted_lens(l0_broadcasted_lens, l1_broadcasted_lens);
+                    l0_broadcasted_lens = output_lens;
+                    l0_broadcasted_lens.insert(l0_broadcasted_lens.end(), l0_it, s0_lens.end());
+                    l1_broadcasted_lens = output_lens;
+                    l1_broadcasted_lens.insert(l1_broadcasted_lens.end(), l1_it, s1_lens.end());
+                    if(s0_lens != l0_broadcasted_lens)
+                    {
+                        ba0 = info.add_instruction(
+                            make_op("multibroadcast", {{"out_lens", l0_broadcasted_lens}}), a0);
+                    }
+                    if(s1_lens != l1_broadcasted_lens)
+                    {
+                        ba1 = info.add_instruction(
+                            make_op("multibroadcast", {{"out_lens", l1_broadcasted_lens}}), a1);
+                    }
+                }
+
+                dot_res = info.add_instruction(make_op("quant_dot"), ba0, ba1);
                 dot_res = info.add_instruction(
                     make_op("convert", {{"target_type", migraphx::shape::int32_type}}), dot_res);
             }


### PR DESCRIPTION
Originally we were using dot and converting the input for MatMulinteger() as it was parsed in.  As a result we were inserting dot() instead of quant_dot into the model.

I've added a change to check for similar data types and then add a shift to an input  where there's a mismatch of int8 and uint8 on input. This is usually seen when dynamicquantizelinear is used as the input as it inserts a uint8 as the zero point which in some models (like gpt2) is operated on.

With this I'm seeing around a 30% boost in the GPT run.

```
Summary:
gpu::code_object::reduce_min_kernel: 2.06349ms / 49 = 0.042112ms, 14%
gpu::code_object::reduce_max_sub_mul_kernel: 2.05264ms / 49 = 0.0418906ms, 13%
gpu::code_object::mlir_quant_dot: 1.87745ms / 61 = 0.0307779ms, 12%
gpu::code_object::concat_kernel: 1.15502ms / 49 = 0.0235718ms, 8%
gpu::code_object::quantizelinear_sub_convert_add_convert_kernel: 1.14867ms / 49 = 0.0234422ms, 8%
gpu::code_object::mul_kernel: 1.13639ms / 49 = 0.0231916ms, 8%
gpu::code_object::neg_div_clip_nearbyint_convert_kernel: 1.13261ms / 49 = 0.0231144ms, 8%
gpu::code_object::contiguous_kernel: 1.12907ms / 48 = 0.0235223ms, 8%
gpu::code_object::quantizelinear_kernel: 0.836898ms / 36 = 0.0232472ms, 6%
gpu::code_object::layernorm_mul_add_kernel: 0.585637ms / 24 = 0.0244015ms, 4%
gpu::code_object::convert_mul_add_add_kernel: 0.545402ms / 23 = 0.0237131ms, 4%
gpu::code_object::convert_mul_add_kernel: 0.310343ms / 13 = 0.0238725ms, 2%
load: 0.307436ms / 515 = 0.000596963ms, 2%
gpu::code_object::dequantizelinear_mul_where_reduce_max_sub_exp_reduce_sum_div_quantizelinear_kernel: 0.294008ms / 12 = 0.0245007ms, 2%
gpu::code_object::convert_mul_add_mul_mul_add_mul_exp_add_div_kernel: 0.28876ms / 12 = 0.0240634ms, 2%
gpu::code_object::mlir_quant_dot_dequantizelinear: 0.285526ms / 12 = 0.0237939ms, 2%
multibroadcast: 0.220696ms / 246 = 0.000897138ms, 2%
reshape_lazy: 0.119711ms / 180 = 0.000665061ms, 1%
hip::hip_copy_literal: 0.100321ms / 151 = 0.00066438ms, 1%
transpose: 0.0685118ms / 48 = 0.00142733ms, 1%
slice: 0.0486096ms / 36 = 0.00135027ms, 1%
gpu::code_object::convert_mul_kernel: 0.0291348ms / 1 = 0.0291348ms, 1%
gpu::code_object::add_layernorm_mul_add_kernel: 0.0249158ms / 1 = 0.0249158ms, 1%
gpu::code_object::dequantizelinear_add_kernel: 0.0237881ms / 1 = 0.0237881ms, 1%
gpu::code_object::gather_kernel: 0.023749ms / 1 = 0.023749ms, 1%
gpu::code_object::convert_kernel: 0.0230378ms / 1 = 0.0230378ms, 1%
@param: 0.00976646ms / 26 = 0.000375633ms, 1%
hip::hip_allocate_memory: 0.000916ms / 1 = 0.000916ms, 1%
check_context::migraphx::gpu::context: 0.000771ms / 1 = 0.000771ms, 1%

Batch size: 1
Rate: 212.998 inferences/sec
Total time: 4.69488ms
Total instructions time: 15.8433ms
Overhead time: 0.376437ms, -11.1484ms
Overhead: 8%, -237%
[ MIGraphX Version: 2.10.0. ] Complete: bin/driver perf ../int8_models/gpt2_1_int8_gpu.onnx --input-dim @input_ids 1 32 --fill1 input_ids --disable-fast-math --int8


```