### PR TITLE
Fix problem with slow performance with reduction fusion

### DIFF
--- a/src/targets/gpu/compile_gen.cpp
+++ b/src/targets/gpu/compile_gen.cpp
@@ -288,6 +288,15 @@ static bool use_lazy_inner(instruction_ref ins)
 {
     if(ins->outputs().size() != 1)
         return false;
+    // When the inputs are broadcasted, it means the lambda will capture SPGRs
+    // when doing block/wave reduction. This can cause register spilling in
+    // the compiler when the lambda is evaluated at a later time although it
+    // shouldn't. Instead, use `inner` to workaround this issue in the
+    // compiler.
+    if(std::any_of(ins->inputs().begin(), ins->inputs().end(), [](instruction_ref input) {
+        return input->get_shape().broadcasted();
+    }))
+        return false;
     auto output = ins->outputs().front();
     return contains(output->name(), "reduce") or output->name() == "@return";
 }

--- a/src/targets/gpu/compile_gen.cpp
+++ b/src/targets/gpu/compile_gen.cpp
@@ -288,7 +288,7 @@ static bool use_lazy_inner(instruction_ref ins)
 {
     if(ins->outputs().size() != 1)
         return false;
-    // When the inputs are broadcasted, it means the lambda will capture SPGRs
+    // When the inputs are broadcasted, it means the lambda will capture SGPRs
     // when doing block/wave reduction. This can cause register spilling in
     // the compiler when the lambda is evaluated at a later time although it
     // shouldn't. Instead, use `inner` to workaround this issue in the

--- a/src/targets/gpu/compile_gen.cpp
+++ b/src/targets/gpu/compile_gen.cpp
@@ -294,8 +294,8 @@ static bool use_lazy_inner(instruction_ref ins)
     // shouldn't. Instead, use `inner` to workaround this issue in the
     // compiler.
     if(std::any_of(ins->inputs().begin(), ins->inputs().end(), [](instruction_ref input) {
-        return input->get_shape().broadcasted();
-    }))
+           return input->get_shape().broadcasted();
+       }))
         return false;
     auto output = ins->outputs().front();
     return contains(output->name(), "reduce") or output->name() == "@return";


### PR DESCRIPTION
This works around an issue in the compiler when the lambda captures SGPRs that leads to register spilling due to the lambda evaluated in a later context. This causes 2x perf drop on mi250 for this layernorm case:

```python
p = migraphx.program()
m = p.get_main_module()
x_0 = m.add_literal(migraphx.generate_argument(migraphx.shape(type="half_type", lens=[640]), 0))
x_1 = m.add_literal(migraphx.generate_argument(migraphx.shape(type="half_type", lens=[1]), 1))
p_input = m.add_parameter("input",migraphx.shape(type="half_type", lens=[64,4096,640]))
x_3 = m.add_instruction(migraphx.op("multibroadcast", out_lens=[64,4096,640]), [x_0])
x_4 = m.add_instruction(migraphx.op("add"), [p_input, x_3])
x_5 = m.add_instruction(migraphx.op("reduce_mean", axes=[2]), [x_4])
x_6 = m.add_instruction(migraphx.op("multibroadcast", out_lens=[64,4096,640]), [x_5])
x_7 = m.add_instruction(migraphx.op("sqdiff"), [x_4, x_6])
x_8 = m.add_instruction(migraphx.op("reduce_mean", axes=[2]), [x_7])
x_9 = m.add_instruction(migraphx.op("sub"), [x_4, x_6])
x_10 = m.add_instruction(migraphx.op("multibroadcast", out_lens=[64,4096,1]), [x_1])
x_11 = m.add_instruction(migraphx.op("add"), [x_8, x_10])
x_12 = m.add_instruction(migraphx.op("rsqrt"), [x_11])
x_13 = m.add_instruction(migraphx.op("multibroadcast", out_lens=[64,4096,640]), [x_12])
m.add_instruction(migraphx.op("mul"), [x_9, x_13])
```

I dont really fully understand why this happens in the compiler, but this at least fixes the issue.