### PR TITLE
Update Depends with correct HIP Runtime package name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,11 +328,17 @@ foreach(py_file ${backend_files})
     configure_file(${py_file} ${DEST_DIR}/lib/onnx_migraphx/. COPYONLY)
 endforeach(py_file)
 
+if(BUILD_ADDRESS_SANITIZER)
+    set(DEPENDS_HIP_RUNTIME "hip-runtime-amd-asan" )
+else()
+    set(DEPENDS_HIP_RUNTIME "hip-runtime-amd" )
++endif()
+
 rocm_create_package(
     NAME MIGraphX
     DESCRIPTION "AMD's graph optimizer"
     MAINTAINER "AMDMIGraphX Maintainer <migraphx-lib.support@amd.com>"
     LDCONFIG
     PTH
-    DEPENDS miopen-hip rocblas hip-rocclr hip-base half ${PACKAGE_DEPENDS}
+    DEPENDS miopen-hip rocblas ${DEPENDS_HIP_RUNTIME} hip-base half ${PACKAGE_DEPENDS}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,7 @@ if(BUILD_ADDRESS_SANITIZER)
     set(DEPENDS_HIP_RUNTIME "hip-runtime-amd-asan" )
 else()
     set(DEPENDS_HIP_RUNTIME "hip-runtime-amd" )
-+endif()
+endif()
 
 rocm_create_package(
     NAME MIGraphX


### PR DESCRIPTION
Proposed Changes:

- hip-rocclr package is deprecated
- This is replaced with latest package hip-runtime-amd.
- This change is to update the package depends of AMDMigraphx to the latest package name.