### PR TITLE
Maxpool. Kernel of size 1: stride being ignored

### DIFF
--- a/src/include/migraphx/op/pooling.hpp
+++ b/src/include/migraphx/op/pooling.hpp
@@ -331,7 +331,7 @@ struct pooling
                 int end;
                 std::size_t dilated_kernel_dim = dilate_dim(kernel_dims[d_2], dilations[d_2]);
                 // NOLINT
-                if(count_include_pad and (mode != pooling_mode::max))
+                if(count_include_pad and mode == pooling_mode::average)
                 {
                     // Even when using padding, if in ceil_mode a window
                     // could extend beyond the end of both input and

--- a/src/targets/gpu/jit/pooling.cpp
+++ b/src/targets/gpu/jit/pooling.cpp
@@ -45,10 +45,10 @@ namespace migraphx {
 
 extern "C" {
 
-MIGRAPHX_GLOBAL void pooling_kernel(void* in_data, void* output) 
+MIGRAPHX_GLOBAL void pooling_kernel(void* in_data, void* output)
 {
-    transform_args(make_tensors(), rotate_last())(in_data, output)([](auto&&... xs) { 
-        pooling<${count_include_pad}>(${op}, make_window(index_ints<${window}>{}, index_ints<${stride}>{}, index_ints<${padding}>{}), xs...); 
+    transform_args(make_tensors(), rotate_last())(in_data, output)([](auto&&... xs) {
+        pooling<${count_include_pad}>(${op}, make_window(index_ints<${window}>{}, index_ints<${stride}>{}, index_ints<${padding}>{}), xs...);
     });
 }
 

--- a/src/targets/gpu/kernels/include/migraphx/kernels/pooling.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/pooling.hpp
@@ -131,10 +131,8 @@ struct window
     constexpr void visit(Index i, F f) const
     {
         auto win_start = generate_array<diff_int>(rank{}, [&](auto j) {
-            diff_int w   = win[j];
             diff_int dim = i[j];
-            (void)w;
-            MIGRAPHX_ASSERT(w >= 1);
+            MIGRAPHX_ASSERT(win[j] >= 1);
             diff_int s = stride[j];
             diff_int p = padding[j];
             return (dim * s) - p;

--- a/src/targets/gpu/kernels/include/migraphx/kernels/pooling.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/pooling.hpp
@@ -133,7 +133,7 @@ struct window
         auto win_start = generate_array<diff_int>(rank{}, [&](auto j) {
             diff_int w   = win[j];
             diff_int dim = i[j];
-	    (void) w;
+            (void)w;
             MIGRAPHX_ASSERT(w >= 1);
             diff_int s = stride[j];
             diff_int p = padding[j];

--- a/src/targets/gpu/kernels/include/migraphx/kernels/pooling.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/pooling.hpp
@@ -133,9 +133,8 @@ struct window
         auto win_start = generate_array<diff_int>(rank{}, [&](auto j) {
             diff_int w   = win[j];
             diff_int dim = i[j];
+	    (void) w;
             MIGRAPHX_ASSERT(w >= 1);
-            if(w == 1)
-                return dim;
             diff_int s = stride[j];
             diff_int p = padding[j];
             return (dim * s) - p;

--- a/src/targets/gpu/lowering.cpp
+++ b/src/targets/gpu/lowering.cpp
@@ -303,7 +303,8 @@ struct miopen_apply
         apply_map.emplace("pooling", [=](instruction_ref ins) {
             auto&& op   = ins->get_operator();
             auto op_val = op.to_value();
-            if(op_val.at("count_include_pad").to<bool>())
+            if(op_val.at("count_include_pad").to<bool>() and
+               op_val["mode"].to<op::pooling_mode>() == op::pooling_mode::average)
             {
                 return insert_precompile_op(ins);
             }

--- a/test/verify/test_max_pooling_1x1_s2.cpp
+++ b/test/verify/test_max_pooling_1x1_s2.cpp
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "verify_program.hpp"
+#include <migraphx/program.hpp>
+#include <migraphx/generate.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/op/common.hpp>
+
+struct test_max_pooling_1x1_s2 : verify_program<test_max_pooling_1x1_s2>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+
+        auto input =
+            mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 4, 112, 112}});
+        mm->add_instruction(migraphx::make_op("pooling",
+                                              {{"mode", migraphx::op::pooling_mode::max},
+                                               {"padding", {0, 0}},
+                                               {"stride", {2, 2}},
+                                               {"lengths", {1, 1}}}),
+                            input);
+        return p;
+    }
+};

--- a/test/verify/test_max_pooling_1x1_s2.cpp
+++ b/test/verify/test_max_pooling_1x1_s2.cpp
@@ -36,7 +36,7 @@ struct test_max_pooling_1x1_s2 : verify_program<test_max_pooling_1x1_s2>
         auto* mm = p.get_main_module();
 
         auto input =
-            mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 4, 112, 112}});
+            mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 4, 16, 16}});
         mm->add_instruction(migraphx::make_op("pooling",
                                               {{"mode", migraphx::op::pooling_mode::max},
                                                {"padding", {0, 0}},


### PR DESCRIPTION
A Resnet50 model isn't being verified properly. The error stems from a JIT maxpool kernel.
