### PR TITLE
Fix bug in finding parallel reductions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG PREFIX=/usr/local
 RUN dpkg --add-architecture i386
 
 # Install rocm key
-RUN apt-get update && apt-get install -y gnupg2 --no-install-recommends curl && \
+RUN apt-get update && apt-get install -y software-properties-common gnupg2 --no-install-recommends curl && \
     curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
 
 # Add rocm repository
@@ -14,6 +14,9 @@ RUN sh -c 'echo deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/6.0
 
 # From docs.amd.com for installing rocm. Needed to install properly
 RUN sh -c "echo 'Package: *\nPin: release o=repo.radeon.com\nPin-priority: 600' > /etc/apt/preferences.d/rocm-pin-600"
+
+# rocgdb doesn't work on 22.04, workaround by installing the older python packages that are in 20.04
+RUN add-apt-repository -y ppa:deadsnakes/ppa
 
 # Install dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
@@ -32,7 +35,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-
     python3 \
     python3-dev \
     python3-pip \
-    software-properties-common \
+    libpython3.8 \
     wget \
     rocm-device-libs \
     hip-base \

--- a/src/targets/cpu/lowering.cpp
+++ b/src/targets/cpu/lowering.cpp
@@ -352,7 +352,6 @@ struct cpu_apply
         extend_op("logsoftmax", "dnnl::logsoftmax");
         extend_op("lrn", "dnnl::lrn");
         extend_op("softmax", "dnnl::softmax");
-        extend_op("sub", "cpu::sub");
 
         extend_op("im2col", "cpu::im2col", false);
         extend_op("leaky_relu", "cpu::leaky_relu", false);

--- a/src/targets/gpu/prepare_reduce.cpp
+++ b/src/targets/gpu/prepare_reduce.cpp
@@ -92,9 +92,8 @@ std::vector<instruction_ref> find_parallel_reduce(const std::vector<instruction_
         ir.end(),
         std::back_inserter(result),
         [&](auto x) {
-            return std::none_of(std::next(x), r.end(), [&](auto reduce) {
-                return reaches(*x, reduce);
-            });
+            return std::none_of(
+                std::next(x), r.end(), [&](auto reduce) { return reaches(*x, reduce); });
         },
         [](auto x) { return *x; });
     return result;
@@ -102,7 +101,7 @@ std::vector<instruction_ref> find_parallel_reduce(const std::vector<instruction_
 
 void fuse_reductions(module& m)
 {
-    auto rs  = find_parallel_reduce(find_reduce(m));
+    auto rs = find_parallel_reduce(find_reduce(m));
     if(rs.size() < 2)
         return;
     // Only handle the same reduction operator for now

--- a/src/targets/gpu/prepare_reduce.cpp
+++ b/src/targets/gpu/prepare_reduce.cpp
@@ -29,7 +29,6 @@
 #include <migraphx/register_op.hpp>
 #include <migraphx/ranges.hpp>
 #include <migraphx/make_op.hpp>
-#include <migraphx/dom_info.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -72,8 +71,19 @@ std::vector<instruction_ref> find_reduce(module& m)
     return result;
 }
 
-std::vector<instruction_ref> find_parallel_reduce(const std::vector<instruction_ref>& r,
-                                                  const dominator_info& dom)
+bool reaches(instruction_ref start, instruction_ref end)
+{
+    std::unordered_set<instruction_ref> visited;
+    return fix<bool>([&](auto self, auto ins) -> bool {
+        if(ins == start)
+            return true;
+        if(not visited.insert(ins).second)
+            return false;
+        return std::any_of(ins->inputs().begin(), ins->inputs().end(), self);
+    })(end);
+}
+
+std::vector<instruction_ref> find_parallel_reduce(const std::vector<instruction_ref>& r)
 {
     std::vector<instruction_ref> result;
     auto ir = iterator_for(r);
@@ -83,7 +93,7 @@ std::vector<instruction_ref> find_parallel_reduce(const std::vector<instruction_
         std::back_inserter(result),
         [&](auto x) {
             return std::none_of(std::next(x), r.end(), [&](auto reduce) {
-                return dom.strictly_dominate(*x, reduce);
+                return reaches(*x, reduce);
             });
         },
         [](auto x) { return *x; });
@@ -92,8 +102,7 @@ std::vector<instruction_ref> find_parallel_reduce(const std::vector<instruction_
 
 void fuse_reductions(module& m)
 {
-    auto dom = compute_dominator(m);
-    auto rs  = find_parallel_reduce(find_reduce(m), dom);
+    auto rs  = find_parallel_reduce(find_reduce(m));
     if(rs.size() < 2)
         return;
     // Only handle the same reduction operator for now

--- a/test/verify/test_reduce_mean_reduce_sum.cpp
+++ b/test/verify/test_reduce_mean_reduce_sum.cpp
@@ -35,15 +35,19 @@ struct test_reduce_mean_reduce_sum : verify_program<test_reduce_mean_reduce_sum>
         migraphx::program p;
         auto* mm = p.get_main_module();
         migraphx::shape s{migraphx::shape::float_type, {5, 784, 768}};
-        auto x        = mm->add_parameter("x", s);
-        auto n = mm->add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type, {1}}, {s.lens().back()}});
-        auto mean     = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), x);
-        auto meanb = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), mean);
+        auto x     = mm->add_parameter("x", s);
+        auto n     = mm->add_literal(migraphx::literal{
+            migraphx::shape{migraphx::shape::float_type, {1}}, {s.lens().back()}});
+        auto mean  = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), x);
+        auto meanb = mm->add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), mean);
         auto sub = mm->add_instruction(migraphx::make_op("sub"), x, meanb);
-        auto nb = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), n);
-        auto div = mm->add_instruction(migraphx::make_op("div"), sub, nb);
-        auto div2       = mm->add_instruction(migraphx::make_op("mul"), div, div);
-        auto mean_div2  = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), div2);
+        auto nb =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), n);
+        auto div  = mm->add_instruction(migraphx::make_op("div"), sub, nb);
+        auto div2 = mm->add_instruction(migraphx::make_op("mul"), div, div);
+        auto mean_div2 =
+            mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), div2);
         mm->add_return({mean_div2});
         return p;
     };

--- a/test/verify/test_reduce_mean_reduce_sum.cpp
+++ b/test/verify/test_reduce_mean_reduce_sum.cpp
@@ -35,19 +35,15 @@ struct test_reduce_mean_reduce_sum : verify_program<test_reduce_mean_reduce_sum>
         migraphx::program p;
         auto* mm = p.get_main_module();
         migraphx::shape s{migraphx::shape::float_type, {5, 784, 768}};
-        auto x = mm->add_parameter("x", s);
-        auto n = mm->add_literal(
-            migraphx::literal{migraphx::shape{migraphx::shape::float_type, {1}}, {768}});
-        auto mean  = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), x);
-        auto meanb = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), mean);
+        auto x        = mm->add_parameter("x", s);
+        auto n = mm->add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type, {1}}, {s.lens().back()}});
+        auto mean     = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), x);
+        auto meanb = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), mean);
         auto sub = mm->add_instruction(migraphx::make_op("sub"), x, meanb);
-        auto nb =
-            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), n);
-        auto div  = mm->add_instruction(migraphx::make_op("div"), sub, nb);
-        auto div2 = mm->add_instruction(migraphx::make_op("mul"), div, div);
-        auto mean_div2 =
-            mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), div2);
+        auto nb = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), n);
+        auto div = mm->add_instruction(migraphx::make_op("div"), sub, nb);
+        auto div2       = mm->add_instruction(migraphx::make_op("mul"), div, div);
+        auto mean_div2  = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), div2);
         mm->add_return({mean_div2});
         return p;
     };

--- a/test/verify/test_reduce_mean_reduce_sum.cpp
+++ b/test/verify/test_reduce_mean_reduce_sum.cpp
@@ -35,15 +35,19 @@ struct test_reduce_mean_reduce_sum : verify_program<test_reduce_mean_reduce_sum>
         migraphx::program p;
         auto* mm = p.get_main_module();
         migraphx::shape s{migraphx::shape::float_type, {5, 784, 768}};
-        auto x        = mm->add_parameter("x", s);
-        auto n = mm->add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type, {1}}, {768}});
-        auto mean     = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), x);
-        auto meanb = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), mean);
+        auto x = mm->add_parameter("x", s);
+        auto n = mm->add_literal(
+            migraphx::literal{migraphx::shape{migraphx::shape::float_type, {1}}, {768}});
+        auto mean  = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), x);
+        auto meanb = mm->add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), mean);
         auto sub = mm->add_instruction(migraphx::make_op("sub"), x, meanb);
-        auto nb = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), n);
-        auto div = mm->add_instruction(migraphx::make_op("div"), sub, nb);
-        auto div2       = mm->add_instruction(migraphx::make_op("mul"), div, div);
-        auto mean_div2  = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), div2);
+        auto nb =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), n);
+        auto div  = mm->add_instruction(migraphx::make_op("div"), sub, nb);
+        auto div2 = mm->add_instruction(migraphx::make_op("mul"), div, div);
+        auto mean_div2 =
+            mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), div2);
         mm->add_return({mean_div2});
         return p;
     };

--- a/test/verify/test_reduce_mean_reduce_sum.cpp
+++ b/test/verify/test_reduce_mean_reduce_sum.cpp
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "verify_program.hpp"
+#include <migraphx/program.hpp>
+#include <migraphx/generate.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/instruction.hpp>
+
+struct test_reduce_mean_reduce_sum : verify_program<test_reduce_mean_reduce_sum>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        migraphx::shape s{migraphx::shape::float_type, {5, 784, 768}};
+        auto x        = mm->add_parameter("x", s);
+        auto n = mm->add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type, {1}}, {768}});
+        auto mean     = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), x);
+        auto meanb = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), mean);
+        auto sub = mm->add_instruction(migraphx::make_op("sub"), x, meanb);
+        auto nb = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), n);
+        auto div = mm->add_instruction(migraphx::make_op("div"), sub, nb);
+        auto div2       = mm->add_instruction(migraphx::make_op("mul"), div, div);
+        auto mean_div2  = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2}}}), div2);
+        mm->add_return({mean_div2});
+        return p;
+    };
+};


### PR DESCRIPTION
Using dominators are not the right tool for this, which lead to making operators parallel when they werent leading to infinite recursion. Parallelism can be detected using post dominance frontiers, but it seems much simpler to check for reachability using DFS. 

This fixes #3046.