### PR TITLE
Append so_version for loading shared libraries (changes from PR#2948 commit 7374d52a76 in develop)

### DIFF
--- a/src/register_target.cpp
+++ b/src/register_target.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/register_target.cpp
+++ b/src/register_target.cpp
@@ -61,22 +61,23 @@ target make_target(const std::string& name)
         std::string target_name = "migraphx_" + name + ".dll";
         store_target_lib(dynamic_loader(target_name));
 #else
-        std::string target_name = "libmigraphx_" + name + ".so";
-        std::string so_version  = "." + std::to_string(MIGRAPHX_SO_MAJOR_VERSION) + ".0";
+        std::string target_name      = "libmigraphx_" + name + ".so";
+        std::string so_major_version = "." + std::to_string(MIGRAPHX_SO_MAJOR_VERSION);
 
-        // Try to load library with so version appended to the name.
-        // If library with so version name is not found,
-        // try loading the library without the so version name appended.
-        // For example, if "libmigraphx_ref.so.2010000.0" is not found,
+        // Try to load library with so_major_version appended to the name.
+        // If library with so_major_version name is not found,
+        // try loading the library without the so_major_version name appended.
+        // For example, if "libmigraphx_ref.so.2010000" is not found,
         // try loading "libmigraphx_ref.so".
         try
         {
-            // Default to loading shared libraries with so version appended.
-            store_target_lib(dynamic_loader(target_name + so_version));
+            // Default to loading shared libraries with
+            // so_major_version appended.
+            store_target_lib(dynamic_loader(target_name + so_major_version));
         }
         catch(...)
         {
-            // Load the library without the so version in the name.
+            // Load the library without the so_major_version in the name.
             store_target_lib(dynamic_loader(target_name));
         }
 #endif

--- a/src/register_target.cpp
+++ b/src/register_target.cpp
@@ -26,6 +26,7 @@
 #include <migraphx/register_target.hpp>
 #include <migraphx/ranges.hpp>
 #include <migraphx/dynamic_loader.hpp>
+#include <migraphx/version.h>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -58,10 +59,27 @@ target make_target(const std::string& name)
     {
 #ifdef _WIN32
         std::string target_name = "migraphx_" + name + ".dll";
+        store_target_lib(dynamic_loader(target_name));
 #else
         std::string target_name = "libmigraphx_" + name + ".so";
+        std::string so_version  = "." + std::to_string(MIGRAPHX_SO_MAJOR_VERSION) + ".0";
+
+        // Try to load library with so version appended to the name.
+        // If library with so version name is not found,
+        // try loading the library without the so version name appended.
+        // For example, if "libmigraphx_ref.so.2010000.0" is not found,
+        // try loading "libmigraphx_ref.so".
+        try
+        {
+            // Default to loading shared libraries with so version appended.
+            store_target_lib(dynamic_loader(target_name + so_version));
+        }
+        catch(...)
+        {
+            // Load the library without the so version in the name.
+            store_target_lib(dynamic_loader(target_name));
+        }
 #endif
-        store_target_lib(dynamic_loader(target_name));
     }
     const auto it = target_map().find(name);
     if(it == target_map().end())

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,4 +26,8 @@
 #define MIGRAPHX_VERSION_MINOR @PROJECT_VERSION_MINOR@
 #define MIGRAPHX_VERSION_PATCH @PROJECT_VERSION_PATCH@
 #define MIGRAPHX_VERSION_TWEAK "@PROJECT_VERSION_TWEAK@"
+#define MIGRAPHX_SO_MAJOR_VERSION           \
+    @PROJECT_VERSION_MAJOR@ * 1000 * 1000 + \
+    @PROJECT_VERSION_MINOR@ * 1000 +        \
+    @PROJECT_VERSION_PATCH@
 // clang-format on


### PR DESCRIPTION
This cherry picks the commit from PR#2948 for change to loading shared libraries with so version name appended to them. It also incorporates changes from https://github.com/ROCm/AMDMIGraphX/pull/2975.