### PR TITLE
Dont copy inner storage in make_inner_slice

### DIFF
--- a/src/targets/gpu/kernels/include/migraphx/kernels/reduce.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/reduce.hpp
@@ -331,7 +331,7 @@ template <class Derived>
 struct reducer_base
 {
     template <class T>
-    __device__ auto make_inner_slice(T x) const
+    __device__ decltype(auto) make_inner_slice(T&& x) const
     {
         if constexpr(is_inner_storage<T>{})
         {


### PR DESCRIPTION
This will allow us to modify the inner storage as a possible optimization.