### PR TITLE
Include <cstdint> in generic_float.hpp

### DIFF
--- a/src/include/migraphx/generic_float.hpp
+++ b/src/include/migraphx/generic_float.hpp
@@ -31,6 +31,7 @@
 #include <limits>
 #include <iostream>
 #include <tuple>
+#include <cstdint>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {


### PR DESCRIPTION
Needed to address ticket #[SWDEV-498402](https://ontrack-internal.amd.com/browse/SWDEV-498402), where required header for fixed-width integer types is missing resulting in the following errors for multiple types:

```
error: no type named 'uint8_t' in namespace 'std'
2024-11-14T13:09:40.241005703Z    80 |     using type = std::uint8_t;
```

