### PR TITLE
Move onnx backend tests to disabled_tests_dynamic_shape category

### DIFF
--- a/src/onnx/parse_resize.cpp
+++ b/src/onnx/parse_resize.cpp
@@ -200,7 +200,10 @@ static bool parse_args(const std::vector<instruction_ref>& args,
 
 struct parse_resize : op_parser<parse_resize>
 {
-    std::vector<op_desc> operators() const { return {{"Resize"}, {"Upsample"}}; }
+    std::vector<op_desc> operators() const
+    {
+        return {{"Resize", "resize"}, {"Upsample", "upsample"}};
+    }
 
     // Helper to add a "reshape" and "gather" instruction.  These can implement
     // Nearest mode resizing if all sizes are known at compile time.

--- a/test/py/onnx_backend_test.py
+++ b/test/py/onnx_backend_test.py
@@ -135,11 +135,9 @@ def disabled_tests_onnx_1_7_0(backend_test):
     backend_test.exclude(
         r'test_resize_downsample_scales_linear_align_corners_cpu')
     backend_test.exclude(r'test_resize_downsample_scales_linear_cpu')
-    backend_test.exclude(r'test_resize_downsample_scales_nearest_cpu')
     backend_test.exclude(r'test_resize_downsample_sizes_cubic_cpu')
     backend_test.exclude(
         r'test_resize_downsample_sizes_linear_pytorch_half_pixel_cpu')
-    backend_test.exclude(r'test_resize_downsample_sizes_nearest_cpu')
     backend_test.exclude(r'test_resize_tf_crop_and_resize_cpu')
     backend_test.exclude(
         r'test_resize_upsample_scales_cubic_A_n0p5_exclude_outside_cpu')
@@ -150,26 +148,15 @@ def disabled_tests_onnx_1_7_0(backend_test):
     backend_test.exclude(
         r'test_resize_upsample_scales_linear_align_corners_cpu')
     backend_test.exclude(r'test_resize_upsample_scales_linear_cpu')
-    backend_test.exclude(r'test_resize_upsample_scales_nearest_cpu')
     backend_test.exclude(r'test_resize_upsample_sizes_cubic_cpu')
-    backend_test.exclude(
-        r'test_resize_upsample_sizes_nearest_ceil_half_pixel_cpu')
-    backend_test.exclude(r'test_resize_upsample_sizes_nearest_cpu')
-    backend_test.exclude(
-        r'test_resize_upsample_sizes_nearest_floor_align_corners_cpu')
-    backend_test.exclude(
-        r'test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric_cpu')
     backend_test.exclude(r'test_reversesequence_batch_cpu')
     backend_test.exclude(r'test_reversesequence_time_cpu')
     backend_test.exclude(r'test_scan9_sum_cpu')
     backend_test.exclude(r'test_scan_sum_cpu')
     backend_test.exclude(r'test_slice_cpu')
-    backend_test.exclude(r'test_slice_default_axes_cpu')
-    backend_test.exclude(r'test_slice_default_steps_cpu')
     backend_test.exclude(r'test_slice_end_out_of_bounds_cpu')
     backend_test.exclude(r'test_slice_neg_cpu')
     backend_test.exclude(r'test_slice_neg_steps_cpu')
-    backend_test.exclude(r'test_slice_negative_axes_cpu')
     backend_test.exclude(r'test_slice_start_out_of_bounds_cpu')
     backend_test.exclude(
         r'test_strnormalizer_export_monday_casesensintive_lower_cpu')
@@ -194,11 +181,8 @@ def disabled_tests_onnx_1_7_0(backend_test):
     backend_test.exclude(r'test_top_k_cpu')
     backend_test.exclude(r'test_top_k_negative_axis_cpu')
     backend_test.exclude(r'test_top_k_smallest_cpu')
-    backend_test.exclude(r'test_unique_not_sorted_without_axis_cpu')
     backend_test.exclude(r'test_unique_sorted_with_axis_3d_cpu')
-    backend_test.exclude(r'test_unique_sorted_with_axis_cpu')
     backend_test.exclude(r'test_unique_sorted_with_negative_axis_cpu')
-    backend_test.exclude(r'test_unique_sorted_without_axis_cpu')
     backend_test.exclude(r'test_upsample_nearest_cpu')
 
     # from OnnxBackendPyTorchConvertedModelTest
@@ -669,6 +653,10 @@ def disabled_tests_dynamic_shape(backend_test):
     # range
     backend_test.exclude(r'test_range_float_type_positive_delta_cpu')
     backend_test.exclude(r'test_range_int32_type_negative_delta_cpu')
+    # slice
+    backend_test.exclude(r'test_slice_default_axes_cpu')
+    backend_test.exclude(r'test_slice_default_steps_cpu')
+    backend_test.exclude(r'test_slice_negative_axes_cpu')
     # split
     backend_test.exclude(r'test_split_variable_parts_1d_opset13_cpu')
     backend_test.exclude(r'test_split_variable_parts_1d_opset18_cpu')
@@ -689,9 +677,24 @@ def disabled_tests_dynamic_shape(backend_test):
     backend_test.exclude(r'test_unsqueeze_three_axes_cpu')
     backend_test.exclude(r'test_unsqueeze_two_axes_cpu')
     backend_test.exclude(r'test_unsqueeze_unsorted_axes_cpu')
+    # unique
+    backend_test.exclude(r'test_unique_not_sorted_without_axis_cpu')
+    backend_test.exclude(r'test_unique_sorted_with_axis_cpu')
+    backend_test.exclude(r'test_unique_sorted_without_axis_cpu')
     # tile
     backend_test.exclude(r'test_tile_cpu')
     backend_test.exclude(r'test_tile_precomputed_cpu')
+    # resize
+    backend_test.exclude(r'test_resize_upsample_scales_nearest_cpu')
+    backend_test.exclude(r'test_resize_downsample_scales_nearest_cpu')
+    backend_test.exclude(r'test_resize_upsample_sizes_nearest_cpu')
+    backend_test.exclude(r'test_resize_downsample_sizes_nearest_cpu')
+    backend_test.exclude(
+        r'test_resize_upsample_sizes_nearest_floor_align_corners_cpu')
+    backend_test.exclude(
+        r'test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric_cpu')
+    backend_test.exclude(
+        r'test_resize_upsample_sizes_nearest_ceil_half_pixel_cpu')
     # reshape
     backend_test.exclude(r'test_reshape_allowzero_reordered_cpu')
     backend_test.exclude(r'test_reshape_extended_dims_cpu')


### PR DESCRIPTION
Update onnx backend test file by moving tests for some operators that crash/fail due to dynamic output shape to appropriate disable category. Expand resize operator descriptor to fix certain incorrect error prints.

Resolves: [#180](https://github.com/migraphx-benchmark/AMDMIGraphX/issues/180), [#181](https://github.com/migraphx-benchmark/AMDMIGraphX/issues/181)