### PR TITLE
Printing Final MLIR Module

### DIFF
--- a/docs/dev/env_vars.rst
+++ b/docs/dev/env_vars.rst
@@ -308,6 +308,11 @@ Enable Split-k perf configs when tuning with MLIR.
 Set to path where MXRs will be saved.
 Dumps MLIRs module to mxr files.
 
+.. envvar:: MIGRAPHX_MLIR_DUMP
+
+Set to path where MLIRs will be saved.
+Dumps MLIRs module to .mlir files.
+
 CK vars
 -----------
 

--- a/src/targets/gpu/include/migraphx/gpu/mlir.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/mlir.hpp
@@ -40,6 +40,7 @@ namespace gpu {
 
 MIGRAPHX_GPU_EXPORT std::string dump_mlir(module m);
 MIGRAPHX_GPU_EXPORT std::string dump_mlir(module m, const std::vector<shape>& inputs);
+MIGRAPHX_GPU_EXPORT std::string dump_mlir(module m, const std::vector<shape>& inputs, const fs::path& location);
 
 MIGRAPHX_GPU_EXPORT bool
 is_module_fusible(const module& m, const context& migraphx_ctx, const value& solution);

--- a/src/targets/gpu/include/migraphx/gpu/mlir.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/mlir.hpp
@@ -40,7 +40,8 @@ namespace gpu {
 
 MIGRAPHX_GPU_EXPORT std::string dump_mlir(module m);
 MIGRAPHX_GPU_EXPORT std::string dump_mlir(module m, const std::vector<shape>& inputs);
-MIGRAPHX_GPU_EXPORT std::string dump_mlir(module m, const std::vector<shape>& inputs, const fs::path& location);
+MIGRAPHX_GPU_EXPORT void
+dump_mlir_to_file(module m, const std::vector<shape>& inputs, const fs::path& location);
 
 MIGRAPHX_GPU_EXPORT bool
 is_module_fusible(const module& m, const context& migraphx_ctx, const value& solution);

--- a/src/targets/gpu/jit/mlir.cpp
+++ b/src/targets/gpu/jit/mlir.cpp
@@ -230,7 +230,6 @@ struct mlir_compiler : compiler<mlir_compiler>
 
     static void trace(std::ostream& os, instruction_ref ins)
     {
-        std::cout << "tracing" << std::endl;
         auto shapes = to_shapes(ins->inputs());
         auto* smod  = ins->module_inputs().front();
         os << dump_mlir(*smod, shapes);

--- a/src/targets/gpu/jit/mlir.cpp
+++ b/src/targets/gpu/jit/mlir.cpp
@@ -39,6 +39,7 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_MLIR_DUMP_TO_MXR);
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_MLIR_DUMP_TO_FILE);
 
 static module create_pointwise_module(module_ref in_mod)
 {
@@ -212,6 +213,7 @@ struct mlir_compiler : compiler<mlir_compiler>
                                               bool exhaustive) const
     {
         static const auto mxr_loc = string_value_of(MIGRAPHX_MLIR_DUMP_TO_MXR{});
+        static const auto mlir_loc = string_value_of(MIGRAPHX_MLIR_DUMP_TO_FILE{});
 
         auto shapes = to_shapes(ins->inputs());
         auto* smod  = ins->module_inputs().front();
@@ -219,11 +221,16 @@ struct mlir_compiler : compiler<mlir_compiler>
         {
             dump_mlir_to_mxr(*smod, ins->inputs(), mxr_loc);
         }
+        if(not mlir_loc.empty())
+        {
+            dump_mlir(*smod, shapes, mlir_loc);
+        }
         return get_tuning_config_mlir(ctx, *smod, shapes, exhaustive);
     }
 
     static void trace(std::ostream& os, instruction_ref ins)
     {
+        std::cout << "tracing" << std::endl;
         auto shapes = to_shapes(ins->inputs());
         auto* smod  = ins->module_inputs().front();
         os << dump_mlir(*smod, shapes);

--- a/src/targets/gpu/jit/mlir.cpp
+++ b/src/targets/gpu/jit/mlir.cpp
@@ -39,7 +39,7 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_MLIR_DUMP_TO_MXR);
-MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_MLIR_DUMP_TO_FILE);
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_MLIR_DUMP);
 
 static module create_pointwise_module(module_ref in_mod)
 {
@@ -213,7 +213,7 @@ struct mlir_compiler : compiler<mlir_compiler>
                                               bool exhaustive) const
     {
         static const auto mxr_loc = string_value_of(MIGRAPHX_MLIR_DUMP_TO_MXR{});
-        static const auto mlir_loc = string_value_of(MIGRAPHX_MLIR_DUMP_TO_FILE{});
+        static const auto mlir_loc = string_value_of(MIGRAPHX_MLIR_DUMP{});
 
         auto shapes = to_shapes(ins->inputs());
         auto* smod  = ins->module_inputs().front();
@@ -223,7 +223,7 @@ struct mlir_compiler : compiler<mlir_compiler>
         }
         if(not mlir_loc.empty())
         {
-            dump_mlir(*smod, shapes, mlir_loc);
+            dump_mlir_to_file(*smod, shapes, mlir_loc);
         }
         return get_tuning_config_mlir(ctx, *smod, shapes, exhaustive);
     }

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1153,7 +1153,6 @@ mlir_code_object compile_mlir(const context& migraphx_ctx,
     if(trace)
     {
         const std::lock_guard<std::mutex> lock(mutex);
-        std::cout << "printing mlir" << std::endl;
         std::cout << mlir_print(&mlirOperationPrint, mod_op) << std::endl;
     }
     auto co            = mp.compile(solution);

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1102,9 +1102,8 @@ static std::string compute_dump_name(const module& m, const std::string& ext)
     std::vector<instruction_ref> sizes;
     for(auto ins : iterator_for(m))
     {
-        if(not contains({"convolution", "dot"}, ins->name()))
-            continue;
-        sizes.insert(sizes.end(), ins->inputs().begin(), ins->inputs().end());
+        if(contains({"convolution", "dot"}, ins->name()))
+            sizes.insert(sizes.end(), ins->inputs().begin(), ins->inputs().end());
     }
     auto name =
         mlir_program::get_symbol_name(m) + "_" + shape::to_sizes_string(to_shapes(sizes)) + ext;
@@ -1254,9 +1253,8 @@ void dump_mlir_to_mxr(module m,
     std::vector<instruction_ref> sizes;
     for(auto ins : iterator_for(m))
     {
-        if(not contains({"convolution", "dot"}, ins->name()))
-            continue;
-        sizes.insert(sizes.end(), ins->inputs().begin(), ins->inputs().end());
+        if(contains({"mlir"}, ins->name()))
+            sizes.insert(sizes.end(), ins->inputs().begin(), ins->inputs().end());
     }
     auto name = compute_dump_name(m, ".mxr");
     std::cout << "Dumping MXR file to: " << name << std::endl;

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1125,7 +1125,7 @@ void dump_mlir_to_file(module m, const std::vector<shape>& inputs, const fs::pat
 
     auto name = compute_dump_name(m, ".mlir");
     std::cout << "Dumping MLIR file to: " << name << std::endl;
-    auto f    = location / name;
+   auto f = location / name;
 
     mlir_program mp;
     mp.parse(m);
@@ -1258,7 +1258,7 @@ void dump_mlir_to_mxr(module m,
     }
     auto name = compute_dump_name(m, ".mxr");
     std::cout << "Dumping MXR file to: " << name << std::endl;
-    auto f    = location / name;
+    auto f = location / name;
     save(program{std::move(m)}, f.string());
 }
 

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1124,7 +1124,7 @@ void dump_mlir_to_file(module m, const std::vector<shape>& inputs, const fs::pat
     rewrite_reduce(m);
 
     auto name = compute_dump_name(m, ".mlir");
-    auto f = location / name;
+    auto f    = location / name;
     std::cout << "Dumping MLIR file to: " << f << std::endl;
 
     mlir_program mp;

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1125,6 +1125,7 @@ void dump_mlir_to_file(module m, const std::vector<shape>& inputs, const fs::pat
     rewrite_reduce(m);
 
     auto name = compute_dump_name(m, ".mlir");
+    std::cout << "Dumping MLIR file to: " << name << std::endl;
     auto f    = location / name;
 
     mlir_program mp;
@@ -1258,6 +1259,7 @@ void dump_mlir_to_mxr(module m,
         sizes.insert(sizes.end(), ins->inputs().begin(), ins->inputs().end());
     }
     auto name = compute_dump_name(m, ".mxr");
+    std::cout << "Dumping MXR file to: " << name << std::endl;
     auto f = location / name;
     save(program{std::move(m)}, f.string());
 }

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1258,7 +1258,7 @@ void dump_mlir_to_mxr(module m,
     }
     auto name = compute_dump_name(m, ".mxr");
     std::cout << "Dumping MXR file to: " << name << std::endl;
-    auto f = location / name;
+    auto f    = location / name;
     save(program{std::move(m)}, f.string());
 }
 

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1245,7 +1245,7 @@ tuning_config get_tuning_config_mlir(const context& migraphx_ctx,
 void dump_mlir_to_mxr(module m,
                       const std::vector<instruction_ref>& inputs,
                       const fs::path& location)
-{ 
+{
     static std::mutex mutex;
     const std::lock_guard<std::mutex> lock(mutex);
 

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1102,7 +1102,7 @@ static std::string compute_dump_name(const module& m, const std::string& ext)
     std::vector<instruction_ref> sizes;
     for(auto ins : iterator_for(m))
     {
-        if(contains({"convolution", "dot"}, ins->name()))
+        if(contains({"quant_convolution", "quant_dot", "convolution", "dot"}, ins->name()))
             sizes.insert(sizes.end(), ins->inputs().begin(), ins->inputs().end());
     }
     auto name =
@@ -1253,7 +1253,7 @@ void dump_mlir_to_mxr(module m,
     std::vector<instruction_ref> sizes;
     for(auto ins : iterator_for(m))
     {
-        if(contains({"mlir"}, ins->name()))
+        if(contains({"quant_convolution", "quant_dot", "convolution", "dot"}, ins->name()))
             sizes.insert(sizes.end(), ins->inputs().begin(), ins->inputs().end());
     }
     auto name = compute_dump_name(m, ".mxr");

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1116,7 +1116,7 @@ std::string dump_mlir(module m, const std::vector<shape>& inputs, const fs::path
 
     std::string mlir_str = mlir_print(&mlirOperationPrint, mod_op);
     
-    std::ofstream outfile(f);
+    std::ofstream outfile(f, std::ios_base::app);
     if (outfile.is_open()) {
         outfile << mlir_str;
         outfile.close();
@@ -1235,7 +1235,7 @@ tuning_config get_tuning_config_mlir(const context& migraphx_ctx,
 void dump_mlir_to_mxr(module m,
                       const std::vector<instruction_ref>& inputs,
                       const fs::path& location)
-{
+{ 
     static std::mutex mutex;
     const std::lock_guard<std::mutex> lock(mutex);
 

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1124,8 +1124,8 @@ void dump_mlir_to_file(module m, const std::vector<shape>& inputs, const fs::pat
     rewrite_reduce(m);
 
     auto name = compute_dump_name(m, ".mlir");
-    std::cout << "Dumping MLIR file to: " << name << std::endl;
-   auto f = location / name;
+    auto f = location / name;
+    std::cout << "Dumping MLIR file to: " << f << std::endl;
 
     mlir_program mp;
     mp.parse(m);
@@ -1257,8 +1257,8 @@ void dump_mlir_to_mxr(module m,
             sizes.insert(sizes.end(), ins->inputs().begin(), ins->inputs().end());
     }
     auto name = compute_dump_name(m, ".mxr");
-    std::cout << "Dumping MXR file to: " << name << std::endl;
     auto f = location / name;
+    std::cout << "Dumping MXR file to: " << f << std::endl;
     save(program{std::move(m)}, f.string());
 }
 

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1097,7 +1097,7 @@ std::string dump_mlir(module m, const std::vector<shape>& inputs)
     return mlir_print(&mlirOperationPrint, mod_op);
 }
 
-static std::string compute_dump_name(const module& m, const std::string ext)
+static std::string compute_dump_name(const module& m, const std::string& ext)
 {
     std::vector<instruction_ref> sizes;
     for(auto ins : iterator_for(m))

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1118,7 +1118,6 @@ void dump_mlir_to_file(module m, const std::vector<shape>& inputs, const fs::pat
     static std::mutex mutex;
     const std::lock_guard<std::mutex> lock(mutex);
 
-    const_module_ref mr = &m;
     if(not inputs.empty())
     {
         adjust_param_shapes(m, inputs);
@@ -1129,7 +1128,7 @@ void dump_mlir_to_file(module m, const std::vector<shape>& inputs, const fs::pat
     auto f    = location / name;
 
     mlir_program mp;
-    mp.parse(*mr);
+    mp.parse(m);
     auto mod_op = mlirModuleGetOperation(mp.mmodule.get());
 
     std::string mlir_str = mlir_print(&mlirOperationPrint, mod_op);


### PR DESCRIPTION
Takes flag MIGRAPHX_MLIR_DUMP_TO_FILE to save final MLIR module as file.