### PR TITLE
Update docker hub image script to support ROCm 6.1 build

### DIFF
--- a/tools/docker/migraphx_with_onnxruntime_pytorch.docker
+++ b/tools/docker/migraphx_with_onnxruntime_pytorch.docker
@@ -17,6 +17,7 @@ RUN apt install -y migraphx
 RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1/onnxruntime_rocm-inference-1.17.0-cp310-cp310-linux_x86_64.whl
 
 #Pieces for pytorch
+RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1/pytorch_triton_rocm-2.1.0%2Brocm6.1.4d510c3a44-cp310-cp310-linux_x86_64.whl
 RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1/torch-2.1.2+rocm6.1-cp310-cp310-linux_x86_64.whl
 RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1/torchvision-0.16.1+rocm6.1-cp310-cp310-linux_x86_64.whl
 

--- a/tools/docker/migraphx_with_onnxruntime_pytorch.docker
+++ b/tools/docker/migraphx_with_onnxruntime_pytorch.docker
@@ -6,19 +6,19 @@ ARG PREFIX=/usr/local
 RUN apt update && apt install -y wget
 
 #Aquire and install ROCm
-RUN wget https://repo.radeon.com/amdgpu-install/6.0.2/ubuntu/jammy/amdgpu-install_6.0.60002-1_all.deb
-RUN apt install -y ./amdgpu-install_6.0.60002-1_all.deb
-RUN amdgpu-install --usecase=rocm -y && rm amdgpu-install_6.0.60002-1_all.deb
+RUN wget https://repo.radeon.com/amdgpu-install/6.1/ubuntu/jammy/amdgpu-install_6.1.60100-1_all.deb
+RUN apt install -y ./amdgpu-install_6.1.60100-1_all.deb
+RUN amdgpu-install --usecase=rocm -y && rm amdgpu-install_6.1.60100-1_all.deb
 
 #Install MIGraphX from package manager
 RUN apt install -y migraphx
 
 #Pieces for Onnxruntime for ROCm and MIGraphX Execution Provider Support
-RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.0.2/onnxruntime_rocm-inference-1.17.0-cp310-cp310-linux_x86_64.whl
+RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1/onnxruntime_rocm-inference-1.17.0-cp310-cp310-linux_x86_64.whl
 
 #Pieces for pytorch
-RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.0/torch-2.1.1+rocm6.0-cp310-cp310-linux_x86_64.whl
-RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.0/torchvision-0.16.1+rocm6.0-cp310-cp310-linux_x86_64.whl
+RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1/torch-2.1.2+rocm6.1-cp310-cp310-linux_x86_64.whl
+RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1/torchvision-0.16.1+rocm6.1-cp310-cp310-linux_x86_64.whl
 
 #Adjust final path for ability to use rocm components
 ENV PATH=$PATH:/opt/rocm/bin/


### PR DESCRIPTION
Update our script to reflect what will be uploaded to Docker hub using ROCm 6.1 and associated pieces for MIGraphX, Pytorch and Onnxruntime.