### PR TITLE
matmulnbits zero_point fix

### DIFF
--- a/src/onnx/parse_matmulnbits.cpp
+++ b/src/onnx/parse_matmulnbits.cpp
@@ -119,7 +119,7 @@ struct parse_matmulnbits : op_parser<parse_matmulnbits>
         }
         else
         {
-            zp = info.add_literal(literal{shape{shape::uint8_type, {1}}, {8}});
+            zp = info.add_literal(literal{shape{args[1]->get_shape().type(), {1}}, {8}});
             zp = info.add_instruction(
                 make_op("multibroadcast", {{"out_lens", b->get_shape().lens()}}), zp);
         }

--- a/test/onnx/gen_onnx.py
+++ b/test/onnx/gen_onnx.py
@@ -9242,6 +9242,27 @@ def matmulnbits_mm2_test():
 
 
 @onnx_test()
+def matmulnbits_mm2_signed_test():
+    a = onnx.helper.make_tensor_value_info("a", onnx.TensorProto.FLOAT,
+                                           [2, 33])
+    b = onnx.helper.make_tensor_value_info("b", onnx.TensorProto.INT8,
+                                           [2, 3, 8])
+    scales = onnx.helper.make_tensor_value_info("scales",
+                                                onnx.TensorProto.FLOAT, [6])
+    c = onnx.helper.make_tensor_value_info("c", onnx.TensorProto.FLOAT, [2, 2])
+
+    node = onnx.helper.make_node("MatMulNBits",
+                                 inputs=["a", "b", "scales"],
+                                 outputs=["c"],
+                                 bits=4,
+                                 block_size=16,
+                                 K=33,
+                                 N=2,
+                                 domain='com.microsoft')
+    return ([node], [a, b, scales], [c])
+
+
+@onnx_test()
 def matmulnbits_vm_test():
     a = onnx.helper.make_tensor_value_info("a", onnx.TensorProto.FLOAT, [20])
     b = onnx.helper.make_tensor_value_info("b", onnx.TensorProto.UINT8,

--- a/test/onnx/matmulnbits_mm2_signed_test.onnx
+++ b/test/onnx/matmulnbits_mm2_signed_test.onnx
@@ -1,0 +1,28 @@
+
+matmulnbits_mm2_signed_test:Ù
+a
+a
+b
+scalesc"MatMulNBits*
+K! *
+N *
+bits *
+
+block_size :com.microsoftmatmulnbits_mm2_signed_testZ
+a
+
+
+!Z
+b
+
+
+
+Z
+scales
+
+
+b
+c
+
+
+B


### PR DESCRIPTION
Currently the matmulnbits parsing introduces a fixed type `uint8_type` for zero_point, and misses `int8_type`.
