### PR TITLE
Fuse reduce when broadcast is after reshape

### DIFF
--- a/src/include/migraphx/rewrite_reshapes.hpp
+++ b/src/include/migraphx/rewrite_reshapes.hpp
@@ -74,14 +74,16 @@ struct rewrite_reshapes
         {
             auto reshape =
                 match::name("reshape", "squeeze", "unsqueeze", "flatten")(match::used_once());
-            auto skip_contiguous_broadcast = match::skip(
-                    match::name("contiguous", "multibroadcast")(match::used_once()));
+            auto skip_contiguous_broadcast =
+                match::skip(match::name("contiguous", "multibroadcast")(match::used_once()));
             auto skip_contiguous_broadcast_arg = [&](auto... ms) {
                 return match::arg(0)(skip_contiguous_broadcast(ms...));
             };
             auto pointwise         = match::name(op1)(match::used_once());
-            auto reshape_pointwise = reshape(skip_contiguous_broadcast_arg(pointwise.bind("x"))).bind("reshape");
-            return match::name(op2)(match::any_of[match::inputs()](skip_contiguous_broadcast(reshape_pointwise).bind("input")));
+            auto reshape_pointwise =
+                reshape(skip_contiguous_broadcast_arg(pointwise.bind("x"))).bind("reshape");
+            return match::name(op2)(match::any_of[match::inputs()](
+                skip_contiguous_broadcast(reshape_pointwise).bind("input")));
         }
 
         template <class F>
@@ -110,10 +112,10 @@ struct rewrite_reshapes
 
         static std::optional<bool> is_broadcasted(instruction_ref start, instruction_ref last)
         {
-            auto broadcast_ins = find_input_if(
-                start, last, [&](auto i) { return i->name() == "multibroadcast"; });
+            auto broadcast_ins =
+                find_input_if(start, last, [&](auto i) { return i->name() == "multibroadcast"; });
             bool result = broadcast_ins != last;
-            if (result and not match_input(broadcast_ins, last))
+            if(result and not match_input(broadcast_ins, last))
                 return nullopt;
             return result;
         }
@@ -123,17 +125,18 @@ struct rewrite_reshapes
             auto ins         = r.result;
             auto x_ins       = r.instructions["x"];
             auto reshape_ins = r.instructions["reshape"];
-            auto input_ins       = r.instructions["input"];
+            auto input_ins   = r.instructions["input"];
 
             const auto has_broadcast_before_reshape = is_broadcasted(reshape_ins, x_ins);
-            const auto has_broadcast_after_reshape = is_broadcasted(input_ins, reshape_ins);
+            const auto has_broadcast_after_reshape  = is_broadcasted(input_ins, reshape_ins);
             if(not has_broadcast_before_reshape.has_value())
                 return;
             if(not has_broadcast_after_reshape.has_value())
                 return;
-            if (*has_broadcast_after_reshape and *has_broadcast_before_reshape)
+            if(*has_broadcast_after_reshape and *has_broadcast_before_reshape)
                 return;
-            const bool has_broadcast = *has_broadcast_after_reshape or *has_broadcast_before_reshape;
+            const bool has_broadcast =
+                *has_broadcast_after_reshape or *has_broadcast_before_reshape;
 
             auto dims1 = T::base_dims(ins);
             auto dims2 = T::base_dims(x_ins);

--- a/src/include/migraphx/rewrite_reshapes.hpp
+++ b/src/include/migraphx/rewrite_reshapes.hpp
@@ -74,13 +74,14 @@ struct rewrite_reshapes
         {
             auto reshape =
                 match::name("reshape", "squeeze", "unsqueeze", "flatten")(match::used_once());
-            auto skip_contiguous = [](auto... ms) {
-                return match::arg(0)(match::skip(
-                    match::name("contiguous", "multibroadcast")(match::used_once()))(ms...));
+            auto skip_contiguous_broadcast = match::skip(
+                    match::name("contiguous", "multibroadcast")(match::used_once()));
+            auto skip_contiguous_broadcast_arg = [&](auto... ms) {
+                return match::arg(0)(skip_contiguous_broadcast(ms...));
             };
             auto pointwise         = match::name(op1)(match::used_once());
-            auto reshape_pointwise = reshape(skip_contiguous(pointwise.bind("x"))).bind("reshape");
-            return match::name(op2)(match::any_of[match::inputs()](reshape_pointwise));
+            auto reshape_pointwise = reshape(skip_contiguous_broadcast_arg(pointwise.bind("x"))).bind("reshape");
+            return match::name(op2)(match::any_of[match::inputs()](skip_contiguous_broadcast(reshape_pointwise).bind("input")));
         }
 
         template <class F>
@@ -107,17 +108,32 @@ struct rewrite_reshapes
             return x_ins == input;
         }
 
+        static std::optional<bool> is_broadcasted(instruction_ref start, instruction_ref last)
+        {
+            auto broadcast_ins = find_input_if(
+                start, last, [&](auto i) { return i->name() == "multibroadcast"; });
+            bool result = broadcast_ins != last;
+            if (result and not match_input(broadcast_ins, last))
+                return nullopt;
+            return result;
+        }
+
         void apply(module_pass_manager& mpm, const match::matcher_result& r) const
         {
             auto ins         = r.result;
             auto x_ins       = r.instructions["x"];
             auto reshape_ins = r.instructions["reshape"];
+            auto input_ins       = r.instructions["input"];
 
-            auto broadcast_ins = find_input_if(
-                reshape_ins, x_ins, [&](auto i) { return i->name() == "multibroadcast"; });
-            const bool has_broadcast = broadcast_ins != x_ins;
-            if(has_broadcast and not match_input(broadcast_ins, x_ins))
+            const auto has_broadcast_before_reshape = is_broadcasted(reshape_ins, x_ins);
+            const auto has_broadcast_after_reshape = is_broadcasted(input_ins, reshape_ins);
+            if(not has_broadcast_before_reshape.has_value())
                 return;
+            if(not has_broadcast_after_reshape.has_value())
+                return;
+            if (*has_broadcast_after_reshape and *has_broadcast_before_reshape)
+                return;
+            const bool has_broadcast = *has_broadcast_after_reshape or *has_broadcast_before_reshape;
 
             auto dims1 = T::base_dims(ins);
             auto dims2 = T::base_dims(x_ins);
@@ -153,7 +169,7 @@ struct rewrite_reshapes
 
             auto inputs = ins->inputs();
             std::transform(inputs.begin(), inputs.end(), inputs.begin(), [&](auto input) {
-                if(input == reshape_ins)
+                if(input == input_ins)
                     return new_x_ins;
                 return reshape_input(ins)(input);
             });

--- a/test/fuse_reduce.cpp
+++ b/test/fuse_reduce.cpp
@@ -792,10 +792,11 @@ TEST_CASE(reduce_reshape_reduce)
         auto y   = mm->add_parameter("y", s2);
         auto x1r = mm->add_instruction(migraphx::make_op("reshape", {{"dims", s3.lens()}}), x1);
         auto x2r = mm->add_instruction(migraphx::make_op("reshape", {{"dims", s3r.lens()}}), x2);
-        auto yr = mm->add_instruction(migraphx::make_op("reshape", {{"dims", s3.lens()}}), y);
+        auto yr      = mm->add_instruction(migraphx::make_op("reshape", {{"dims", s3.lens()}}), y);
         auto freduce = add_reduce(
             p2,
-            "main:pointwise2:main:reduce_sum2_reshape_reshape:main:pointwise3_reshape:main:reduce_sum1:main:reduce_sum0:main:pointwise0:main:pointwise1_reshape",
+            "main:pointwise2:main:reduce_sum2_reshape_reshape:main:pointwise3_reshape:main:reduce_"
+            "sum1:main:reduce_sum0:main:pointwise0:main:pointwise1_reshape",
             {x1r, x2r, yr},
             {3, 4},
             [&](auto* rm, const auto& inputs, const auto& axes) {
@@ -813,9 +814,12 @@ TEST_CASE(reduce_reshape_reduce)
                     migraphx::make_op("multibroadcast", {{"out_lens", s3.lens()}}), rsum2);
                 auto sub2 = add_pointwise(
                     p2, rm, "main:pointwise2", {rsum2b, inputs[0]}, single_pointwise("sub"));
-                auto rsum3 = rm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", axes}}), sub2);
-                auto rsum3b = rm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s3.lens()}}), rsum3);
-                return add_pointwise(p2, rm, "main:pointwise3", {rsum3b, inputs[2]}, single_pointwise("add"));
+                auto rsum3 =
+                    rm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", axes}}), sub2);
+                auto rsum3b = rm->add_instruction(
+                    migraphx::make_op("multibroadcast", {{"out_lens", s3.lens()}}), rsum3);
+                return add_pointwise(
+                    p2, rm, "main:pointwise3", {rsum3b, inputs[2]}, single_pointwise("add"));
             });
         auto freducer =
             mm->add_instruction(migraphx::make_op("reshape", {{"dims", s2.lens()}}), freduce);


### PR DESCRIPTION
We already do the fusion when a broadcast precedes a reshape, but this also handles the case when the broadcast is after the reshape. This fixes a TODO in the test.