### PR TITLE
Add onnx_options external data path setter

### DIFF
--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -162,6 +162,11 @@ void set_default_dyn_dim_value(onnx_options& options, const shape::dynamic_dimen
 void set_default_loop_iterations(onnx_options& options, int64_t value)
 {
     options.max_loop_iterations = value;
+}
+
+void set_external_data_path(onnx_options& options, const char* external_data_path)
+{
+    options.external_data_path = std::string(external_data_path);
 }
 
 void set_limit_loop_iterations(onnx_options& options, int64_t value)
@@ -1916,6 +1921,18 @@ migraphx_onnx_options_set_limit_loop_iterations(migraphx_onnx_options_t onnx_opt
         if(onnx_options == nullptr)
             MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter onnx_options: Null pointer");
         migraphx::set_limit_loop_iterations((onnx_options->object), (value));
+    });
+    return api_error_result;
+}
+
+extern "C" migraphx_status
+migraphx_onnx_options_set_external_data_path(migraphx_onnx_options_t onnx_options,
+                                             const char* external_data_path)
+{
+    auto api_error_result = migraphx::try_([&] {
+        if(onnx_options == nullptr)
+            MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter onnx_options: Null pointer");
+        migraphx::set_external_data_path((onnx_options->object), (external_data_path));
     });
     return api_error_result;
 }

--- a/src/api/include/migraphx/migraphx.h
+++ b/src/api/include/migraphx/migraphx.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -517,6 +517,9 @@ MIGRAPHX_C_EXPORT migraphx_status migraphx_onnx_options_set_default_loop_iterati
 
 MIGRAPHX_C_EXPORT migraphx_status migraphx_onnx_options_set_limit_loop_iterations(
     migraphx_onnx_options_t onnx_options, int64_t value);
+
+MIGRAPHX_C_EXPORT migraphx_status migraphx_onnx_options_set_external_data_path(
+    migraphx_onnx_options_t onnx_options, const char* external_data_path);
 
 MIGRAPHX_C_EXPORT migraphx_status
 migraphx_file_options_destroy(migraphx_file_options_t file_options);

--- a/src/api/include/migraphx/migraphx.hpp
+++ b/src/api/include/migraphx/migraphx.hpp
@@ -273,8 +273,9 @@ struct handle_lookup
 #endif
 
 template <class T>
-using as_handle = decltype(
-    migraphx_adl_handle_lookup(holder<std::remove_cv_t<std::remove_pointer_t<T>>>{}).get());
+using as_handle =
+    decltype(migraphx_adl_handle_lookup(holder<std::remove_cv_t<std::remove_pointer_t<T>>>{})
+                 .get());
 
 struct own
 {
@@ -1026,9 +1027,9 @@ struct modules : MIGRAPHX_HANDLE_BASE(modules)
 struct module
 {
     MIGRAPHX_DEPRECATED("Constructor without lifetime annotation is deprecated.")
-    module(migraphx_module* m) : mm(std::shared_ptr<migraphx_module*>(), m) {}
+    module(migraphx_module* m) :mm(std::shared_ptr<migraphx_module*>(), m) {}
 
-    module(migraphx_module* m, borrow) : mm(std::shared_ptr<migraphx_module*>(), m) {}
+    module(migraphx_module* m, borrow) :mm(std::shared_ptr<migraphx_module*>(), m) {}
 
     template <class T>
     module(migraphx_module* m, share<T> b) : mm(b.alias(m))
@@ -1343,6 +1344,14 @@ struct onnx_options : MIGRAPHX_HANDLE_BASE(onnx_options)
     {
         call(&migraphx_onnx_options_set_limit_loop_iterations, this->get_handle_ptr(), value);
     }
+
+    /// Set absolute path for external data files
+    void set_external_data_path(const std::string& external_data_path)
+    {
+        call(&migraphx_onnx_options_set_external_data_path,
+             this->get_handle_ptr(),
+             external_data_path.c_str());
+    }
 };
 
 /// Parse an onnx file into a migraphx program
@@ -1509,8 +1518,8 @@ quantize_int8(const program& prog, const target& ptarget, const quantize_int8_op
 
 struct experimental_custom_op_base
 {
-    experimental_custom_op_base()                                   = default;
-    experimental_custom_op_base(const experimental_custom_op_base&) = default;
+    experimental_custom_op_base()                                              = default;
+    experimental_custom_op_base(const experimental_custom_op_base&)            = default;
     experimental_custom_op_base& operator=(const experimental_custom_op_base&) = default;
     virtual ~experimental_custom_op_base()                                     = default;
 

--- a/src/api/migraphx.py
+++ b/src/api/migraphx.py
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -353,6 +353,11 @@ def onnx_options(h):
         'set_limit_loop_iterations',
         api.params(value='int64_t'),
         invoke='migraphx::set_limit_loop_iterations($@)',
+    )
+    h.method(
+        'set_external_data_path',
+        api.params(external_data_path='const char*'),
+        invoke='migraphx::set_external_data_path($@)',
     )
 
 

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -520,7 +520,8 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
            std::unordered_map<std::string, std::vector<migraphx::shape::dynamic_dimension>>
                map_dyn_input_dims,
            bool skip_unknown_operators,
-           bool print_program_on_error) {
+           bool print_program_on_error,
+           const std::string& external_data_path) {
             migraphx::onnx_options options;
             options.default_dim_value      = default_dim_value;
             options.default_dyn_dim_value  = default_dyn_dim_value;
@@ -528,6 +529,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             options.map_dyn_input_dims     = map_dyn_input_dims;
             options.skip_unknown_operators = skip_unknown_operators;
             options.print_program_on_error = print_program_on_error;
+            options.external_data_path     = external_data_path;
             return migraphx::parse_onnx_buffer(onnx_buffer, options);
         },
         "Parse onnx file",
@@ -538,7 +540,8 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         py::arg("map_dyn_input_dims") =
             std::unordered_map<std::string, std::vector<migraphx::shape::dynamic_dimension>>(),
         py::arg("skip_unknown_operators") = false,
-        py::arg("print_program_on_error") = false);
+        py::arg("print_program_on_error") = false,
+        py::arg("external_data_path")     = "");
 
     m.def(
         "load",

--- a/tools/api/api.cpp
+++ b/tools/api/api.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -164,6 +164,11 @@ void set_default_loop_iterations(onnx_options& options, int64_t value)
     options.max_loop_iterations = value;
 }
 
+void set_external_data_path(onnx_options& options, const char* external_data_path)
+{
+    options.external_data_path = std::string(external_data_path);
+}
+
 void set_limit_loop_iterations(onnx_options& options, int64_t value)
 {
     options.limit_max_iterations = value;
@@ -231,7 +236,7 @@ void quantize_fp16_with_op_names(program& prog, std::vector<std::string>& names)
 
 struct quantize_int8_options
 {
-    std::vector<parameter_map> calibration = {};
+    std::vector<parameter_map> calibration   = {};
     std::unordered_set<std::string> op_names = {};
 };
 

--- a/tools/api/migraphx.h
+++ b/tools/api/migraphx.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
There was no support for setting external_data_path property in onnx_options structure. This is needed so that this path cen be set from onnxruntime. 