### PR TITLE
fix compilation on Windows

### DIFF
--- a/src/include/migraphx/argument.hpp
+++ b/src/include/migraphx/argument.hpp
@@ -117,7 +117,7 @@ struct MIGRAPHX_EXPORT argument : raw_data<argument>
     data_t m_data{};
 };
 
-std::vector<argument> flatten(const std::vector<argument>& args);
+MIGRAPHX_EXPORT std::vector<argument> flatten(const std::vector<argument>& args);
 
 MIGRAPHX_EXPORT std::vector<shape> to_shapes(const std::vector<argument>& args);
 MIGRAPHX_EXPORT void migraphx_to_value(value& v, const argument& a);

--- a/src/include/migraphx/shape.hpp
+++ b/src/include/migraphx/shape.hpp
@@ -429,7 +429,7 @@ struct MIGRAPHX_EXPORT shape
 };
 
 /// Flatten subshapes to a single vector of non-tuple type of shapes
-std::vector<shape> flatten(const std::vector<shape>& shapes);
+MIGRAPHX_EXPORT std::vector<shape> flatten(const std::vector<shape>& shapes);
 
 MIGRAPHX_EXPORT void migraphx_to_value(value& v, const shape& s);
 MIGRAPHX_EXPORT void migraphx_from_value(const value& v, shape& s);


### PR DESCRIPTION
The function `flatten` is missing `MIGRAPHX_EXPORT`, and that broke compilation on Windows.