### PR TITLE
export API symbols from dynamic libraries for MLIR pointwise

### DIFF
--- a/src/include/migraphx/param_utils.hpp
+++ b/src/include/migraphx/param_utils.hpp
@@ -41,7 +41,7 @@ void sort_params(std::vector<instruction_ref>& params);
 // Find the inputs for a module by finding instructions that are mapped to the
 // parameters in the module
 std::vector<instruction_ref>
-find_inputs(const std::unordered_map<instruction_ref, instruction_ref>& map_ins,
+MIGRAPHX_EXPORT find_inputs(const std::unordered_map<instruction_ref, instruction_ref>& map_ins,
             const_module_ref parent,
             const_module_ref sub);
 

--- a/src/include/migraphx/param_utils.hpp
+++ b/src/include/migraphx/param_utils.hpp
@@ -41,9 +41,9 @@ void sort_params(std::vector<instruction_ref>& params);
 // Find the inputs for a module by finding instructions that are mapped to the
 // parameters in the module
 std::vector<instruction_ref>
-MIGRAPHX_EXPORT find_inputs(const std::unordered_map<instruction_ref, instruction_ref>& map_ins,
-            const_module_ref parent,
-            const_module_ref sub);
+    MIGRAPHX_EXPORT find_inputs(const std::unordered_map<instruction_ref, instruction_ref>& map_ins,
+                                const_module_ref parent,
+                                const_module_ref sub);
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx


### PR DESCRIPTION
Export API symbols for find_inputs function used in find_pointwise_mlir struct. Otherwise there will be undefined symbol error during Windows build.

@apwojcik 