### PR TITLE
Script optimization: put output memcpy out of session run

### DIFF
--- a/examples/onnxruntime/resnet50/resnet50.py
+++ b/examples/onnxruntime/resnet50/resnet50.py
@@ -116,7 +116,7 @@ def run_sample(session,
                verbose=False):
     io_binding = session.io_binding()
     io_binding.bind_cpu_input('input', inputs.cpu().detach().numpy())
-    io_binding.bind_output('output')
+    io_binding.bind_output('output', 'cuda')
     start = time.time()
     session.run_with_iobinding(io_binding)
     latency.append(time.time() - start)


### PR DESCRIPTION
1. with io_binding.bind_output('output')
![ort1](https://github.com/ROCm/AMDMIGraphX/assets/150102070/7f470872-a2d4-4d1b-b713-41e236a96c8c)

2. with io_binding.bind_output('output', 'cuda')
![ort2](https://github.com/ROCm/AMDMIGraphX/assets/150102070/79e8303b-55f6-424d-9b95-8d606b7b1b37)

it slightly improves the measured performance results.