### PR TITLE
catch python buffer unsupported types

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1291,7 +1291,7 @@ module::print_py(std::ostream& os,
                 os << cpp_var_name(ins_names.at(ins)) << " = ";
             if(ins->name() == "@literal")
             {
-                os << mname << ".add_literal_from_argument(";
+                os << mname << ".add_literal(";
                 if(ins->get_shape().elements() < 10)
                 {
                     os << "migraphx.create_argument(";

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1291,7 +1291,7 @@ module::print_py(std::ostream& os,
                 os << cpp_var_name(ins_names.at(ins)) << " = ";
             if(ins->name() == "@literal")
             {
-                os << mname << ".add_literal(";
+                os << mname << ".add_literal_from_argument(";
                 if(ins->get_shape().elements() < 10)
                 {
                     os << "migraphx.create_argument(";

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -268,7 +268,7 @@ migraphx::shape to_shape(const py::buffer_info& info)
     {
         MIGRAPHX_THROW(
             "MIGRAPHX PYTHON: Unsupported data type. For fp8 and bf16 literals try using "
-            "migraphx.generate_argument and migraphx.add_literal_from_argument");
+            "migraphx.generate_argument with migraphx.add_literal");
     }
     visit_types([&](auto as) {
         if(info.format == py::format_descriptor<decltype(as())>::format() or

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -397,16 +397,16 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             py::arg("mod_args") = std::vector<migraphx::module*>{})
         .def(
             "add_literal",
+            [](migraphx::module& mm, migraphx::argument a) {
+                return mm.add_literal(a.get_shape(), a.data());
+            },
+            py::arg("data"))
+        .def(
+            "add_literal",
             [](migraphx::module& mm, py::buffer data) {
                 py::buffer_info info = data.request();
                 auto literal_shape   = to_shape(info);
                 return mm.add_literal(literal_shape, reinterpret_cast<char*>(info.ptr));
-            },
-            py::arg("data"))
-        .def(
-            "add_literal_from_argument",
-            [](migraphx::module& mm, migraphx::argument a) {
-                return mm.add_literal(a.get_shape(), a.data());
             },
             py::arg("data"))
         .def(

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -266,8 +266,9 @@ migraphx::shape to_shape(const py::buffer_info& info)
     // Unsupported pybuffer types lead to undefined behaviour when comparing with migraphx type enum
     if(info.format == "z")
     {
-        MIGRAPHX_THROW("MIGRAPHX PYTHON: Unsupported data type. For fp8 and bf16 literals try using "
-                       "migraphx.generate_argument and migraphx.add_literal_from_argument");
+        MIGRAPHX_THROW(
+            "MIGRAPHX PYTHON: Unsupported data type. For fp8 and bf16 literals try using "
+            "migraphx.generate_argument and migraphx.add_literal_from_argument");
     }
     visit_types([&](auto as) {
         if(info.format == py::format_descriptor<decltype(as())>::format() or


### PR DESCRIPTION
Issue:
New datatypes (fp8 and bf16) are not natively supported by the python buffer protocol. See https://docs.python.org/3/library/struct.html#format-characters

This can lead to some silly behavior since all unsupported types seem to give format string "z". Example:
```
import migraphx
p = migraphx.program()
mm = p.get_main_module()
s = migraphx.shape(type="bf16_type", lens=[16])
a = migraphx.generate_argument(s) 
l = mm.add_literal(a)
print(a.get_shape()) # bf16_type, {16}, {1}
print(l.shape()) # fp8e5m2fnuz_type, {16}, {2} ??????????
```

Fix:
1) explicitly error out if the python buffer format string is "z".
2) add add_literal_from_argument method that allows the user to directly add an argument to some module they may or may not be a recognized type by py buffer protocol.