### PR TITLE
Update Stable Diffusion 2.1 example

### DIFF
--- a/examples/diffusion/python_stable_diffusion_21/README.md
+++ b/examples/diffusion/python_stable_diffusion_21/README.md
@@ -1,6 +1,6 @@
 # Stable Diffusion 2.1
 
-This version was tested with [rocm 5.7](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/tree/rocm-5.7.0) revision.
+This version was tested with [rocm 6.0](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/tree/rocm-6.0.0) revision.
 
 ## Jupyter notebook
 

--- a/examples/diffusion/python_stable_diffusion_21/README.md
+++ b/examples/diffusion/python_stable_diffusion_21/README.md
@@ -33,7 +33,7 @@ export PYTHONPATH=/opt/rocm/lib:$PYTHONPATH
 Get models with optimum
 
 ```bash
-optimum-cli export onnx --model stabilityai/stable-diffusion-2-1 models/sd21-onnx
+optimum-cli export onnx --model stabilityai/stable-diffusion-2-1 models/sd21-onnx --task stable-diffusion
 ```
 *Note: `models/sd21-onnx` will be used in the scripts.*
 

--- a/examples/diffusion/python_stable_diffusion_21/README.md
+++ b/examples/diffusion/python_stable_diffusion_21/README.md
@@ -61,7 +61,7 @@ pip install -r gradio_requirements.txt
 Usage
 
 ```bash
-python gradio_app.py
+python gradio_app.py -p "a photograph of an astronaut riding a horse" --seed 13
 ```
 
 This will load the models (which can take several minutes), and when the setup is ready, starts a server on `http://127.0.0.1:7860`.

--- a/examples/diffusion/python_stable_diffusion_21/gradio_app.py
+++ b/examples/diffusion/python_stable_diffusion_21/gradio_app.py
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/diffusion/python_stable_diffusion_21/gradio_app.py
+++ b/examples/diffusion/python_stable_diffusion_21/gradio_app.py
@@ -27,7 +27,6 @@ import gradio as gr
 
 
 def main():
-    # we ignore runtime args here
     args = get_args()
     # Note: This will load the models, which can take several minutes
     sd = StableDiffusionMGX(args.onnx_model_path, args.compiled_model_path,
@@ -43,12 +42,14 @@ def main():
     demo = gr.Interface(
         gr_wrapper,
         [
-            gr.Textbox(value="a photograph of an astronaut riding a horse",
-                       label="Prompt"),
-            gr.Textbox(value="", label="Negative prompt (Optional)"),
-            gr.Slider(1, 100, step=1, value=20, label="Number of steps"),
-            gr.Textbox(value=13, label="Random seed"),
-            gr.Slider(1, 20, step=0.1, value=7.0, label="Guidance scale"),
+            gr.Textbox(value=args.prompt, label="Prompt"),
+            gr.Textbox(value=args.negative_prompt,
+                       label="Negative prompt (Optional)"),
+            gr.Slider(
+                1, 100, step=1, value=args.steps, label="Number of steps"),
+            gr.Textbox(value=args.seed, label="Random seed"),
+            gr.Slider(
+                1, 20, step=0.1, value=args.scale, label="Guidance scale"),
         ],
         "image",
     )

--- a/examples/diffusion/python_stable_diffusion_21/gradio_app.py
+++ b/examples/diffusion/python_stable_diffusion_21/gradio_app.py
@@ -22,13 +22,16 @@
 # THE SOFTWARE.
 #####################################################################################
 
-from txt2img import StableDiffusionMGX
+from txt2img import StableDiffusionMGX, get_args
 import gradio as gr
 
 
 def main():
+    # we ignore runtime args here
+    args = get_args()
     # Note: This will load the models, which can take several minutes
-    sd = StableDiffusionMGX()
+    sd = StableDiffusionMGX(args.onnx_model_path, args.compiled_model_path,
+                            args.force_compile, args.exhaustive_tune)
 
     def gr_wrapper(prompt, negative_prompt, steps, seed, scale):
         result = sd.run(str(prompt), str(negative_prompt), int(steps),

--- a/examples/diffusion/python_stable_diffusion_21/gradio_app.py
+++ b/examples/diffusion/python_stable_diffusion_21/gradio_app.py
@@ -32,6 +32,7 @@ def main():
     # Note: This will load the models, which can take several minutes
     sd = StableDiffusionMGX(args.onnx_model_path, args.compiled_model_path,
                             args.force_compile, args.exhaustive_tune)
+    sd.warmup(5)
 
     def gr_wrapper(prompt, negative_prompt, steps, seed, scale):
         result = sd.run(str(prompt), str(negative_prompt), int(steps),

--- a/examples/diffusion/python_stable_diffusion_21/gradio_app.py
+++ b/examples/diffusion/python_stable_diffusion_21/gradio_app.py
@@ -31,7 +31,8 @@ def main():
     args = get_args()
     # Note: This will load the models, which can take several minutes
     sd = StableDiffusionMGX(args.onnx_model_path, args.compiled_model_path,
-                            args.force_compile, args.exhaustive_tune)
+                            args.fp16, args.force_compile,
+                            args.exhaustive_tune)
     sd.warmup(5)
 
     def gr_wrapper(prompt, negative_prompt, steps, seed, scale):

--- a/examples/diffusion/python_stable_diffusion_21/gradio_reqirements.txt
+++ b/examples/diffusion/python_stable_diffusion_21/gradio_reqirements.txt
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/diffusion/python_stable_diffusion_21/gradio_requirements.txt
+++ b/examples/diffusion/python_stable_diffusion_21/gradio_requirements.txt
@@ -21,5 +21,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #####################################################################################
--f requirements.txt
+-r requirements.txt
 gradio

--- a/examples/diffusion/python_stable_diffusion_21/requirements.txt
+++ b/examples/diffusion/python_stable_diffusion_21/requirements.txt
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/diffusion/python_stable_diffusion_21/requirements.txt
+++ b/examples/diffusion/python_stable_diffusion_21/requirements.txt
@@ -21,6 +21,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #####################################################################################
+-f https://repo.radeon.com/rocm/manylinux/rocm-rel-6.0/
+torch==2.1.1
 accelerate
 diffusers
 optimum[onnxruntime]

--- a/examples/diffusion/python_stable_diffusion_21/sd21.ipynb
+++ b/examples/diffusion/python_stable_diffusion_21/sd21.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,6 +52,8 @@
    "outputs": [],
    "source": [
     "# Install dependencies\n",
+    "# We need this version to run torch with gpu tensors\n",
+    "!pip install torch==2.1.1 -f https://repo.radeon.com/rocm/manylinux/rocm-rel-6.0/\n",
     "!pip install optimum[onnxruntime] transformers diffusers accelerate"
    ]
   },
@@ -69,7 +71,38 @@
    "outputs": [],
    "source": [
     "# export models\n",
-    "!optimum-cli export onnx --model stabilityai/stable-diffusion-2-1 models/sd21-onnx"
+    "!optimum-cli export onnx --model stabilityai/stable-diffusion-2-1 models/sd21-onnx --task stable-diffusion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will use torch tensors for all calculation. Everything will be allocated on the GPU to avoid Host-Device copies.\n",
+    "\n",
+    "We installed the rocm version of pytorch, let's confirm that we can access the GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.version\n",
+    "\n",
+    "print(f\"{torch.cuda.is_available() = }\")\n",
+    "print(f\"{torch.cuda.get_device_name(0) = }\")\n",
+    "print(f\"{torch.version.cuda = }\")\n",
+    "print(f\"{torch.version.hip = }\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If it is not working properly, try restaring the kernel."
    ]
   },
   {
@@ -88,7 +121,9 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "mgx_lib_path = \"/opt/rocm/lib/\" # or \"/code/AMDMIGraphX/build/lib/\"\n",
+    "mgx_lib_path = \"/opt/rocm/lib/\"\n",
+    "# or if you locally built MIGraphX\n",
+    "# mgx_lib_path = \"/code/AMDMIGraphX/build/lib/\"\n",
     "if mgx_lib_path not in sys.path:\n",
     "    sys.path.append(mgx_lib_path)\n",
     "import migraphx as mgx"
@@ -120,7 +155,7 @@
     "    elif os.path.isfile(f\"{file}.onnx\"):\n",
     "        print(f\"Parsing from onnx file...\")\n",
     "        model = mgx.parse_onnx(f\"{file}.onnx\", map_input_dims=shapes)\n",
-    "        model.compile(mgx.get_target(\"gpu\"))\n",
+    "        model.compile(mgx.get_target(\"gpu\"), offload_copy=False)\n",
     "        print(f\"Saving {name} model to mxr file...\")\n",
     "        mgx.save(model, f\"{file}.mxr\", format=\"msgpack\")\n",
     "    else:\n",
@@ -142,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "text_encoder = load_mgx_model(\"text_encoder\", {\"input_ids\": [1, 77]})"
+    "text_encoder = load_mgx_model(\"text_encoder\", {\"input_ids\": [2, 77]})"
    ]
   },
   {
@@ -153,8 +188,8 @@
    "source": [
     "unet = load_mgx_model(\n",
     "        \"unet\", {\n",
-    "            \"sample\": [1, 4, 64, 64],\n",
-    "            \"encoder_hidden_states\": [1, 77, 1024],\n",
+    "            \"sample\": [2, 4, 64, 64],\n",
+    "            \"encoder_hidden_states\": [2, 77, 1024],\n",
     "            \"timestep\": [1],\n",
     "        })"
    ]
@@ -172,6 +207,149 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "To pass a tensor to MIGraphX, first we need to convert it an argument.\n",
+    "\n",
+    "We avoid the copy via allocating the tensor on the gpu, so we only need to pass the address of the tensor."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we need to have a mapping between torch and migraphx data types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mgx_to_torch_dtype_dict = {\n",
+    "    \"bool_type\": torch.bool,\n",
+    "    \"uint8_type\": torch.uint8,\n",
+    "    \"int8_type\": torch.int8,\n",
+    "    \"int16_type\": torch.int16,\n",
+    "    \"int32_type\": torch.int32,\n",
+    "    \"int64_type\": torch.int64,\n",
+    "    \"float_type\": torch.float32,\n",
+    "    \"double_type\": torch.float64,\n",
+    "    \"half_type\": torch.float16,\n",
+    "}\n",
+    "\n",
+    "torch_to_mgx_dtype_dict = {\n",
+    "    value: key\n",
+    "    for (key, value) in mgx_to_torch_dtype_dict.items()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we need a way to allocate the torch buffers for the models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def allocate_torch_tensors(model):\n",
+    "    input_shapes = model.get_parameter_shapes()\n",
+    "    data_mapping = {\n",
+    "        name:\n",
+    "        torch.zeros(shape.lens()).to(\n",
+    "            mgx_to_torch_dtype_dict[shape.type_string()]).to(device=\"cuda\")\n",
+    "        for name, shape in input_shapes.items()\n",
+    "    }\n",
+    "    return data_mapping"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we allocate tensors for the models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text_encoder_tensors = allocate_torch_tensors(text_encoder)\n",
+    "unet_tensors = allocate_torch_tensors(unet)\n",
+    "vae_tensors = allocate_torch_tensors(vae)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lastly, we need to tell MIGraphX how to access these tensors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tensor_to_arg(tensor):\n",
+    "    return mgx.argument_from_pointer(\n",
+    "        mgx.shape(\n",
+    "            **{\n",
+    "                \"type\": torch_to_mgx_dtype_dict[tensor.dtype],\n",
+    "                \"lens\": list(tensor.size()),\n",
+    "                \"strides\": list(tensor.stride())\n",
+    "            }), tensor.data_ptr())\n",
+    "\n",
+    "def tensors_to_args(tensors):\n",
+    "    return {name: tensor_to_arg(tensor) for name, tensor in tensors.items()}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since the tensors won't change, we only need to do this once, an cache it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text_encoder_args = tensors_to_args(text_encoder_tensors)\n",
+    "unet_args = tensors_to_args(unet_tensors)\n",
+    "vae_args = tensors_to_args(vae_tensors)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The model outputs will be called `main:#output_*`. We create a helper to access them more easily."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_output_name(idx):\n",
+    "    return f\"main:#output_{idx}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Import the remaining packages."
    ]
   },
@@ -183,8 +361,6 @@
    "source": [
     "from diffusers import EulerDiscreteScheduler\n",
     "from transformers import CLIPTokenizer\n",
-    "import torch\n",
-    "import numpy as np\n",
     "from tqdm.auto import tqdm\n",
     "from PIL import Image"
    ]
@@ -223,12 +399,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def tokenize(input):\n",
-    "    return tokenizer([input],\n",
+    "def tokenize(*inputs):\n",
+    "    return tokenizer([*inputs],\n",
     "                     padding=\"max_length\",\n",
     "                     max_length=tokenizer.model_max_length,\n",
     "                     truncation=True,\n",
-    "                     return_tensors=\"np\")"
+    "                     return_tensors=\"pt\")"
    ]
   },
   {
@@ -246,7 +422,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We run the tokenized prompt through the `Text Encoder` model. It expects the `(1, 77)` data as `int32`."
+    "We run the tokenized prompts through the `Text Encoder` model. It expects the `(2, 77)` data as `int32`. It is `2` because we will also pass the negative prompt."
    ]
   },
   {
@@ -265,10 +441,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_embeddings(input):\n",
-    "    return np.array(\n",
-    "        text_encoder.run({\"input_ids\": input.input_ids.astype(np.int32)\n",
-    "                          })[0]).astype(np.float32)"
+    "def get_embeddings(prompt_tokens):\n",
+    "    text_encoder_tensors[\"input_ids\"].copy_(prompt_tokens.input_ids.to(torch.int32))\n",
+    "    torch.cuda.synchronize()\n",
+    "\n",
+    "    text_encoder.run(text_encoder_args)\n",
+    "    mgx.gpu_sync()\n",
+    "\n",
+    "    return text_encoder_tensors[get_output_name(0)]"
    ]
   },
   {
@@ -300,7 +480,7 @@
     "    return torch.randn(\n",
     "        (1, 4, 64, 64),\n",
     "        generator=torch.manual_seed(seed),\n",
-    "    )"
+    "    ).to(device=\"cuda\")"
    ]
   },
   {
@@ -311,7 +491,7 @@
    "source": [
     "# Optional\n",
     "test_latents = generate_latents(42)\n",
-    "latents.shape"
+    "test_latents.shape"
    ]
   },
   {
@@ -328,11 +508,10 @@
    "outputs": [],
    "source": [
     "def get_scaled_sample(latents, t):\n",
-    "    return scheduler.scale_model_input(latents, t).numpy().astype(np.float32)\n",
-    "\n",
+    "    return scheduler.scale_model_input(latents, t).to(torch.float32).to(device=\"cuda\")\n",
     "\n",
     "def get_timestep(t):\n",
-    "    return np.atleast_1d(t.numpy().astype(np.int64))  # convert 0D -> 1D"
+    "    return torch.atleast_1d(t.to(torch.int64).to(device=\"cuda\"))  # convert 0D -> 1D"
    ]
   },
   {
@@ -359,12 +538,15 @@
    "outputs": [],
    "source": [
     "def denoise(sample, embeddings, timestep):\n",
-    "    return np.array(\n",
-    "        unet.run({\n",
-    "            \"sample\": sample,\n",
-    "            \"encoder_hidden_states\": embeddings,\n",
-    "            \"timestep\": timestep\n",
-    "        })[0])"
+    "    unet_tensors[\"sample\"].copy_(sample)\n",
+    "    unet_tensors[\"encoder_hidden_states\"].copy_(embeddings)\n",
+    "    unet_tensors[\"timestep\"].copy_(timestep)\n",
+    "    torch.cuda.synchronize()\n",
+    "\n",
+    "    unet.run(unet_args)\n",
+    "    mgx.gpu_sync()\n",
+    "\n",
+    "    return torch.tensor_split(unet_tensors[get_output_name(0)], 2)"
    ]
   },
   {
@@ -406,8 +588,13 @@
     "\n",
     "\n",
     "def decode(latents):\n",
-    "    return np.array(\n",
-    "        vae.run({\"latent_sample\": latents.numpy().astype(np.float32)})[0])"
+    "    vae_tensors[\"latent_sample\"].copy_(latents)\n",
+    "    torch.cuda.synchronize()\n",
+    "\n",
+    "    vae.run(vae_args)\n",
+    "    mgx.gpu_sync()\n",
+    "\n",
+    "    return vae_tensors[get_output_name(0)]"
    ]
   },
   {
@@ -424,8 +611,8 @@
    "outputs": [],
    "source": [
     "def convert_to_rgb_image(image):\n",
-    "    image = np.clip(image / 2 + 0.5, 0, 1)\n",
-    "    image = np.transpose(image, (0, 2, 3, 1))\n",
+    "    image = (image / 2 + 0.5).clamp(0, 1)\n",
+    "    image = image.detach().cpu().permute(0, 2, 3, 1).numpy()\n",
     "    images = (image * 255).round().astype(\"uint8\")\n",
     "    return Image.fromarray(images[0])\n",
     "\n",
@@ -466,22 +653,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scheduler.set_timesteps(steps)\n",
+    "scheduler.set_timesteps(steps, device=\"cuda\")\n",
     "\n",
-    "text_input, uncond_input = tokenize(prompt), tokenize(negative_prompt)\n",
-    "text_embeddings, uncond_embeddings = get_embeddings(\n",
-    "    text_input), get_embeddings(uncond_input)\n",
+    "input_tokens = tokenize(prompt, negative_prompt)\n",
+    "text_embeddings = get_embeddings(input_tokens)\n",
     "latents = generate_latents(seed) * scheduler.init_noise_sigma\n",
     "\n",
     "for t in tqdm(scheduler.timesteps):\n",
-    "    sample = get_scaled_sample(latents, t)\n",
+    "    sample = get_scaled_sample(torch.cat([latents] * 2), t)\n",
     "    timestep = get_timestep(t)\n",
     "\n",
-    "    noise_pred_uncond = denoise(sample, uncond_embeddings, timestep)\n",
-    "    noise_pred_text = denoise(sample, text_embeddings, timestep)\n",
+    "    noise_pred_text, noise_pred_uncond = denoise(sample, text_embeddings, timestep)\n",
     "\n",
     "    noise_pred = perform_guidance(noise_pred_uncond, noise_pred_text, scale)\n",
-    "    latents = compute_previous(torch.from_numpy(noise_pred), t, latents)\n",
+    "    latents = compute_previous(noise_pred, t, latents)\n",
     "\n",
     "latents = scale_denoised(latents)\n",
     "result = decode(latents)\n",
@@ -524,7 +709,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/examples/diffusion/python_stable_diffusion_21/txt2img.py
+++ b/examples/diffusion/python_stable_diffusion_21/txt2img.py
@@ -177,7 +177,7 @@ def run_model_sync(model, args):
     mgx.gpu_sync()
 
 
-def allocate_torch_buffers(model):
+def allocate_torch_tensors(model):
     input_shapes = model.get_parameter_shapes()
     data_mapping = {
         name:
@@ -235,9 +235,9 @@ class StableDiffusionMGX():
         }
 
         self.tensors = {
-            "clip": allocate_torch_buffers(self.models["clip"]),
-            "unet": allocate_torch_buffers(self.models["unet"]),
-            "vae": allocate_torch_buffers(self.models["vae"]),
+            "clip": allocate_torch_tensors(self.models["clip"]),
+            "unet": allocate_torch_tensors(self.models["unet"]),
+            "vae": allocate_torch_tensors(self.models["vae"]),
         }
 
         self.model_args = {

--- a/examples/diffusion/python_stable_diffusion_21/txt2img.py
+++ b/examples/diffusion/python_stable_diffusion_21/txt2img.py
@@ -92,7 +92,7 @@ def get_args():
         "-o",
         "--output",
         type=str,
-        default="output.png",
+        default=None,
         help="Output name",
     )
     return parser.parse_args()
@@ -254,5 +254,5 @@ if __name__ == "__main__":
     print("Convert result to rgb image...")
     image = StableDiffusionMGX.convert_to_rgb_image(result)
     filename = args.output if args.output else f"output_s{args.seed}_t{args.steps}.png"
-    StableDiffusionMGX.save_image(image, args.output)
+    StableDiffusionMGX.save_image(image, filename)
     print(f"Image saved to {filename}")

--- a/examples/diffusion/python_stable_diffusion_21/txt2img.py
+++ b/examples/diffusion/python_stable_diffusion_21/txt2img.py
@@ -35,7 +35,6 @@ from functools import wraps
 
 # measurement helper
 def measure(fn):
-
     @wraps(fn)
     def measure_ms(*args, **kwargs):
         start_time = time.perf_counter_ns()
@@ -180,8 +179,7 @@ def run_model_sync(model, args):
 def allocate_torch_tensors(model):
     input_shapes = model.get_parameter_shapes()
     data_mapping = {
-        name:
-        torch.zeros(shape.lens()).to(
+        name: torch.zeros(shape.lens()).to(
             mgx_to_torch_dtype_dict[shape.type_string()]).to(device="cuda")
         for name, shape in input_shapes.items()
     }
@@ -189,7 +187,6 @@ def allocate_torch_tensors(model):
 
 
 class StableDiffusionMGX():
-
     def __init__(self, onnx_model_path, compiled_model_path, force_compile,
                  exhaustive_tune):
         model_id = "stabilityai/stable-diffusion-2-1"

--- a/examples/diffusion/python_stable_diffusion_21/txt2img.py
+++ b/examples/diffusion/python_stable_diffusion_21/txt2img.py
@@ -42,7 +42,9 @@ def measure(fn):
         start_time = time.perf_counter_ns()
         result = fn(*args, **kwargs)
         end_time = time.perf_counter_ns()
-        print(f"Elapsed time: {(end_time - start_time) * 1e-6:.4f} ms\n")
+        print(
+            f"Elapsed time for {fn.__name__}: {(end_time - start_time) * 1e-6:.4f} ms\n"
+        )
         return result
 
     return measure_ms


### PR DESCRIPTION
Update the Stable Diffusion 2.1 example to use torch gpu buffers.
Also there are some optimization with batching certain tensors.

The notebook is not updated, after it is done, i will mark it ready.

The denoise_step time: ~85.7930 ms -> 77.4980 ms
The others are not really comparable, because there was no warmup, and those are run once.