### PR TITLE
update python module versioning for dev builds

### DIFF
--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -613,8 +613,13 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
 #ifdef VERSION_INFO
     m.attr("__version__") = VERSION_INFO;
 #else
-    m.attr("__version__") = std::to_string(MIGRAPHX_VERSION_MAJOR) + "." +
-                            std::to_string(MIGRAPHX_VERSION_MINOR) + "." +
-                            std::to_string(MIGRAPHX_VERSION_PATCH) + ".dev";
+    auto version_string = std::to_string(MIGRAPHX_VERSION_MAJOR) + "." +
+                          std::to_string(MIGRAPHX_VERSION_MINOR) + "." +
+                          std::to_string(MIGRAPHX_VERSION_PATCH) + ".dev";
+
+    if(*MIGRAPHX_VERSION_TWEAK)
+        version_string += "+" MIGRAPHX_VERSION_TWEAK;
+
+    m.attr("__version__") = version_string;
 #endif
 }

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -618,7 +618,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
                           std::to_string(MIGRAPHX_VERSION_PATCH) + ".dev";
 
     std::string tweak(MIGRAPHX_VERSION_TWEAK);
-    if(!tweak.empty())
+    if(not tweak.empty())
         version_string += "+" + tweak;
 
     m.attr("__version__") = version_string;

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -43,6 +43,7 @@
 #include <migraphx/op/common.hpp>
 #include <migraphx/float8.hpp>
 #include <migraphx/pass_manager.hpp>
+#include <migraphx/version.h>
 #ifdef HAVE_GPU
 #include <migraphx/gpu/hip.hpp>
 #endif
@@ -612,6 +613,8 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
 #ifdef VERSION_INFO
     m.attr("__version__") = VERSION_INFO;
 #else
-    m.attr("__version__") = "dev";
+    m.attr("__version__") = std::to_string(MIGRAPHX_VERSION_MAJOR) + "." +
+                            std::to_string(MIGRAPHX_VERSION_MINOR) + "." +
+                            std::to_string(MIGRAPHX_VERSION_PATCH) + ".dev";
 #endif
 }

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -617,8 +617,9 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
                           std::to_string(MIGRAPHX_VERSION_MINOR) + "." +
                           std::to_string(MIGRAPHX_VERSION_PATCH) + ".dev";
 
-    if(*MIGRAPHX_VERSION_TWEAK)
-        version_string += "+" MIGRAPHX_VERSION_TWEAK;
+    std::string tweak(MIGRAPHX_VERSION_TWEAK);
+    if(!tweak.empty())
+        version_string += "+" + tweak;
 
     m.attr("__version__") = version_string;
 #endif

--- a/tools/docker/migraphx_with_onnxruntime_pytorch.docker
+++ b/tools/docker/migraphx_with_onnxruntime_pytorch.docker
@@ -6,22 +6,22 @@ ARG PREFIX=/usr/local
 RUN apt update && apt install -y wget
 
 #Aquire and install ROCm
-RUN wget https://repo.radeon.com/amdgpu-install/6.1/ubuntu/jammy/amdgpu-install_6.1.60100-1_all.deb
-RUN apt install -y ./amdgpu-install_6.1.60100-1_all.deb
-RUN amdgpu-install --usecase=rocm -y && rm amdgpu-install_6.1.60100-1_all.deb
+RUN wget https://repo.radeon.com/amdgpu-install/6.1.3/ubuntu/jammy/amdgpu-install_6.1.60103-1_all.deb
+RUN apt install -y ./amdgpu-install_6.1.60103-1_all.deb
+RUN amdgpu-install --usecase=rocm -y && rm amdgpu-install_6.1.60103-1_all.deb
 
 #Install MIGraphX from package manager
 RUN apt install -y migraphx
 
 #Pieces for Onnxruntime for ROCm and MIGraphX Execution Provider Support
-RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1/onnxruntime_rocm-inference-1.17.0-cp310-cp310-linux_x86_64.whl
+
+ RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1.3/onnxruntime_rocm-1.17.0-cp310-cp310-linux_x86_64.whl
 
 #Pieces for pytorch
-RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1/pytorch_triton_rocm-2.1.0%2Brocm6.1.4d510c3a44-cp310-cp310-linux_x86_64.whl
-RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1/torch-2.1.2+rocm6.1-cp310-cp310-linux_x86_64.whl
-RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1/torchvision-0.16.1+rocm6.1-cp310-cp310-linux_x86_64.whl
+RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1.3/pytorch_triton_rocm-2.1.0%2Brocm6.1.3.4d510c3a44-cp310-cp310-linux_x86_64.whl
+RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1.3/torch-2.1.2+rocm6.1.3-cp310-cp310-linux_x86_64.whl
+RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.1.3/torchvision-0.16.1+rocm6.1.3-cp310-cp310-linux_x86_64.whl
 
 #Adjust final path for ability to use rocm components
 ENV PATH=$PATH:/opt/rocm/bin/
-
 


### PR DESCRIPTION
Currently when we do a local build, the python version is just set to "dev". Ie:
```
>>> import migraphx
>>> migraphx.__version__
'dev'
```
This is not very useful. This PR uses the version header file to populate this field properly for dev builds. Refer to https://packaging.python.org/en/latest/discussions/versioning/ for official packaging library recommendation for versioning dev builds/releases.