### PR TITLE
Fix compute_type_name() when MSVC is used

### DIFF
--- a/src/driver/argument_parser.hpp
+++ b/src/driver/argument_parser.hpp
@@ -121,7 +121,11 @@ inline std::string colorize(color c, const std::string& s)
 template <class T>
 struct type_name
 {
-    static const std::string& apply() { return migraphx::get_type_name<T>(); }
+    static const std::string& apply()
+    {
+        static const std::string name{migraphx::get_type_name<T>()};
+        return name;
+    }
 };
 
 template <>

--- a/src/driver/command.hpp
+++ b/src/driver/command.hpp
@@ -51,13 +51,13 @@ inline auto& get_commands()
 template <class T>
 std::string compute_command_name()
 {
-    static const std::string& tname = get_type_name<T>();
-    auto name                       = tname.substr(tname.rfind("::") + 2);
+    auto type = get_type_name<T>();
+    auto name = type.substr(type.rfind("::") + 2);
     if(ends_with(name, "_command"))
         name = name.substr(0, name.size() - 8);
     if(ends_with(name, "_cmd"))
         name = name.substr(0, name.size() - 4);
-    return name;
+    return std::string{name};
 }
 
 template <class T>

--- a/src/include/migraphx/any_ptr.hpp
+++ b/src/include/migraphx/any_ptr.hpp
@@ -73,7 +73,7 @@ struct any_ptr
     std::string_view name        = "";
 
     template <class T>
-    static const std::string& get_name()
+    constexpr std::string_view get_name() const
     {
         return get_type_name<std::remove_cv_t<std::remove_pointer_t<T>>>();
     }

--- a/src/include/migraphx/op/name.hpp
+++ b/src/include/migraphx/op/name.hpp
@@ -37,7 +37,7 @@ struct op_name
 {
     std::string name() const
     {
-        static const std::string& name = get_type_name<Derived>();
+        static const std::string name{get_type_name<Derived>()};
         return name.substr(name.rfind("::") + 2);
     }
 };

--- a/src/include/migraphx/stringutils.hpp
+++ b/src/include/migraphx/stringutils.hpp
@@ -62,7 +62,7 @@ replace_string(std::string subject, const std::string& search, const std::string
     return subject;
 }
 
-inline bool ends_with(const std::string& value, const std::string& suffix)
+inline bool ends_with(std::string_view value, const std::string& suffix)
 {
     if(suffix.size() > value.size())
         return false;
@@ -83,10 +83,11 @@ inline std::string join_strings(Strings strings, const std::string& delim)
     });
 }
 
-inline std::vector<std::string> split_string(const std::string& s, char delim)
+template <class StringLike>
+inline std::vector<std::string> split_string(StringLike s, char delim)
 {
     std::vector<std::string> elems;
-    std::stringstream ss(s + delim);
+    std::stringstream ss(std::string{s} + delim);
     std::string item;
     while(std::getline(ss, item, delim))
     {

--- a/src/include/migraphx/type_name.hpp
+++ b/src/include/migraphx/type_name.hpp
@@ -31,39 +31,59 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
 template <class PrivateMigraphTypeNameProbe>
-std::string compute_type_name()
+constexpr std::string_view compute_type_name()
 {
-    std::string name;
+    using namespace std::string_view_literals;
+
 #if defined(_MSC_VER) && !defined(__clang__)
-    name = typeid(PrivateMigraphTypeNameProbe).name();
-    name = name.substr(7);
+    constexpr auto struct_name = "struct "sv;
+    constexpr auto class_name = "class "sv;
+    constexpr auto function_name = "compute_type_name<"sv;
+    constexpr auto parameter_name = "(void)"sv;
+
+    constexpr std::string_view name{__FUNCSIG__};
+
+    auto begin = name.find(function_name) + function_name.length();
+    auto length = name.find_last_of(parameter_name) - parameter_name.length() - begin;
+
+    auto result = name.substr(begin, length);
+    begin = result.find(class_name);
+    if(begin == 0)
+        return result.substr(class_name.length());
+    begin = result.find(struct_name);
+    if(begin == 0)
+        return result.substr(struct_name.length());
+    return result;
 #else
-    const char parameter_name[] = "PrivateMigraphTypeNameProbe ="; // NOLINT
+    const auto parameter_name = "PrivateMigraphTypeNameProbe ="sv;
 
-    name = __PRETTY_FUNCTION__;
+    constexpr std::string_view name{__PRETTY_FUNCTION__};
 
-    auto begin  = name.find(parameter_name) + sizeof(parameter_name);
+    auto begin  = name.find(parameter_name) + parameter_name.length();
 #if(defined(__GNUC__) && !defined(__clang__) && __GNUC__ == 4 && __GNUC_MINOR__ < 7)
     auto length = name.find_last_of(",") - begin;
 #else
     auto length = name.find_first_of("];", begin) - begin;
 #endif
-    name        = name.substr(begin, length);
+    return name.substr(begin, length);
 #endif
-    return name;
 }
 
 template <class T>
-const std::string& get_type_name()
+constexpr std::string_view get_type_name()
 {
-    static const std::string name = compute_type_name<T>();
-    return name;
+    return compute_type_name<T>();
 }
 
 template <class T>
-const std::string& get_type_name(const T&)
+constexpr std::string_view get_type_name(const T&)
 {
-    return migraphx::get_type_name<T>();
+    return get_type_name<T>();
+}
+
+inline std::string operator+(std::string_view l, std::string_view r)
+{
+    return std::string{l}.append(r);
 }
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/targets/gpu/driver/action.cpp
+++ b/src/targets/gpu/driver/action.cpp
@@ -42,7 +42,10 @@ action_function get_action(const std::string& name)
     return action_map().at(name);
 }
 
-void register_action(const std::string& name, const action_function& a) { action_map()[name] = a; }
+void register_action(std::string_view name, const action_function& a)
+{
+    action_map().emplace(name, a);
+}
 
 } // namespace driver
 } // namespace gpu

--- a/src/targets/gpu/driver/include/migraphx/gpu/driver/action.hpp
+++ b/src/targets/gpu/driver/include/migraphx/gpu/driver/action.hpp
@@ -37,7 +37,7 @@ namespace driver {
 using action_function = std::function<void(const parser&, const value&)>;
 
 action_function get_action(const std::string& name);
-void register_action(const std::string& name, const action_function& a);
+void register_action(std::string_view name, const action_function& a);
 
 struct auto_register_action
 {

--- a/src/targets/gpu/include/migraphx/gpu/name.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/name.hpp
@@ -41,19 +41,21 @@ struct oper
     // "gpu::sin" as the operator name
     std::string name() const
     {
-        const std::string& name = get_type_name<Derived>();
+        using namespace std::string_view_literals;
+
+        constexpr auto name = get_type_name<Derived>();
         // search the namespace gpu (::gpu::)
         auto pos_ns = name.find("::gpu::");
-        if(pos_ns != std::string::npos)
+        if(pos_ns != std::string_view::npos)
         {
-            auto pos_name = name.find("hip_", pos_ns + std::string("::gpu::").length());
-            if(pos_name != std::string::npos)
+            auto pos_name = name.find("hip_", pos_ns + "::gpu::"sv.length());
+            if(pos_name != std::string_view::npos)
             {
-                return std::string("gpu::") + name.substr(pos_name + 4);
+                return "gpu::" + name.substr(pos_name + 4);
             }
             else
             {
-                return name.substr(pos_ns + 2);
+                return std::string{name.substr(pos_ns + 2)};
             }
         }
         return "unknown_operator_name";

--- a/test/verify/verify_program.hpp
+++ b/test/verify/verify_program.hpp
@@ -50,7 +50,7 @@ struct register_verify_program_action
     {
         T x;
         program_info pi;
-        const std::string& test_type_name             = migraphx::get_type_name<T>();
+        const auto test_type_name                     = migraphx::get_type_name<T>();
         const auto& split_name                        = migraphx::split_string(test_type_name, ':');
         std::vector<std::string> name_without_version = {};
         // test_type_name could contain internal namespace name with version_x_y_z i.e.


### PR DESCRIPTION
The PR is related to the Microsoft Visual C++ compiler when building applications with the MIGraphX C++ interface.
We require that fix for the ONNXRT MIGraphX EP on Windows, which we build with Visual C++ compiler (not HIP SDK C++ compiler). The current implementation of `compute_type_name()` incorrectly decyphers the type name from the `typeid()` operator. Additionally, it does not work on incomplete types. It is hard, however, to obtain the same results as for __PRETTY_FUNCTION__ from the `typeid()` operator. So, on Windows, we use `__FUNCSIG__` instead.
The PR changes the function to resolve type names at compile time instead of runtime. Therefore, there is no need for a static storage duration for type names.