### PR TITLE
license check on push too

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -356,7 +356,7 @@ jobs:
       with:
         python-version: 3.8
     - name: run License Check
-      run: python3 tools/check_stamped.py ${{ github.base_ref }}
+      run: python3 tools/check_stamped.py ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
 
   linux:
 


### PR DESCRIPTION
Turns out that "github.base_ref" is only populated for `pull_request`.  Push's also occur.  A push happens when a PR is merged in to the develop branch.  So this code change allows for both cases