### PR TITLE
Use number of specified thread for the compilation

### DIFF
--- a/src/include/migraphx/par.hpp
+++ b/src/include/migraphx/par.hpp
@@ -94,7 +94,7 @@ OutputIt par_transform(
 }
 
 template <class InputIt, class UnaryFunction>
-void par_for_each(InputIt first, InputIt last, UnaryFunction f)
+void par_for_each(InputIt first, InputIt last, size_t min_grain, UnaryFunction f)
 {
 #if MIGRAPHX_HAS_EXECUTORS
     // Propagate the exception
@@ -102,7 +102,7 @@ void par_for_each(InputIt first, InputIt last, UnaryFunction f)
     std::for_each(std::execution::par, first, last, ex.collect(std::move(f)));
     ex.throw_if_exception();
 #else
-    simple_par_for(last - first, [&](auto i) { f(first[i]); });
+    simple_par_for(last - first, min_grain, [&](auto i) { f(first[i]); });
 #endif
 }
 

--- a/src/include/migraphx/par.hpp
+++ b/src/include/migraphx/par.hpp
@@ -94,7 +94,7 @@ OutputIt par_transform(
 }
 
 template <class InputIt, class UnaryFunction>
-void par_for_each(InputIt first, InputIt last, size_t min_grain, UnaryFunction f)
+void par_for_each(InputIt first, InputIt last, UnaryFunction f)
 {
 #if MIGRAPHX_HAS_EXECUTORS
     // Propagate the exception
@@ -102,7 +102,7 @@ void par_for_each(InputIt first, InputIt last, size_t min_grain, UnaryFunction f
     std::for_each(std::execution::par, first, last, ex.collect(std::move(f)));
     ex.throw_if_exception();
 #else
-    simple_par_for(last - first, min_grain, [&](auto i) { f(first[i]); });
+    simple_par_for(last - first, [&](auto i) { f(first[i]); });
 #endif
 }
 

--- a/src/include/migraphx/par_for.hpp
+++ b/src/include/migraphx/par_for.hpp
@@ -31,17 +31,16 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
 template <class F>
-void par_for(std::size_t n, std::size_t min_grain, F f)
+void par_for(std::size_t n, F f)
 {
     using iterator = basic_iota_iterator<id, std::size_t>;
-    par_for_each(iterator{0, {}}, iterator{n, {}}, min_grain, f);
+    par_for_each(iterator{0, {}}, iterator{n, {}}, f);
 }
 
 template <class F>
-void par_for(std::size_t n, F f)
+void par_for(std::size_t n, std::size_t min_grain, F f)
 {
-    std::size_t min_grain = 8;
-    par_for(n, min_grain, f);
+    simple_par_for(n, min_grain, f);
 }
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/include/migraphx/par_for.hpp
+++ b/src/include/migraphx/par_for.hpp
@@ -31,16 +31,17 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
 template <class F>
-void par_for(std::size_t n, F f)
+void par_for(std::size_t n, std::size_t min_grain, F f)
 {
     using iterator = basic_iota_iterator<id, std::size_t>;
-    par_for_each(iterator{0, {}}, iterator{n, {}}, f);
+    par_for_each(iterator{0, {}}, iterator{n, {}}, min_grain, f);
 }
 
 template <class F>
-void par_for(std::size_t n, std::size_t, F f)
+void par_for(std::size_t n, F f)
 {
-    par_for(n, f);
+    std::size_t min_grain = 8;
+    par_for(n, min_grain, f);
 }
 
 } // namespace MIGRAPHX_INLINE_NS


### PR DESCRIPTION
Currently `MIGRAPHX_GPU_COMPILE_PARALLEL` has no effect because `par_for.hpp` is not passing `min_grain` param. This PR fixes that.