### PR TITLE
Concat - multibroadcast fix

### DIFF
--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -282,7 +282,7 @@ struct find_concat_multibroadcasts
             return;
         }
 
-        // Get the inputs of multibroadcast ops, will be used as inputs to new concat op
+        // Get the inputs of multibroadcast ops. Will be used as inputs to new concat op
         std::vector<instruction_ref> mb_inputs(concat_inputs.size());
         std::transform(concat_inputs.begin(), concat_inputs.end(), mb_inputs.begin(), [](auto i) {
             return i->inputs().front();
@@ -307,15 +307,9 @@ struct find_concat_multibroadcasts
         const auto& front_in_lens = mb_inputs.front()->get_shape().lens();
         for(std::size_t ax = 0; ax < front_in_lens.size(); ++ax)
         {
-            if(ax != concat_op.axis)
-            {
-                if(not std::all_of(mb_inputs.begin(), mb_inputs.end(), [&](auto input_to_mb) {
-                       return input_to_mb->get_shape().lens()[ax] == front_in_lens[ax];
-                   }))
-                {
-                    return;
-                }
-            }
+			const auto& lens = input_to_mb->get_shape().lens();
+			return std::equal(lens.begin(), lens.begin() + concat_op.axis, front_in_lens.begin()) and 
+				   std::equal(lens.begin() + concat_op.axis + 1, lens.end(), front_in_lens.begin() + concat_op.axis + 1);
         }
 
         auto new_concat_ins = m.insert_instruction(concat_ins, concat_op, mb_inputs);

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -273,6 +273,7 @@ struct find_concat_multibroadcasts
         auto concat_out_lens  = concat_ins->get_shape().lens();
         auto concat_inputs    = concat_ins->inputs();
         auto front_mb_strides = concat_inputs.front()->get_shape().strides();
+        assert(concat_op.axis >= 0);
 
         // Only apply when concat axis is not a broadcasted dimension
         if(std::any_of(concat_inputs.begin(), concat_inputs.end(), [&](auto i) {

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -244,6 +244,21 @@ struct find_nested_slice
     }
 };
 
+/**
+ *  Example case
+ *  From:
+ *  param0: lens = [3, 4], strides = [4, 1]
+ *  param1: lens = [3, 4], strides = [4, 1]
+ *  mb0: multibroadcast(param0, output_lens = [2, 3, 4])
+ *  mb1: multibroadcast(param1, output_lens = [2, 3, 4])
+ *  concat(mb0, mb1, axis = 2)
+ *
+ *  To:
+ *  param0: lens = [3, 4], strides = [4, 1]
+ *  param1: lens = [3, 4], strides = [4, 1]
+ *  con0: concat(param0, param1, axis = 1)
+ *  multibroadcast(con0, lens = [2, 3, 4])
+ */
 struct find_concat_multibroadcasts
 {
     auto matcher() const
@@ -253,34 +268,46 @@ struct find_concat_multibroadcasts
 
     void apply(module& m, const match::matcher_result& mr) const
     {
-        auto ins        = mr.result;
-        auto op         = any_cast<op::concat>(ins->get_operator());
-        auto out_lens   = ins->get_shape().lens();
-        auto inputs     = ins->inputs();
-        auto in_strides = inputs.front()->get_shape().strides();
+        auto concat_ins        = mr.result;
+        auto concat_op         = any_cast<op::concat>(concat_ins->get_operator());
+        auto concat_out_lens   = concat_ins->get_shape().lens();
+        auto concat_inputs     = concat_ins->inputs();
+        auto front_mb_strides  = concat_inputs.front()->get_shape().strides();
 
         // Only apply when concat axis is not a broadcasted dimension
-        if(std::any_of(inputs.begin(), inputs.end(), [&](auto i) {
-               return i->get_shape().strides()[op.axis] == 0;
+        if(std::any_of(concat_inputs.begin(), concat_inputs.end(), [&](auto i) {
+               return i->get_shape().strides()[concat_op.axis] == 0;
            }))
         {
             return;
         }
-
+    
         // Get the inputs of multibroadcast ops, will be used as inputs to new concat op
-        std::transform(inputs.begin(), inputs.end(), inputs.begin(), [](auto i) {
+        std::vector<instruction_ref> mb_inputs(concat_inputs.size());
+        std::transform(concat_inputs.begin(), concat_inputs.end(), mb_inputs.begin(), [](auto i) {
             return i->inputs().front();
         });
 
-        // inputs to multibroadcasts should have the same dimensions except for the axis to
-        // concatenate n skips apply if not true
-        const auto& first_out_lens = inputs.front()->get_shape().lens();
-        for(std::size_t ax = 0; ax < first_out_lens.size(); ++ax)
+        // Check that the inputs into the multibroadcasts have the same rank
+        const auto& first_shape = mb_inputs.front()->get_shape();
+        if(not std::all_of(mb_inputs.begin() + 1, mb_inputs.end(), [&](auto mb_in) { return mb_in->get_shape().ndim() == first_shape.ndim(); }))
         {
-            if(ax != op.axis)
+            return;
+        }
+
+        // Reduce axis by number of leading broadcasted dimensions
+        if(mb_inputs.front()->get_shape().lens().size() < concat_out_lens.size())
+            concat_op.axis -= std::count(front_mb_strides.begin(), front_mb_strides.begin() + concat_op.axis, 0);
+
+        // Inputs to multibroadcasts should have the same dimensions except for the axis to
+        // concatenate over
+        const auto& front_in_lens = mb_inputs.front()->get_shape().lens();
+        for(std::size_t ax = 0; ax < front_in_lens.size(); ++ax)
+        {
+            if(ax != concat_op.axis)
             {
-                if(not std::all_of(inputs.begin(), inputs.end(), [&](auto input_to_mb) {
-                       return input_to_mb->get_shape().lens()[ax] == first_out_lens[ax];
+                if(not std::all_of(mb_inputs.begin(), mb_inputs.end(), [&](auto input_to_mb) {
+                       return input_to_mb->get_shape().lens()[ax] == front_in_lens[ax];
                    }))
                 {
                     return;
@@ -288,13 +315,9 @@ struct find_concat_multibroadcasts
             }
         }
 
-        // Reduce axis by number of leading broadcasted dimensions
-        if(inputs.front()->get_shape().lens().size() < out_lens.size())
-            op.axis -= std::count(in_strides.begin(), in_strides.begin() + op.axis, 0);
-
-        auto concat = m.insert_instruction(ins, op, inputs);
+        auto new_concat_ins = m.insert_instruction(concat_ins, concat_op, mb_inputs);
         m.replace_instruction(
-            ins, migraphx::make_op("multibroadcast", {{"out_lens", out_lens}}), concat);
+            concat_ins, migraphx::make_op("multibroadcast", {{"out_lens", concat_out_lens}}), new_concat_ins);
     }
 };
 

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -932,7 +932,7 @@ TEST_CASE(concat_multibroadcasts4)
 }
 
 // different input parameter shapes
-// dimensions other than concat axis do not match
+// matched by find_concat_multibroadcasts but dimensions other than concat axis do not match
 // skips this case
 TEST_CASE(concat_multibroadcasts5)
 {

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -918,9 +918,10 @@ TEST_CASE(concat_multibroadcasts3)
     EXPECT(new_concat->get_operator().to_value()["axis"].to<int>() == 2);
 }
 
+// Broadcasted batch dim, axis is broadcasted dim
+// skips this case
 TEST_CASE(concat_multibroadcasts4)
 {
-    // Broadcasted batch dim, axis is broadcasted dim
     std::vector<std::size_t> in_lens     = {3, 4};
     std::vector<std::size_t> mbcast_lens = {2, 3, 4};
     const int axis                       = 0;
@@ -928,6 +929,48 @@ TEST_CASE(concat_multibroadcasts4)
     auto m1                              = m;
     run_pass(m);
     EXPECT(m1 == m);
+}
+
+// different input parameter shapes
+// dimensions other than concat axis do not match
+// skips this case
+TEST_CASE(concat_multibroadcasts5)
+{
+    migraphx::module m;
+    auto s0 = migraphx::shape{migraphx::shape::float_type, {1, 1, 1, 1, 64}};
+    auto s1 = migraphx::shape{migraphx::shape::float_type, {1, 1, 60, 64, 192}};
+    auto x = m.add_parameter("x", s0);
+    auto y = m.add_parameter("y", s1);
+    std::vector<std::size_t> mb_lens0 = {1, 12, 60, 64, 64};
+    std::vector<std::size_t> mb_lens1 = {1, 12, 60, 64, 192};
+    auto mb_x = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens0}}), x);
+    auto mb_y = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens1}}), y);
+    auto concat_xy = m.add_instruction(migraphx::make_op("concat", {{"axis", 4}}), mb_x, mb_y);
+    m.add_return({concat_xy});
+    auto m_original = m;
+    run_pass(m);
+    EXPECT(m == m_original);
+}
+
+// concat axis moved because rank(in_dims) < rank(out_dims)
+// parameter inputs are not the same rank
+// skips this case
+TEST_CASE(concat_multibroadcasts6)
+{
+    migraphx::module m;
+    auto s0 = migraphx::shape{migraphx::shape::float_type, {64}};
+    auto s1 = migraphx::shape{migraphx::shape::float_type, {60, 64, 192}};
+    auto x = m.add_parameter("x", s0);
+    auto y = m.add_parameter("y", s1);
+    std::vector<std::size_t> mb_lens0 = {1, 12, 60, 64, 64};
+    std::vector<std::size_t> mb_lens1 = {1, 12, 60, 64, 192};
+    auto mb_x = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens0}}), x);
+    auto mb_y = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens1}}), y);
+    auto concat_xy = m.add_instruction(migraphx::make_op("concat", {{"axis", 4}}), mb_x, mb_y);
+    m.add_return({concat_xy});
+    auto m_original = m;
+    run_pass(m);
+    EXPECT(m == m_original);
 }
 
 TEST_CASE(concat_transpose1)

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -931,9 +931,8 @@ TEST_CASE(concat_multibroadcasts4)
     EXPECT(m1 == m);
 }
 
-// different input parameter shapes
-// matched by find_concat_multibroadcasts but dimensions other than concat axis do not match
-// skips this case
+// Matched by find_concat_multibroadcasts but skipped because dimensions other than concat axis do
+// not match
 TEST_CASE(concat_multibroadcasts5)
 {
     migraphx::module m;
@@ -952,13 +951,35 @@ TEST_CASE(concat_multibroadcasts5)
     EXPECT(m == m_original);
 }
 
-// concat axis moved because rank(in_dims) < rank(out_dims)
-// matched by find_concat_multibroadcasts but parameter inputs are not the same rank
-// skips this case
+// Matched by find_concat_multibroadcasts but skipped because parameter inputs are not the same
+// rank.
 TEST_CASE(concat_multibroadcasts6)
 {
     migraphx::module m;
     auto s0                           = migraphx::shape{migraphx::shape::float_type, {64}};
+    auto s1                           = migraphx::shape{migraphx::shape::float_type, {60, 64, 192}};
+    auto x                            = m.add_parameter("x", s0);
+    auto y                            = m.add_parameter("y", s1);
+    std::vector<std::size_t> mb_lens0 = {12, 60, 64, 64};
+    std::vector<std::size_t> mb_lens1 = {12, 60, 64, 192};
+    auto mb_x = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens0}}), x);
+    auto mb_y = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens1}}), y);
+    auto concat_xy = m.add_instruction(migraphx::make_op("concat", {{"axis", 3}}), mb_x, mb_y);
+    m.add_return({concat_xy});
+    auto m_original = m;
+    run_pass(m);
+    EXPECT(m == m_original);
+}
+
+// Concat axis moved to 2 because rank(in_dims) < rank(out_dims)
+// Matched by find_concat_multibroadcasts but skipped because the dimensions
+// other than the concat axis are not the same.
+// TODO: has common broadcast axes, so can be simplified by moving multibroadcast up to have a
+// smaller concat.
+TEST_CASE(concat_multibroadcasts7)
+{
+    migraphx::module m;
+    auto s0                           = migraphx::shape{migraphx::shape::float_type, {1, 1, 64}};
     auto s1                           = migraphx::shape{migraphx::shape::float_type, {60, 64, 192}};
     auto x                            = m.add_parameter("x", s0);
     auto y                            = m.add_parameter("y", s1);
@@ -967,6 +988,49 @@ TEST_CASE(concat_multibroadcasts6)
     auto mb_x = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens0}}), x);
     auto mb_y = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens1}}), y);
     auto concat_xy = m.add_instruction(migraphx::make_op("concat", {{"axis", 4}}), mb_x, mb_y);
+    m.add_return({concat_xy});
+    auto m_original = m;
+    run_pass(m);
+    EXPECT(m == m_original);
+}
+
+// Shape of inputs to multibroadcasts do not have the same rank.
+// Matched by find_concat_multibroadcasts but skipped.
+// TODO: has a common broadcast axis, so can be simplified by moving multibroadcast up to have a
+// smaller concat.
+TEST_CASE(concat_multibroadcasts8)
+{
+    migraphx::module m;
+    auto s0                           = migraphx::shape{migraphx::shape::float_type, {64, 64}};
+    auto s1                           = migraphx::shape{migraphx::shape::float_type, {60, 1, 192}};
+    auto x                            = m.add_parameter("x", s0);
+    auto y                            = m.add_parameter("y", s1);
+    std::vector<std::size_t> mb_lens0 = {60, 64, 64};
+    std::vector<std::size_t> mb_lens1 = {60, 64, 192};
+    auto mb_x = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens0}}), x);
+    auto mb_y = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens1}}), y);
+    auto concat_xy = m.add_instruction(migraphx::make_op("concat", {{"axis", 2}}), mb_x, mb_y);
+    m.add_return({concat_xy});
+    auto m_original = m;
+    run_pass(m);
+    EXPECT(m == m_original);
+}
+
+// Shape of inputs to multibroadcasts do not have a common broadcast axis.
+// Matched by find_concat_multibroadcasts, but skipped because the dimensions other than
+// the concat axis are not the same.
+TEST_CASE(concat_multibroadcasts9)
+{
+    migraphx::module m;
+    auto s0                           = migraphx::shape{migraphx::shape::float_type, {1, 64, 64}};
+    auto s1                           = migraphx::shape{migraphx::shape::float_type, {60, 1, 192}};
+    auto x                            = m.add_parameter("x", s0);
+    auto y                            = m.add_parameter("y", s1);
+    std::vector<std::size_t> mb_lens0 = {60, 64, 64};
+    std::vector<std::size_t> mb_lens1 = {60, 64, 192};
+    auto mb_x = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens0}}), x);
+    auto mb_y = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens1}}), y);
+    auto concat_xy = m.add_instruction(migraphx::make_op("concat", {{"axis", 2}}), mb_x, mb_y);
     m.add_return({concat_xy});
     auto m_original = m;
     run_pass(m);

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -953,7 +953,7 @@ TEST_CASE(concat_multibroadcasts5)
 }
 
 // concat axis moved because rank(in_dims) < rank(out_dims)
-// parameter inputs are not the same rank
+// matched by find_concat_multibroadcasts but parameter inputs are not the same rank
 // skips this case
 TEST_CASE(concat_multibroadcasts6)
 {

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -938,8 +938,8 @@ TEST_CASE(concat_multibroadcasts5)
     migraphx::module m;
     auto s0 = migraphx::shape{migraphx::shape::float_type, {1, 1, 1, 1, 64}};
     auto s1 = migraphx::shape{migraphx::shape::float_type, {1, 1, 60, 64, 192}};
-    auto x                            = m.add_parameter("x", s0);
-    auto y                            = m.add_parameter("y", s1);
+    auto x  = m.add_parameter("x", s0);
+    auto y  = m.add_parameter("y", s1);
     std::vector<std::size_t> mb_lens0 = {1, 12, 60, 64, 64};
     std::vector<std::size_t> mb_lens1 = {1, 12, 60, 64, 192};
     auto mb_x = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens0}}), x);

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -919,7 +919,7 @@ TEST_CASE(concat_multibroadcasts3)
 }
 
 // Broadcasted batch dim, axis is broadcasted dim
-// skips this case
+// matched by find_concat_multibroadcasts but it skips this case
 TEST_CASE(concat_multibroadcasts4)
 {
     std::vector<std::size_t> in_lens     = {3, 4};

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -939,8 +939,8 @@ TEST_CASE(concat_multibroadcasts5)
     migraphx::module m;
     auto s0 = migraphx::shape{migraphx::shape::float_type, {1, 1, 1, 1, 64}};
     auto s1 = migraphx::shape{migraphx::shape::float_type, {1, 1, 60, 64, 192}};
-    auto x = m.add_parameter("x", s0);
-    auto y = m.add_parameter("y", s1);
+    auto x                            = m.add_parameter("x", s0);
+    auto y                            = m.add_parameter("y", s1);
     std::vector<std::size_t> mb_lens0 = {1, 12, 60, 64, 64};
     std::vector<std::size_t> mb_lens1 = {1, 12, 60, 64, 192};
     auto mb_x = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens0}}), x);
@@ -958,10 +958,10 @@ TEST_CASE(concat_multibroadcasts5)
 TEST_CASE(concat_multibroadcasts6)
 {
     migraphx::module m;
-    auto s0 = migraphx::shape{migraphx::shape::float_type, {64}};
-    auto s1 = migraphx::shape{migraphx::shape::float_type, {60, 64, 192}};
-    auto x = m.add_parameter("x", s0);
-    auto y = m.add_parameter("y", s1);
+    auto s0                           = migraphx::shape{migraphx::shape::float_type, {64}};
+    auto s1                           = migraphx::shape{migraphx::shape::float_type, {60, 64, 192}};
+    auto x                            = m.add_parameter("x", s0);
+    auto y                            = m.add_parameter("y", s1);
     std::vector<std::size_t> mb_lens0 = {1, 12, 60, 64, 64};
     std::vector<std::size_t> mb_lens1 = {1, 12, 60, 64, 192};
     auto mb_x = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_lens0}}), x);


### PR DESCRIPTION
* Resolves #3023
* Adds checks and their respective tests for cases that the concat-multibroadcast matcher cannot currently handle.
  * See the issue for a breakdown and #3095 to track a rewrite of the this matcher to handle these cases.
* Added documentation and chose new variable names to make what the matcher is doing more clear.