### PR TITLE
MI300 specific FP8 ASM fix

### DIFF
--- a/src/targets/gpu/kernels/include/migraphx/kernels/float8.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/float8.hpp
@@ -137,7 +137,7 @@ struct float8
            migraphx::fp8::rounding_mode rm = migraphx::fp8::rounding_mode::standard,
            uint32_t rng                    = 0)
     {
-        if constexpr(FNUZ)
+        if(__builtin_is_constant_evaluated() or FNUZ)
         {
             if constexpr(T == migraphx::fp8::f8_type::fp8)
             {
@@ -150,35 +150,18 @@ struct float8
                     cast_to_f8<3, 4, float, FNUZ /*negative_zero_nan*/, false /*clip*/>(
                         v, (rm == migraphx::fp8::rounding_mode::stochastic), rng);
 #endif // MIGRAPHX_F8_DOWNCAST_CLIPPING
-        }
-        else
-        {
-            if(__builtin_is_constant_evaluated())
+            }
+            else
             {
-                if constexpr(T == migraphx::fp8::f8_type::fp8)
-                {
 #ifdef MIGRAPHX_F8_DOWNCAST_CLIPPING
-                    data = migraphx::fp8::impl::
-                        cast_to_f8<3, 4, float, FNUZ /*negative_zero_nan*/, true /*clip*/>(
-                            v, (rm == migraphx::fp8::rounding_mode::stochastic), rng);
+                data = migraphx::fp8::impl::
+                    cast_to_f8<2, 5, float, FNUZ /*negative_zero_nan*/, true /*clip*/>(
+                        v, (rm == migraphx::fp8::rounding_mode::stochastic), rng);
 #else  // MIGRAPHX_F8_DOWNCAST_CLIPPING
-                    data = migraphx::fp8::impl::
-                        cast_to_f8<3, 4, float, FNUZ /*negative_zero_nan*/, false /*clip*/>(
-                            v, (rm == migraphx::fp8::rounding_mode::stochastic), rng);
-#endif // MIGRAPHX_F8_DOWNCAST_CLIPPING
-                }
-                else
-                {
-#ifdef MIGRAPHX_F8_DOWNCAST_CLIPPING
-                    data = migraphx::fp8::impl::
-                        cast_to_f8<2, 5, float, FNUZ /*negative_zero_nan*/, true /*clip*/>(
-                            v, (rm == migraphx::fp8::rounding_mode::stochastic), rng);
-#else  // MIGRAPHX_F8_DOWNCAST_CLIPPING
-                    data = migraphx::fp8::impl::
-                        cast_to_f8<2, 5, float, FNUZ /*negative_zero_nan*/, false /*clip*/>(
-                            v, (rm == migraphx::fp8::rounding_mode::stochastic), rng);
+                data = migraphx::fp8::impl::
+                    cast_to_f8<2, 5, float, FNUZ /*negative_zero_nan*/, false /*clip*/>(
+                        v, (rm == migraphx::fp8::rounding_mode::stochastic), rng);
 #endif // MIGRAPHX_FP8_DOWNCAST_CLIPPING}
-                }
             }
         }
         else

--- a/src/targets/gpu/kernels/include/migraphx/kernels/float8.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/float8.hpp
@@ -137,7 +137,7 @@ struct float8
            migraphx::fp8::rounding_mode rm = migraphx::fp8::rounding_mode::standard,
            uint32_t rng                    = 0)
     {
-        if(__builtin_is_constant_evaluated() or FNUZ)
+        if(__builtin_is_constant_evaluated() or !FNUZ)
         {
             if constexpr(T == migraphx::fp8::f8_type::fp8)
             {
@@ -246,16 +246,7 @@ struct float8
     // upcast using device specific intrinsic
     inline constexpr __device__ operator float() const
     {
-        if constexpr(FNUZ)
-        {
-            if constexpr(T == migraphx::fp8::f8_type::fp8)
-            {
-                return migraphx::fp8::impl::cast_from_f8<3, 4, float, FNUZ /*negative_zero_nan*/>(
-                    data);
-            } // else
-            return migraphx::fp8::impl::cast_from_f8<2, 5, float, FNUZ /*negative_zero_nan*/>(data);
-        }
-        if(__builtin_is_constant_evaluated())
+        if(__builtin_is_constant_evaluated() or !FNUZ)
         {
             if constexpr(T == migraphx::fp8::f8_type::fp8)
             {

--- a/src/targets/gpu/kernels/include/migraphx/kernels/math.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/math.hpp
@@ -79,19 +79,17 @@ constexpr T as_float(T x)
         MIGRAPHX_RETURNS(fname(math::as_float(x), math::as_float(xs)...))
 
 // NOLINTNEXTLINE
-#define MIGRAPHX_DEVICE_MATH_FP8(name, fname)                                                      \
-    template <class... Ts, MIGRAPHX_REQUIRES(not is_any_vec<Ts...>())>                             \
-    auto __device__ name(migraphx::fp8::fp8e4m3fnuz x, Ts... xs)                                   \
-        MIGRAPHX_RETURNS(migraphx::fp8::fp8e4m3fnuz(                                               \
-            fname(math::as_float(x),                                                               \
-                  math::as_float(                                                                  \
-                      xs)...))) template <class... Ts, MIGRAPHX_REQUIRES(not is_any_vec<Ts...>())> \
-        auto __device__ name(migraphx::fp8::fp8e4m3fn x, Ts... xs)                                 \
-            MIGRAPHX_RETURNS(migraphx::fp8::fp8e4m3fn(fname(                                       \
-                math::as_float(x),                                                                 \
-                math::as_float(                                                                    \
-                    xs)...))) template <class... Ts, MIGRAPHX_REQUIRES(not is_any_vec<Ts...>())>   \
-            auto __device__ name(migraphx::fp8::fp8e5m2 x, Ts... xs) MIGRAPHX_RETURNS(             \
+#define MIGRAPHX_DEVICE_MATH_FP8(name, fname)                                          \
+    template <class... Ts, MIGRAPHX_REQUIRES(not is_any_vec<Ts...>())>                 \
+    auto __device__ name(migraphx::fp8::fp8e4m3fnuz x, Ts... xs) MIGRAPHX_RETURNS(     \
+        migraphx::fp8::fp8e4m3fnuz(fname(math::as_float(x), math::as_float(xs)...)))   \
+                                                                                       \
+        template <class... Ts, MIGRAPHX_REQUIRES(not is_any_vec<Ts...>())>             \
+        auto __device__ name(migraphx::fp8::fp8e4m3fn x, Ts... xs) MIGRAPHX_RETURNS(   \
+            migraphx::fp8::fp8e4m3fn(fname(math::as_float(x), math::as_float(xs)...))) \
+                                                                                       \
+            template <class... Ts, MIGRAPHX_REQUIRES(not is_any_vec<Ts...>())>         \
+            auto __device__ name(migraphx::fp8::fp8e5m2 x, Ts... xs) MIGRAPHX_RETURNS( \
                 migraphx::fp8::fp8e5m2(fname(math::as_float(x), math::as_float(xs)...)))
 
 // Template with two overloads for math functions, one for half2 type and one for more generic


### PR DESCRIPTION
Disables the fp8 ASM on MI300 for non-FNUZ types. MI300 only has hardware support for FNUZ FP8 types. Fixes test_verify bugs seen on MI300.