### PR TITLE
add migraphx load and save functions, allowing the hiding of an error message

### DIFF
--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -1805,27 +1805,35 @@ migraphx_operation_name(char* out, size_t out_size, migraphx_operation_t operati
     return api_error_result;
 }
 
-extern "C" migraphx_status
-migraphx_load(migraphx_program_t* out, const char* name, migraphx_file_options_t options)
+extern "C" migraphx_status migraphx_load_v2(migraphx_program_t* out,
+                                            const char* name,
+                                            migraphx_file_options_t options,
+                                            bool output_error)
 {
-    auto api_error_result = migraphx::try_([&] {
-        if(options == nullptr)
-            MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter options: Null pointer");
-        *out = allocate<migraphx_program_t>(migraphx::load((name), (options->object)));
-    });
+    auto api_error_result = migraphx::try_(
+        [&] {
+            if(options == nullptr)
+                MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter options: Null pointer");
+            *out = allocate<migraphx_program_t>(migraphx::load((name), (options->object)));
+        },
+        output_error);
     return api_error_result;
 }
 
-extern "C" migraphx_status
-migraphx_save(migraphx_program_t p, const char* name, migraphx_file_options_t options)
+extern "C" migraphx_status migraphx_save_v2(migraphx_program_t p,
+                                            const char* name,
+                                            migraphx_file_options_t options,
+                                            bool output_error)
 {
-    auto api_error_result = migraphx::try_([&] {
-        if(p == nullptr)
-            MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter p: Null pointer");
-        if(options == nullptr)
-            MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter options: Null pointer");
-        migraphx::save((p->object), (name), (options->object));
-    });
+    auto api_error_result = migraphx::try_(
+        [&] {
+            if(p == nullptr)
+                MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter p: Null pointer");
+            if(options == nullptr)
+                MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter options: Null pointer");
+            migraphx::save((p->object), (name), (options->object));
+        },
+        output_error);
     return api_error_result;
 }
 

--- a/src/api/include/migraphx/migraphx.h
+++ b/src/api/include/migraphx/migraphx.h
@@ -64,6 +64,12 @@ typedef enum
 
 } migraphx_status;
 
+// A backward compatibility macro for migraphx_load()
+#define migraphx_load(out, name, options) migraphx_load_v2(out, name, options, true)
+
+// A backward compatibility macro for migraphx_save()
+#define migraphx_save(p, name, options) migraphx_save_v2(p, name, options, true)
+
 #define MIGRAPHX_SHAPE_GENERATE_ENUM_TYPES(x, t) migraphx_shape_##x,
 /// An enum to represent the different data type inputs
 typedef enum
@@ -485,13 +491,15 @@ MIGRAPHX_C_EXPORT migraphx_status migraphx_operation_name(char* out,
                                                           size_t out_size,
                                                           migraphx_operation_t operation);
 
-MIGRAPHX_C_EXPORT migraphx_status migraphx_load(migraphx_program_t* out,
-                                                const char* name,
-                                                migraphx_file_options_t options);
+MIGRAPHX_C_EXPORT migraphx_status migraphx_load_v2(migraphx_program_t* out,
+                                                   const char* name,
+                                                   migraphx_file_options_t options,
+                                                   bool output_error);
 
-MIGRAPHX_C_EXPORT migraphx_status migraphx_save(migraphx_program_t p,
-                                                const char* name,
-                                                migraphx_file_options_t options);
+MIGRAPHX_C_EXPORT migraphx_status migraphx_save_v2(migraphx_program_t p,
+                                                   const char* name,
+                                                   migraphx_file_options_t options,
+                                                   bool output_error);
 
 MIGRAPHX_C_EXPORT migraphx_status
 migraphx_onnx_options_destroy(migraphx_onnx_options_t onnx_options);

--- a/src/api/include/migraphx/migraphx.hpp
+++ b/src/api/include/migraphx/migraphx.hpp
@@ -1269,30 +1269,30 @@ struct file_options : MIGRAPHX_HANDLE_BASE(file_options)
 };
 
 /// Load a saved migraphx program from a file
-inline program load(const char* filename, const file_options& options)
+inline program load(const char* filename, const file_options& options, bool output_error = true)
 {
-    return program(make<migraphx_program>(&migraphx_load, filename, options.get_handle_ptr()),
-                   own{});
+    return program(make<migraphx_program>(&migraphx_load_v2, filename, options.get_handle_ptr(),
+        output_error), own{});
 }
 
 /// Load a saved migraphx program from a file
-inline program load(const char* filename)
+inline program load(const char* filename, bool output_error = true)
 {
     return program(
-        make<migraphx_program>(&migraphx_load, filename, migraphx::file_options{}.get_handle_ptr()),
-        own{});
+        make<migraphx_program>(&migraphx_load_v2, filename, file_options{}.get_handle_ptr(),
+        output_error), own{});
 }
 
 /// Save a program to a file
-inline void save(const program& p, const char* filename, const file_options& options)
+inline void save(const program& p, const char* filename, const file_options& options, bool output_error = true)
 {
-    call(&migraphx_save, p.get_handle_ptr(), filename, options.get_handle_ptr());
+    call(&migraphx_save_v2, p.get_handle_ptr(), filename, options.get_handle_ptr(), output_error);
 }
 
 /// Save a program to a file
-inline void save(const program& p, const char* filename)
+inline void save(const program& p, const char* filename, bool output_error = true)
 {
-    call(&migraphx_save, p.get_handle_ptr(), filename, migraphx::file_options{}.get_handle_ptr());
+    call(&migraphx_save_v2, p.get_handle_ptr(), filename, file_options{}.get_handle_ptr(), output_error);
 }
 
 /// Options for parsing onnx options

--- a/src/api/migraphx.py
+++ b/src/api/migraphx.py
@@ -307,17 +307,19 @@ def operation(h):
     h.method('name', returns='std::string')
 
 
-api.add_function('migraphx_load',
+api.add_function('migraphx_load_v2',
                  api.params(name='const char*',
                             options='migraphx::file_options'),
                  fname='migraphx::load',
-                 returns='migraphx::program')
+                 returns='migraphx::program',
+                 output_error=True)
 
-api.add_function('migraphx_save',
+api.add_function('migraphx_save_v2',
                  api.params(p='migraphx::program&',
                             name='const char*',
                             options='migraphx::file_options'),
-                 fname='migraphx::save')
+                 fname='migraphx::save',
+                 output_error=True)
 
 
 @auto_handle()

--- a/tools/api/migraphx.h
+++ b/tools/api/migraphx.h
@@ -64,6 +64,12 @@ typedef enum
 
 } migraphx_status;
 
+// A backward compatibility macro for migraphx_load()
+#define migraphx_load(out, name, options) migraphx_load_v2(out, name, options, true)
+
+// A backward compatibility macro for migraphx_save()
+#define migraphx_save(p, name, options) migraphx_save_v2(p, name, options, true)
+
 #define MIGRAPHX_SHAPE_GENERATE_ENUM_TYPES(x, t) migraphx_shape_##x,
 /// An enum to represent the different data type inputs
 typedef enum


### PR DESCRIPTION
The MIGraphX EP uses the `migraphx_load` and `migraphx_save` functions for MXR caching. If a model is not yet compiled (file missing from cache), a message in the console states an error occurred, which misled users. The v2 version of the functions allows error message reporting to be turned off.

The PR introduces the `migraphx_load_v2` and `migraphx_save_v2` functions. The original functions were replaced with macros, emulating the old behavior with the help of v2 functions.