### PR TITLE
Allow PR from fork to access repo token

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -1,7 +1,7 @@
 name: MIGraphX Performance Tests
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [develop]
     types: [opened, synchronize, closed]
   schedule:


### PR DESCRIPTION
This change should allow PRs from forks to access repo token.