### PR TITLE
Fix bug in 1arg dynamic reshape

### DIFF
--- a/src/include/migraphx/op/reshape.hpp
+++ b/src/include/migraphx/op/reshape.hpp
@@ -76,22 +76,24 @@ struct reshape
         const bool has_negative_dim_attr = neg_dim_num < dims.size();
         // construct output dynamic shape from dims attribute
         std::vector<shape::dynamic_dimension> output_dyn_dims(dims.size());
-        std::transform(dims.begin(),
-                       dims.end(),
-                       input_dyn_dims.begin(),
-                       output_dyn_dims.begin(),
-                       [](auto dim, auto input_dyn_dim) -> shape::dynamic_dimension {
-                           if(dim == 0)
-                           {
-                               return input_dyn_dim;
-                           }
-                           if(dim == -1)
-                           {
-                               return {1, 1};
-                           }
-                           std::size_t u_dim = dim;
-                           return {u_dim, u_dim};
-                       });
+        // NOTE: input_dyn_dims.size() may not equal dims.size()
+        for(std::size_t i = 0; i < dims.size(); ++i)
+        {
+            auto d = dims.at(i);
+            if(d == 0)
+            {
+                output_dyn_dims.at(i) = input_dyn_dims.at(i);
+            }
+            else if(d == -1)
+            {
+                output_dyn_dims.at(i) = {1, 1};
+            }
+            else
+            {
+                std::size_t u_dim     = d;
+                output_dyn_dims.at(i) = {u_dim, u_dim};
+            }
+        }
 
         if(has_negative_dim_attr)
         {

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -3270,6 +3270,22 @@ TEST_CASE(reshape_dyn_1in_negative_1_dims_1)
     expect_shape(output, migraphx::make_op("reshape", {{"dims", {0, -1, 2, 2}}}), input);
 }
 
+TEST_CASE(reshape_dyn_1in_negative_1_dims_2)
+{
+    migraphx::shape input{migraphx::shape::float_type, {{1, 4}, {24, 24}, {2, 8}, {2, 8}}};
+    std::vector<migraphx::shape::dynamic_dimension> out_dyn_dims = {{1, 4}, {24, 24}, {4, 64}};
+    migraphx::shape output{migraphx::shape::float_type, out_dyn_dims};
+    expect_shape(output, migraphx::make_op("reshape", {{"dims", {0, 0, -1}}}), input);
+}
+
+TEST_CASE(reshape_dyn_1in_negative_1_dims_3)
+{
+    migraphx::shape input{migraphx::shape::float_type, {{1, 4}, {24, 24}}};
+    std::vector<migraphx::shape::dynamic_dimension> out_dyn_dims = {{1, 4}, {4, 4}, {3, 3}, {2, 2}};
+    migraphx::shape output{migraphx::shape::float_type, out_dyn_dims};
+    expect_shape(output, migraphx::make_op("reshape", {{"dims", {0, 4, 3, 2}}}), input);
+}
+
 // note how non-fixed dynamic dimension on axis=0 goes to 2 from `dims` attribute
 // code assumes that this will work at run-time
 TEST_CASE(reshape_dyn_1in_dyn_to_fixed)


### PR DESCRIPTION
* Fixes a bug when the input shape and `dims` attribute have a different number of dimensions
* Fixes bug seen in bertsquad-12