### PR TITLE
Support QDQ patterns from brevitas

### DIFF
--- a/src/simplify_qdq.cpp
+++ b/src/simplify_qdq.cpp
@@ -43,8 +43,8 @@ namespace {
 template <class... Ms>
 auto skip_post_dq_ops(Ms... ms)
 {
-    return match::skip(
-        match::name("broadcast", "multibroadcast", "contiguous", "transpose", "reshape"))(ms...);
+    return match::skip(match::name(
+        "broadcast", "multibroadcast", "contiguous", "transpose", "reshape", "convert"))(ms...);
 }
 
 std::unordered_set<std::string> get_quantizable_op_names()
@@ -90,8 +90,10 @@ struct match_find_quantizable_ops
 
     // Helper function to insert quantized versions of any broadcasts and transpose ops that
     // occur between dequantizelinear and the quantized op
-    static auto
-    propagate_quantized_ins(module& m, const instruction_ref dqins, const instruction_ref qop_arg)
+    static auto propagate_quantized_ins(module& m,
+                                        const instruction_ref dqins,
+                                        const instruction_ref qop_arg,
+                                        bool is_fp16_model = false)
     {
         auto prev_ins = qop_arg;
         std::vector<instruction_ref> ins_inbetween;
@@ -105,6 +107,10 @@ struct match_find_quantizable_ops
         auto qinp = dqins->inputs().front();
         for(auto ins : reverse_iterator_for(ins_inbetween))
         {
+            if((*ins)->name() == "convert" and is_fp16_model)
+            {
+                continue;
+            }
             qinp = m.insert_instruction(dqins, (*ins)->get_operator(), {qinp});
         }
         return qinp;
@@ -143,8 +149,15 @@ struct match_find_quantizable_ops
 
         // Propagate q1 and q2 through any broadcasts and transposes before qop
         auto qop_args  = qop->inputs();
-        qop_args.at(0) = propagate_quantized_ins(m, dq1, qop_args[0]);
-        qop_args.at(1) = propagate_quantized_ins(m, dq2, qop_args[1]);
+        bool is_fp16_model = false;
+        if(dq1->get_shape().type() != qop->get_shape().type() and
+           qop->get_shape().type() == migraphx::shape::half_type)
+        {
+            assert(dq1->get_shape().type() == migraphx::shape::float_type);
+            is_fp16_model = true;
+        }
+        qop_args.at(0) = propagate_quantized_ins(m, dq1, qop_args[0], is_fp16_model);
+        qop_args.at(1) = propagate_quantized_ins(m, dq2, qop_args[1], is_fp16_model);
         auto arg1_lens = qop_args[0]->get_shape().lens();
         auto arg2_lens = qop_args[1]->get_shape().lens();
         instruction_ref dq;
@@ -260,6 +273,11 @@ struct match_find_quantizable_ops
         }
 
         dq = m.insert_instruction(qop, make_op("dequantizelinear"), dq, out_scale, out_zp);
+        if(is_fp16_model)
+        {
+            dq = m.insert_instruction(
+                qop, make_op("convert", {{"target_type", migraphx::shape::half_type}}), dq);
+        }
         m.replace_instruction(qop, dq);
     }
 };

--- a/test/simplify_qdq_test.cpp
+++ b/test/simplify_qdq_test.cpp
@@ -217,6 +217,60 @@ TEST_CASE(dot)
     EXPECT(m1 == m2);
 }
 
+TEST_CASE(dot_fp16)
+{
+    migraphx::shape sh1{migraphx::shape::half_type, {1280, 1000}};
+    migraphx::shape sh2{migraphx::shape::half_type, {1000, 1024}};
+
+    migraphx::module m1;
+    {
+        auto t1    = m1.add_parameter("t1", sh1);
+        auto t2    = m1.add_parameter("t2", sh2);
+        auto scale = m1.add_literal(0.5f);
+        auto zero  = m1.add_literal(std::int8_t{0});
+        auto t1f   = m1.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), t1);
+        auto t2f = m1.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), t2);
+        auto q1  = add_quantize_op(m1, "quantizelinear", t1f, scale, zero);
+        auto d1  = add_quantize_op(m1, "dequantizelinear", q1, scale, zero);
+        auto q2  = add_quantize_op(m1, "quantizelinear", t2f, scale, zero);
+        auto d2  = add_quantize_op(m1, "dequantizelinear", q2, scale, zero);
+        auto d1h = m1.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), d1);
+        auto d2h = m1.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), d2);
+        auto dot = m1.add_instruction(migraphx::make_op("dot"), d1h, d2h);
+        m1.add_return({dot});
+    }
+
+    migraphx::module m2;
+    {
+        auto t1    = m2.add_parameter("t1", sh1);
+        auto t2    = m2.add_parameter("t2", sh2);
+        auto scale = m2.add_literal(0.5f);
+        auto zero  = m2.add_literal(std::int8_t{0});
+        auto t1f   = m2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), t1);
+        auto t2f = m2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), t2);
+
+        auto q1 = add_quantize_op(m2, "quantizelinear", t1f, scale, zero);
+        auto q2 = add_quantize_op(m2, "quantizelinear", t2f, scale, zero);
+
+        auto dot       = m2.add_instruction(migraphx::make_op("quant_dot"), q1, q2);
+        auto out_scale = add_scale_mul(m2, scale, scale, 1, 1, dot->get_shape().lens());
+        auto out_zp    = init_zero_point(m2, dot);
+        auto d3        = add_quantize_op(m2, "dequantizelinear", dot, out_scale, out_zp);
+        auto d3h       = m2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), d3);
+        m2.add_return({d3h});
+    }
+
+    run_pass(m1);
+    EXPECT(m1 == m2);
+}
+
 TEST_CASE(dot_multi_scale)
 {
     migraphx::shape sh1{migraphx::shape::float_type, {1280, 1000}};
@@ -482,6 +536,8 @@ TEST_CASE(dot_multi_scale_unsupported_axis)
     run_pass(m1);
     EXPECT(m1 == m2);
 }
+
+TEST_CASE(dot_fp16_model) {}
 
 TEST_CASE(dot_asymmetric_first_arg)
 {

--- a/test/simplify_qdq_test.cpp
+++ b/test/simplify_qdq_test.cpp
@@ -537,8 +537,6 @@ TEST_CASE(dot_multi_scale_unsupported_axis)
     EXPECT(m1 == m2);
 }
 
-TEST_CASE(dot_fp16_model) {}
-
 TEST_CASE(dot_asymmetric_first_arg)
 {
     migraphx::shape sh1{migraphx::shape::float_type, {1280, 1000}};


### PR DESCRIPTION
Solves https://github.com/ROCm/AMDMIGraphX/issues/3049

Brevitas quantizes fp16 model to int8 and generates patterns described in #3049  

This PR adds changes to handle those.