### PR TITLE
fix conv_concat matcher when original convolutions are grouped

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -767,9 +767,9 @@ struct find_concat_conv
             return;
 
         auto original_group = from_value<int>(conv.to_value()["group"]);
-        auto x = m.insert_instruction(ins, make_op("concat", {{"axis", 1}}), inputs);
-        auto w = m.insert_instruction(ins, make_op("concat", {{"axis", 0}}), weights);
-        conv.from_value({{"group", original_group*inputs.size()}});
+        auto x              = m.insert_instruction(ins, make_op("concat", {{"axis", 1}}), inputs);
+        auto w              = m.insert_instruction(ins, make_op("concat", {{"axis", 0}}), weights);
+        conv.from_value({{"group", original_group * inputs.size()}});
         m.replace_instruction(ins, conv, x, w);
     }
 };

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -766,9 +766,10 @@ struct find_concat_conv
            }))
             return;
 
+        auto original_group = from_value<int>(conv.to_value()["group"]);
         auto x = m.insert_instruction(ins, make_op("concat", {{"axis", 1}}), inputs);
         auto w = m.insert_instruction(ins, make_op("concat", {{"axis", 0}}), weights);
-        conv.from_value({{"group", inputs.size()}});
+        conv.from_value({{"group", original_group*inputs.size()}});
         m.replace_instruction(ins, conv, x, w);
     }
 };

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -3711,4 +3711,36 @@ TEST_CASE(conv_concat)
     EXPECT(m1.sort() == m2.sort());
 }
 
+TEST_CASE(conv_concat_group)
+{
+    migraphx::shape xs{migraphx::shape::float_type, {1, 8, 4, 4}};
+    migraphx::shape ws{migraphx::shape::float_type, {2, 4, 3, 3}};
+    migraphx::module m1;
+    {
+        auto x      = m1.add_parameter("x", xs);
+        auto w      = m1.add_literal(migraphx::generate_literal(ws, 1));
+        auto y      = m1.add_parameter("y", xs);
+        auto v      = m1.add_literal(migraphx::generate_literal(ws, 2));
+        auto conv1  = m1.add_instruction(migraphx::make_op("convolution", {{"group", 2}}), x, w);
+        auto conv2  = m1.add_instruction(migraphx::make_op("convolution", {{"group", 2}}), y, v);
+        auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), conv1, conv2);
+        m1.add_instruction(migraphx::make_op("exp"), concat);
+    };
+    migraphx::module m2;
+    {
+        auto x       = m2.add_parameter("x", xs);
+        auto w       = m2.add_literal(migraphx::generate_literal(ws, 1));
+        auto y       = m2.add_parameter("y", xs);
+        auto v       = m2.add_literal(migraphx::generate_literal(ws, 2));
+        auto xconcat = m2.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), x, y);
+        auto wconcat = m2.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), w, v);
+        auto conv =
+            m2.add_instruction(migraphx::make_op("convolution", {{"group", 4}}), xconcat, wconcat);
+        m2.add_instruction(migraphx::make_op("exp"), conv);
+    }
+    run_pass(m1);
+
+    EXPECT(m1.sort() == m2.sort());
+}
+
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/verify/test_conv_concat.cpp
+++ b/test/verify/test_conv_concat.cpp
@@ -47,3 +47,24 @@ struct test_conv_concat : verify_program<test_conv_concat>
     }
     std::string section() const { return "conv"; }
 };
+
+struct test_conv_concat_group : verify_program<test_conv_concat_group>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        auto x   = mm->add_parameter("x", {migraphx::shape::float_type, {1, 8, 4, 4}});
+        auto w   = mm->add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {2, 4, 3, 3}}, 1));
+        auto y = mm->add_parameter("y", {migraphx::shape::float_type, {1, 8, 4, 4}});
+        auto v = mm->add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {2, 4, 3, 3}}, 2));
+        auto conv1 = mm->add_instruction(migraphx::make_op("convolution", {{"group", 2}}), x, w);
+        auto conv2 = mm->add_instruction(migraphx::make_op("convolution", {{"group", 2}}), y, v);
+        auto sum   = mm->add_instruction(migraphx::make_op("concat", {{"axis", 1}}), conv1, conv2);
+        mm->add_instruction(migraphx::make_op("exp"), sum);
+        return p;
+    }
+    std::string section() const { return "conv"; }
+};


### PR DESCRIPTION
The original `find_concat_conv` pass from #2639  has a bug when it matches with original convolutions that have group != 1. This is a fairly simple change to handle that case. 
