### PR TITLE
Fix input args order in split module functionality

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -922,8 +922,7 @@ generic_split(const module& m,
         instructions2.push_back(ins);
     }
 
-    std::vector<instruction_ref> inputs2 = select_params(instructions2, param_map);
-    inputs2.insert(inputs2.begin(), splits.begin(), splits.end());
+    std::vector<instruction_ref> inputs2 = splits;
     module m2;
     std::size_t n = 0;
     std::unordered_map<instruction_ref, instruction_ref> map_ins2;
@@ -935,6 +934,7 @@ generic_split(const module& m,
             continue;
         if(not contains(instructions2, ins))
             continue;
+        inputs2.push_back(param_map.at(ins));
         map_ins2[ins] = m2.add_parameter(param_name(n++), ins->get_shape().as_standard());
     }
     auto r = m2.add_instructions(instructions2, &map_ins2);

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -509,7 +509,7 @@ TEST_CASE(module_split2)
     EXPECT(bool{mods[1].inputs[1] == inputs[2]});
 }
 
-TEST_CASE(module_split_2_fix)
+TEST_CASE(module_split_2_dot_ins)
 {
     std::vector<migraphx::instruction_ref> inputs;
     std::vector<migraphx::instruction_ref> mod_0_expected_inputs;

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -509,6 +509,96 @@ TEST_CASE(module_split2)
     EXPECT(bool{mods[1].inputs[1] == inputs[2]});
 }
 
+TEST_CASE(module_split_2_fix)
+{
+    std::vector<migraphx::instruction_ref> inputs;
+    std::vector<migraphx::instruction_ref> mod_0_expected_inputs;
+    std::vector<migraphx::instruction_ref> mod_1_expected_inputs;
+    migraphx::shape s1 = migraphx::shape{migraphx::shape::float_type, {2, 5}};
+    migraphx::shape s2 = migraphx::shape{migraphx::shape::float_type, {5, 5}};
+    migraphx::module input_m;
+    {
+        auto x1               = input_m.add_parameter("x1", s1);
+        auto x2               = input_m.add_parameter("x2", s1);
+        auto x3               = input_m.add_parameter("x3", s1);
+        auto x4               = input_m.add_parameter("x4", s1);
+        auto y0               = input_m.add_parameter("y0", s1);
+        auto y1               = input_m.add_parameter("y1", s2);
+        auto sx1              = input_m.add_instruction(migraphx::make_op("sqrt"), x1);
+        auto sx2              = input_m.add_instruction(migraphx::make_op("sqrt"), x2);
+        auto sx3              = input_m.add_instruction(migraphx::make_op("sqrt"), x3);
+        auto sx4              = input_m.add_instruction(migraphx::make_op("sqrt"), x4);
+        auto sy0              = input_m.add_instruction(migraphx::make_op("sqrt"), y0);
+        auto sy1              = input_m.add_instruction(migraphx::make_op("sqrt"), y1);
+        inputs                = {sx1, sx2, sx3, sx4, sy0, sy1};
+        mod_0_expected_inputs = {sy0, sy1};
+        mod_1_expected_inputs = {sx4, sx3, sx2, sx1};
+    }
+    std::vector<migraphx::instruction_ref> splits;
+    migraphx::module m1;
+    {
+        // params --> {x1, x2, x3, x4, y0, y1} binds to input args {sx1, sx2, sx3, sx4, sy0, sy1}
+        auto m1_y0 = m1.add_parameter("y0", s1);
+        auto m1_y1 = m1.add_parameter("y1", s2);
+        auto m1_x1 = m1.add_parameter("x1", s1);
+        auto m1_x2 = m1.add_parameter("x2", s1);
+        auto m1_x3 = m1.add_parameter("x3", s1);
+        auto m1_x4 = m1.add_parameter("x4", s1);
+        // m1_dot = dot(y0, y1) --> dot(sy0, sy1)
+        auto m1_dot = m1.add_instruction(migraphx::make_op("dot"), m1_y0, m1_y1);
+        // m1_add = add(x0, m1_dot)  --> add(sx1, m1_dot)
+        auto m1_add_1 = m1.add_instruction(migraphx::make_op("add"), m1_x1, m1_dot);
+        // m1_add_2 = add(x2, x3) --> add(sx2, sx3)
+        auto m1_add_2 = m1.add_instruction(migraphx::make_op("add"), m1_x2, m1_x3);
+        // m1_sub = sub(x4, m1_relu_2) --> sub(sx4, m1_add_2)
+        auto m1_sub = m1.add_instruction(migraphx::make_op("sub"), m1_x4, m1_add_2);
+        // m1_mul = mul(m1_sub, m1_add_1)
+        auto m1_mul = m1.add_instruction(migraphx::make_op("mul"), m1_sub, m1_add_1);
+        m1.add_return({m1_mul});
+        splits.push_back(m1_dot);
+    }
+
+    migraphx::module mod_0;
+    {
+        auto mod_0_y1 = mod_0.add_parameter("y1", s2);
+        auto mod_0_y0 = mod_0.add_parameter("y0", s1);
+        // mod_0_dot(y0, y1) --> dot(sy0, sy1)
+        auto mod_0_dot = mod_0.add_instruction(migraphx::make_op("dot"), mod_0_y0, mod_0_y1);
+        mod_0.add_return({mod_0_dot});
+    }
+    migraphx::module mod_1;
+    {
+        // expected input args are {dot_ins, sx4, sx3, sx2, sx1}
+        auto m1_x0 = mod_1.add_parameter("x0", s1);
+        auto m1_x1 = mod_1.add_parameter("x1", s1);
+        auto m1_x2 = mod_1.add_parameter("x2", s1);
+        auto m1_x3 = mod_1.add_parameter("x3", s1);
+        auto m1_x4 = mod_1.add_parameter("x4", s1);
+        // m1_add = add(x4, m1_dot)  --> add(sx1, m1_dot)
+        auto m1_add = mod_1.add_instruction(migraphx::make_op("add"), m1_x4, m1_x0);
+        // m1_add_2 = add(x3, x2) --> add(sx2, sx3)
+        auto m1_add_2 = mod_1.add_instruction(migraphx::make_op("add"), m1_x3, m1_x2);
+        // m1_sub = sub(x1, m1_relu_2) --> sub(sx4, m1_add_2)
+        auto m1_sub = mod_1.add_instruction(migraphx::make_op("sub"), m1_x1, m1_add_2);
+        // m1_mul = mul(m1_sub, m1_add)
+        auto m1_mul = mod_1.add_instruction(migraphx::make_op("mul"), m1_sub, m1_add);
+        mod_1.add_return({m1_mul});
+    }
+    auto mods = m1.split(inputs, splits);
+    EXPECT(bool{mods[0].mod.sort() == mod_0.sort()});
+    const auto mod_0_inputs = mods[0].inputs;
+    EXPECT(bool{mod_0_inputs[0] == mod_0_expected_inputs[0]});
+    EXPECT(bool{mod_0_inputs[1] == mod_0_expected_inputs[1]});
+    const auto mod_1_inputs = mods[1].inputs;
+    // first input arg should be the split instruction
+    EXPECT(bool{mods[1].mod.sort() == mod_1.sort()});
+    EXPECT(bool{mod_1_inputs[0] == splits.front()});
+    EXPECT(bool{mod_1_inputs[1] == mod_1_expected_inputs[0]});
+    EXPECT(bool{mod_1_inputs[2] == mod_1_expected_inputs[1]});
+    EXPECT(bool{mod_1_inputs[3] == mod_1_expected_inputs[2]});
+    EXPECT(bool{mod_1_inputs[4] == mod_1_expected_inputs[3]});
+}
+
 TEST_CASE(module_split3)
 {
     migraphx::shape s{migraphx::shape::float_type, {1}};

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -569,17 +569,17 @@ TEST_CASE(module_split_2_dot_ins)
     migraphx::module mod_1;
     {
         // expected input args are {dot_ins, sx4, sx3, sx2, sx1}
-        auto m1_x0 = mod_1.add_parameter("x0", s1);
-        auto m1_x1 = mod_1.add_parameter("x1", s1);
-        auto m1_x2 = mod_1.add_parameter("x2", s1);
-        auto m1_x3 = mod_1.add_parameter("x3", s1);
-        auto m1_x4 = mod_1.add_parameter("x4", s1);
+        auto mod_1_x0 = mod_1.add_parameter("x0", s1);
+        auto mod_1_x1 = mod_1.add_parameter("x1", s1);
+        auto mod_1_x2 = mod_1.add_parameter("x2", s1);
+        auto mod_1_x3 = mod_1.add_parameter("x3", s1);
+        auto mod_1_x4 = mod_1.add_parameter("x4", s1);
         // m1_add = add(x4, m1_dot)  --> add(sx1, m1_dot)
-        auto m1_add = mod_1.add_instruction(migraphx::make_op("add"), m1_x4, m1_x0);
+        auto m1_add = mod_1.add_instruction(migraphx::make_op("add"), mod_1_x4, mod_1_x0);
         // m1_add_2 = add(x3, x2) --> add(sx2, sx3)
-        auto m1_add_2 = mod_1.add_instruction(migraphx::make_op("add"), m1_x3, m1_x2);
+        auto m1_add_2 = mod_1.add_instruction(migraphx::make_op("add"), mod_1_x3, mod_1_x2);
         // m1_sub = sub(x1, m1_relu_2) --> sub(sx4, m1_add_2)
-        auto m1_sub = mod_1.add_instruction(migraphx::make_op("sub"), m1_x1, m1_add_2);
+        auto m1_sub = mod_1.add_instruction(migraphx::make_op("sub"), mod_1_x1, m1_add_2);
         // m1_mul = mul(m1_sub, m1_add)
         auto m1_mul = mod_1.add_instruction(migraphx::make_op("mul"), m1_sub, m1_add);
         mod_1.add_return({m1_mul});


### PR DESCRIPTION
Current logic:

1. Current logic is setting input argument order for the second module based on parameter order in input module. 
2. Next it is creating new parameter by traversing the input module, which doesn't gurantee traversing parameters in same order as input arguments order selected in step 1. 

For example, look the unit-test in this PR.  With current logic `add_1` instruction would do `add(sx4, dot_ins)` instead of original operation of `add(sx1, dot_ins)`. 

Solves #2994 