### PR TITLE
Fix sd3-lite clip-l model swapped outputs

### DIFF
--- a/examples/diffusion/python_stable_diffusion_3/txt2img.py
+++ b/examples/diffusion/python_stable_diffusion_3/txt2img.py
@@ -488,7 +488,7 @@ class StableDiffusionMGX():
         # stable-diffusion-3-lite-onnx has swapped outputs for clip-l text encoder
         if l_out.shape != (1, 77, 768):
             l_out, l_pooled = l_pooled, l_out
-    
+
         g_out, g_pooled = self.encode_token_weights("clip-g",
                                                     prompt_tokens["g"])
         if not self.skip_t5:

--- a/examples/diffusion/python_stable_diffusion_3/txt2img.py
+++ b/examples/diffusion/python_stable_diffusion_3/txt2img.py
@@ -485,10 +485,9 @@ class StableDiffusionMGX():
     def get_embeddings(self, prompt_tokens):
         l_out, l_pooled = self.encode_token_weights("clip-l",
                                                     prompt_tokens["l"])
+        # stable-diffusion-3-lite-onnx has swapped outputs for clip-l text encoder
         if l_out.shape != (1, 77, 768):
-            tmp = l_pooled
-            l_pooled = l_out
-            l_out = tmp
+            l_out, l_pooled = l_pooled, l_out
     
         g_out, g_pooled = self.encode_token_weights("clip-g",
                                                     prompt_tokens["g"])

--- a/examples/diffusion/python_stable_diffusion_3/txt2img.py
+++ b/examples/diffusion/python_stable_diffusion_3/txt2img.py
@@ -485,6 +485,11 @@ class StableDiffusionMGX():
     def get_embeddings(self, prompt_tokens):
         l_out, l_pooled = self.encode_token_weights("clip-l",
                                                     prompt_tokens["l"])
+        if l_out.shape != (1, 77, 768):
+            tmp = l_pooled
+            l_pooled = l_out
+            l_out = tmp
+    
         g_out, g_pooled = self.encode_token_weights("clip-g",
                                                     prompt_tokens["g"])
         if not self.skip_t5:


### PR DESCRIPTION
The clip-l model from [stable-diffusion-3-lite-onnx](https://huggingface.co/TensorStack/stable-diffusion-3-lite-onnx) has swapped outputs, so this results in runtime error because of mismatched shapes. This fix proposes swapping the output tensors for the clip-l outputs if the shape doesn't match the required shape for one of the outputs, making stable-diffusion-3-lite-onnx run successfully.