### PR TITLE
Windows fixes for generic_float

### DIFF
--- a/src/include/migraphx/generic_float.hpp
+++ b/src/include/migraphx/generic_float.hpp
@@ -52,12 +52,12 @@ constexpr std::size_t bit_ceil(std::size_t v)
     if(v <= 1)
         return 1;
     v--;
-    v |= v >> 1;
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-    v |= v >> 32;
+    v |= v >> 1u;
+    v |= v >> 2u;
+    v |= v >> 4u;
+    v |= v >> 8u;
+    v |= v >> 16u;
+    v |= v >> 32u;
     return v + 1;
 }
 
@@ -165,7 +165,7 @@ struct __attribute__((packed, may_alias)) generic_float
                 if(MantissaSize < float32_parts::mantissa_width())
                 {
                     shift = MantissaSize - ((sizeof(type) * 8) - countl_zero(mantissa));
-                    f.mantissa <<= (shift + 1);
+                    f.mantissa <<= (shift + 1u);
                 }
 
                 f.exponent = float32_parts::exponent_bias() - exponent_bias() - shift;

--- a/src/include/migraphx/generic_float.hpp
+++ b/src/include/migraphx/generic_float.hpp
@@ -66,29 +66,30 @@ constexpr std::size_t integer_divide_ceil(std::size_t x, std::size_t y)
     return (x + y - std::size_t{1}) / y;
 }
 
-template<unsigned int Bytes>
+template <unsigned int Bytes>
 struct unsigned_type
-{};
+{
+};
 
-template<>
+template <>
 struct unsigned_type<1>
 {
     using type = std::uint8_t;
 };
 
-template<>
+template <>
 struct unsigned_type<2>
 {
     using type = std::uint16_t;
 };
 
-template<>
+template <>
 struct unsigned_type<4>
 {
     using type = std::uint32_t;
 };
 
-template<>
+template <>
 struct unsigned_type<8>
 {
     using type = std::uint64_t;
@@ -117,7 +118,8 @@ constexpr float32_parts get_parts(float f) { return migraphx::bit_cast<float32_p
 template <unsigned int MantissaSize, unsigned int ExponentSize, unsigned int Flags = 0>
 struct __attribute__((packed, may_alias)) generic_float
 {
-    using type = typename unsigned_type<bit_ceil(integer_divide_ceil(MantissaSize + ExponentSize + 1, 8))>::type;
+    using type = typename unsigned_type<bit_ceil(
+        integer_divide_ceil(MantissaSize + ExponentSize + 1, 8))>::type;
 
     type mantissa : MantissaSize;
     type exponent : ExponentSize;
@@ -157,7 +159,7 @@ struct __attribute__((packed, may_alias)) generic_float
             }
             else
             {
-                type shift = 0;
+                type shift         = 0;
                 f.mantissa         = mantissa;
 
                 if(MantissaSize < float32_parts::mantissa_width())

--- a/src/include/migraphx/generic_float.hpp
+++ b/src/include/migraphx/generic_float.hpp
@@ -47,6 +47,53 @@ constexpr int countl_zero(T value)
     return 8 * sizeof(value) - r;
 }
 
+constexpr std::size_t bit_ceil(std::size_t v)
+{
+    if(v <= 1)
+        return 1;
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    v |= v >> 32;
+    return v + 1;
+}
+
+constexpr std::size_t integer_divide_ceil(std::size_t x, std::size_t y)
+{
+    return (x + y - std::size_t{1}) / y;
+}
+
+template<unsigned int Bytes>
+struct unsigned_type
+{};
+
+template<>
+struct unsigned_type<1>
+{
+    using type = std::uint8_t;
+};
+
+template<>
+struct unsigned_type<2>
+{
+    using type = std::uint16_t;
+};
+
+template<>
+struct unsigned_type<4>
+{
+    using type = std::uint32_t;
+};
+
+template<>
+struct unsigned_type<8>
+{
+    using type = std::uint64_t;
+};
+
 struct float32_parts
 {
     unsigned int mantissa : 23;
@@ -70,9 +117,11 @@ constexpr float32_parts get_parts(float f) { return migraphx::bit_cast<float32_p
 template <unsigned int MantissaSize, unsigned int ExponentSize, unsigned int Flags = 0>
 struct __attribute__((packed, may_alias)) generic_float
 {
-    unsigned int mantissa : MantissaSize;
-    unsigned int exponent : ExponentSize;
-    unsigned int sign : 1;
+    using type = typename unsigned_type<bit_ceil(integer_divide_ceil(MantissaSize + ExponentSize + 1, 8))>::type;
+
+    type mantissa : MantissaSize;
+    type exponent : ExponentSize;
+    type sign : 1;
 
     static constexpr int exponent_bias() { return all_ones<ExponentSize - 1>(); }
 
@@ -108,12 +157,12 @@ struct __attribute__((packed, may_alias)) generic_float
             }
             else
             {
-                unsigned int shift = 0;
+                type shift = 0;
                 f.mantissa         = mantissa;
 
                 if(MantissaSize < float32_parts::mantissa_width())
                 {
-                    shift = MantissaSize - ((sizeof(unsigned int) * 8) - countl_zero(mantissa));
+                    shift = MantissaSize - ((sizeof(type) * 8) - countl_zero(mantissa));
                     f.mantissa <<= (shift + 1);
                 }
 
@@ -184,7 +233,7 @@ struct __attribute__((packed, may_alias)) generic_float
             }
         }
 
-        exponent = std::min(exponent, all_ones<ExponentSize>());
+        exponent = std::min<type>(exponent, all_ones<ExponentSize>());
     }
 
     constexpr bool is_normal() const noexcept


### PR DESCRIPTION
This is similar to #3599, but passes the tests. There is no macro, and `all_ones` function doesn't change, so there is less code changes here.