### PR TITLE
Benchmark candidate programs instead of code objects in compile_ops

### DIFF
--- a/src/include/migraphx/program.hpp
+++ b/src/include/migraphx/program.hpp
@@ -51,7 +51,6 @@ struct program_impl;
 
 struct marker;
 
-
 /**
  * @brief Stores the instruction stream
  */
@@ -81,9 +80,7 @@ struct MIGRAPHX_EXPORT program
     std::vector<argument> eval(parameter_map params,
                                execution_environment exec_env = execution_environment{}) const;
 
-    std::vector<argument> eval_with_context(
-                                   std::vector<context>& ctx,
-                                   parameter_map params) const;
+    std::vector<argument> eval_with_context(std::vector<context>& ctx, parameter_map params) const;
 
     void finish() const;
 

--- a/src/include/migraphx/program.hpp
+++ b/src/include/migraphx/program.hpp
@@ -51,9 +51,6 @@ struct program_impl;
 
 struct marker;
 
-std::vector<argument> generic_eval(const migraphx::program& p,
-                                   std::vector<context>& ctx,
-                                   std::unordered_map<std::string, argument> params);
 
 /**
  * @brief Stores the instruction stream
@@ -83,6 +80,11 @@ struct MIGRAPHX_EXPORT program
 
     std::vector<argument> eval(parameter_map params,
                                execution_environment exec_env = execution_environment{}) const;
+
+    std::vector<argument> eval_with_context(
+                                   std::vector<context>& ctx,
+                                   parameter_map params) const;
+
     void finish() const;
 
     std::size_t size() const;

--- a/src/include/migraphx/program.hpp
+++ b/src/include/migraphx/program.hpp
@@ -51,6 +51,10 @@ struct program_impl;
 
 struct marker;
 
+std::vector<argument> generic_eval(const migraphx::program& p,
+                                   std::vector<context>& ctx,
+                                   std::unordered_map<std::string, argument> params);
+
 /**
  * @brief Stores the instruction stream
  */
@@ -79,7 +83,6 @@ struct MIGRAPHX_EXPORT program
 
     std::vector<argument> eval(parameter_map params,
                                execution_environment exec_env = execution_environment{}) const;
-
     void finish() const;
 
     std::size_t size() const;

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -527,7 +527,7 @@ std::vector<argument> program::eval_with_context(std::vector<context>& ctx,
                                                  parameter_map params) const
 {
     const module* mm = this->get_main_module();
-    return generic_eval(mm, ctx, params, {}, [](auto&&, auto f) { return f(); });
+    return generic_eval(mm, ctx, std::move(params), {}, [](auto&&, auto f) { return f(); });
 }
 
 std::vector<argument> program::eval(parameter_map params, execution_environment exec_env) const

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -523,9 +523,8 @@ std::vector<argument> generic_eval(const program& p,
     return generic_eval(mm, ctx, params, {}, trace);
 }
 
-std::vector<argument> program::eval_with_context(
-                                   std::vector<context>& ctx,
-                                   parameter_map params) const
+std::vector<argument> program::eval_with_context(std::vector<context>& ctx,
+                                                 parameter_map params) const
 {
     const module* mm = this->get_main_module();
     return generic_eval(mm, ctx, params, {}, [](auto&&, auto f) { return f(); });

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -523,6 +523,14 @@ std::vector<argument> generic_eval(const program& p,
     return generic_eval(mm, ctx, params, {}, trace);
 }
 
+std::vector<argument> generic_eval(const program& p,
+                                   std::vector<context>& ctx,
+                                   std::unordered_map<std::string, argument> params)
+{
+    const module* mm = p.get_main_module();
+    return generic_eval(mm, ctx, params, {}, [](auto&&, auto f) { return f(); });
+}
+
 std::vector<argument> program::eval(parameter_map params, execution_environment exec_env) const
 {
     auto& contexts = this->impl->contexts;

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -523,11 +523,11 @@ std::vector<argument> generic_eval(const program& p,
     return generic_eval(mm, ctx, params, {}, trace);
 }
 
-std::vector<argument> generic_eval(const program& p,
+std::vector<argument> program::eval_with_context(
                                    std::vector<context>& ctx,
-                                   std::unordered_map<std::string, argument> params)
+                                   parameter_map params) const
 {
-    const module* mm = p.get_main_module();
+    const module* mm = this->get_main_module();
     return generic_eval(mm, ctx, params, {}, [](auto&&, auto f) { return f(); });
 }
 

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -189,7 +189,7 @@ struct compile_plan
                            /*
                            create a small program with insturction being compiled and call "replace"
                            on that which would insert all the compiled code objects, prefills etc.
-                           necessary to run that instruction
+                           necessary to run candidate code object
                            */
                            migraphx::program bench_prog;
                            auto* bench_mm = bench_prog.get_main_module();

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <migraphx/program.hpp>
 #include <migraphx/module.hpp>
 #include <migraphx/iterator_for.hpp>
 #include <migraphx/instruction.hpp>
@@ -185,17 +186,25 @@ struct compile_plan
                                    std::cout << "No binary" << std::endl;
                                return std::numeric_limits<double>::max();
                            }
-                           // Time all the code objects for a given perf config and calculate total
-                           // time e.g. in case of split-K GEMM, it may or may not support fusion.
-                           // In that case MLIR compile would return code objects for individual
-                           // GEMM and pre/post fusion code objects.
-                           auto cobjs = cr->replace.code_objects;
-                           double t   = transform_accumulate(
-                               cobjs.begin(),
-                               cobjs.end(),
-                               double{0},
-                               std::plus<>{},
-                               [&](const operation& op) { return time_op(*ctx, op, 20); });
+                           /*
+                           create a small program with insturction being compiled and call "replace"
+                           on that which would insert all the compiled code objects, prefills etc.
+                           necessary to run that instruction
+                           */
+                           migraphx::program bench_prog;
+                           auto* bench_mm = bench_prog.get_main_module();
+                           std::vector<instruction_ref> bench_ins_inputs;
+                           for(auto&& arg : cr->ins->inputs())
+                           {
+                               bench_ins_inputs.push_back(bench_mm->add_parameter(
+                                   std::to_string(bench_ins_inputs.size()), arg->get_shape()));
+                           }
+                           auto bench_ins = bench_mm->add_instruction(
+                               cr->ins->get_operator(), bench_ins_inputs, cr->ins->module_inputs());
+                           cr->replace.replace(*bench_mm, bench_ins);
+                           // do dead code elimination by directly removing instruction
+                           bench_mm->remove_instruction(bench_ins);
+                           auto t = time_program(*ctx, bench_prog, 20);
                            if(trace_level > 1)
                                std::cout << t << "ms" << std::endl;
                            return t;

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -194,11 +194,15 @@ struct compile_plan
                            migraphx::program bench_prog;
                            auto* bench_mm = bench_prog.get_main_module();
                            std::vector<instruction_ref> bench_ins_inputs;
-                           for(auto&& arg : cr->ins->inputs())
-                           {
-                               bench_ins_inputs.push_back(bench_mm->add_parameter(
-                                   std::to_string(bench_ins_inputs.size()), arg->get_shape()));
-                           }
+
+                           std::transform(cr->ins->inputs().begin(),
+                                          cr->ins->inputs().end(),
+                                          std::back_inserter(bench_ins_inputs),
+                                          [&](const auto& arg) {
+                                              return bench_mm->add_parameter(
+                                                  std::to_string(bench_ins_inputs.size()),
+                                                  arg->get_shape());
+                                          });
                            auto bench_ins = bench_mm->add_instruction(
                                cr->ins->get_operator(), bench_ins_inputs, cr->ins->module_inputs());
                            cr->replace.replace(*bench_mm, bench_ins);

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -191,7 +191,7 @@ struct compile_plan
                            on that which would insert all the compiled code objects, prefills etc.
                            necessary to run candidate code object
                            */
-                           migraphx::program bench_prog;
+                           program bench_prog;
                            auto* bench_mm = bench_prog.get_main_module();
                            std::vector<instruction_ref> bench_ins_inputs;
 

--- a/src/targets/gpu/include/migraphx/gpu/time_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/time_op.hpp
@@ -34,12 +34,12 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
 MIGRAPHX_GPU_EXPORT double
-time_op(context& ictx, operation op, const std::vector<shape>& inputs, int n = 100);
+time_op(const context& ictx, operation op, const std::vector<shape>& inputs, int n = 100);
 
-MIGRAPHX_GPU_EXPORT double time_program(context& ictx, migraphx::program p, int n = 100);
+MIGRAPHX_GPU_EXPORT double time_program(const context& ictx, migraphx::program p, int n = 100);
 
 /* benchmark gpu::code_object with expected input shapes over n iterations */
-MIGRAPHX_GPU_EXPORT double time_op(context& ictx, operation op, int n = 100);
+MIGRAPHX_GPU_EXPORT double time_op(const context& ictx, operation op, int n = 100);
 
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/targets/gpu/include/migraphx/gpu/time_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/time_op.hpp
@@ -36,7 +36,7 @@ namespace gpu {
 MIGRAPHX_GPU_EXPORT double
 time_op(const context& ictx, operation op, const std::vector<shape>& inputs, int n = 100);
 
-MIGRAPHX_GPU_EXPORT double time_program(const context& ictx, migraphx::program p, int n = 100);
+MIGRAPHX_GPU_EXPORT double time_program(const context& ictx, program p, int n = 100);
 
 /* benchmark gpu::code_object with expected input shapes over n iterations */
 MIGRAPHX_GPU_EXPORT double time_op(const context& ictx, operation op, int n = 100);

--- a/src/targets/gpu/include/migraphx/gpu/time_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/time_op.hpp
@@ -24,6 +24,7 @@
 #ifndef MIGRAPHX_GUARD_GPU_DRIVER_PERF_HPP
 #define MIGRAPHX_GUARD_GPU_DRIVER_PERF_HPP
 
+#include <migraphx/program.hpp>
 #include <migraphx/config.hpp>
 #include <migraphx/gpu/context.hpp>
 #include <migraphx/operation.hpp>
@@ -34,6 +35,8 @@ namespace gpu {
 
 MIGRAPHX_GPU_EXPORT double
 time_op(context& ictx, operation op, const std::vector<shape>& inputs, int n = 100);
+
+MIGRAPHX_GPU_EXPORT double time_program(context& ictx, migraphx::program p, int n = 100);
 
 /* benchmark gpu::code_object with expected input shapes over n iterations */
 MIGRAPHX_GPU_EXPORT double time_op(context& ictx, operation op, int n = 100);

--- a/src/targets/gpu/time_op.cpp
+++ b/src/targets/gpu/time_op.cpp
@@ -89,7 +89,7 @@ double time_program(context& ictx, migraphx::program p, int n)
     {
         param_map[name] = to_gpu(generate_argument(shape, seed++));
     }
-    auto run   = [&] { generic_eval(p, ctx_vec, param_map); };
+    auto run   = [&] { p.eval_with_context(ctx_vec, param_map); };
     return time_loop(gctx, n, run); 
 }
 

--- a/src/targets/gpu/time_op.cpp
+++ b/src/targets/gpu/time_op.cpp
@@ -59,7 +59,7 @@ double time_loop(migraphx::gpu::context& gctx, int n, F f)
     return context::get_elapsed_ms(start.get(), stop.get()) / n;
 }
 
-double time_op(context& ictx, operation op, const std::vector<shape>& inputs, int n)
+double time_op(const context& ictx, operation op, const std::vector<shape>& inputs, int n)
 {
     // TODO: Use std::ref
     migraphx::context ctx = ictx;
@@ -71,13 +71,13 @@ double time_op(context& ictx, operation op, const std::vector<shape>& inputs, in
     return time_loop(gctx, n, run);
 }
 
-double time_op(context& ictx, operation op, int n)
+double time_op(const context& ictx, operation op, int n)
 {
     auto inputs = any_cast<migraphx::gpu::code_object_op>(op).expected_inputs;
     return time_op(ictx, op, inputs, n);
 }
 
-double time_program(context& ictx, migraphx::program p, int n)
+double time_program(const context& ictx, migraphx::program p, int n)
 {
     std::vector<migraphx::context> ctx_vec = {ictx};
     auto& gctx                             = any_cast<migraphx::gpu::context>(ctx_vec.front());

--- a/src/targets/gpu/time_op.cpp
+++ b/src/targets/gpu/time_op.cpp
@@ -43,7 +43,8 @@ std::vector<argument> generate_arguments(const std::vector<shape>& shapes, unsig
 }
 
 template <class F>
-double time_loop(migraphx::gpu::context& gctx, int n, F f) {
+double time_loop(migraphx::gpu::context& gctx, int n, F f)
+{
     auto start = context::create_event_for_timing();
     auto stop  = context::create_event_for_timing();
     f();
@@ -66,8 +67,8 @@ double time_op(context& ictx, operation op, const std::vector<shape>& inputs, in
     auto output           = op.compute_shape(inputs);
     op.finalize(ctx, output, inputs);
     auto args = generate_arguments(inputs);
-    auto run   = [&] { op.compute(ctx, output, args); };
-    return time_loop(gctx, n, run); 
+    auto run  = [&] { op.compute(ctx, output, args); };
+    return time_loop(gctx, n, run);
 }
 
 double time_op(context& ictx, operation op, int n)
@@ -89,11 +90,9 @@ double time_program(context& ictx, migraphx::program p, int n)
     {
         param_map[name] = to_gpu(generate_argument(shape, seed++));
     }
-    auto run   = [&] { p.eval_with_context(ctx_vec, param_map); };
-    return time_loop(gctx, n, run); 
+    auto run = [&] { p.eval_with_context(ctx_vec, param_map); };
+    return time_loop(gctx, n, run);
 }
-
-
 
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/targets/gpu/time_op.cpp
+++ b/src/targets/gpu/time_op.cpp
@@ -77,7 +77,7 @@ double time_op(const context& ictx, operation op, int n)
     return time_op(ictx, op, inputs, n);
 }
 
-double time_program(const context& ictx, migraphx::program p, int n)
+double time_program(const context& ictx, program p, int n)
 {
     std::vector<migraphx::context> ctx_vec = {ictx};
     auto& gctx                             = any_cast<migraphx::gpu::context>(ctx_vec.front());


### PR DESCRIPTION
Split-k GEMM compilation with MLIR would require unfusing dot + pointwise. 
Dot further requires a "Fill" instruction to instantiate output buffer with zeros.
While benchmarking different candidate during tuning, MIGraphX would need to account for the `hip::fill` call as well for the Splitk-GEMM configuration. 

Creating a program using `compiler_replace` provided by JIT compiler of MLIR would insert all the necessary calls and pointwise op to run Split-K gemm. That way MIGraphX can account for `hip::fill` calls as well.

This PR makes necessary changes to create a program using "compiler_replace" when doing benchmarking.