### PR TITLE
Windows/fix memory issue

### DIFF
--- a/src/targets/gpu/hip.cpp
+++ b/src/targets/gpu/hip.cpp
@@ -108,10 +108,10 @@ static host_ptr_cache& get_host_ptr_cache()
 
 std::shared_ptr<void> allocate_gpu(std::size_t sz, bool host = false)
 {
-    #ifndef _WIN32
+#ifndef _WIN32
     if(sz > get_available_gpu_memory())
         MIGRAPHX_THROW("Memory not available to allocate buffer: " + std::to_string(sz));
-    #endif
+#endif
     void* alloc_ptr = nullptr;
     auto status     = host ? hipHostMalloc(&alloc_ptr, sz) : hipMalloc(&alloc_ptr, sz);
     if(status != hipSuccess)

--- a/src/targets/gpu/hip.cpp
+++ b/src/targets/gpu/hip.cpp
@@ -108,8 +108,8 @@ static host_ptr_cache& get_host_ptr_cache()
 
 std::shared_ptr<void> allocate_gpu(std::size_t sz, bool host = false)
 {
-    if(sz > get_available_gpu_memory())
-        MIGRAPHX_THROW("Memory not available to allocate buffer: " + std::to_string(sz));
+    //if(sz > get_available_gpu_memory())
+       //MIGRAPHX_THROW("Memory not available to allocate buffer: " + std::to_string(sz));
     void* alloc_ptr = nullptr;
     auto status     = host ? hipHostMalloc(&alloc_ptr, sz) : hipMalloc(&alloc_ptr, sz);
     if(status != hipSuccess)

--- a/src/targets/gpu/hip.cpp
+++ b/src/targets/gpu/hip.cpp
@@ -108,8 +108,10 @@ static host_ptr_cache& get_host_ptr_cache()
 
 std::shared_ptr<void> allocate_gpu(std::size_t sz, bool host = false)
 {
-    //if(sz > get_available_gpu_memory())
-       //MIGRAPHX_THROW("Memory not available to allocate buffer: " + std::to_string(sz));
+    #ifndef _WIN32
+    if(sz > get_available_gpu_memory())
+       MIGRAPHX_THROW("Memory not available to allocate buffer: " + std::to_string(sz));
+    #endif
     void* alloc_ptr = nullptr;
     auto status     = host ? hipHostMalloc(&alloc_ptr, sz) : hipMalloc(&alloc_ptr, sz);
     if(status != hipSuccess)

--- a/src/targets/gpu/hip.cpp
+++ b/src/targets/gpu/hip.cpp
@@ -110,7 +110,7 @@ std::shared_ptr<void> allocate_gpu(std::size_t sz, bool host = false)
 {
     #ifndef _WIN32
     if(sz > get_available_gpu_memory())
-       MIGRAPHX_THROW("Memory not available to allocate buffer: " + std::to_string(sz));
+        MIGRAPHX_THROW("Memory not available to allocate buffer: " + std::to_string(sz));
     #endif
     void* alloc_ptr = nullptr;
     auto status     = host ? hipHostMalloc(&alloc_ptr, sz) : hipMalloc(&alloc_ptr, sz);


### PR DESCRIPTION
Disabling the check for 'get_available_gpu_memory' on Windows, which relies on hipMemGetInfo to determine free memory.