### PR TITLE
ENV variable MIGRAPHX_VERIFY_DUMP_DIFF

### DIFF
--- a/docs/dev/env_vars.rst
+++ b/docs/dev/env_vars.rst
@@ -314,3 +314,8 @@ Prints the reference and target programs even if the verify tests pass.
 
 Set to "1", "enable", "enabled", "yes", or "true" to use.
 Dumps verify tests to ``.mxr`` files.
+
+.. envvar:: MIGRAPHX_VERIFY_DUMP_DIFF
+
+Set to "1", "enable", "enabled", "yes", or "true" to use.
+Dumps the output of the test (and the reference) results when they differ.

--- a/src/verify_args.cpp
+++ b/src/verify_args.cpp
@@ -24,6 +24,8 @@
 
 #include <migraphx/verify_args.hpp>
 
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_VERIFY_DUMP_DIFF);
+
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
@@ -42,9 +44,9 @@ bool verify_args(const std::string& name,
             // TODO: Check for nans
             std::cout << "FAILED: " << name << std::endl;
             std::cout << "RMS Error: " << rms_error << std::endl;
-            if(ref.size() < 32)
+            if(ref.size() < 32 or enabled(MIGRAPHX_VERIFY_DUMP_DIFF{}))
                 std::cout << "ref:" << ref << std::endl;
-            if(target.size() < 32)
+            if(target.size() < 32 or enabled(MIGRAPHX_VERIFY_DUMP_DIFF{}))
                 std::cout << "target:" << target << std::endl;
             if(verify::range_zero(ref))
                 std::cout << "Ref data is all zeros" << std::endl;


### PR DESCRIPTION
Using this environment variable to dump large set of differing data if test_verify fails. Currently we only do it for upto 32 bytes max.