### PR TITLE
Fix tidy check by getting rid of unused variables.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,6 @@ rocm_enable_clang_tidy(
 	-bugprone-multi-level-implicit-pointer-conversion
         -bugprone-signed-char-misuse
         -bugprone-unchecked-optional-access
-	-bugprone-unused-local-non-trivial-variable
         # Disable the aliased reserved identifiers
         -cert-dcl37-c
         -cert-dcl51-cpp

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1124,7 +1124,7 @@ void module::debug_print(instruction_ref ins,
         std::cout << "Instruction not part of module" << std::endl;
         return;
     }
-    std::stringstream ss;
+
     names = this->print(
         [&](auto x, auto ins_names) {
             if(x == ins)

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1005,7 +1005,6 @@ void program::debug_print(instruction_ref ins) const
         return;
     }
 
-    std::stringstream ss;
     this->print(names, [&](auto x, auto ins_names) {
         if(x == ins)
         {


### PR DESCRIPTION
Fix #3471, removed unused variables, and re-enabled the tidy check.