### PR TITLE
print labels at beginning of stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,8 +57,7 @@ def rocmtestnode(Map conf) {
     node(name) {
         withEnv(['HSA_ENABLE_SDMA=0']) {
             stage("checkout ${variant}") {
-                echo env
-                sh env
+                sh 'printenv'
                 checkout scm
             }
             gitStatusWrapper(credentialsId: "${env.status_wrapper_creds}", gitHubContext: "Jenkins - ${variant}", account: 'ROCmSoftwarePlatform', repo: 'AMDMIGraphX') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,8 @@ def rocmtestnode(Map conf) {
     node(name) {
         withEnv(['HSA_ENABLE_SDMA=0']) {
             stage("checkout ${variant}") {
+                echo env
+                sh env
                 checkout scm
             }
             gitStatusWrapper(credentialsId: "${env.status_wrapper_creds}", gitHubContext: "Jenkins - ${variant}", account: 'ROCmSoftwarePlatform', repo: 'AMDMIGraphX') {


### PR DESCRIPTION
Failures that occur prior to the running of the command in Jenkins do not print the environment variables that distinguish server names.  Print them out at the beginning of the stage