### PR TITLE
Added missing op_name values for operators in onnx and tf parsers

### DIFF
--- a/src/onnx/parse_aten.cpp
+++ b/src/onnx/parse_aten.cpp
@@ -39,7 +39,7 @@ enum class reduce_mode_t
 
 struct parse_aten : op_parser<parse_aten>
 {
-    std::vector<op_desc> operators() const { return {{"ATen"}}; }
+    std::vector<op_desc> operators() const { return {{"ATen", "aten"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_batchnorm.cpp
+++ b/src/onnx/parse_batchnorm.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_batchnorm : op_parser<parse_batchnorm>
 {
-    std::vector<op_desc> operators() const { return {{"BatchNormalization"}}; }
+    std::vector<op_desc> operators() const { return {{"BatchNormalization", "batch_normalization"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_cast.cpp
+++ b/src/onnx/parse_cast.cpp
@@ -31,7 +31,7 @@ namespace onnx {
 
 struct parse_cast : op_parser<parse_cast>
 {
-    std::vector<op_desc> operators() const { return {{"Cast"}}; }
+    std::vector<op_desc> operators() const { return {{"Cast", "cast"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_castlike.cpp
+++ b/src/onnx/parse_castlike.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_castlike : op_parser<parse_castlike>
 {
-    std::vector<op_desc> operators() const { return {{"CastLike"}}; }
+    std::vector<op_desc> operators() const { return {{"CastLike", "cast_like"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_celu.cpp
+++ b/src/onnx/parse_celu.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_celu : op_parser<parse_celu>
 {
-    std::vector<op_desc> operators() const { return {{"Celu"}}; }
+    std::vector<op_desc> operators() const { return {{"Celu", "celu"}}; }
 
     instruction_ref parse(const op_desc&,
                           const onnx_parser&,

--- a/src/onnx/parse_clip.cpp
+++ b/src/onnx/parse_clip.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_clip : op_parser<parse_clip>
 {
-    std::vector<op_desc> operators() const { return {{"Clip"}}; }
+    std::vector<op_desc> operators() const { return {{"Clip", "clip"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_constant.cpp
+++ b/src/onnx/parse_constant.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_constant : op_parser<parse_constant>
 {
-    std::vector<op_desc> operators() const { return {{"Constant"}}; }
+    std::vector<op_desc> operators() const { return {{"Constant", "constant"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_constant_fill.cpp
+++ b/src/onnx/parse_constant_fill.cpp
@@ -37,7 +37,7 @@ namespace onnx {
 // operator
 struct parse_constant_fill : op_parser<parse_constant_fill>
 {
-    std::vector<op_desc> operators() const { return {{"ConstantFill"}}; }
+    std::vector<op_desc> operators() const { return {{"ConstantFill", "constant_fill"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_constant_of_shape.cpp
+++ b/src/onnx/parse_constant_of_shape.cpp
@@ -34,7 +34,7 @@ namespace onnx {
 
 struct parse_constant_of_shape : op_parser<parse_constant_of_shape>
 {
-    std::vector<op_desc> operators() const { return {{"ConstantOfShape"}}; }
+    std::vector<op_desc> operators() const { return {{"ConstantOfShape", "constant_of_shape"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_conv_transpose.cpp
+++ b/src/onnx/parse_conv_transpose.cpp
@@ -44,7 +44,7 @@ std::vector<int64_t> to_int64_vector(const std::vector<T>& input_vector)
 
 struct parse_conv_transpose : op_parser<parse_conv_transpose>
 {
-    std::vector<op_desc> operators() const { return {{"ConvTranspose"}}; }
+    std::vector<op_desc> operators() const { return {{"ConvTranspose", "conv_transpose"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_depthtospace.cpp
+++ b/src/onnx/parse_depthtospace.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_depthtospace : op_parser<parse_depthtospace>
 {
-    std::vector<op_desc> operators() const { return {{"DepthToSpace"}}; }
+    std::vector<op_desc> operators() const { return {{"DepthToSpace", "depth_to_space"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_dequantizelinear.cpp
+++ b/src/onnx/parse_dequantizelinear.cpp
@@ -34,7 +34,7 @@ namespace onnx {
 
 struct parse_dequantizelinear : op_parser<parse_dequantizelinear>
 {
-    std::vector<op_desc> operators() const { return {{"DequantizeLinear"}}; }
+    std::vector<op_desc> operators() const { return {{"DequantizeLinear", "dequantize_linear"}}; }
 
     instruction_ref parse(const op_desc& opd,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_dropout.cpp
+++ b/src/onnx/parse_dropout.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_dropout : op_parser<parse_dropout>
 {
-    std::vector<op_desc> operators() const { return {{"Dropout"}}; }
+    std::vector<op_desc> operators() const { return {{"Dropout", "dropout"}}; }
 
     std::vector<instruction_ref> parse(const op_desc& /*opd*/,
                                        const onnx_parser& /*parser*/,

--- a/src/onnx/parse_dynamicquantizelinear.cpp
+++ b/src/onnx/parse_dynamicquantizelinear.cpp
@@ -85,7 +85,7 @@ Constrain 'y_zero_point' and 'y' to 8-bit unsigned integer tensor.
 
 struct parse_dynamicquantizelinear : op_parser<parse_dynamicquantizelinear>
 {
-    std::vector<op_desc> operators() const { return {{"DynamicQuantizeLinear"}}; }
+    std::vector<op_desc> operators() const { return {{"DynamicQuantizeLinear", "dynamic_quantize_linear"}}; }
 
     std::vector<instruction_ref> parse(const op_desc& /*opd*/,
                                        const onnx_parser& /*parser*/,

--- a/src/onnx/parse_expand.cpp
+++ b/src/onnx/parse_expand.cpp
@@ -34,7 +34,7 @@ namespace onnx {
 
 struct parse_expand : op_parser<parse_expand>
 {
-    std::vector<op_desc> operators() const { return {{"Expand"}}; }
+    std::vector<op_desc> operators() const { return {{"Expand", "expand"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_eyelike.cpp
+++ b/src/onnx/parse_eyelike.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_eyelike : op_parser<parse_eyelike>
 {
-    std::vector<op_desc> operators() const { return {{"EyeLike"}}; }
+    std::vector<op_desc> operators() const { return {{"EyeLike", "eye_like"}}; }
 
     instruction_ref parse(const op_desc&,
                           const onnx_parser&,

--- a/src/onnx/parse_gather_elements.cpp
+++ b/src/onnx/parse_gather_elements.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_gather_elements : op_parser<parse_gather_elements>
 {
-    std::vector<op_desc> operators() const { return {{"GatherElements"}}; }
+    std::vector<op_desc> operators() const { return {{"GatherElements", "gather_elements"}}; }
 
     instruction_ref parse(const op_desc& opd,
                           const onnx_parser& parser,

--- a/src/onnx/parse_gemm.cpp
+++ b/src/onnx/parse_gemm.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_gemm : op_parser<parse_gemm>
 {
-    std::vector<op_desc> operators() const { return {{"Gemm"}}; }
+    std::vector<op_desc> operators() const { return {{"Gemm", "gemm"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_greaterorequal.cpp
+++ b/src/onnx/parse_greaterorequal.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_greaterorequal : op_parser<parse_greaterorequal>
 {
-    std::vector<op_desc> operators() const { return {{"GreaterOrEqual"}}; }
+    std::vector<op_desc> operators() const { return {{"GreaterOrEqual", "greater_or_equal"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_groupnorm.cpp
+++ b/src/onnx/parse_groupnorm.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_groupnorm : op_parser<parse_groupnorm>
 {
-    std::vector<op_desc> operators() const { return {{"GroupNormalization"}}; }
+    std::vector<op_desc> operators() const { return {{"GroupNormalization", "group_normalization"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_gru.cpp
+++ b/src/onnx/parse_gru.cpp
@@ -58,7 +58,7 @@ void gru_transpose_outputs(onnx_parser::node_info& info,
 
 struct parse_gru : op_parser<parse_gru>
 {
-    std::vector<op_desc> operators() const { return {{"GRU"}}; }
+    std::vector<op_desc> operators() const { return {{"GRU", "gru"}}; }
 
     std::vector<instruction_ref> parse(const op_desc& /*opd*/,
                                        const onnx_parser& parser,

--- a/src/onnx/parse_if.cpp
+++ b/src/onnx/parse_if.cpp
@@ -35,7 +35,7 @@ namespace onnx {
 
 struct parse_if : op_parser<parse_if>
 {
-    std::vector<op_desc> operators() const { return {{"If"}}; }
+    std::vector<op_desc> operators() const { return {{"If", "if"}}; }
 
     std::vector<instruction_ref> parse(const op_desc& /*opd*/,
                                        onnx_parser& parser,

--- a/src/onnx/parse_imagescalar.cpp
+++ b/src/onnx/parse_imagescalar.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_imagescalar : op_parser<parse_imagescalar>
 {
-    std::vector<op_desc> operators() const { return {{"ImageScaler"}}; }
+    std::vector<op_desc> operators() const { return {{"ImageScaler", "image_scaler"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_instancenorm.cpp
+++ b/src/onnx/parse_instancenorm.cpp
@@ -38,7 +38,7 @@ struct parse_instancenorm : op_parser<parse_instancenorm>
 {
     std::set<shape::type_t> valid_types = {shape::float_type, shape::half_type, shape::double_type};
 
-    std::vector<op_desc> operators() const { return {{"InstanceNormalization"}}; }
+    std::vector<op_desc> operators() const { return {{"InstanceNormalization", "instance_normalization"}}; }
 
     instruction_ref parse(const op_desc& opd,
                           const onnx_parser& parser,
@@ -79,6 +79,7 @@ struct parse_instancenorm : op_parser<parse_instancenorm>
         auto x     = args[0];
         auto scale = args[1];
         auto bias  = args[2];
+
         if(not contains(valid_types, dtype))
             MIGRAPHX_THROW(opd.op_name + ": invalid output type: " + std::to_string(dtype) +
                            ". Valid types are 1 (float), 10 (half), and 11 (double).");

--- a/src/onnx/parse_isinf.cpp
+++ b/src/onnx/parse_isinf.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_isinf : op_parser<parse_isinf>
 {
-    std::vector<op_desc> operators() const { return {{"IsInf", "isinf"}}; }
+    std::vector<op_desc> operators() const { return {{"IsInf", "is_inf"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_layernorm.cpp
+++ b/src/onnx/parse_layernorm.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_layernorm : op_parser<parse_layernorm>
 {
-    std::vector<op_desc> operators() const { return {{"LayerNormalization"}}; }
+    std::vector<op_desc> operators() const { return {{"LayerNormalization", "layer_normalization"}}; }
 
     std::vector<instruction_ref> parse(const op_desc& /*opd*/,
                                        const onnx_parser& parser,

--- a/src/onnx/parse_lessorequal.cpp
+++ b/src/onnx/parse_lessorequal.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_lessorequal : op_parser<parse_lessorequal>
 {
-    std::vector<op_desc> operators() const { return {{"LessOrEqual"}}; }
+    std::vector<op_desc> operators() const { return {{"LessOrEqual", "less_or_equal"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_loop.cpp
+++ b/src/onnx/parse_loop.cpp
@@ -34,7 +34,7 @@ namespace onnx {
 
 struct parse_loop : op_parser<parse_loop>
 {
-    std::vector<op_desc> operators() const { return {{"Loop"}}; }
+    std::vector<op_desc> operators() const { return {{"Loop", "loop"}}; }
 
     std::vector<instruction_ref> parse(const op_desc& /*opd*/,
                                        onnx_parser& parser,

--- a/src/onnx/parse_lpnormalization.cpp
+++ b/src/onnx/parse_lpnormalization.cpp
@@ -38,7 +38,7 @@ namespace onnx {
 */
 struct parse_lpnormalization : op_parser<parse_lpnormalization>
 {
-    std::vector<op_desc> operators() const { return {{"LpNormalization"}}; }
+    std::vector<op_desc> operators() const { return {{"LpNormalization", "Lp_normalization"}}; }
 
     instruction_ref parse(const op_desc&,
                           const onnx_parser&,

--- a/src/onnx/parse_lstm.cpp
+++ b/src/onnx/parse_lstm.cpp
@@ -77,7 +77,7 @@ void lstm_transpose_outputs(onnx_parser::node_info& info,
 
 struct parse_lstm : op_parser<parse_lstm>
 {
-    std::vector<op_desc> operators() const { return {{"LSTM"}}; }
+    std::vector<op_desc> operators() const { return {{"LSTM", "LSTM"}}; }
 
     std::vector<instruction_ref> parse(const op_desc& /*opd*/,
                                        const onnx_parser& parser,

--- a/src/onnx/parse_mean.cpp
+++ b/src/onnx/parse_mean.cpp
@@ -35,7 +35,7 @@ struct parse_mean : op_parser<parse_mean>
 {
     std::set<shape::type_t> float_types = {shape::float_type, shape::half_type, shape::double_type};
 
-    std::vector<op_desc> operators() const { return {{"Mean"}}; }
+    std::vector<op_desc> operators() const { return {{"Mean", "mean"}}; }
 
     /// Calculates the element-wise mean of n>=1 input tensors
     instruction_ref parse(const op_desc& /*opd*/,

--- a/src/onnx/parse_mean_variance_normalization.cpp
+++ b/src/onnx/parse_mean_variance_normalization.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_mean_variance_normalization : op_parser<parse_mean_variance_normalization>
 {
-    std::vector<op_desc> operators() const { return {{"MeanVarianceNormalization"}}; }
+    std::vector<op_desc> operators() const { return {{"MeanVarianceNormalization", "mean_variance_normalization"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_mod.cpp
+++ b/src/onnx/parse_mod.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_mod : op_parser<parse_mod>
 {
-    std::vector<op_desc> operators() const { return {{"Mod"}}; }
+    std::vector<op_desc> operators() const { return {{"Mod", "mod"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_multinomial.cpp
+++ b/src/onnx/parse_multinomial.cpp
@@ -34,7 +34,7 @@ namespace onnx {
 
 struct parse_multinomial : op_parser<parse_multinomial>
 {
-    std::vector<op_desc> operators() const { return {{"Multinomial"}}; }
+    std::vector<op_desc> operators() const { return {{"Multinomial", "multinomial"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_nonmaxsuppression.cpp
+++ b/src/onnx/parse_nonmaxsuppression.cpp
@@ -31,7 +31,7 @@ namespace onnx {
 
 struct parse_nonmaxsuppression : op_parser<parse_nonmaxsuppression>
 {
-    std::vector<op_desc> operators() const { return {{"NonMaxSuppression", "nonmaxsuppression"}}; }
+    std::vector<op_desc> operators() const { return {{"NonMaxSuppression", "non_max_suppression"}}; }
 
     instruction_ref parse(const op_desc& opd,
                           const onnx_parser& parser,

--- a/src/onnx/parse_nonzero.cpp
+++ b/src/onnx/parse_nonzero.cpp
@@ -46,7 +46,7 @@ static std::vector<std::size_t> nonzero_indices(const std::vector<T>& data)
 
 struct parse_nonzero : op_parser<parse_nonzero>
 {
-    std::vector<op_desc> operators() const { return {{"NonZero"}}; }
+    std::vector<op_desc> operators() const { return {{"NonZero", "non_zero"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_onehot.cpp
+++ b/src/onnx/parse_onehot.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_onehot : op_parser<parse_onehot>
 {
-    std::vector<op_desc> operators() const { return {{"OneHot"}}; }
+    std::vector<op_desc> operators() const { return {{"OneHot", "one_hot"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_pad.cpp
+++ b/src/onnx/parse_pad.cpp
@@ -113,7 +113,7 @@ instruction_ref reflect_pad(const onnx_parser::node_info& info,
 
 struct parse_pad : op_parser<parse_pad>
 {
-    std::vector<op_desc> operators() const { return {{"Pad"}}; }
+    std::vector<op_desc> operators() const { return {{"Pad", "pad"}}; }
 
     std::string parse_mode(const onnx_parser::node_info& info,
                            const std::vector<instruction_ref>& args) const

--- a/src/onnx/parse_pow.cpp
+++ b/src/onnx/parse_pow.cpp
@@ -56,7 +56,7 @@ auto compute_type(shape::type_t t1, shape::type_t t2)
 
 struct parse_pow : op_parser<parse_pow>
 {
-    std::vector<op_desc> operators() const { return {{"Pow"}}; }
+    std::vector<op_desc> operators() const { return {{"Pow", "pow"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_qlinearconcat.cpp
+++ b/src/onnx/parse_qlinearconcat.cpp
@@ -38,7 +38,7 @@ namespace onnx {
 
 struct parse_qlinearconcat : op_parser<parse_qlinearconcat>
 {
-    std::vector<op_desc> operators() const { return {{"QLinearConcat"}}; }
+    std::vector<op_desc> operators() const { return {{"QLinearConcat", "q_linear_concat"}}; }
 
     // basic type checking for QLinearConcat Operator
     void check_inputs(const std::vector<instruction_ref>& args) const

--- a/src/onnx/parse_qlinearconv.cpp
+++ b/src/onnx/parse_qlinearconv.cpp
@@ -83,7 +83,7 @@ https://xadupre.github.io/draft/onnx/onnx_doc_folder/onnx__QLinearConv.html
 
 struct parse_qlinearconv : op_parser<parse_qlinearconv>
 {
-    std::vector<op_desc> operators() const { return {{"QLinearConv"}}; }
+    std::vector<op_desc> operators() const { return {{"QLinearConv", "q_linear_conv"}}; }
 
     // basic type checking for QLinearConv Operator
     void check_inputs(const std::vector<instruction_ref>& inp_arg) const

--- a/src/onnx/parse_qlinearmatmul.cpp
+++ b/src/onnx/parse_qlinearmatmul.cpp
@@ -89,7 +89,7 @@ integer tensor.
 
 struct parse_qlinearmatmul : op_parser<parse_qlinearmatmul>
 {
-    std::vector<op_desc> operators() const { return {{"QLinearMatMul"}}; }
+    std::vector<op_desc> operators() const { return {{"QLinearMatMul", "q_linear_mat_mul"}}; }
 
     // basic type checking for QLinearMatMul Operator
 

--- a/src/onnx/parse_quantizelinear.cpp
+++ b/src/onnx/parse_quantizelinear.cpp
@@ -35,7 +35,7 @@ namespace onnx {
 
 struct parse_quantizelinear : op_parser<parse_quantizelinear>
 {
-    std::vector<op_desc> operators() const { return {{"QuantizeLinear"}}; }
+    std::vector<op_desc> operators() const { return {{"QuantizeLinear", "quantize_linear"}}; }
 
     instruction_ref parse(const op_desc& opd,
                           const onnx_parser& parser,

--- a/src/onnx/parse_randomnormal_ops.cpp
+++ b/src/onnx/parse_randomnormal_ops.cpp
@@ -37,7 +37,7 @@ struct parse_randomnormal_ops : op_parser<parse_randomnormal_ops>
 {
     std::set<shape::type_t> valid_types = {shape::float_type, shape::half_type, shape::double_type};
 
-    std::vector<op_desc> operators() const { return {{"RandomNormal"}, {"RandomNormalLike"}}; }
+    std::vector<op_desc> operators() const { return {{"RandomNormal", "random_normal"}, {"RandomNormalLike", "random_normal_like"}}; }
 
     instruction_ref parse(const op_desc& opd,
                           const onnx_parser& parser,

--- a/src/onnx/parse_randomuniform_ops.cpp
+++ b/src/onnx/parse_randomuniform_ops.cpp
@@ -37,7 +37,7 @@ struct parse_randomuniform_ops : op_parser<parse_randomuniform_ops>
 {
     std::set<shape::type_t> valid_types = {shape::float_type, shape::half_type, shape::double_type};
 
-    std::vector<op_desc> operators() const { return {{"RandomUniform"}, {"RandomUniformLike"}}; }
+    std::vector<op_desc> operators() const { return {{"RandomUniform", "random_uniform"}, {"RandomUniformLike", "random_uniform_like"}}; }
 
     instruction_ref parse(const op_desc& opd,
                           const onnx_parser& parser,

--- a/src/onnx/parse_range.cpp
+++ b/src/onnx/parse_range.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_range : op_parser<parse_range>
 {
-    std::vector<op_desc> operators() const { return {{"Range"}}; }
+    std::vector<op_desc> operators() const { return {{"Range", "range"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_reduce_op.cpp
+++ b/src/onnx/parse_reduce_op.cpp
@@ -158,7 +158,7 @@ struct parse_reduce_op : reduce_parser<parse_reduce_op>
 
 struct parse_reduce_l1 : reduce_parser<parse_reduce_l1>
 {
-    std::vector<op_desc> operators() const { return {{"ReduceL1"}}; }
+    std::vector<op_desc> operators() const { return {{"ReduceL1", "reduce_L1"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,
@@ -172,7 +172,7 @@ struct parse_reduce_l1 : reduce_parser<parse_reduce_l1>
 
 struct parse_reduce_l2 : reduce_parser<parse_reduce_l2>
 {
-    std::vector<op_desc> operators() const { return {{"ReduceL2"}}; }
+    std::vector<op_desc> operators() const { return {{"ReduceL2", "reduce_L2"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,
@@ -187,7 +187,7 @@ struct parse_reduce_l2 : reduce_parser<parse_reduce_l2>
 
 struct parse_reduce_log_sum : reduce_parser<parse_reduce_log_sum>
 {
-    std::vector<op_desc> operators() const { return {{"ReduceLogSum"}}; }
+    std::vector<op_desc> operators() const { return {{"ReduceLogSum", "reduce_log_sum"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,
@@ -201,7 +201,7 @@ struct parse_reduce_log_sum : reduce_parser<parse_reduce_log_sum>
 
 struct parse_reduce_log_sum_exp : reduce_parser<parse_reduce_log_sum_exp>
 {
-    std::vector<op_desc> operators() const { return {{"ReduceLogSumExp"}}; }
+    std::vector<op_desc> operators() const { return {{"ReduceLogSumExp", "reduce_log_sum_exp"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,
@@ -216,7 +216,7 @@ struct parse_reduce_log_sum_exp : reduce_parser<parse_reduce_log_sum_exp>
 
 struct parse_reduce_sum_square : reduce_parser<parse_reduce_sum_square>
 {
-    std::vector<op_desc> operators() const { return {{"ReduceSumSquare"}}; }
+    std::vector<op_desc> operators() const { return {{"ReduceSumSquare", "reduce_sum_square"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_reshape.cpp
+++ b/src/onnx/parse_reshape.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_reshape : op_parser<parse_reshape>
 {
-    std::vector<op_desc> operators() const { return {{"Reshape"}}; }
+    std::vector<op_desc> operators() const { return {{"Reshape", "reshape"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_reversesequence.cpp
+++ b/src/onnx/parse_reversesequence.cpp
@@ -41,7 +41,7 @@ namespace onnx {
 */
 struct parse_reversesequence : op_parser<parse_reversesequence>
 {
-    std::vector<op_desc> operators() const { return {{"ReverseSequence"}}; }
+    std::vector<op_desc> operators() const { return {{"ReverseSequence", "reverse_sequence"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_rnn.cpp
+++ b/src/onnx/parse_rnn.cpp
@@ -58,7 +58,7 @@ void rnn_transpose_outputs(onnx_parser::node_info& info,
 
 struct parse_rnn : op_parser<parse_rnn>
 {
-    std::vector<op_desc> operators() const { return {{"RNN"}}; }
+    std::vector<op_desc> operators() const { return {{"RNN", "RNN"}}; }
 
     std::vector<instruction_ref> parse(const op_desc& /*opd*/,
                                        const onnx_parser& parser,

--- a/src/onnx/parse_roialign.cpp
+++ b/src/onnx/parse_roialign.cpp
@@ -34,7 +34,7 @@ namespace onnx {
 
 struct parse_roialign : op_parser<parse_roialign>
 {
-    std::vector<op_desc> operators() const { return {{"RoiAlign"}}; }
+    std::vector<op_desc> operators() const { return {{"RoiAlign", "RoI_align"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_scatter.cpp
+++ b/src/onnx/parse_scatter.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_scatter : op_parser<parse_scatter>
 {
-    std::vector<op_desc> operators() const { return {{"ScatterElements"}, {"Scatter"}}; }
+    std::vector<op_desc> operators() const { return {{"ScatterElements", "scatter_elements"}, {"Scatter", "scatter"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_scatternd.cpp
+++ b/src/onnx/parse_scatternd.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_scatternd : op_parser<parse_scatternd>
 {
-    std::vector<op_desc> operators() const { return {{"ScatterND"}}; }
+    std::vector<op_desc> operators() const { return {{"ScatterND", "scatter_nd"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_selu.cpp
+++ b/src/onnx/parse_selu.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_selu : op_parser<parse_selu>
 {
-    std::vector<op_desc> operators() const { return {{"Selu"}}; }
+    std::vector<op_desc> operators() const { return {{"Selu", "selu"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_shape.cpp
+++ b/src/onnx/parse_shape.cpp
@@ -37,7 +37,7 @@ namespace onnx {
  */
 struct parse_shape : op_parser<parse_shape>
 {
-    std::vector<op_desc> operators() const { return {{"Shape"}}; }
+    std::vector<op_desc> operators() const { return {{"Shape", "shape"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_shrink.cpp
+++ b/src/onnx/parse_shrink.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_shrink : op_parser<parse_shrink>
 {
-    std::vector<op_desc> operators() const { return {{"Shrink"}}; }
+    std::vector<op_desc> operators() const { return {{"Shrink", "shrink"}}; }
 
     instruction_ref parse(const op_desc&,
                           const onnx_parser& parser,

--- a/src/onnx/parse_size.cpp
+++ b/src/onnx/parse_size.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_size : op_parser<parse_size>
 {
-    std::vector<op_desc> operators() const { return {{"Size"}}; }
+    std::vector<op_desc> operators() const { return {{"Size", "size"}}; }
 
     instruction_ref parse(const op_desc&,
                           const onnx_parser&,

--- a/src/onnx/parse_slice.cpp
+++ b/src/onnx/parse_slice.cpp
@@ -35,7 +35,7 @@ namespace onnx {
 struct parse_slice : op_parser<parse_slice>
 {
 
-    std::vector<op_desc> operators() const { return {{"Slice"}}; }
+    std::vector<op_desc> operators() const { return {{"Slice", "slice"}}; }
 
     struct slice_desc
     {

--- a/src/onnx/parse_softplus.cpp
+++ b/src/onnx/parse_softplus.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_softplus : op_parser<parse_softplus>
 {
-    std::vector<op_desc> operators() const { return {{"Softplus"}}; }
+    std::vector<op_desc> operators() const { return {{"Softplus", "softplus"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_softsign.cpp
+++ b/src/onnx/parse_softsign.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_softsign : op_parser<parse_softsign>
 {
-    std::vector<op_desc> operators() const { return {{"Softsign"}}; }
+    std::vector<op_desc> operators() const { return {{"Softsign", "softsign"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_spacetodepth.cpp
+++ b/src/onnx/parse_spacetodepth.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_spacetodepth : op_parser<parse_spacetodepth>
 {
-    std::vector<op_desc> operators() const { return {{"SpaceToDepth"}}; }
+    std::vector<op_desc> operators() const { return {{"SpaceToDepth", "space_to_depth"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_split.cpp
+++ b/src/onnx/parse_split.cpp
@@ -161,7 +161,7 @@ auto parse_static_split(const onnx_parser::node_info& info,
 
 struct parse_split : op_parser<parse_split>
 {
-    std::vector<op_desc> operators() const { return {{"Split"}}; }
+    std::vector<op_desc> operators() const { return {{"Split", "split"}}; }
 
     std::vector<instruction_ref> parse(const op_desc& opd,
                                        const onnx_parser& parser,

--- a/src/onnx/parse_thresholdedrelu.cpp
+++ b/src/onnx/parse_thresholdedrelu.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_thresholdedrelu : op_parser<parse_thresholdedrelu>
 {
-    std::vector<op_desc> operators() const { return {{"ThresholdedRelu"}}; }
+    std::vector<op_desc> operators() const { return {{"ThresholdedRelu", "thresholded_relu"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& parser,

--- a/src/onnx/parse_tile.cpp
+++ b/src/onnx/parse_tile.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_tile : op_parser<parse_tile>
 {
-    std::vector<op_desc> operators() const { return {{"Tile"}}; }
+    std::vector<op_desc> operators() const { return {{"Tile", "tile"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_topk.cpp
+++ b/src/onnx/parse_topk.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_topk : op_parser<parse_topk>
 {
-    std::vector<op_desc> operators() const { return {{"TopK"}}; }
+    std::vector<op_desc> operators() const { return {{"TopK", "top_k"}}; }
 
     std::vector<instruction_ref> parse(const op_desc& /*opd*/,
                                        const onnx_parser& parser,

--- a/src/onnx/parse_transpose.cpp
+++ b/src/onnx/parse_transpose.cpp
@@ -32,7 +32,7 @@ namespace onnx {
 
 struct parse_transpose : op_parser<parse_transpose>
 {
-    std::vector<op_desc> operators() const { return {{"Transpose"}}; }
+    std::vector<op_desc> operators() const { return {{"Transpose", "transpose"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/onnx/parse_trilu.cpp
+++ b/src/onnx/parse_trilu.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_trilu : op_parser<parse_trilu>
 {
-    std::vector<op_desc> operators() const { return {{"Trilu"}}; }
+    std::vector<op_desc> operators() const { return {{"Trilu", "trilu"}}; }
 
     instruction_ref parse(const op_desc&,
                           const onnx_parser&,

--- a/src/onnx/parse_unique.cpp
+++ b/src/onnx/parse_unique.cpp
@@ -54,7 +54,7 @@ namespace onnx {
 struct parse_unique : op_parser<parse_unique>
 {
 
-    std::vector<op_desc> operators() const { return {{"Unique"}}; }
+    std::vector<op_desc> operators() const { return {{"Unique", "unique"}}; }
 
     std::vector<instruction_ref> parse(const op_desc& opd,
                                        const onnx_parser& parser,

--- a/src/onnx/parse_where.cpp
+++ b/src/onnx/parse_where.cpp
@@ -33,7 +33,7 @@ namespace onnx {
 
 struct parse_where : op_parser<parse_where>
 {
-    std::vector<op_desc> operators() const { return {{"Where"}}; }
+    std::vector<op_desc> operators() const { return {{"Where", "where"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const onnx_parser& /*parser*/,

--- a/src/tf/parse_batchnorm.cpp
+++ b/src/tf/parse_batchnorm.cpp
@@ -34,7 +34,7 @@ namespace tf {
 struct parse_batchnorm : op_parser<parse_batchnorm>
 {
     bool transpose() const { return true; }
-    std::vector<op_desc> operators() const { return {{"FusedBatchNorm"}, {"FusedBatchNormV3"}}; }
+    std::vector<op_desc> operators() const { return {{"FusedBatchNorm", "fused_batch_norm" }, {"FusedBatchNormV3", "fused_batch_norm_v3"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& /*parser*/,

--- a/src/tf/parse_biasadd.cpp
+++ b/src/tf/parse_biasadd.cpp
@@ -33,7 +33,7 @@ namespace tf {
 struct parse_biasadd : op_parser<parse_biasadd>
 {
     bool transpose() const { return true; }
-    std::vector<op_desc> operators() const { return {{"BiasAdd"}}; }
+    std::vector<op_desc> operators() const { return {{"BiasAdd", "bias_add"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& /*parser*/,

--- a/src/tf/parse_cast.cpp
+++ b/src/tf/parse_cast.cpp
@@ -33,7 +33,7 @@ namespace tf {
 
 struct parse_cast : op_parser<parse_cast>
 {
-    std::vector<op_desc> operators() const { return {{"Cast"}}; }
+    std::vector<op_desc> operators() const { return {{"Cast", "cast"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& parser,

--- a/src/tf/parse_concat.cpp
+++ b/src/tf/parse_concat.cpp
@@ -33,7 +33,7 @@ namespace tf {
 
 struct parse_concat : op_parser<parse_concat>
 {
-    std::vector<op_desc> operators() const { return {{"ConcatV2"}}; }
+    std::vector<op_desc> operators() const { return {{"ConcatV2", "concat_v2"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& /*parser*/,

--- a/src/tf/parse_constant.cpp
+++ b/src/tf/parse_constant.cpp
@@ -33,7 +33,7 @@ namespace tf {
 struct parse_constant_op : op_parser<parse_constant_op>
 {
     bool transpose() const { return true; }
-    std::vector<op_desc> operators() const { return {{"Const"}}; }
+    std::vector<op_desc> operators() const { return {{"Const", "const"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& parser,

--- a/src/tf/parse_conv.cpp
+++ b/src/tf/parse_conv.cpp
@@ -35,7 +35,7 @@ namespace tf {
 struct parse_conv : op_parser<parse_conv>
 {
     bool transpose() const { return true; }
-    std::vector<op_desc> operators() const { return {{"Conv2D"}}; }
+    std::vector<op_desc> operators() const { return {{"Conv2D", "conv2d"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& parser,

--- a/src/tf/parse_depthwiseconv.cpp
+++ b/src/tf/parse_depthwiseconv.cpp
@@ -35,7 +35,7 @@ namespace tf {
 struct parse_depthwiseconv : op_parser<parse_depthwiseconv>
 {
     bool transpose() const { return true; }
-    std::vector<op_desc> operators() const { return {{"DepthwiseConv2dNative"}}; }
+    std::vector<op_desc> operators() const { return {{"DepthwiseConv2dNative", "depthwise_conv2d_native"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& parser,

--- a/src/tf/parse_expanddims.cpp
+++ b/src/tf/parse_expanddims.cpp
@@ -33,7 +33,7 @@ namespace tf {
 
 struct parse_expanddims : op_parser<parse_expanddims>
 {
-    std::vector<op_desc> operators() const { return {{"ExpandDims"}}; }
+    std::vector<op_desc> operators() const { return {{"ExpandDims", "expand_dims"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& /*parser*/,

--- a/src/tf/parse_gather.cpp
+++ b/src/tf/parse_gather.cpp
@@ -33,7 +33,7 @@ namespace tf {
 
 struct parse_gather : op_parser<parse_gather>
 {
-    std::vector<op_desc> operators() const { return {{"GatherV2"}}; }
+    std::vector<op_desc> operators() const { return {{"GatherV2", "gather_v2"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& /*parser*/,

--- a/src/tf/parse_matmul.cpp
+++ b/src/tf/parse_matmul.cpp
@@ -35,7 +35,7 @@ struct parse_matmul : op_parser<parse_matmul>
 {
     std::vector<op_desc> operators() const
     {
-        return {{"BatchMatMul"}, {"BatchMatMulV2"}, {"MatMul"}};
+        return {{"BatchMatMul", "batch_mat_mul"}, {"BatchMatMulV2", "batch_mat_mul_v2"}, {"MatMul", "mat_mul"}};
     }
 
     instruction_ref parse(const op_desc& /*opd*/,

--- a/src/tf/parse_mean.cpp
+++ b/src/tf/parse_mean.cpp
@@ -33,7 +33,7 @@ namespace tf {
 
 struct parse_mean : op_parser<parse_mean>
 {
-    std::vector<op_desc> operators() const { return {{"Mean"}}; }
+    std::vector<op_desc> operators() const { return {{"Mean", "mean"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& /*parser*/,

--- a/src/tf/parse_onehot.cpp
+++ b/src/tf/parse_onehot.cpp
@@ -33,7 +33,7 @@ namespace tf {
 
 struct parse_onehot : op_parser<parse_onehot>
 {
-    std::vector<op_desc> operators() const { return {{"OneHot"}}; }
+    std::vector<op_desc> operators() const { return {{"OneHot", "one_hot"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& /*parser*/,

--- a/src/tf/parse_pack.cpp
+++ b/src/tf/parse_pack.cpp
@@ -34,7 +34,7 @@ namespace tf {
 
 struct parse_pack : op_parser<parse_pack>
 {
-    std::vector<op_desc> operators() const { return {{"Pack"}}; }
+    std::vector<op_desc> operators() const { return {{"Pack", "pack"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& parser,

--- a/src/tf/parse_pad.cpp
+++ b/src/tf/parse_pad.cpp
@@ -34,7 +34,7 @@ namespace tf {
 struct parse_pad : op_parser<parse_pad>
 {
     bool transpose() const { return true; }
-    std::vector<op_desc> operators() const { return {{"Pad"}}; }
+    std::vector<op_desc> operators() const { return {{"Pad", "pad"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& parser,

--- a/src/tf/parse_pooling.cpp
+++ b/src/tf/parse_pooling.cpp
@@ -35,7 +35,7 @@ namespace tf {
 struct parse_pooling : op_parser<parse_pooling>
 {
     bool transpose() const { return true; }
-    std::vector<op_desc> operators() const { return {{"AvgPool"}, {"MaxPool"}}; }
+    std::vector<op_desc> operators() const { return {{"AvgPool", "avg_pool"}, {"MaxPool", "max_pool"}}; }
 
     instruction_ref parse(const op_desc& opd,
                           const tf_parser& parser,

--- a/src/tf/parse_relu6.cpp
+++ b/src/tf/parse_relu6.cpp
@@ -34,7 +34,7 @@ namespace tf {
 struct parse_relu6 : op_parser<parse_relu6>
 {
     bool transpose() const { return true; }
-    std::vector<op_desc> operators() const { return {{"Relu6"}}; }
+    std::vector<op_desc> operators() const { return {{"Relu6", "relu6"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& /*parser*/,

--- a/src/tf/parse_reshape.cpp
+++ b/src/tf/parse_reshape.cpp
@@ -33,7 +33,7 @@ namespace tf {
 
 struct parse_reshape : op_parser<parse_reshape>
 {
-    std::vector<op_desc> operators() const { return {{"Reshape"}}; }
+    std::vector<op_desc> operators() const { return {{"Reshape", "reshape"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& /*parser*/,

--- a/src/tf/parse_shape.cpp
+++ b/src/tf/parse_shape.cpp
@@ -33,7 +33,7 @@ namespace tf {
 
 struct parse_shape : op_parser<parse_shape>
 {
-    std::vector<op_desc> operators() const { return {{"Shape"}}; }
+    std::vector<op_desc> operators() const { return {{"Shape", "shape"}}; }
 
     // Use a literal instruction to replace the shape since output of
     // shape operator are literals in migraphx

--- a/src/tf/parse_slice.cpp
+++ b/src/tf/parse_slice.cpp
@@ -33,7 +33,7 @@ namespace tf {
 
 struct parse_slice : op_parser<parse_slice>
 {
-    std::vector<op_desc> operators() const { return {{"Slice"}}; }
+    std::vector<op_desc> operators() const { return {{"Slice", "slice"}}; }
 
     // Use a literal instruction to replace the shape since output of
     // shape operator are literals in migraphx

--- a/src/tf/parse_softmax.cpp
+++ b/src/tf/parse_softmax.cpp
@@ -34,7 +34,7 @@ namespace tf {
 
 struct parse_softmax : op_parser<parse_softmax>
 {
-    std::vector<op_desc> operators() const { return {{"Softmax"}}; }
+    std::vector<op_desc> operators() const { return {{"Softmax", "softmax"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& /*parser*/,

--- a/src/tf/parse_split.cpp
+++ b/src/tf/parse_split.cpp
@@ -33,7 +33,7 @@ namespace tf {
 
 struct parse_split : op_parser<parse_split>
 {
-    std::vector<op_desc> operators() const { return {{"Split"}, {"SplitV"}}; }
+    std::vector<op_desc> operators() const { return {{"Split", "split"}, {"SplitV", "split_v"}}; }
 
     std::vector<instruction_ref> parse(const op_desc& /*opd*/,
                                        const tf_parser& /*parser*/,

--- a/src/tf/parse_squeeze.cpp
+++ b/src/tf/parse_squeeze.cpp
@@ -33,7 +33,7 @@ namespace tf {
 
 struct parse_squeeze : op_parser<parse_squeeze>
 {
-    std::vector<op_desc> operators() const { return {{"Squeeze"}}; }
+    std::vector<op_desc> operators() const { return {{"Squeeze", "squeeze"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& /*parser*/,

--- a/src/tf/parse_stridedslice.cpp
+++ b/src/tf/parse_stridedslice.cpp
@@ -33,7 +33,7 @@ namespace tf {
 
 struct parse_strideslice : op_parser<parse_strideslice>
 {
-    std::vector<op_desc> operators() const { return {{"StridedSlice"}}; }
+    std::vector<op_desc> operators() const { return {{"StridedSlice", "strided_slice"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& /*parser*/,

--- a/src/tf/parse_transpose.cpp
+++ b/src/tf/parse_transpose.cpp
@@ -33,7 +33,7 @@ namespace tf {
 
 struct parse_transpose : op_parser<parse_transpose>
 {
-    std::vector<op_desc> operators() const { return {{"Transpose"}}; }
+    std::vector<op_desc> operators() const { return {{"Transpose", "transpose"}}; }
 
     instruction_ref parse(const op_desc& /*opd*/,
                           const tf_parser& /*parser*/,


### PR DESCRIPTION
op_name is empty in the op_desc of many operators in the onnx and tf parsers ([issue](https://github.com/ROCm/AMDMIGraphX/issues/2952))