### PR TITLE
Add --use_rocm flag to Onnxrt build

### DIFF
--- a/tools/build_and_test_onnxrt.sh
+++ b/tools/build_and_test_onnxrt.sh
@@ -31,7 +31,7 @@ pip3 install -r requirements-dev.txt
 # Add newer cmake to the path
 export PATH="/opt/cmake/bin:$PATH"
 export CXXFLAGS="-D__HIP_PLATFORM_AMD__=1 -w"
-./build.sh --config Release  --cmake_extra_defines CMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ --update --build --build_wheel --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --skip_tests --rocm_home /opt/rocm --use_migraphx --migraphx_home /opt/rocm --rocm_version=`cat /opt/rocm/.info/version-dev` --allow_running_as_root
+./build.sh --config Release  --cmake_extra_defines CMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ --update --build --build_wheel --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --skip_tests --use_rocm --rocm_home /opt/rocm --use_migraphx --migraphx_home /opt/rocm --rocm_version=`cat /opt/rocm/.info/version-dev` --allow_running_as_root
 
 cd build/Linux/Release
 #Add test launcher for onnxrt tests


### PR DESCRIPTION
Need to add the use_rocm flag in our build script as our Onnxruntime changes now require that each EP can be built separately or together.