### PR TITLE
skip inner broadcast simplification for layout

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -764,6 +764,8 @@ struct find_inner_broadcast
         const auto& broadcasts = ins->inputs();
         if(broadcasts.empty())
             return;
+        if(ins->get_operator().name() == "layout")
+            return;
         // Skip if different data types are used
         if(any_of(broadcasts, [&](auto i) {
                return i->get_shape().type() != broadcasts.front()->get_shape().type();


### PR DESCRIPTION
This is more of a temporary fix for https://github.com/ROCm/AMDMIGraphX/issues/3649 since its causing multiple regressions.  This simplification does not really make much sense to me with the layout op anyways. 

I think the real issue is, should there even be a layout inserted here? Seems wrong that a "layout_convolution" pass is adding an op in a graph that has no convolutions?