### PR TITLE
Remove or edit multinomial tests due to precision error (#3809)

### DIFF
--- a/test/verify/main.cpp
+++ b/test/verify/main.cpp
@@ -79,7 +79,6 @@ int main(int argc, const char* argv[])
          "test_resize_dyn",
          "test_instancenorm_large_3d<migraphx::shape::float_type>",
          "test_instancenorm_large_3d<migraphx::shape::half_type>",
-         "test_multinomial<migraphx::shape::bf16_type>",
          "test_isinf<migraphx::generic_float<7, 8> >",
          "test_isinf<migraphx::bf16>",
     // these tests are disabled due issue of lossy downcast, see issue#2517

--- a/test/verify/test_multinomial.cpp
+++ b/test/verify/test_multinomial.cpp
@@ -62,7 +62,9 @@ struct test_multinomial : verify_program<test_multinomial<DType>>
 
 template struct test_multinomial<migraphx::shape::float_type>;
 template struct test_multinomial<migraphx::shape::half_type>;
-template struct test_multinomial<migraphx::shape::bf16_type>;
+// TODO bf16 accumulates more rounding errors in exp() and prefix_scan_sum, which is slightly
+// shifting the cdf values and causing off-by-one errors.
+//  template struct test_multinomial<migraphx::shape::bf16_type>;
 // TODO This fails, need to figure out why
 //  template struct test_multinomial<migraphx::shape::fp8e4m3fnuz_type>;
 //  template struct test_multinomial<migraphx::shape::fp8e5m2fnuz_type>;


### PR DESCRIPTION
BF16 accumulates more rounding errors in exp() and prefix_scan_sum, which is slightly shifting the cdf values and causing off-by-one errors.

Alternative: Compute cdf in FP32, then cast to BF16 before sampling.