### PR TITLE
Bump timeout to 4 hrs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ def rocmtestnode(Map conf) {
                     pre()
                     sh "docker pull ${DOCKER_IMAGE}:${env.IMAGE_TAG}"
                     withDockerContainer(image: "${DOCKER_IMAGE}:${env.IMAGE_TAG}", args: "--device=/dev/kfd --device=/dev/dri --group-add video --cap-add SYS_PTRACE -v=/home/jenkins/:/home/jenkins ${docker_args}") {
-                        timeout(time: 3, unit: 'HOURS') {
+                        timeout(time: 4, unit: 'HOURS') {
                             body(cmake_build)
                         }
                     }


### PR DESCRIPTION
Seeing logs where the debug builds take 2 hours to compile.  

The linking alone is taking 40 minutes... 

[2024-12-08T23:07:33.108Z] make[2]: Leaving directory '/home/jenkins/workspace/AMDMIGraphX_PR-3693/build'
[2024-12-08T23:07:33.108Z] [ 31%] Built target onnx-proto
[2024-12-08T23:41:26.805Z] [ 31%] Linking CXX shared library ../lib/libmigraphx.so

I'll bump to 4 hours to let the make check timeout pop first.  This will help dump additional information when it does timeout