### PR TITLE
Make libmigraphx_onnx.so a private library

### DIFF
--- a/src/onnx/CMakeLists.txt
+++ b/src/onnx/CMakeLists.txt
@@ -48,5 +48,6 @@ endif()
 target_link_libraries(migraphx_onnx PUBLIC migraphx)
 
 rocm_install_targets(
+  PRIVATE
   TARGETS migraphx_onnx
 )


### PR DESCRIPTION
Since libmigraphx_onnx.so has unstable ABI, we would like to make it private. This was missed in the earlier change #3108.