### PR TITLE
Remove the hard coded path in MIGRAPHX_CXX_COMPILER

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -285,20 +285,6 @@ rocm_install_targets(
     ${CMAKE_CURRENT_BINARY_DIR}/include
 )
 
-set(COMPILER_NAME ${CMAKE_CXX_COMPILER})
-if(NOT WIN32)
-    if(MIGRAPHX_ENABLE_CPU)
-        # Set the compiler as c++ for CPU compilation in linux
-        set(COMPILER_NAME "c++")
-    else()
-        # For GPU compilation, use amdclang
-        get_filename_component(GET_COMPILER_NAME ${CMAKE_CXX_COMPILER} NAME)
-        if(${GET_COMPILER_NAME} MATCHES "^amdclang")
-            set(COMPILER_NAME ${GET_COMPILER_NAME})
-        endif()
-    endif()# end of CPU/GPU check
-endif()
-
 if(NOT WIN32)
     check_cxx_linker_flag(-lstdc++fs HAS_LIB_STD_FILESYSTEM)
     if(HAS_LIB_STD_FILESYSTEM)
@@ -388,7 +374,7 @@ if(BUILD_DEV)
     target_compile_definitions(migraphx PUBLIC -DBUILD_DEV)
 endif()
 
-target_compile_definitions(migraphx PUBLIC MIGRAPHX_CXX_COMPILER="${COMPILER_NAME}")
+target_compile_definitions(migraphx PUBLIC MIGRAPHX_CXX_COMPILER="${CMAKE_CXX_COMPILER}")
 
 rocm_export_targets(
   TARGETS migraphx::migraphx_c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -287,10 +287,16 @@ rocm_install_targets(
 
 set(COMPILER_NAME ${CMAKE_CXX_COMPILER})
 if(NOT WIN32)
-    get_filename_component(GET_COMPILER_NAME ${CMAKE_CXX_COMPILER} NAME)
-    if(${GET_COMPILER_NAME} MATCHES "^amdclang")
-        set(COMPILER_NAME ${GET_COMPILER_NAME})
-    endif()
+    if(MIGRAPHX_ENABLE_CPU)
+        # Set the compiler as c++ for CPU compilation in linux
+        set(COMPILER_NAME "c++")
+    else()
+        # For GPU compilation, use amdclang
+        get_filename_component(GET_COMPILER_NAME ${CMAKE_CXX_COMPILER} NAME)
+        if(${GET_COMPILER_NAME} MATCHES "^amdclang")
+            set(COMPILER_NAME ${GET_COMPILER_NAME})
+        endif()
+    endif()# end of CPU/GPU check
 endif()
 
 if(NOT WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -285,6 +285,14 @@ rocm_install_targets(
     ${CMAKE_CURRENT_BINARY_DIR}/include
 )
 
+set(COMPILER_NAME ${CMAKE_CXX_COMPILER})
+if(NOT WIN32)
+    get_filename_component(GET_COMPILER_NAME ${CMAKE_CXX_COMPILER} NAME)
+    if(${GET_COMPILER_NAME} MATCHES "^amdclang")
+        set(COMPILER_NAME ${GET_COMPILER_NAME})
+    endif()
+endif()
+
 if(NOT WIN32)
     check_cxx_linker_flag(-lstdc++fs HAS_LIB_STD_FILESYSTEM)
     if(HAS_LIB_STD_FILESYSTEM)
@@ -374,7 +382,7 @@ if(BUILD_DEV)
     target_compile_definitions(migraphx PUBLIC -DBUILD_DEV)
 endif()
 
-target_compile_definitions(migraphx PUBLIC MIGRAPHX_CXX_COMPILER="${CMAKE_CXX_COMPILER}")
+target_compile_definitions(migraphx PUBLIC MIGRAPHX_CXX_COMPILER="${COMPILER_NAME}")
 
 rocm_export_targets(
   TARGETS migraphx::migraphx_c
@@ -383,5 +391,5 @@ rocm_export_targets(
     Threads
     ${MIGRAPHX_CONFIG_DEPENDS}
 )
- 
+
 

--- a/src/include/migraphx/compile_src.hpp
+++ b/src/include/migraphx/compile_src.hpp
@@ -56,7 +56,7 @@ struct MIGRAPHX_EXPORT src_compiler
 #ifdef _WIN32
     fs::path compiler                         = MIGRAPHX_CXX_COMPILER;
 #else
-    fs::path compiler                         = "c++";
+    fs::path compiler = "c++";
 #endif
     std::vector<std::string> flags            = {};
     fs::path output                           = {};

--- a/src/include/migraphx/compile_src.hpp
+++ b/src/include/migraphx/compile_src.hpp
@@ -53,11 +53,11 @@ struct src_file
 
 struct MIGRAPHX_EXPORT src_compiler
 {
-    #ifdef _WIN32
+#ifdef _WIN32
     fs::path compiler                         = MIGRAPHX_CXX_COMPILER;
-    #else
+#else
     fs::path compiler                         = "c++";
-    #endif
+#endif
     std::vector<std::string> flags            = {};
     fs::path output                           = {};
     fs::path launcher                         = {};

--- a/src/include/migraphx/compile_src.hpp
+++ b/src/include/migraphx/compile_src.hpp
@@ -53,7 +53,11 @@ struct src_file
 
 struct MIGRAPHX_EXPORT src_compiler
 {
+    #ifdef _WIN32
     fs::path compiler                         = MIGRAPHX_CXX_COMPILER;
+    #else
+    fs::path compiler                         = "c++";
+    #endif
     std::vector<std::string> flags            = {};
     fs::path output                           = {};
     fs::path launcher                         = {};

--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -298,7 +298,7 @@ else()
     endif()
 endif()
 
-target_compile_definitions(migraphx_gpu PUBLIC MIGRAPHX_CXX_COMPILER="${CMAKE_CXX_COMPILER}")
+target_compile_definitions(migraphx_gpu PUBLIC MIGRAPHX_CXX_COMPILER="${COMPILER_NAME}")
 
 # Check miopen find mode api
 

--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -298,7 +298,7 @@ else()
     endif()
 endif()
 
-target_compile_definitions(migraphx_gpu PUBLIC MIGRAPHX_CXX_COMPILER="${COMPILER_NAME}")
+target_compile_definitions(migraphx_gpu PUBLIC MIGRAPHX_CXX_COMPILER="${CMAKE_CXX_COMPILER}")
 
 # Check miopen find mode api
 


### PR DESCRIPTION
amdclang++/amdclang can be invoked without providing absolute path, since update-alternatives command has been run for these binaries This will also help to remove the hard coded paths in cmake target files for these compilers