### PR TITLE
print uint8 and int8 numbers

### DIFF
--- a/src/include/migraphx/as_number.hpp
+++ b/src/include/migraphx/as_number.hpp
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MIGRAPHX_GUARD_RTGLIB_AS_NUMBER_HPP
+#define MIGRAPHX_GUARD_RTGLIB_AS_NUMBER_HPP
+
+#include <cstdint>
+#include <migraphx/config.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+
+template <class T>
+T as_number(T x)
+{
+    return x;
+}
+inline int32_t as_number(int8_t x) { return static_cast<int32_t>(x); }
+inline uint32_t as_number(uint8_t x) { return static_cast<uint32_t>(x); }
+
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+#endif // MIGRAPHX_GUARD_RTGLIB_AS_NUMBER_HPP

--- a/src/include/migraphx/stringutils.hpp
+++ b/src/include/migraphx/stringutils.hpp
@@ -196,7 +196,7 @@ inline std::string to_string_range(Iterator start, Iterator last, const char* de
     std::stringstream ss;
     if(start != last)
     {
-        ss << *start;
+        ss << as_number(*start);
         std::for_each(std::next(start), last, [&](auto&& x) { ss << delim << as_number(x); });
     }
     return ss.str();

--- a/src/include/migraphx/stringutils.hpp
+++ b/src/include/migraphx/stringutils.hpp
@@ -31,6 +31,7 @@
 #include <unordered_map>
 #include <vector>
 #include <migraphx/config.hpp>
+#include <migraphx/tensor_view.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -196,7 +197,7 @@ inline std::string to_string_range(Iterator start, Iterator last, const char* de
     if(start != last)
     {
         ss << *start;
-        std::for_each(std::next(start), last, [&](auto&& x) { ss << delim << x; });
+        std::for_each(std::next(start), last, [&](auto&& x) { ss << delim << as_number(x); });
     }
     return ss.str();
 }

--- a/src/include/migraphx/stringutils.hpp
+++ b/src/include/migraphx/stringutils.hpp
@@ -30,8 +30,7 @@
 #include <sstream>
 #include <unordered_map>
 #include <vector>
-#include <migraphx/config.hpp>
-#include <migraphx/tensor_view.hpp>
+#include <migraphx/as_number.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {

--- a/src/include/migraphx/tensor_view.hpp
+++ b/src/include/migraphx/tensor_view.hpp
@@ -28,21 +28,13 @@
 #include <migraphx/float_equal.hpp>
 #include <migraphx/requires.hpp>
 #include <migraphx/iota_iterator.hpp>
-#include <migraphx/config.hpp>
+#include <migraphx/as_number.hpp>
 
 #include <iostream>
 #include <utility>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
-
-template <class T>
-T as_number(T x)
-{
-    return x;
-}
-inline int32_t as_number(int8_t x) { return static_cast<int32_t>(x); }
-inline uint32_t as_number(uint8_t x) { return static_cast<uint32_t>(x); }
 
 template <class T>
 struct tensor_view_iterator_read


### PR DESCRIPTION
`MIGRAPHX_TRACE_EVAL=2` is not printing output values for the uint8_type or int8_type operations currently. 
For example on the develop branch : 

Running uint8 maxpool with trace_eval=2 prints nothing for the output. 

```
Run instruction: @8 = gpu::code_object[code_object=7968,symbol_name=convert_kernel,global=81,local=1024,](@6,output) -> uint8_type, {1, 3, 3, 3, 3}, {81, 27, 9, 3, 1}, target_id=0
Time: 0.0068ms, 0.01965ms
Output has zero, normal
Output: , , , , , ..., , , , ,
Min value: , Max value: , Mean: 8.90123, StdDev: 13.729

```

With this PR, it prints output buffer. 
```
Run instruction: @8 = gpu::code_object[code_object=7968,symbol_name=convert_kernel,global=81,local=1024,](@6,output) -> uint8_type, {1, 3, 3, 3, 3}, {81, 27, 9, 3, 1}, target_id=0
Time: 0.00694ms, 0.01933ms
Output has zero, normal
Output: 28, 30, 0, 28, 31, ..., 0, 0, 0, 0, 0
Min value: , Max value: , Mean: 8.90123, StdDev: 13.729

```