### PR TITLE
fix corruption when using "--run 1"

### DIFF
--- a/examples/onnxruntime/inceptionV3/inceptionv3.py
+++ b/examples/onnxruntime/inceptionV3/inceptionv3.py
@@ -257,7 +257,7 @@ def main():
         print("Running samples")
 
     latency = []
-    for i in range(flags.run):
+    for i in range(flags.run + 1):  # +1 for warm-up run
         run_sample(session_fp32, categories, latency, input_batch, flags.top,
                    flags.batch)
 

--- a/examples/onnxruntime/resnet50/resnet50.py
+++ b/examples/onnxruntime/resnet50/resnet50.py
@@ -253,7 +253,7 @@ def main():
     latency = []
     if flags.verbose:
         print("Running samples")
-    for i in range(flags.run):
+    for i in range(flags.run + 1):  # +1 for warm-up run
         run_sample(session_fp32, categories, latency, input_batch, flags.top,
                    flags.batch)
 


### PR DESCRIPTION
set a warm-up run outside of estimation to avoid crashing with "--run 1".