### PR TITLE
Do not run hip gemm pointwise fusion for quant_dot

### DIFF
--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -715,6 +715,9 @@ struct find_hipblas_gemm_pointwise : gemm_pointwise
 
         auto gemm_op = any_cast<hipblaslt_op>(gemm_ins->get_operator()).op;
 
+        if(gemm_op.name() != "gpu::hip_gemm")
+            return;
+
         auto gemm = any_cast<hip_gemm<op::dot>>(gemm_op);
 
         // Already fused gemm


### PR DESCRIPTION
This PR makes change to ensure that hip gemm pointwise fusion
is performed for `dot`, and not for `quant_dot`.