### PR TITLE
HIP SDK 6.3 for Windows bug workaround

### DIFF
--- a/cmake/EnableCompilerWarnings.cmake
+++ b/cmake/EnableCompilerWarnings.cmake
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/cmake/EnableCompilerWarnings.cmake
+++ b/cmake/EnableCompilerWarnings.cmake
@@ -106,7 +106,7 @@ else()
                 -Wno-unsafe-buffer-usage
                 # -Wno-c++2a-designator
             )
-            if(WIN32 AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "6.3")
+            if(WIN32 AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19")
                 list(APPEND CMAKE_COMPILER_WARNINGS
                     -Wno-missing-include-dirs
                 )

--- a/cmake/EnableCompilerWarnings.cmake
+++ b/cmake/EnableCompilerWarnings.cmake
@@ -106,6 +106,11 @@ else()
                 -Wno-unsafe-buffer-usage
                 # -Wno-c++2a-designator
             )
+            if(WIN32 AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "6.3")
+                list(APPEND CMAKE_COMPILER_WARNINGS
+                    -Wno-missing-include-dirs
+                )
+            endif()
         else()
             list(APPEND CMAKE_COMPILER_WARNINGS
                 -Wno-missing-field-initializers


### PR DESCRIPTION
The HIP SDK 6.3 for Windows has a nasty bug (reported) that the compiler keeps using the Linux paths to include header files for the standard library among the correct Windows paths. As a result, the compiler reports many warning messages about missing include directories, and the CMake option turns them into error messages, forbidding the successful compilation. The problem does not occur in HIP SDK 6.2 for Windows.