### PR TITLE
Revert fusion for gfx941/gfx942

### DIFF
--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -167,7 +167,7 @@ struct fusion
 const std::unordered_set<std::string>& get_supported_archs()
 {
     static std::unordered_set<std::string> supported_archs{
-        "gfx900", "gfx906", "gfx908", "gfx1030", "gfx940", "gfx941", "gfx942"};
+        "gfx900", "gfx906", "gfx908", "gfx1030"};
     return supported_archs;
 }
 #if MIGRAPHX_USE_MIOPEN

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -167,7 +167,7 @@ struct fusion
 const std::unordered_set<std::string>& get_supported_archs()
 {
     static std::unordered_set<std::string> supported_archs{
-        "gfx900", "gfx906", "gfx908", "gfx1030"};
+        "gfx900", "gfx906", "gfx908", "gfx1030", "gfx940"};
     return supported_archs;
 }
 #if MIGRAPHX_USE_MIOPEN


### PR DESCRIPTION
MIOpen fusions are causing perf drops for certain models. 
Disabling fusion on Gfx941/2 for now 

Reverts some of the changes from earlier PR
https://github.com/ROCm/AMDMIGraphX/pull/3084