### PR TITLE
Fix docs, add netron output docs

### DIFF
--- a/docs/driver/read.rst
+++ b/docs/driver/read.rst
@@ -78,6 +78,10 @@ Print out the program as cpp program.
 
 Print out program as json.
 
+.. option::  --netron
+
+Print out program as a Netron viewable json file.
+
 .. option::  --text
 
 Print out program in text format.

--- a/docs/migraphx-driver.rst
+++ b/docs/migraphx-driver.rst
@@ -85,6 +85,8 @@ To learn which options can be used with which commands, see the :ref:`MIGraphX d
       - Prints the program in .txt format
    *  - --binary
       - Prints the program in binary format
+   *  - --netron
+      - Prints the program in Netron viewable JSON format
    *  - --output | -o
       - Writes output in a file
    *  - --fill0

--- a/docs/reference/driver-options.rst
+++ b/docs/reference/driver-options.rst
@@ -16,7 +16,7 @@ read
 
 Loads and prints input graph.
 
-.. include:: ./driver/read.rst
+.. include:: ../driver/read.rst
 
 compile
 -------
@@ -25,8 +25,8 @@ compile
 
 Compiles and prints input graph.
 
-.. include:: ./driver/read.rst
-.. include:: ./driver/compile.rst
+.. include:: ../driver/read.rst
+.. include:: ../driver/compile.rst
 
 run
 ---
@@ -35,8 +35,8 @@ run
 
 Loads and prints input graph.
 
-.. include:: ./driver/read.rst
-.. include:: ./driver/compile.rst
+.. include:: ../driver/read.rst
+.. include:: ../driver/compile.rst
 
 perf
 ----
@@ -45,8 +45,8 @@ perf
 
 Compiles and runs input graph then prints performance report.
 
-.. include:: ./driver/read.rst
-.. include:: ./driver/compile.rst
+.. include:: ../driver/read.rst
+.. include:: ../driver/compile.rst
 
 .. option::  --iterations, -n [unsigned int]
 
@@ -59,8 +59,8 @@ verify
 
 Runs reference and CPU or GPU implementations and checks outputs for consistency.
 
-.. include:: ./driver/read.rst
-.. include:: ./driver/compile.rst
+.. include:: ../driver/read.rst
+.. include:: ../driver/compile.rst
 
 .. option::  --rms-tol [double]
 
@@ -104,5 +104,5 @@ Here is how you can use ``roctx`` combined with :doc:`rocprof <rocprofiler:rocpr
 Running :doc:`rocprof <rocprofiler:rocprofv1>` generates trace information for HIP, HCC and ROCTX in separate ``.txt`` files.
 To understand the interactions between API calls, utilize the :ref:`roctx.py <tools>` helper script.
 
-.. include:: ./driver/read.rst
-.. include:: ./driver/compile.rst
+.. include:: ../driver/read.rst
+.. include:: ../driver/compile.rst


### PR DESCRIPTION
The docs were broken for the driver options. Added note about `--netron` output.