### PR TITLE
Reapply default behavior when comparing instruction_ref with ==

### DIFF
--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -422,10 +422,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         .def("__hash__",
              [](const migraphx::instruction_ref& i) {
                  return std::hash<migraphx::instruction_ref>()(i);
-             })
-        .def("__eq__", [](const migraphx::instruction_ref& i, const migraphx::instruction_ref& j) {
-            return std::equal_to<migraphx::instruction_ref>()(i, j);
-        });
+             });
 
     py::class_<migraphx::module, std::unique_ptr<migraphx::module, py::nodelete>>(m, "module")
         .def("print", [](const migraphx::module& mm) { std::cout << mm << std::endl; })

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -419,10 +419,9 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         .def("op", [](migraphx::instruction_ref i) { return i->get_operator(); })
         .def("inputs", [](migraphx::instruction_ref i) { return i->inputs(); })
         .def("name", [](migraphx::instruction_ref i) { return i->name(); })
-        .def("__hash__",
-             [](const migraphx::instruction_ref& i) {
-                 return std::hash<migraphx::instruction_ref>()(i);
-             });
+        .def("__hash__", std::hash<migraphx::instruction_ref>{})
+        .def("__eq__", std::equal_to<migraphx::instruction_ref>{})
+        .def("__eq__", std::equal_to<py::object>{});
 
     py::class_<migraphx::module, std::unique_ptr<migraphx::module, py::nodelete>>(m, "module")
         .def("print", [](const migraphx::module& mm) { std::cout << mm << std::endl; })


### PR DESCRIPTION
torch-migraphx sometimes expects default python object comparison in if-else trees when working with instruction_refs. This should keep the correct behavior added by #3682 but add fallback for when not comparing 2 instruction_refs