### PR TITLE
Fix Ref implementation of LpPool with Asym padding

### DIFF
--- a/src/insert_pad.cpp
+++ b/src/insert_pad.cpp
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "migraphx/op/common.hpp"
 #include <migraphx/insert_pad.hpp>
 #include <migraphx/program.hpp>
 #include <migraphx/instruction.hpp>
@@ -91,8 +92,12 @@ static void update_pooling(const instruction_ref& input, const instruction_ref& 
     std::copy(pads_l.begin(), pads_l.end(), padding.begin() + 2);
     std::copy(pads_r.begin(), pads_r.end(), padding.begin() + kdims + 2 + 2);
 
-    // maxpool uses lowest value for padding
-    float pad_val = std::numeric_limits<float>::lowest();
+    float pad_val = 0.0f; // for the lpnorm
+    if(op.mode == op::pooling_mode::max)
+    {
+        // maxpool uses lowest value for padding
+        pad_val = std::numeric_limits<float>::lowest();
+    }
     auto pad_op   = m.insert_instruction(ins, op::pad{padding, pad_val}, input);
 
     auto new_inputs    = ins->inputs();

--- a/src/insert_pad.cpp
+++ b/src/insert_pad.cpp
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include "migraphx/op/common.hpp"
 #include <migraphx/insert_pad.hpp>
 #include <migraphx/program.hpp>
 #include <migraphx/instruction.hpp>

--- a/test/ref/pooling.cpp
+++ b/test/ref/pooling.cpp
@@ -605,7 +605,6 @@ TEST_CASE(lppool_l2_norm_test)
 
 TEST_CASE(lppool_l2_norm_test_asym_padding)
 {
-    // L2 norm test
     migraphx::program p;
     auto* mm     = p.get_main_module();
     auto s       = migraphx::shape{migraphx::shape::float_type, {1, 1, 5, 4}};

--- a/test/ref/pooling.cpp
+++ b/test/ref/pooling.cpp
@@ -603,6 +603,35 @@ TEST_CASE(lppool_l2_norm_test)
     EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
 }
 
+TEST_CASE(lppool_l2_norm_test_asym_padding)
+{
+    // L2 norm test
+    migraphx::program p;
+    auto* mm     = p.get_main_module();
+    auto s       = migraphx::shape{migraphx::shape::float_type, {1, 1, 5, 4}};
+    auto op      = migraphx::op::pooling{migraphx::op::pooling_mode::lpnorm};
+    op.lengths   = {2, 1};
+    op.padding   = {1, 0, 0, 0};
+    op.stride    = {1, 1};
+    op.dilations = {1, 1};
+    op.lp_order  = 2;
+
+    std::vector<float> data{0.3, 0.2, 0.4, 0.1, 0.8, 0.5, 0.9,  0.1, 0.1, 0.7,
+                            0.1, 0.6, 0.7, 0.5, 0.1, 0.2, 0.11, 0.2, 0.3, 0.4};
+    auto l0 = mm->add_literal(migraphx::literal{s, data});
+    mm->add_instruction(op, l0);
+    p.compile(migraphx::make_target("ref"));
+    auto result = p.eval({}).back();
+
+    std::vector<float> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    std::vector<float> gold{0.3,        0.2,        0.4,        0.1,        0.8544004,
+                            0.53851646, 0.98488575, 0.14142136, 0.8062258,  0.86023253,
+                            0.9055385,  0.60827625, 0.70710677, 0.86023253, 0.14142136,
+                            0.6324555,  0.70859015, 0.53851646, 0.31622776, 0.44721362};
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+}
+
 TEST_CASE(lppool_dyn_test)
 {
     migraphx::program p;

--- a/test/verify/test_lpnorm_pooling_asym_pad.cpp
+++ b/test/verify/test_lpnorm_pooling_asym_pad.cpp
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "verify_program.hpp"
+#include <migraphx/program.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/op/common.hpp>
+
+struct test_lpnorm_pooling_asym_pad : verify_program<test_lpnorm_pooling_asym_pad>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        auto x   = mm->add_parameter("x", {migraphx::shape::float_type, {1, 1, 5, 4}});
+        mm->add_instruction(migraphx::make_op("pooling",
+                                              {{"mode", migraphx::op::pooling_mode::lpnorm},
+                                               {"padding", {1, 0, 0, 0}},
+                                               {"stride", {1, 1}},
+                                               {"lengths", {2, 1}},
+                                               {"lp_order", 2}}),
+                            x);
+        return p;
+    }
+};


### PR DESCRIPTION
Ref implementation uses "insert_pad" pass to handle padding. 
It didn't initialize padding value for the lppool properly. 