### PR TITLE
Fix `is_module_fusible()` bug in MIGraphX 

### DIFF
--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/include/migraphx/gpu/mlir.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/mlir.hpp
@@ -39,7 +39,7 @@ namespace gpu {
 
 MIGRAPHX_GPU_EXPORT std::string dump_mlir(const module& m);
 
-MIGRAPHX_GPU_EXPORT bool is_module_fusible(const module& m, const value& solution);
+MIGRAPHX_GPU_EXPORT bool is_module_fusible(const module& m, const context& migraphx_ctx, const value& solution);
 
 struct mlir_code_object
 {

--- a/src/targets/gpu/include/migraphx/gpu/mlir.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/mlir.hpp
@@ -39,7 +39,8 @@ namespace gpu {
 
 MIGRAPHX_GPU_EXPORT std::string dump_mlir(const module& m);
 
-MIGRAPHX_GPU_EXPORT bool is_module_fusible(const module& m, const context& migraphx_ctx, const value& solution);
+MIGRAPHX_GPU_EXPORT bool
+is_module_fusible(const module& m, const context& migraphx_ctx, const value& solution);
 
 struct MIGRAPHX_GPU_EXPORT mlir_code_object
 {

--- a/src/targets/gpu/jit/mlir.cpp
+++ b/src/targets/gpu/jit/mlir.cpp
@@ -79,8 +79,6 @@ struct mlir_compiler : compiler<mlir_compiler>
         auto gemm_ins = std::find_if(smod->begin(), smod->end(), [&](const auto& i) {
             return i.name() == "dot" or i.name() == "quant_dot";
         });
-        std::cout << "Compiling solution: \n";
-        solution.debug_print();
         // check if (a) module is fused (b) contains a dot instruction and (c) perfConfig can not
         // allow fused module
         if(gemm_ins != smod->end() and std::distance(gemm_ins, smod->end()) > 2 and

--- a/src/targets/gpu/jit/mlir.cpp
+++ b/src/targets/gpu/jit/mlir.cpp
@@ -78,6 +78,9 @@ struct mlir_compiler : compiler<mlir_compiler>
         auto gemm_ins = std::find_if(smod->begin(), smod->end(), [&](const auto& i) {
             return i.name() == "dot" or i.name() == "quant_dot";
         });
+        std::cout << "Compiling solution: \n";
+        solution.debug_print();
+        std::cout << "is module fusible: " << is_module_fusible(*smod, solution) << "\n";
         // check if (a) module is fused (b) contains a dot instruction and (c) perfConfig can not
         // allow fused module
         if(gemm_ins != smod->end() and std::distance(gemm_ins, smod->end()) > 2 and

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -947,10 +947,12 @@ struct mlir_program
     std::string sym_name;
 };
 
-bool is_module_fusible(const module& m, const value& solution)
+bool is_module_fusible(const module& m, const context& migraphx_ctx, const value& solution)
 {
     mlir_program mp;
+    mp.set_gpu_properties(migraphx_ctx);
     mp.parse(m);
+    mp.run_high_level_pipeline();
     return mlirIsModuleFusible(mp.mmodule.get(), make_mlir_string_ref(*solution.if_string()));
 }
 

--- a/test/verify/gemm_add.cpp
+++ b/test/verify/gemm_add.cpp
@@ -47,6 +47,8 @@ struct gemm_add : verify_program<gemm_add<DType>>
         return p;
     }
     std::string section() const { return "gemm"; }
+
+    // Turn on Exhaustive-tune to enable split-k GEMM perf-configs from MLIR
     migraphx::compile_options get_compile_options() const
     {
         return migraphx::compile_options{.exhaustive_tune = true};

--- a/test/verify/gemm_add.cpp
+++ b/test/verify/gemm_add.cpp
@@ -35,9 +35,9 @@ struct gemm_add : verify_program<gemm_add<DType>>
     {
         migraphx::program p;
         auto* mm = p.get_main_module();
-        migraphx::shape m1_shape{DType, {1, 2, 3}};
-        migraphx::shape m2_shape{DType, {1, 3, 4}};
-        migraphx::shape m3_shape{DType, {1, 2, 4}};
+        migraphx::shape m1_shape{DType, {1, 2, 1280}};
+        migraphx::shape m2_shape{DType, {1, 1280, 320}};
+        migraphx::shape m3_shape{DType, {1, 2, 320}};
         auto l1 = mm->add_parameter("1", m1_shape);
         auto l2 = mm->add_parameter("2", m2_shape);
         auto l3 = mm->add_parameter("3", m3_shape);
@@ -47,6 +47,10 @@ struct gemm_add : verify_program<gemm_add<DType>>
         return p;
     }
     std::string section() const { return "gemm"; }
+    migraphx::compile_options get_compile_options() const
+    {
+        return migraphx::compile_options{.exhaustive_tune = true};
+    }
 };
 
 template struct gemm_add<migraphx::shape::float_type>;

--- a/test/verify/test_gemm.cpp
+++ b/test/verify/test_gemm.cpp
@@ -22,11 +22,11 @@
  * THE SOFTWARE.
  */
 
-#include "migraphx/compile_options.hpp"
 #include "verify_program.hpp"
 #include <migraphx/program.hpp>
 #include <migraphx/generate.hpp>
 #include <migraphx/make_op.hpp>
+
 template <migraphx::shape::type_t DType>
 struct test_gemm : verify_program<test_gemm<DType>>
 {
@@ -40,10 +40,6 @@ struct test_gemm : verify_program<test_gemm<DType>>
         return p;
     }
     std::string section() const { return "gemm"; }
-    migraphx::compile_options get_compile_options() const
-    {
-        return migraphx::compile_options{.exhaustive_tune = true};
-    }
 };
 
 template struct test_gemm<migraphx::shape::float_type>;

--- a/test/verify/test_gemm.cpp
+++ b/test/verify/test_gemm.cpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  */
 
+#include "migraphx/compile_options.hpp"
 #include "verify_program.hpp"
 #include <migraphx/program.hpp>
 #include <migraphx/generate.hpp>
@@ -39,6 +40,10 @@ struct test_gemm : verify_program<test_gemm<DType>>
         return p;
     }
     std::string section() const { return "gemm"; }
+    migraphx::compile_options get_compile_options() const
+    {
+        return migraphx::compile_options{.exhaustive_tune = true};
+    }
 };
 
 template struct test_gemm<migraphx::shape::float_type>;


### PR DESCRIPTION
`is_module_fusible()` needs to be run after `run_highlevel_pipeline()` otherwise it always returns True. 

Enable test for the split-k + pointwise by turning on exhaustive-tune for the `gemm_add` test.

Also fixes #3079 
