### PR TITLE
Fixed instruction::replace() logic. 

### DIFF
--- a/src/include/migraphx/output_iterator.hpp
+++ b/src/include/migraphx/output_iterator.hpp
@@ -72,6 +72,12 @@ auto join_back_inserter(Container& c)
         [&](const auto& r) { c.insert(c.end(), r.begin(), r.end()); });
 }
 
+template <class Container>
+auto push_inserter(Container& c)
+{
+    return make_function_output_iterator([&](const auto& x) { c.push(x); });
+}
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
+
 #endif // MIGRAPHX_GUARD_MIGRAPHX_OUTPUT_ITERATOR_HPP

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -26,6 +26,7 @@
 #include <migraphx/erase.hpp>
 #include <migraphx/module.hpp>
 #include <migraphx/ranges.hpp>
+#include <migraphx/output_iterator.hpp>
 #include <queue>
 
 namespace migraphx {
@@ -90,10 +91,7 @@ void instruction::replace(const shape& r)
             if(new_r != ins->result)
             {
                 ins->result = new_r;
-                for(auto&& child : ins->output)
-                {
-                    q.push(child);
-                }
+                std::copy(ins->output.begin(), ins->output.end(), migraphx::push_inserter(q));
             }
         }
     }

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -62,10 +62,7 @@ struct replace_shape_order
 {
     instruction_ref start;
 
-    std::size_t location(instruction_ref x) const
-    {
-        return std::distance(start, x);
-    }
+    std::size_t location(instruction_ref x) const { return std::distance(start, x); }
 
     bool operator()(instruction_ref x, instruction_ref y) const
     {
@@ -78,11 +75,12 @@ void instruction::replace(const shape& r)
     if(r != result)
     {
         result = r;
-        auto start = std::find_if(output.front()->inputs().begin(), output.front()->inputs().end(), [&](instruction_ref x) {
-            return this == as_address(x);
-        });
+        auto start = std::find_if(output.front()->inputs().begin(),
+                                  output.front()->inputs().end(),
+                                  [&](instruction_ref x) { return this == as_address(x); });
         assert(as_address(*start) == this);
-        std::priority_queue<instruction_ref, std::vector<instruction_ref>, replace_shape_order> q(output.begin(), output.end(), replace_shape_order{*start});
+        std::priority_queue<instruction_ref, std::vector<instruction_ref>, replace_shape_order> q(
+            output.begin(), output.end(), replace_shape_order{*start});
         while(not q.empty())
         {
             instruction_ref ins = q.top();
@@ -92,7 +90,7 @@ void instruction::replace(const shape& r)
             if(new_r != ins->result)
             {
                 ins->result = new_r;
-                for(auto&& child: ins->output)
+                for(auto&& child : ins->output)
                 {
                     q.push(child);
                 }


### PR DESCRIPTION
The previous fix with BFS doesn't fully work in more complex cases (e.g. it will fail in the newly added test case `check_replace_dag`). This fix implements topological sorting to replace instructions in topological order which should work for all cases.

More details:

In a dummy scenario of `add2(reduce(x), add1(abs(reduce(x)), sin(reduce(x))))`, we will have a dependency tree looking like
```tree
reduce _
        \_abs__
         \_sin__\_add1_
          \_____________\_add2
```
If we call reduce.replace(), BFS will visit the instructions in the following order:
```
reduce -> abs -> sin -> add2 -> add1
```
This will causes an error of shape mismatch at `add2` because it is called before its input `add1`.

Topological sorting the instruction tree will yield:

```
reduce -> sin -> abs -> add1 -> add2
```

Which is the correct order to process the instructions.

This should be able to extend to more complex cases.

