### PR TITLE
Limit parallelism for constant propagation when parallel STL is not enabled

### DIFF
--- a/src/propagate_constant.cpp
+++ b/src/propagate_constant.cpp
@@ -28,6 +28,7 @@
 #include <migraphx/functional.hpp>
 #include <migraphx/simple_par_for.hpp>
 #include <migraphx/env.hpp>
+#include <thread>
 #include <unordered_set>
 
 namespace migraphx {
@@ -83,7 +84,12 @@ void propagate_constant::apply(module& m) const
     // Compute literals in parallel
     std::vector<instruction_ref> const_instrs_vec{const_instrs.begin(), const_instrs.end()};
     std::vector<argument> literals(const_instrs_vec.size());
-    simple_par_for(const_instrs_vec.size(), 1, [&](const auto i) {
+    int n = 1;
+#ifndef ParallelSTL_FOUND
+    n = std::max<std::size_t>(
+        std::ceil(static_cast<double>(1024) / std::thread::hardware_concurrency()), 1);
+#endif
+    simple_par_for(const_instrs_vec.size(), n, [&](const auto i) {
         literals[i] = const_instrs_vec[i]->eval();
     });
 


### PR DESCRIPTION
This limits the parallelism for constant propagate pass when parallel STL is not enabled.