### PR TITLE
fix attn fusion when trailing pointwise has literal

### DIFF
--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -872,7 +872,10 @@ struct find_mlir_standalone_attention_op
         if(contains(r.instructions, "trailing_pm"))
         {
             auto trailing_pm_ins = r.instructions["trailing_pm"];
+            auto lit_map         = create_param_map_with_literals(
+                &m_attn, trailing_pm_ins->module_inputs().front(), trailing_pm_ins->get_shape());
             m_attn.add_params(trailing_pm_ins->inputs(), &map_main_to_mattn);
+            map_main_to_mattn.insert(lit_map.begin(), lit_map.end());
             std::unordered_map<instruction_ref, instruction_ref> map_pm_to_mattn(map_main_to_mattn);
             auto fused_pw_outs = m_attn
                                      .fuse(*trailing_pm_ins->module_inputs().front(),


### PR DESCRIPTION
Currently, it would error out with shape mismatch when trying to fuse a training pointwise module to attention module if the pw module has a literal. 