### PR TITLE
Move addition of repo before zypper install command for sles docker

### DIFF
--- a/tools/docker/sles.docker
+++ b/tools/docker/sles.docker
@@ -11,6 +11,9 @@ gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key\n\
 
 RUN cat /etc/zypp/repos.d/rocm.repo
 
+#addition of repos for packages
+RUN zypper addrepo https://download.opensuse.org/repositories/devel:/languages:/perl/15.5/devel:languages:perl.repo 
+
 RUN zypper -n --gpg-auto-import-keys refresh
 
 RUN zypper install -y -t pattern devel_basis enhanced_base
@@ -21,9 +24,6 @@ RUN zypper --gpg-auto-import-keys install -y \
     git \
     python3-pip \
     rpm-build
-
-#addition of repos for packages
-RUN zypper addrepo https://download.opensuse.org/repositories/devel:/languages:/perl/15.5/devel:languages:perl.repo 
 
 # Workaround broken rocm packages
 RUN ln -s /opt/rocm-* /opt/rocm


### PR DESCRIPTION
Repo is added after zypper install command in the docker file.
Move the addition of repo in the file before install command.
This helps find packages listed in the install command.