### PR TITLE
Skip FP8 dot/gemm for MLIR and offload them to rocBLAS

### DIFF
--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -277,8 +277,9 @@ auto is_mlir_dot(mlir_mode mode)
             return false;
         if(mode != mlir_mode::fast)
             return true;
-        // dot operation where (FP8 * FP8 = FP8) is not available in MLIR. rocBLAS has the support for it. 
-        if(ins->get_shape().type() == migraphx::shape::fp8e4m3fnuz_type) 
+        // dot operation where (FP8 * FP8 = FP8) is not available in MLIR. rocBLAS has the support
+        // for it.
+        if(ins->get_shape().type() == migraphx::shape::fp8e4m3fnuz_type)
             return false;
         auto a = ins->inputs().front()->get_shape();
         auto b = ins->inputs().back()->get_shape();

--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -277,6 +277,11 @@ auto is_mlir_dot(mlir_mode mode)
             return false;
         if(mode != mlir_mode::fast)
             return true;
+        // dot operation where (FP8 * FP8 = FP8) is not available in MLIR. rocBLAS has the support for it. 
+        // This is case (FP8 * FP8  = FP8) is unlikely to happen in real workloads.  
+        if(ins->get_shape().type() == migraphx::shape::fp8e4m3fnuz_type) {
+            return false;
+        }
         auto a = ins->inputs().front()->get_shape();
         auto b = ins->inputs().back()->get_shape();
         // auto m = a.lens()[a.lens().size() - 2];

--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -278,10 +278,8 @@ auto is_mlir_dot(mlir_mode mode)
         if(mode != mlir_mode::fast)
             return true;
         // dot operation where (FP8 * FP8 = FP8) is not available in MLIR. rocBLAS has the support for it. 
-        // This is case (FP8 * FP8  = FP8) is unlikely to happen in real workloads.  
-        if(ins->get_shape().type() == migraphx::shape::fp8e4m3fnuz_type) {
+        if(ins->get_shape().type() == migraphx::shape::fp8e4m3fnuz_type) 
             return false;
-        }
         auto a = ins->inputs().front()->get_shape();
         auto b = ins->inputs().back()->get_shape();
         // auto m = a.lens()[a.lens().size() - 2];


### PR DESCRIPTION
MIGraphX has verify tests where it tests `FP8 * FP8 = FP8` case. 
rocBLAS has support for it but not the MLIR. rocBLAS internally converts the output of the GEMM to fp8. 

`FP8 * FP8 = FP8` case is probably unlikely to happen for the gemm/dot operations. It should mostly be `fp8 * fp8 = fp32`. 

FP8 tests are run on MI300 hardware and therefore Jenkins has not seen any failures but https://github.com/ROCm/AMDMIGraphX/commit/1416489d518a98aea67894d87cdb19f574e9fcbc broke unit-tests for FP8 * FP8 = FP8 case on MI300 because with that change all the gemms with `k<=1028` are now being offloaded to MLIR. 
