### PR TITLE
Fix matcher Bindings when doing attention fusion

### DIFF
--- a/src/targets/gpu/prefuse_ops.cpp
+++ b/src/targets/gpu/prefuse_ops.cpp
@@ -196,9 +196,10 @@ struct find_gemm_softmax_gemm
                 .bind("gemm1")));
         auto mul   = match::name("mul")(
             match::nargs(2), match::either_arg(0, 1)(match::is_constant().bind("scale"), gemm1));
-        auto add = match::name("add")(is_bias_supported(),
-                                      match::nargs(2),
-                                      match::any_arg(0, 1)(match::none_of(mul).bind("bias")));
+        auto add =
+            match::name("add")(is_bias_supported(),
+                               match::nargs(2),
+                               match::either_arg(0, 1)(match::none_of(mul).bind("bias"), mul));
         auto softmax =
             match::name("softmax")(match::arg(0)(match::any_of(mul, add, gemm1))).bind("softmax");
 


### PR DESCRIPTION
Fixes vicuna compilation failure
Partly Fixes : https://github.com/ROCm/AMDMIGraphX/issues/3317

Traceback (most recent call last):
  File "/src/AMDMIGraphX/tools/accuracy/accuracy_checker.py", line 340, in <module>
    main()
  File "/src/AMDMIGraphX/tools/accuracy/accuracy_checker.py", line 227, in main
    model.compile(
RuntimeError: /src/AMDMIGraphX/src/include/migraphx/matcher.hpp:316: operator[]: Accessing name that wasn't bound in matcher: gemm1