### PR TITLE
Fixed the ROCM Install Guide Url

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ To use MIGraphX, you can install the binaries or build from source code. Refer t
 for Ubuntu installation instructions (we'll provide instructions for other Linux distributions in the future).
 
 > [!NOTE] 
-> You must [install ROCm](https://rocm.docs.amd.com/en/latest/deploy/linux/quick_start.html) before
+> You must [install ROCm](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/index.html) before
 > installing MIGraphX.
 
 ## Installing from binaries


### PR DESCRIPTION
Changed from 'https://rocm.docs.amd.com/en/latest/deploy/linux/quick_start.html'  (404 not found)
to 'https://rocm.docs.amd.com/projects/install-on-linux/en/latest/index.html'