### PR TITLE
Fix remove rocblas tests

### DIFF
--- a/src/targets/gpu/include/migraphx/gpu/rocblas.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/rocblas.hpp
@@ -38,13 +38,13 @@ using rocblas_handle_ptr = MIGRAPHX_MANAGE_PTR(rocblas_handle, rocblas_destroy_h
 
 rocblas_handle_ptr create_rocblas_handle_ptr();
 rocblas_handle_ptr create_rocblas_handle_ptr(hipStream_t s);
-
+#endif
 struct context;
 
 MIGRAPHX_GPU_EXPORT bool get_compute_fp32_flag();
 
 MIGRAPHX_GPU_EXPORT bool rocblas_fp8_available();
-#endif
+
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/targets/gpu/rocblas.cpp
+++ b/src/targets/gpu/rocblas.cpp
@@ -48,7 +48,7 @@ rocblas_handle_ptr create_rocblas_handle_ptr(hipStream_t s)
     rocblas_set_stream(rb.get(), s);
     return rb;
 }
-
+#endif
 bool get_compute_fp32_flag()
 {
     const auto device_name = trim(split_string(get_device_name(), ':').front());
@@ -57,13 +57,17 @@ bool get_compute_fp32_flag()
 
 bool rocblas_fp8_available()
 {
-#ifndef MIGRAPHX_USE_ROCBLAS_FP8_API
-    return false;
-#else
-    return gfx_has_fp8_intrinsics();
-#endif
+    #if MIGRAPHX_USE_ROCBLAS
+        #ifndef MIGRAPHX_USE_ROCBLAS_FP8_API
+            return false;
+        #else
+            return gfx_has_fp8_intrinsics();
+        #endif
+    #else
+        return false;
+    #endif
 }
-#endif
+
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/targets/gpu/rocblas.cpp
+++ b/src/targets/gpu/rocblas.cpp
@@ -57,15 +57,15 @@ bool get_compute_fp32_flag()
 
 bool rocblas_fp8_available()
 {
-    #if MIGRAPHX_USE_ROCBLAS
-        #ifndef MIGRAPHX_USE_ROCBLAS_FP8_API
-            return false;
-        #else
-            return gfx_has_fp8_intrinsics();
-        #endif
-    #else
-        return false;
-    #endif
+#if MIGRAPHX_USE_ROCBLAS
+#ifndef MIGRAPHX_USE_ROCBLAS_FP8_API
+    return false;
+#else
+    return gfx_has_fp8_intrinsics();
+#endif
+#else
+    return false;
+#endif
 }
 
 } // namespace gpu

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -104,9 +104,9 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
         unsupported_fp8_ops.insert("quant_dot");
     }
 #else
-        // mlir doesn't support fp8 dot
-        unsupported_fp8_ops.insert("dot");
-        unsupported_fp8_ops.insert("quant_dot");
+    // mlir doesn't support fp8 dot
+    unsupported_fp8_ops.insert("dot");
+    unsupported_fp8_ops.insert("quant_dot");
 #endif
     // MIOpen doesn't have support for fp8 pooling yet.
     unsupported_fp8_ops.insert("pooling");

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -103,6 +103,10 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
         unsupported_fp8_ops.insert("dot");
         unsupported_fp8_ops.insert("quant_dot");
     }
+#else
+        // mlir doesn't support fp8 dot
+        unsupported_fp8_ops.insert("dot");
+        unsupported_fp8_ops.insert("quant_dot");
 #endif
     // MIOpen doesn't have support for fp8 pooling yet.
     unsupported_fp8_ops.insert("pooling");

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -97,17 +97,11 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
     unsupported_types.erase(shape::type_t::tuple_type);
     // whiltelist supported Ops for the FP8
     std::set<std::string> unsupported_fp8_ops = {};
-#if MIGRAPHX_USE_ROCBLAS
     if(not gpu::rocblas_fp8_available())
     {
         unsupported_fp8_ops.insert("dot");
         unsupported_fp8_ops.insert("quant_dot");
     }
-#else
-    // mlir doesn't support fp8 dot
-    unsupported_fp8_ops.insert("dot");
-    unsupported_fp8_ops.insert("quant_dot");
-#endif
     // MIOpen doesn't have support for fp8 pooling yet.
     unsupported_fp8_ops.insert("pooling");
     if(not gpu::gfx_has_fp8_intrinsics())

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/test/gpu/gemm_tune.cpp
+++ b/test/gpu/gemm_tune.cpp
@@ -182,7 +182,6 @@ TEST_CASE(gemm_tune_strided_lowered)
     EXPECT(0 == solution_idx.to<std::size_t>());
 #endif
 }
-#endif
 
 TEST_CASE(gemm_tune_invalid_sol_index)
 {
@@ -223,5 +222,6 @@ TEST_CASE(gemm_tune_invalid_sol_index)
     EXPECT(0 != solution_idx.to<std::size_t>());
 #endif
 }
+#endif
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
- Added unsupported fp8 type for dot in case when MIGRAPHX_USE_ROCBLAS is OFF since mlir dot doesn't support fp8
- execute gemm tune tests when MIGRAPHX_USE_ROCBLAS is ON since they use rocBLAS

@apwojcik 