### PR TITLE
Add spell checker workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -605,4 +605,6 @@ jobs:
         uses: reviewdog/action-misspell@v1
         with:
           locale: "US"
+          reporter: github-pr-check
+          level: warning
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -596,7 +596,7 @@ jobs:
       #    ./codecov -t ${CODECOV_TOKEN}
       #    echo "Uploaded"
   misspell:
-    name: runner / misspell
+    name: misspell
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code.
@@ -604,7 +604,5 @@ jobs:
       - name: misspell
         uses: reviewdog/action-misspell@v1
         with:
-          path: ${{ github.workspace }}/ccache
-          key: ${{ matrix.os }}-${{ matrix.configuration }}-ccache-${{ github.ref }}
           locale: "US"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -595,4 +595,16 @@ jobs:
       #    chmod +x codecov
       #    ./codecov -t ${CODECOV_TOKEN}
       #    echo "Uploaded"
+  misspell:
+    name: runner / misspell
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code.
+        uses: actions/checkout@v4
+      - name: misspell
+        uses: reviewdog/action-misspell@v1
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ matrix.os }}-${{ matrix.configuration }}-ccache-${{ github.ref }}
+          locale: "US"
 

--- a/spellcheck.txt
+++ b/spellcheck.txt
@@ -1,1 +1,0 @@
-tsting if wordsa re misspeled

--- a/spellcheck.txt
+++ b/spellcheck.txt
@@ -1,0 +1,1 @@
+tsting if wordsa re misspeled


### PR DESCRIPTION
If working correctly, this should catch common typos. We can add words to the ignore list as they appear in our PRs.