### PR TITLE
Fix input args capture when replacing split module

### DIFF
--- a/src/targets/gpu/jit/mlir.cpp
+++ b/src/targets/gpu/jit/mlir.cpp
@@ -135,7 +135,7 @@ struct mlir_compiler : compiler<mlir_compiler>
         auto precompiled_inputs = precompile_ins->inputs();
         return {
             cobjs, [=](module& m, instruction_ref ins, const std::vector<operation>& ops) {
-                auto compiled_inputs    = ins->inputs();
+                auto compiled_inputs = ins->inputs();
                 std::unordered_map<instruction_ref, instruction_ref> inputs_rep_map;
                 for(const auto i : range(precompiled_inputs.size()))
                 {

--- a/src/targets/gpu/jit/mlir.cpp
+++ b/src/targets/gpu/jit/mlir.cpp
@@ -132,10 +132,10 @@ struct mlir_compiler : compiler<mlir_compiler>
         std::vector<operation> cobjs(mcos.size());
         std::transform(
             mcos.begin(), mcos.end(), cobjs.begin(), [](const auto& mco) { return mco.cop; });
+        auto precompiled_inputs = precompile_ins->inputs();
         return {
             cobjs, [=](module& m, instruction_ref ins, const std::vector<operation>& ops) {
                 auto compiled_inputs    = ins->inputs();
-                auto precompiled_inputs = precompile_ins->inputs();
                 std::unordered_map<instruction_ref, instruction_ref> inputs_rep_map;
                 for(const auto i : range(precompiled_inputs.size()))
                 {


### PR DESCRIPTION
Fixes Compilation for BERT model. 

Current logic is capturing "precompiled_instruction" which is a pointer to instruction. 

Replacement requires access to inputs to the precompiled_instruction.  Need to capture those instead, otherwise they will get replaced out during compilation process. 