### PR TITLE
Optimize CPU and Memory performance for Resize linear mode parser

### DIFF
--- a/src/onnx/parse_resize.cpp
+++ b/src/onnx/parse_resize.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/onnx/parse_resize.cpp
+++ b/src/onnx/parse_resize.cpp
@@ -99,24 +99,21 @@ calc_neighbor_points(const std::vector<std::vector<std::vector<std::size_t>>>& v
 
     if(n_bits >= std::numeric_limits<std::size_t>::digits)
     {
-        throw std::runtime_error("Shape dimension " + std::to_string(n_bits) + " exceeds " +
-                                 std::to_string(std::numeric_limits<std::size_t>::digits));
+        MIGRAPHX_THROW("PARSE_RESIZE: Shape dimension " + std::to_string(n_bits) + " exceeds " +
+                       std::to_string(std::numeric_limits<std::size_t>::digits));
     }
 
     for(std::size_t val = 0; val < (std::size_t{1} << n_bits); val++)
     {
         std::bitset<std::numeric_limits<std::size_t>::digits> bits_val = val;
         std::vector<std::size_t> indices(n_bits);
-        transform(
-            range(m_elements), std::back_inserter(vec_ind), [&](const std::size_t& i_element) {
-                transform(vvv_ind,
-                          range(n_bits),
-                          indices.begin(),
-                          [&](const auto& vv_ind, const std::size_t& bit) {
-                              return vv_ind[bits_val[bit]][i_element];
-                          });
-                return in_s.index(indices);
-            });
+        transform(range(m_elements), std::back_inserter(vec_ind), [&](std::size_t i_element) {
+            transform(
+                vvv_ind, range(n_bits), indices.begin(), [&](const auto& vv_ind, std::size_t bit) {
+                    return vv_ind[bits_val[bit]][i_element];
+                });
+            return in_s.index(indices);
+        });
     }
 
     return vec_ind;


### PR DESCRIPTION
Re-write calc_neighbor_points() by composing index from binary bits instead of recursion.

With the optimized calc_neighbor_points(), CPU time required by 90% and peak memory utilization is significantly reduced.

Perf. comparision on VM w/ 12-Core EPYC 9V64 + 128 GB mem:

| n_dim | out_elements | New t-CPU (us) | Old t-CPU (us) | t-CPU Ratio |
|------:|-------------:|---------------:|---------------:|------------:|
|     4 |       786432 |         120405 | 1494350        | 0.0806      |
|     4 |      1572864 |         282763 | 3826060        | 0.0739      |
|     4 |      3145728 |         650957 | 7941436        | 0.0820      |
|     4 |      6291456 |        1304652 | 14869059       | 0.0877      |
|     4 |     12582912 |        2608523 | 29432326       | 0.0886      |
|     4 |     25165824 |        5175560 | 58848631       | 0.0879      |
|     4 |     50331648 |       10486676 | 118005802      | 0.0889      |
|     4 |    100663296 |       21141464 | OOM Kill       | N/A         |