### PR TITLE
Fix "All Targets" CI test

### DIFF
--- a/test/multi_target/multitarget_test.cpp
+++ b/test/multi_target/multitarget_test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/multi_target/multitarget_test.cpp
+++ b/test/multi_target/multitarget_test.cpp
@@ -95,7 +95,8 @@ bool is_compiled_cpu_module(const migraphx::module& m)
 {
     return std::all_of(m.begin(), m.end(), [](auto ins) {
         auto ins_name = ins.name();
-        if(not migraphx::starts_with(ins_name, "@"))
+        // sub is not lowered on CPU backend due to vectorization on non-aligned memory.
+        if(not migraphx::starts_with(ins_name, "@") and ins_name != "sub")
         {
             if(not migraphx::starts_with(ins_name, "cpu::") and
                not migraphx::starts_with(ins_name, "dnnl::") and
@@ -111,6 +112,7 @@ bool is_compiled_cpu_module(const migraphx::module& m)
 
 bool is_compiled_ref_module(const migraphx::module& m)
 {
+
     return std::all_of(m.begin(), m.end(), [](auto ins) {
         auto ins_name = ins.name();
         if(not migraphx::starts_with(ins_name, "@"))

--- a/test/multi_target/multitarget_test.cpp
+++ b/test/multi_target/multitarget_test.cpp
@@ -112,7 +112,6 @@ bool is_compiled_cpu_module(const migraphx::module& m)
 
 bool is_compiled_ref_module(const migraphx::module& m)
 {
-
     return std::all_of(m.begin(), m.end(), [](auto ins) {
         auto ins_name = ins.name();
         if(not migraphx::starts_with(ins_name, "@"))


### PR DESCRIPTION
https://github.com/ROCm/AMDMIGraphX/pull/3070/files introduced change in CPU lowering for the `sub` which caused unit-test failure for the multi-target test. 