### PR TITLE
Move up pybind to support new builds of ONNX Runtime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@
 google/protobuf@v3.19.0 -DCMAKE_POSITION_INDEPENDENT_CODE=On -X subdir -Dprotobuf_BUILD_TESTS=Off
 nlohmann/json@v3.8.0
 ROCm/half@rocm-5.6.0
-pybind/pybind11@d159a563383d10c821ba7b2a71905d1207db6de4 --build
+pybind/pybind11@3e9dfa2866941655c56877882565e7577de6fc7b --build
 msgpack/msgpack-c@cpp-3.3.0 -DMSGPACK_BUILD_TESTS=Off
 sqlite3@3.43.2 -DCMAKE_POSITION_INDEPENDENT_CODE=On
 ROCm/composable_kernel@57cdd70b7cb14e5e3b60cd9a5f96ba8dc343763e -DCK_BUILD_JIT_LIB=On -DCMAKE_POSITION_INDEPENDENT_CODE=On


### PR DESCRIPTION
We build pybind as part of the requirements.txt file.  The commit hash is from 2020.  I discovered this 2020 version is now incompatible with upstream ONNX Runtime.  I moved the commit hash to the lasted tagged release March 2024.  Now ORT tip builds fine