### PR TITLE
make license check branch specific

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -337,9 +337,6 @@ jobs:
   licensing:
     runs-on: ubuntu-20.04
 
-    env:
-      BASE_BRANCH: ${{ GITHUB_BASE_REF }}
-
     steps:
     - name: Free space
       uses: jlumbroso/free-disk-space@main
@@ -359,7 +356,7 @@ jobs:
       with:
         python-version: 3.8
     - name: run License Check
-      run: python3 tools/check_stamped.py ${{ BASE_BRANCH }}
+      run: python3 tools/check_stamped.py ${{ GITHUB_BASE_REF }}
 
   linux:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -337,6 +337,9 @@ jobs:
   licensing:
     runs-on: ubuntu-20.04
 
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
     steps:
     - name: Free space
       uses: jlumbroso/free-disk-space@main
@@ -356,7 +359,7 @@ jobs:
       with:
         python-version: 3.8
     - name: run License Check
-      run: python3 tools/check_stamped.py
+      run: python3 tools/check_stamped.py $BRANCH_NAME
 
   linux:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -356,7 +356,7 @@ jobs:
       with:
         python-version: 3.8
     - name: run License Check
-      run: python3 tools/check_stamped.py ${{ GITHUB_BASE_REF }}
+      run: python3 tools/check_stamped.py ${{ github.base_ref }}
 
   linux:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     env:
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BASE_BRANCH: ${{ GITHUB_BASE_REF }}
 
     steps:
     - name: Free space
@@ -359,7 +359,7 @@ jobs:
       with:
         python-version: 3.8
     - name: run License Check
-      run: python3 tools/check_stamped.py $BRANCH_NAME
+      run: python3 tools/check_stamped.py ${{ BASE_BRANCH }}
 
   linux:
 

--- a/tools/check_stamped.py
+++ b/tools/check_stamped.py
@@ -30,7 +30,7 @@
 # in the license stamp, with the assumption being that any modifications/creations will need to be stamped to the year that the
 # modification/creation was made.
 #####################################################################################
-import subprocess, sys, datetime
+import subprocess, sys, datetime, argparse
 
 debug = False
 
@@ -111,14 +111,14 @@ def check_filename(filename: str, fileTuple: tuple or list) -> bool:
     return False
 
 
-def main() -> None:
+def main(branch) -> None:
     unsupported_file_types.extend(specificIgnores)
 
     ## Get a list of all files (not including deleted) that have changed/added in comparison to the latest Dev branch from MI Graphx
 
     # Subprocess 1 is fetching the latest dev branch from the MIgraphX Url and naming it as 'FETCH_HEAD'
     subprocess.run(
-        "git fetch https://github.com/ROCmSoftwarePlatform/AMDMIGraphX develop --quiet",
+        "git fetch https://github.com/ROCmSoftwarePlatform/AMDMIGraphX {0} --quiet".format(branch),
         shell=True,
         stdout=subprocess.PIPE)
 
@@ -153,7 +153,7 @@ def main() -> None:
 
     elif len(stampedFilesWithBadYear) > 0:
         print(
-            f"\nError: The licenses for the following {str(len(stampedFilesWithBadYear))} file(s) either... do not match the year of commit, have a different copyright format or have not been synced from the latest develop branch:\n{str(stampedFilesWithBadYear)}\nThere is a license_stamper script (./tools/license_stamper.py), which you can run to automatically update and add any needed license stamps"
+            f"\nError: The licenses for the following {str(len(stampedFilesWithBadYear))} file(s) either... do not match the year of commit, have a different copyright format or have not been synced from the latest {branch} branch:\n{str(stampedFilesWithBadYear)}\nThere is a license_stamper script (./tools/license_stamper.py), which you can run to automatically update and add any needed license stamps"
         )
         sys.exit(1)
 
@@ -168,4 +168,9 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+
+    parser=argparse.ArgumentParser()
+    parser.add_argument("branch")
+    args=parser.parse_args()
+
+    main(args.branch)

--- a/tools/check_stamped.py
+++ b/tools/check_stamped.py
@@ -118,7 +118,8 @@ def main(branch) -> None:
 
     # Subprocess 1 is fetching the latest dev branch from the MIgraphX Url and naming it as 'FETCH_HEAD'
     subprocess.run(
-        "git fetch https://github.com/ROCmSoftwarePlatform/AMDMIGraphX {0} --quiet".format(branch),
+        "git fetch https://github.com/ROCmSoftwarePlatform/AMDMIGraphX {0} --quiet"
+        .format(branch),
         shell=True,
         stdout=subprocess.PIPE)
 
@@ -169,8 +170,8 @@ def main(branch) -> None:
 
 if __name__ == "__main__":
 
-    parser=argparse.ArgumentParser()
+    parser = argparse.ArgumentParser()
     parser.add_argument("branch")
-    args=parser.parse_args()
+    args = parser.parse_args()
 
     main(args.branch)


### PR DESCRIPTION
Currently the license check compares against the "develop" branch.  This is fine normally but for release branches it means it compares against develop and files NOT changed in the release branch but did change in develop are flagged.  