### PR TITLE
Trigger only when rocMLIR-sync-* merged

### DIFF
--- a/.github/workflows/sync_rocMLIR.yaml
+++ b/.github/workflows/sync_rocMLIR.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 7 * * sun'
   pull_request:
-    branches: [develop]
+    branches: [rocMLIR-sync-*]
     types: [synchronize, closed]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Fixing trigger workflow only on PR merge from rocMLIR-sync branches