### PR TITLE
fix warning about wrong use of export

### DIFF
--- a/src/include/migraphx/generate.hpp
+++ b/src/include/migraphx/generate.hpp
@@ -33,7 +33,7 @@
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
-enum class MIGRAPHX_EXPORT random_mode
+enum class random_mode
 {
     legacy,
     random


### PR DESCRIPTION
We are turning on -Werror on Windows builds. That warning breaks it all. We need this PR in 6.2, too.