### PR TITLE
Horizontally fuse elementwise operators with more then 2 inputs across concat

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -906,6 +906,18 @@ struct find_concat_op
         });
     }
 
+    static bool rejected_inputs(const std::vector<instruction_ref>& inputs)
+    {
+        if(inputs.empty())
+            return true;
+        if(inputs.size() < 3)
+            return false;
+        auto nonconst = std::count_if(inputs.begin(), inputs.end(), [](instruction_ref ins) {
+            return not ins->can_eval();
+        });
+        return nonconst > 2;
+    }
+
     void apply(module& m, const match::matcher_result& r) const
     {
         auto ins  = r.result;
@@ -915,7 +927,7 @@ struct find_concat_op
             if(std::distance(start, last) < 2)
                 return {start, last};
             auto x = *start;
-            if(x->inputs().size() > 2 or x->inputs().empty() or x->outputs().size() > 1)
+            if(x->outputs().size() > 1 or rejected_inputs(x->inputs()))
                 return {start, last};
             auto op = x->get_operator();
             if(not is_valid_op(op))

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -912,9 +912,8 @@ struct find_concat_op
             return true;
         if(inputs.size() < 3)
             return false;
-        auto nonconst = std::count_if(inputs.begin(), inputs.end(), [](instruction_ref ins) {
-            return not ins->can_eval();
-        });
+        auto nonconst = std::count_if(
+            inputs.begin(), inputs.end(), [](instruction_ref ins) { return not ins->can_eval(); });
         return nonconst > 2;
     }
 

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -1227,8 +1227,8 @@ TEST_CASE(simplify_concat_clip)
         auto y      = m1.add_parameter("y", s);
         auto min    = m1.add_literal({s, {0}});
         auto max    = m1.add_literal({s, {10}});
-        auto clip1   = m1.add_instruction(migraphx::make_op("clip"), x, min, max);
-        auto clip2   = m1.add_instruction(migraphx::make_op("clip"), y, min, max);
+        auto clip1  = m1.add_instruction(migraphx::make_op("clip"), x, min, max);
+        auto clip2  = m1.add_instruction(migraphx::make_op("clip"), y, min, max);
         auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), clip1, clip2);
         m1.add_instruction(pass_op{}, concat);
     }
@@ -1238,12 +1238,12 @@ TEST_CASE(simplify_concat_clip)
     {
         auto x       = m2.add_parameter("x", s);
         auto y       = m2.add_parameter("y", s);
-        auto min    = m2.add_literal({s, {0}});
-        auto max    = m2.add_literal({s, {10}});
+        auto min     = m2.add_literal({s, {0}});
+        auto max     = m2.add_literal({s, {10}});
         auto concat1 = m2.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), x, y);
         auto concat2 = m2.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), min, min);
         auto concat3 = m2.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), max, max);
-        auto clip     = m2.add_instruction(migraphx::make_op("clip"), concat1, concat2, concat3);
+        auto clip    = m2.add_instruction(migraphx::make_op("clip"), concat1, concat2, concat3);
         m2.add_instruction(pass_op{}, clip);
     }
     EXPECT(m1 == m2);


### PR DESCRIPTION
If the other inputs are const then it will do the horizontal fusion across concat.