### PR TITLE
Fix matching of concat op in eliminate_concat on the gpu

### DIFF
--- a/src/eliminate_concat.cpp
+++ b/src/eliminate_concat.cpp
@@ -40,8 +40,9 @@ void eliminate_concat::apply(module& m) const
 {
     for(auto ins : iterator_for(m))
     {
+        auto concat_op         = concat_opt.get_concat(ins->get_operator());
         // Look for the concat operator
-        if(ins->name() != concat_opt.name())
+        if(not concat_op.has_value())
             continue;
         // If any inputs are builtin or context free then abort
         // If any inputs are used more than once, then abort since there could
@@ -58,8 +59,7 @@ void eliminate_concat::apply(module& m) const
         // Since we've already checked that the non-axis dimensions are identical
         // we only need to check the first input
         auto lens              = ins->inputs().front()->get_shape().lens();
-        auto concat_op         = concat_opt.get_concat(ins->get_operator());
-        std::size_t axis_index = tune_axis(lens.size(), concat_op.axis, concat_op.name());
+        std::size_t axis_index = tune_axis(lens.size(), concat_op->axis, concat_op->name());
         if(axis_index == 0 or
            std::all_of(lens.begin(), lens.begin() + axis_index, [](auto x) { return x == 1; }))
         {

--- a/src/include/migraphx/concat_opt.hpp
+++ b/src/include/migraphx/concat_opt.hpp
@@ -33,6 +33,7 @@
 
 #include <migraphx/operation.hpp>
 #include <migraphx/op/concat.hpp>
+#include <migraphx/optional.hpp>
 #include <migraphx/config.hpp>
 
 namespace migraphx {
@@ -43,12 +44,10 @@ inline namespace MIGRAPHX_INLINE_NS {
 /// An interface for target-dependent optimization for the concat instruction
 struct concat_optimization
 {
-    /// The name of the target-dependent concat operator
-    std::string name() const;
     /// A name of the target-dependent allocate operator
     std::string allocate() const;
     /// Return the target-independent concat operator
-    op::concat get_concat(const operation& op) const;
+    optional<op::concat> get_concat(const operation& op) const;
 };
 
 #else
@@ -59,11 +58,9 @@ struct concat_optimization
 struct MIGRAPHX_EXPORT concat_optimization
 {
     //
-    std::string name() const;
-    //
     std::string allocate() const;
     //
-    op::concat get_concat(const operation& op) const;
+    optional<op::concat> get_concat(const operation& op) const;
 };
 
 #else
@@ -87,8 +84,7 @@ struct concat_optimization
 
     template <class PrivateDetailTypeErasedT>
     using private_te_constraints_impl =
-        decltype(std::declval<PrivateDetailTypeErasedT>().name(),
-                 std::declval<PrivateDetailTypeErasedT>().allocate(),
+        decltype(std::declval<PrivateDetailTypeErasedT>().allocate(),
                  std::declval<PrivateDetailTypeErasedT>().get_concat(
                      std::declval<const operation&>()),
                  void());
@@ -167,19 +163,13 @@ struct concat_optimization
             return private_detail_te_get_handle().type();
     }
 
-    std::string name() const
-    {
-        assert((*this).private_detail_te_handle_mem_var);
-        return (*this).private_detail_te_get_handle().name();
-    }
-
     std::string allocate() const
     {
         assert((*this).private_detail_te_handle_mem_var);
         return (*this).private_detail_te_get_handle().allocate();
     }
 
-    op::concat get_concat(const operation& op) const
+    optional<op::concat> get_concat(const operation& op) const
     {
         assert((*this).private_detail_te_handle_mem_var);
         return (*this).private_detail_te_get_handle().get_concat(op);
@@ -199,9 +189,8 @@ struct concat_optimization
         virtual std::shared_ptr<private_detail_te_handle_base_type> clone() const = 0;
         virtual const std::type_info& type() const                                = 0;
 
-        virtual std::string name() const                         = 0;
-        virtual std::string allocate() const                     = 0;
-        virtual op::concat get_concat(const operation& op) const = 0;
+        virtual std::string allocate() const                               = 0;
+        virtual optional<op::concat> get_concat(const operation& op) const = 0;
     };
 
     template <typename PrivateDetailTypeErasedT>
@@ -232,11 +221,9 @@ struct concat_optimization
 
         const std::type_info& type() const override { return typeid(private_detail_te_value); }
 
-        std::string name() const override { return private_detail_te_value.name(); }
-
         std::string allocate() const override { return private_detail_te_value.allocate(); }
 
-        op::concat get_concat(const operation& op) const override
+        optional<op::concat> get_concat(const operation& op) const override
         {
 
             return private_detail_te_value.get_concat(op);

--- a/src/targets/gpu/include/migraphx/gpu/concat_gpu_opt.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/concat_gpu_opt.hpp
@@ -33,12 +33,15 @@ namespace gpu {
 
 struct concat_gpu_optimization
 {
-    std::string name() const { return "gpu::concat"; }
     std::string allocate() const { return "hip::allocate"; }
-    migraphx::op::concat get_concat(const migraphx::operation& op) const
+    optional<migraphx::op::concat> get_concat(const migraphx::operation& op) const
     {
-        auto v = op.to_value();
-        return from_value<migraphx::op::concat>(v.at("op"));
+        if(op.name() != "gpu::precompile_op")
+            return nullopt;
+        auto r = from_value<operation>(op.to_value().at("op"));
+        if(r.name() == "concat")
+            return any_cast<migraphx::op::concat>(r);
+        return nullopt;
     }
 };
 

--- a/test/eliminate_concat_test.cpp
+++ b/test/eliminate_concat_test.cpp
@@ -29,6 +29,7 @@
 #include <migraphx/op/identity.hpp>
 #include <migraphx/op/normalize_attribute.hpp>
 #include <migraphx/normalize_attributes.hpp>
+#include <migraphx/optional.hpp>
 #include <basic_ops.hpp>
 #include <test.hpp>
 
@@ -66,13 +67,13 @@ struct concat
 
 struct concat_test_optimization
 {
-    /// A unique name used to identify the concat optimization
-    std::string name() const { return "eliminate_concat::concat"; }
     /// A unique name used to identify the allocate operator
     std::string allocate() const { return "allocate"; }
     /// Return the lowered concat operator
-    migraphx::op::concat get_concat(const migraphx::operation& op) const
+    std::optional<migraphx::op::concat> get_concat(const migraphx::operation& op) const
     {
+        if(op.name() != "eliminate_concat::concat")
+            return std::nullopt;
         return migraphx::any_cast<concat>(op).op;
     }
 };

--- a/tools/include/concat_opt.hpp
+++ b/tools/include/concat_opt.hpp
@@ -33,6 +33,7 @@
 
 #include <migraphx/operation.hpp>
 #include <migraphx/op/concat.hpp>
+#include <migraphx/optional.hpp>
 #include <migraphx/config.hpp>
 
 namespace migraphx {
@@ -43,21 +44,18 @@ inline namespace MIGRAPHX_INLINE_NS {
 /// An interface for target-dependent optimization for the concat instruction
 struct concat_optimization
 {
-    /// The name of the target-dependent concat operator
-    std::string name() const;
     /// A name of the target-dependent allocate operator
     std::string allocate() const;
     /// Return the target-independent concat operator
-    op::concat get_concat(const operation& op) const;
+    optional<op::concat> get_concat(const operation& op) const;
 };
 
 #else
 
 <%
 interface('concat_optimization',
-    virtual('name', returns='std::string', const=True),
     virtual('allocate', returns='std::string', const=True),
-    virtual('get_concat', returns='op::concat', op='const operation&', const=True)
+    virtual('get_concat', returns='optional<op::concat>', op='const operation&', const=True)
 )
 %>
 


### PR DESCRIPTION
Since concat is now a jit operator, this was matching the old name. However, since its now wrapped in a `gpu::precompile_op` we can't really just match the name, so instead I updated `get_concat` to return an optional if it can get the original concat operator. 