### PR TITLE
Limit parallelism for constant propagation cherry-pick

### DIFF
--- a/src/propagate_constant.cpp
+++ b/src/propagate_constant.cpp
@@ -84,12 +84,12 @@ void propagate_constant::apply(module& m) const
     // Compute literals in parallel
     std::vector<instruction_ref> const_instrs_vec{const_instrs.begin(), const_instrs.end()};
     std::vector<argument> literals(const_instrs_vec.size());
-    std::size_t n = 1;
+    std::size_t grainsize = 1;
 #if !MIGRAPHX_HAS_EXECUTORS
-    n = std::max<std::size_t>(
-        std::ceil(static_cast<double>(1024) / std::thread::hardware_concurrency()), 1);
+    std::size_t n = std::max<std::size_t>(2048 / std::thread::hardware_concurrency(), 1);
+    grainsize     = const_instrs_vec.size() / n;
 #endif
-    simple_par_for(const_instrs_vec.size(), n, [&](const auto i) {
+    simple_par_for(const_instrs_vec.size(), grainsize, [&](const auto i) {
         literals[i] = const_instrs_vec[i]->eval();
     });
 

--- a/src/propagate_constant.cpp
+++ b/src/propagate_constant.cpp
@@ -28,6 +28,7 @@
 #include <migraphx/functional.hpp>
 #include <migraphx/simple_par_for.hpp>
 #include <migraphx/env.hpp>
+#include <thread>
 #include <unordered_set>
 
 namespace migraphx {
@@ -83,7 +84,12 @@ void propagate_constant::apply(module& m) const
     // Compute literals in parallel
     std::vector<instruction_ref> const_instrs_vec{const_instrs.begin(), const_instrs.end()};
     std::vector<argument> literals(const_instrs_vec.size());
-    simple_par_for(const_instrs_vec.size(), 1, [&](const auto i) {
+    std::size_t n = 1;
+#if !MIGRAPHX_HAS_EXECUTORS
+    n = std::max<std::size_t>(
+        std::ceil(static_cast<double>(1024) / std::thread::hardware_concurrency()), 1);
+#endif
+    simple_par_for(const_instrs_vec.size(), n, [&](const auto i) {
         literals[i] = const_instrs_vec[i]->eval();
     });
 


### PR DESCRIPTION
This is a Cherry-pick of... Limit parallelism for constant propagation when parallel STL is not enabled (#2987) against the rocm-rel-6.1 branch.  