### PR TITLE
Improve mul_add const folding with broadcasted matrix

### DIFF
--- a/src/optimize_module.cpp
+++ b/src/optimize_module.cpp
@@ -38,7 +38,7 @@ void optimize_module::apply(module_pass_manager& mpm) const
     for(int i = 0; i < 2; i++)
     {
         // loop to further optimize after initial transformations
-        for(int j = 0; j < 2; j++)
+        for(int j = 0; j < 3; j++)
         {
             mpm.run_pass(simplify_reshapes{});
             mpm.run_pass(eliminate_convert{});

--- a/test/optimize_module_test.cpp
+++ b/test/optimize_module_test.cpp
@@ -144,7 +144,7 @@ TEST_CASE(mul_add_transpose_dot)
     migraphx::module lit_mod;
     {
         auto lit1_ins  = lit_mod.add_literal(lit1);
-        auto lit1_b = lit_mod.add_instruction(
+        auto lit1_b    = lit_mod.add_instruction(
             migraphx::make_op("broadcast", {{"axis", 0}, {"out_lens", {64, 64}}}), lit1_ins);
 
         auto lit3_ins = lit_mod.add_literal(lit3);
@@ -171,8 +171,9 @@ TEST_CASE(mul_add_transpose_dot)
             migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), in1);
 
         auto lit13_ins = m2.add_literal(lit13);
-        auto lit13_b = m2.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 64, 64}}}), lit13_ins);
-        auto dot       = m2.add_instruction(migraphx::make_op("dot"), in_tp, lit13_b);
+        auto lit13_b   = m2.add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 64, 64}}}), lit13_ins);
+        auto dot = m2.add_instruction(migraphx::make_op("dot"), in_tp, lit13_b);
 
         auto lit23_ins = m2.add_literal(lit23);
         auto lit23_mb  = m2.add_instruction(


### PR DESCRIPTION
Applying more iterations in `optimize_module` before doing propagate_const helps preserve the broadcasted matrix when const folding the mul_add with dot. 

With the B matrix broadcasted we can use a a regular gemm instead of a batched gemm which should be faster.