### PR TITLE
disable f8 test

### DIFF
--- a/test/verify/test_gemm_add.cpp
+++ b/test/verify/test_gemm_add.cpp
@@ -57,4 +57,4 @@ struct test_gemm_add : verify_program<test_gemm_add<DType>>
 
 template struct test_gemm_add<migraphx::shape::float_type>;
 template struct test_gemm_add<migraphx::shape::half_type>;
-template struct test_gemm_add<migraphx::shape::fp8e4m3fnuz_type>;
+// template struct test_gemm_add<migraphx::shape::fp8e4m3fnuz_type>;


### PR DESCRIPTION
I had put a fix earlier but that works only with private changes. When i tested i had rocBLAS installed with those fixes. 

Unfortunately, rocBLAS doesn't plan to port those changes to public release. Therefore disable this test untill we have alternate route.
https://github.com/ROCm/AMDMIGraphX/pull/3243