### PR TITLE
Call register function so ROCMLIR_DEBUG_FLAGS can be used to pass options to libRockCompiler.

### DIFF
--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -729,6 +729,7 @@ struct mlir_program
     void run_high_level_pipeline()
     {
         mlir_pass_manager pm_front{mlirPassManagerCreate(ctx.get())};
+        mlirRegisterRocMLIROptions();
         mlirMIGraphXAddHighLevelPipeline(pm_front.get());
         logger.clear();
         if(mlirLogicalResultIsFailure(
@@ -746,6 +747,7 @@ struct mlir_program
     void run_backend_pipeline()
     {
         mlir_pass_manager pm_back{mlirPassManagerCreate(ctx.get())};
+        mlirRegisterRocMLIROptions();
         mlirMIGraphXAddBackendPipeline(pm_back.get(), target_arch.c_str());
         logger.clear();
         const size_t trace = value_of(MIGRAPHX_TRACE_MLIR{});


### PR DESCRIPTION
Call register function so ROCMLIR_DEBUG_FLAGS can be used to pass options to libRockCompiler.

Typical anticipated use is something like

    MIGRAPHX_GPU_COMPILE_PARALLEL=1 ROCMLIR_DEBUG_FLAGS='--mlir-disable-threading --mlir-print-ir-after-all' ./build/bin/test_verify ...

to print pass-by-pass output from MLIR from with the MIGraphX test program.  The parallel and threading settings are there to keep the debug output clean.