### PR TITLE
Update Cmake since ORT 1.21 requires newer CMake 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN pip3 install -r /doc-requirements.txt
 # Install latest ccache version
 RUN cget -p $PREFIX install facebook/zstd@v1.4.5 -X subdir -DCMAKE_DIR=build/cmake
 RUN cget -p $PREFIX install ccache@v4.1 -DENABLE_TESTING=OFF
-RUN cget -p /opt/cmake install kitware/cmake@v3.27.0
+RUN cget -p /opt/cmake install kitware/cmake@v3.28.0
 # Install a newer version of doxygen because the one that comes with ubuntu is broken
 RUN cget -p $PREFIX install doxygen@Release_1_9_8
 


### PR DESCRIPTION
Solves bug with builds in onnxruntime when using our env to build. 

Issue brought up in Onnxruntime here: https://github.com/microsoft/onnxruntime/issues/23584

Will be updating infra/ci to ensure we're not introducing any issues for tests