### PR TITLE
Modify parse_shrink to remove redundant convert operations

### DIFF
--- a/src/onnx/parse_shrink.cpp
+++ b/src/onnx/parse_shrink.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,11 +66,8 @@ struct parse_shrink : op_parser<parse_shrink>
         auto cond2_b = info.add_common_op("greater", x, lit_lambd);
         auto cond2   = info.add_common_op("logical_and", cond2_a, cond2_b);
 
-        auto mul1 = info.add_instruction(make_op("convert", {{"target_type", x_type}}), cond1);
-        auto mul2 = info.add_instruction(make_op("convert", {{"target_type", x_type}}), cond2);
-
-        auto first  = info.add_common_op("mul", mul1, x_plus_bias);
-        auto second = info.add_common_op("mul", mul2, x_min_bias);
+        auto first  = info.add_common_op("mul", cond1, x_plus_bias);
+        auto second = info.add_common_op("mul", cond2, x_min_bias);
         auto ret    = info.add_common_op("add", first, second);
         if(ret->get_shape().type() != x_type)
         {

--- a/test/onnx/parse/shrink_hard_test.cpp
+++ b/test/onnx/parse/shrink_hard_test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,13 +44,8 @@ TEST_CASE(shrink_hard_test)
     auto cond2_b = add_common_op(*mm, migraphx::make_op("greater"), {x, lit_lambd});
     auto cond2   = add_common_op(*mm, migraphx::make_op("logical_and"), {cond2_a, cond2_b});
 
-    auto mul1 = mm->add_instruction(
-        migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), cond1);
-    auto mul2 = mm->add_instruction(
-        migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), cond2);
-
-    auto first  = add_common_op(*mm, migraphx::make_op("mul"), {mul1, x_plus_bias});
-    auto second = add_common_op(*mm, migraphx::make_op("mul"), {mul2, x_min_bias});
+    auto first  = add_common_op(*mm, migraphx::make_op("mul"), {cond1, x_plus_bias});
+    auto second = add_common_op(*mm, migraphx::make_op("mul"), {cond2, x_min_bias});
     add_common_op(*mm, migraphx::make_op("add"), {first, second});
     auto prog = optimize_onnx("shrink_hard_test.onnx");
     EXPECT(p == prog);

--- a/test/onnx/parse/shrink_int8_test.cpp
+++ b/test/onnx/parse/shrink_int8_test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,13 +44,8 @@ TEST_CASE(shrink_int8_test)
     auto cond2_b = add_common_op(*mm, migraphx::make_op("greater"), {x, lit_lambd});
     auto cond2   = add_common_op(*mm, migraphx::make_op("logical_and"), {cond2_a, cond2_b});
 
-    auto mul1 = mm->add_instruction(
-        migraphx::make_op("convert", {{"target_type", migraphx::shape::int8_type}}), cond1);
-    auto mul2 = mm->add_instruction(
-        migraphx::make_op("convert", {{"target_type", migraphx::shape::int8_type}}), cond2);
-
-    auto first  = add_common_op(*mm, migraphx::make_op("mul"), {mul1, x_plus_bias});
-    auto second = add_common_op(*mm, migraphx::make_op("mul"), {mul2, x_min_bias});
+    auto first  = add_common_op(*mm, migraphx::make_op("mul"), {cond1, x_plus_bias});
+    auto second = add_common_op(*mm, migraphx::make_op("mul"), {cond2, x_min_bias});
     auto ret    = add_common_op(*mm, migraphx::make_op("add"), {first, second});
     mm->add_instruction(migraphx::make_op("convert", {{"target_type", migraphx::shape::int8_type}}),
                         ret);


### PR DESCRIPTION
This modifies parse_shrink to remove redundant convert operations and update tests.