### PR TITLE
Handle more reshapes with the shape transform descriptor

### DIFF
--- a/src/include/migraphx/shape_transform_descriptor.hpp
+++ b/src/include/migraphx/shape_transform_descriptor.hpp
@@ -76,6 +76,7 @@ struct MIGRAPHX_EXPORT shape_transform_descriptor
 
     bool apply(const std::vector<operation>& ops);
     bool apply_reshape(const std::vector<std::size_t>& rdims);
+    bool apply_reshape_impl(const std::vector<std::size_t>& rdims);
     bool apply_transpose(const std::vector<std::int64_t>& permutation);
     bool apply_broadcast(const std::vector<std::size_t>& out_lens,
                          optional<std::size_t> axis = nullopt);

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -145,12 +145,13 @@ bool shape_transform_descriptor::apply(const std::vector<operation>& ops)
 bool shape_transform_descriptor::apply_reshape(const std::vector<std::size_t>& rdims)
 {
     std::vector<std::size_t> idims;
-    transform(get_all_subdimensions(dimensions), std::back_inserter(idims), std::mem_fn(&dimension::sub::len));
+    transform(get_all_subdimensions(dimensions),
+              std::back_inserter(idims),
+              std::mem_fn(&dimension::sub::len));
     auto cdims = common_dims::compute(idims, rdims).dims;
     if(not cdims.empty() and not apply_reshape_impl(common_dims::compute(idims, rdims).dims))
         return false;
     return apply_reshape_impl(rdims);
-
 }
 bool shape_transform_descriptor::apply_reshape_impl(const std::vector<std::size_t>& rdims)
 {

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -155,6 +155,10 @@ bool shape_transform_descriptor::apply_reshape(const std::vector<std::size_t>& r
 bool shape_transform_descriptor::apply_reshape_impl(const std::vector<std::size_t>& rdims)
 {
     assert(migraphx::elements(rdims) == this->elements());
+    if(migraphx::equal(dimensions, rdims, [](const dimension& d, std::size_t rdim) {
+        return d.len() == rdim;
+    }))
+        return true;
     std::vector<dimension> new_dims;
     auto subs     = get_all_subdimensions(dimensions);
     std::size_t i = 0;

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -155,9 +155,8 @@ bool shape_transform_descriptor::apply_reshape(const std::vector<std::size_t>& r
 bool shape_transform_descriptor::apply_reshape_impl(const std::vector<std::size_t>& rdims)
 {
     assert(migraphx::elements(rdims) == this->elements());
-    if(migraphx::equal(dimensions, rdims, [](const dimension& d, std::size_t rdim) {
-        return d.len() == rdim;
-    }))
+    if(migraphx::equal(
+           dimensions, rdims, [](const dimension& d, std::size_t rdim) { return d.len() == rdim; }))
         return true;
     std::vector<dimension> new_dims;
     auto subs     = get_all_subdimensions(dimensions);

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -144,6 +144,16 @@ bool shape_transform_descriptor::apply(const std::vector<operation>& ops)
 }
 bool shape_transform_descriptor::apply_reshape(const std::vector<std::size_t>& rdims)
 {
+    std::vector<std::size_t> idims;
+    transform(get_all_subdimensions(dimensions), std::back_inserter(idims), std::mem_fn(&dimension::sub::len));
+    auto cdims = common_dims::compute(idims, rdims).dims;
+    if(not cdims.empty() and not apply_reshape_impl(common_dims::compute(idims, rdims).dims))
+        return false;
+    return apply_reshape_impl(rdims);
+
+}
+bool shape_transform_descriptor::apply_reshape_impl(const std::vector<std::size_t>& rdims)
+{
     assert(migraphx::elements(rdims) == this->elements());
     std::vector<dimension> new_dims;
     auto subs     = get_all_subdimensions(dimensions);

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -145,12 +145,13 @@ bool shape_transform_descriptor::apply(const std::vector<operation>& ops)
 bool shape_transform_descriptor::apply_reshape(const std::vector<std::size_t>& rdims)
 {
     std::vector<std::size_t> idims;
-    transform(get_all_subdimensions(dimensions), std::back_inserter(idims), std::mem_fn(&dimension::sub::len));
+    transform(get_all_subdimensions(dimensions),
+              std::back_inserter(idims),
+              std::mem_fn(&dimension::sub::len));
     auto cdims = common_dims::compute(idims, rdims).dims;
     if(not cdims.empty() and not apply_reshape_impl(cdims))
         return false;
     return apply_reshape_impl(rdims);
-
 }
 bool shape_transform_descriptor::apply_reshape_impl(const std::vector<std::size_t>& rdims)
 {

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -147,7 +147,7 @@ bool shape_transform_descriptor::apply_reshape(const std::vector<std::size_t>& r
     std::vector<std::size_t> idims;
     transform(get_all_subdimensions(dimensions), std::back_inserter(idims), std::mem_fn(&dimension::sub::len));
     auto cdims = common_dims::compute(idims, rdims).dims;
-    if(not cdims.empty() and not apply_reshape_impl(cdims)
+    if(not cdims.empty() and not apply_reshape_impl(cdims))
         return false;
     return apply_reshape_impl(rdims);
 

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -145,13 +145,12 @@ bool shape_transform_descriptor::apply(const std::vector<operation>& ops)
 bool shape_transform_descriptor::apply_reshape(const std::vector<std::size_t>& rdims)
 {
     std::vector<std::size_t> idims;
-    transform(get_all_subdimensions(dimensions),
-              std::back_inserter(idims),
-              std::mem_fn(&dimension::sub::len));
+    transform(get_all_subdimensions(dimensions), std::back_inserter(idims), std::mem_fn(&dimension::sub::len));
     auto cdims = common_dims::compute(idims, rdims).dims;
-    if(not cdims.empty() and not apply_reshape_impl(common_dims::compute(idims, rdims).dims))
+    if(not cdims.empty() and not apply_reshape_impl(cdims)
         return false;
     return apply_reshape_impl(rdims);
+
 }
 bool shape_transform_descriptor::apply_reshape_impl(const std::vector<std::size_t>& rdims)
 {

--- a/test/shape_transform_descriptor.cpp
+++ b/test/shape_transform_descriptor.cpp
@@ -139,7 +139,8 @@ TEST_CASE(record_reshape_merge_split)
     auto desc = make_descriptor({3, 10, 16}, make_op("reshape", {{"dims", {3, 40, 2, 2}}}));
     EXPECT(get_final_lens(desc) == final_lens{3, 40, 2, 2});
     EXPECT(get_all_lens(desc) == all_lens{{3}, {10, 4}, {2}, {2}});
-    EXPECT(get_all_axes(desc) == all_axes{d_axes{{0}}, d_axes{{1}, {2, 0}}, d_axes{{2, 1}}, d_axes{{2, 2}}});
+    EXPECT(get_all_axes(desc) ==
+           all_axes{d_axes{{0}}, d_axes{{1}, {2, 0}}, d_axes{{2, 1}}, d_axes{{2, 2}}});
 }
 
 TEST_CASE(record_squeeze_trailing_1s)

--- a/test/shape_transform_descriptor.cpp
+++ b/test/shape_transform_descriptor.cpp
@@ -134,6 +134,14 @@ TEST_CASE(record_reshape_split)
     EXPECT(get_all_axes(desc) == all_axes{d_axes{{0}}, d_axes{{1, 0}}, d_axes{{1, 1}}});
 }
 
+TEST_CASE(record_reshape_merge_split)
+{
+    auto desc = make_descriptor({3, 10, 16}, make_op("reshape", {{"dims", {3, 40, 2, 2}}}));
+    EXPECT(get_final_lens(desc) == final_lens{3, 40, 2, 2});
+    EXPECT(get_all_lens(desc) == all_lens{{3}, {10, 4}, {2}, {2}});
+    EXPECT(get_all_axes(desc) == all_axes{d_axes{{0}}, d_axes{{1}, {2, 0}}, d_axes{{2, 1}}, d_axes{{2, 2}}});
+}
+
 TEST_CASE(record_squeeze_trailing_1s)
 {
     auto desc = make_descriptor({3, 4, 4, 1, 1}, make_op("reshape", {{"dims", {3, 4, 4}}}));


### PR DESCRIPTION
This handles cases where there is a merge and split used together, such as `{3, 10, 16} -> {3, 40, 2, 2}`. This currently is not supported. We need to keep track of a remainder in the loop to properly do this. Since it is fairly complicated to do, this just reuses common_dims, which already handles the remainder. So it reshapes to the common_dims and then reshapes to the final dimensions. 