### PR TITLE
Disable FP8 gemm-add test temporarily

### DIFF
--- a/test/verify/test_gemm_add.cpp
+++ b/test/verify/test_gemm_add.cpp
@@ -57,4 +57,6 @@ struct test_gemm_add : verify_program<test_gemm_add<DType>>
 
 template struct test_gemm_add<migraphx::shape::float_type>;
 template struct test_gemm_add<migraphx::shape::half_type>;
-template struct test_gemm_add<migraphx::shape::fp8e4m3fnuz_type>;
+// TODO: Investigate failure: rocblas_invoke: rocBLAS call failed with status 2
+//       Github Issue: #3199
+// template struct test_gemm_add<migraphx::shape::fp8e4m3fnuz_type>;


### PR DESCRIPTION
This PR disables the FP8 gemm-add test temporarily to fix the issue with rocblas failure with exhaustive tune.