### PR TITLE
bump perf checks to 6.3.1

### DIFF
--- a/.github/workflows/config.md
+++ b/.github/workflows/config.md
@@ -1,7 +1,7 @@
 #=====ROCM INFO=====
-ROCM_VERSION : '6.0.2'
+ROCM_VERSION : '6.3.1'
 #default ROCm version to be used
-ROCM_BASE_IMAGE : 'rocm/dev-ubuntu-20.04'
+ROCM_BASE_IMAGE : 'rocm/dev-ubuntu-22.04'
 #base image from dockerhub to be used
 ROCM_BUILT_IMAGE : 'rocm-migraphx'
 #name of the docker image built upon ROCm base

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -12,7 +12,7 @@ on:
       rocm_release:
         description: ROCm Version
         required: true
-        default: '6.0.2'
+        default: '6.3.1'
       performance_reports_repo:
         description: Repository where performance reports are stored
         required: true


### PR DESCRIPTION
Move CI to use ROCm 6.3.1 for perf tests