### PR TITLE
Fix compilation when using STL headers for GCC 14

### DIFF
--- a/src/include/migraphx/lexing.hpp
+++ b/src/include/migraphx/lexing.hpp
@@ -27,6 +27,7 @@
 #include <functional>
 #include <string>
 #include <vector>
+#include <algorithm>
 #include <migraphx/errors.hpp>
 
 namespace migraphx {

--- a/src/include/migraphx/par.hpp
+++ b/src/include/migraphx/par.hpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <mutex>
 #include <vector>
+#include <exception>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {


### PR DESCRIPTION
For gcc 13 and earlier, including `<mutex>` would include `<exception>` internally so there would be no need to do so explicitly to use std::exception_ptr . For gcc 14, "Some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library" ([source](https://gcc.gnu.org/gcc-14/porting_to.html)). This likely includes `<mutex>` so `<exception>` will have to be included explicitly.