### PR TITLE
Enable test_mod<migraphx::shape::half_type> verify test

### DIFF
--- a/test/verify/test_fmod_mod.cpp
+++ b/test/verify/test_fmod_mod.cpp
@@ -80,6 +80,5 @@ struct test_mod : verify_program<test_mod<DType>>
 };
 
 template struct test_mod<migraphx::shape::float_type>;
-// TODO: Fix half type test
-// template struct test_mod<migraphx::shape::half_type>;
+template struct test_mod<migraphx::shape::half_type>;
 template struct test_mod<migraphx::shape::fp8e4m3fnuz_type>;


### PR DESCRIPTION
This is a follow up on https://github.com/ROCm/AMDMIGraphX/pull/3086 . That change fixed the `test_mod<migraphx::shape::half_type>` verify test as well. We can enable it now.
Fixes https://github.com/ROCm/AMDMIGraphX/issues/2488