### PR TITLE
Quote paths used for creating a process

### DIFF
--- a/src/include/migraphx/stringutils.hpp
+++ b/src/include/migraphx/stringutils.hpp
@@ -189,6 +189,8 @@ inline std::string to_c_id(const std::string& name, char rep = '_')
     return id;
 }
 
+inline std::string quote_string(const std::string& str) { return "\"" + str + "\""; }
+
 template <class Iterator>
 inline std::string to_string_range(Iterator start, Iterator last, const char* delim = ", ")
 {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -207,7 +207,7 @@ int exec(const std::string& cmd, const std::string& cwd, const std::string& args
     constexpr std::size_t CMDLINE_LENGTH = 32767;
 
     // Build lpCommandLine parameter.
-    std::string cmdline = cmd;
+    std::string cmdline = quote_string(cmd);
     if(not args.empty())
         cmdline += " " + args;
 

--- a/src/targets/gpu/compile_hip.cpp
+++ b/src/targets/gpu/compile_hip.cpp
@@ -275,7 +275,9 @@ std::vector<std::vector<char>> compile_hip_src(const std::vector<src_file>& srcs
         tmp_dir td{};
         auto out = td.path / "output";
 
-        process(driver, {out.string()}).write([&](auto writer) { to_msgpack(v, writer); });
+        process(driver, {quote_string(out.string())}).write([&](auto writer) {
+            to_msgpack(v, writer);
+        });
         if(fs::exists(out))
             return {read_buffer(out)};
     }


### PR DESCRIPTION
Process for migraphx-hiprtc-driver.exe was failing on Windows because the path to the exe contains a space character. All paths that have space characters and are included in lpCommandLine parameter for CreateProcess API need to be quoted. Argument that is a path is also quoted just in case.