### PR TITLE
Use the package name hip-dev/devel rather than using the deprecated package name hip-base.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,8 +343,8 @@ if(MIGRAPHX_USE_ROCBLAS)
     list(APPEND PACKAGE_DEPENDS rocblas)
 endif()
 
-rocm_package_add_deb_dependencies(DEPENDS "hip-dev")
-rocm_package_add_rpm_dependencies(DEPENDS "hip-devel")
+rocm_package_add_deb_dependencies(SHARED_DEPENDS "hip-dev")
+rocm_package_add_rpm_dependencies(SHARED_DEPENDS "hip-devel")
 
 rocm_create_package(
     NAME MIGraphX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,11 +343,14 @@ if(MIGRAPHX_USE_ROCBLAS)
     list(APPEND PACKAGE_DEPENDS rocblas)
 endif()
 
+rocm_package_add_deb_dependencies(DEPENDS "hip-dev")
+rocm_package_add_rpm_dependencies(DEPENDS "hip-devel")
+
 rocm_create_package(
     NAME MIGraphX
     DESCRIPTION "AMD's graph optimizer"
     MAINTAINER "AMDMIGraphX Maintainer <migraphx-lib.support@amd.com>"
     LDCONFIG
     PTH
-    DEPENDS miopen-hip ${DEPENDS_HIP_RUNTIME} hip-base half ${PACKAGE_DEPENDS}
+    DEPENDS miopen-hip ${DEPENDS_HIP_RUNTIME} half ${PACKAGE_DEPENDS}
 )

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-
     libpython3.8 \
     wget \
     rocm-device-libs \
-    hip-base \
+    hip-dev \
     libnuma-dev \
     miopen-hip \
     rocblas \

--- a/hip-clang.docker
+++ b/hip-clang.docker
@@ -27,7 +27,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-
     software-properties-common \
     wget \
     rocm-device-libs \
-    hip-base \
+    hip-dev \
     libnuma-dev \
     miopen-hip \
     rocblas \

--- a/tools/docker/ubuntu_2204.dockerfile
+++ b/tools/docker/ubuntu_2204.dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-
     software-properties-common \
     wget \
     rocm-device-libs \
-    hip-base \
+    hip-dev \
     libnuma-dev \
     miopen-hip \
     rocblas \


### PR DESCRIPTION
While installing versioned packages, the dependency list also contains non versioned package hip-dev. This was due to the usage of deprecated package name hip-base in the dependency list of mipgraphx. Replaced the same with hip-dev/devel