### PR TITLE
Enable MIOpen and CK fusion on gfx941 and gfx942

### DIFF
--- a/src/targets/gpu/fuse_ck.cpp
+++ b/src/targets/gpu/fuse_ck.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/fuse_ck.cpp
+++ b/src/targets/gpu/fuse_ck.cpp
@@ -21,11 +21,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include <migraphx/gpu/fuse_ck.hpp>
-#include <migraphx/gpu/gemm_softmax_gemm.hpp>
+
 #include <migraphx/matcher.hpp>
 #include <migraphx/pass_manager.hpp>
+#include <migraphx/stringutils.hpp>
 #include <migraphx/register_op.hpp>
+#include <migraphx/gpu/fuse_ck.hpp>
+#include <migraphx/gpu/gemm_softmax_gemm.hpp>
 #include <migraphx/gpu/device_name.hpp>
 
 namespace migraphx {
@@ -106,7 +108,7 @@ MIGRAPHX_PRED_MATCHER(is_ck_gemm, instruction_ref ins)
             return false;
     }
     auto device_name = trim(split_string(get_device_name(), ':').front());
-    if(device_name == "gfx940")
+    if(starts_with(device_name, "gfx94"))
     {
         if(ins->get_shape().type() == shape::half_type)
         {

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -166,7 +166,7 @@ struct fusion
 const std::unordered_set<std::string>& get_supported_archs()
 {
     static std::unordered_set<std::string> supported_archs{
-        "gfx900", "gfx906", "gfx908", "gfx1030", "gfx940"};
+        "gfx900", "gfx906", "gfx908", "gfx1030", "gfx940", "gfx941", "gfx942"};
     return supported_archs;
 }
 


### PR DESCRIPTION
Testing on gfx942
`make check` passes
`MIGRAPHX_ENABLE_CK=1 ./bin/test_verify "ck_gemm_softmax_gemm"` passes.