### PR TITLE
Fix --enable-offload-copy warning

### DIFF
--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -531,12 +531,12 @@ struct compiler
                            "passing "
                            "`--enable-offload-copy` if program run fails.\n";
                 }
-                else if(co.offload_copy)
+                else if(not is_offload_copy_set(p) and co.offload_copy)
                 {
                     std::cout << "[WARNING]: MIGraphX program was likely compiled without "
                                  "offload_copy set, Try "
                                  "removing "
-                                 "`--enable-offload-copy` flag if passed to driver, if program run "
+                                 "`--enable-offload-copy` if program run "
                                  "fails.\n";
                 }
             }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -772,9 +772,9 @@ void program::from_value(const value& v)
     auto migx_version = v.at("migraphx_version").to<std::string>();
     if(migx_version != get_migraphx_version())
     {
-        std::cout << "WARNING: MXR File was created using MIGraphX version: " << migx_version
+        std::cout << "[WARNING]: MXR File was created using MIGraphX version: " << migx_version
                   << ", while installed MIGraphX is at version: " << get_migraphx_version()
-                  << ", operators implementation could be mismatched.";
+                  << ", operators implementation could be mismatched.\n";
     }
 
     migraphx::from_value(v.at("targets"), this->impl->targets);


### PR DESCRIPTION
Quick fix in logic to ensure warning doesn't appear when a model built with `--enable-offload-copy` has the flag passed in when run. Also adds newline to different warning for readability.

Closes #2478.