### PR TITLE
Fix windows build error due to extra copy caused by missing const& for iterator

### DIFF
--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -540,7 +540,7 @@ struct find_mlir_split_reduce
                 fused_ins);
 
             mpm.get_module().replace_instruction(gemm_ins, dot_ins);
-            for(const auto outs : reduce_ins->outputs())
+            for(const auto& outs : reduce_ins->outputs())
             {
                 assert(outs->get_operator().name() == "get_tuple_elem");
                 mpm.get_module().replace_instruction(outs, outs->get_operator(), fused_ins);


### PR DESCRIPTION
Here is an excerpt for the error on Windows:
```
2024-08-21 08:12:57 :543:28: error: loop variable 'outs' creates a copy from type 'const value_type' (aka 'const migraphx::instruction_ref') [-Werror,-Wrange-loop-construct]
2024-08-21 08:12:57   543 |             for(const auto outs : reduce_ins->outputs())
2024-08-21 08:12:57       |                            ^
2024-08-21 08:12:57 C:\home\jenkins\agent\workspace\UIF2_AMDMIGraphX_develop\AMDMIGraphX\src\targets\gpu\fuse_mlir.cpp:543:17: note: use reference type 'const value_type &' (aka 'const migraphx::instruction_ref &') to prevent copying
2024-08-21 08:12:57   543 |             for(const auto outs : reduce_ins->outputs())
2024-08-21 08:12:57       |                 ^~~~~~~~~~~~~~~~~
2024-08-21 08:12:57       |                            &
2024-08-21 08:12:57 1 error generated.
```

The error was caused by new code introduced with [a fuse_mlir change](https://github.com/ROCm/AMDMIGraphX/commit/7ab413ff03ca35b02f604d7e8a1963fcbbce45b4#diff-e1ec511a415d6a6be56de27d0555a2ea329640ac8319944ec1d53b7dea80d4e4).

The error is related to a copy in the iterator that can be resolved with using a const& which is also more performant.