### PR TITLE
fix compilation on HIP SDK 6.3 for Windows - undefined behavior

### DIFF
--- a/src/api/include/migraphx/migraphx.hpp
+++ b/src/api/include/migraphx/migraphx.hpp
@@ -486,7 +486,7 @@ struct interface_base : Base
               class = std::enable_if_t<std::is_void<X>{}>>
     static void call_cast_arg(rank<1>, F f, R result, X* obj, Xs... xs)
     {
-        f(*reinterpret_cast<T*>(obj), result, no_out_arg{}, xs...);
+        f(*static_cast<T*>(obj), result, no_out_arg{}, xs...);
     }
 
     template <class T,
@@ -498,7 +498,7 @@ struct interface_base : Base
               class = std::enable_if_t<std::is_void<X>{}>>
     static void call_cast_arg(rank<2>, F f, R1 result1, R2 result2, X* obj, Xs... xs)
     {
-        f(*reinterpret_cast<T*>(obj), result1, result2, xs...);
+        f(*static_cast<T*>(obj), result1, result2, xs...);
     }
 
     template <class F, class T1, class T2, class... Ts>


### PR DESCRIPTION
The HIP SDK 6.3 compiler for Windows reports the following warning message, which is treated as an error when compiling MIGraphX on Windows.
```cmd
C:\...\MIGraphX\src\api\include\migraphx\migraphx.hpp:489:12: error: dereference of type 'T *' that was reinterpret_cast from type 'X *' has undefined behavior [-Werror,-Wundefined-reinterpret-cast]
  489 |         f(*reinterpret_cast<T*>(obj), result, no_out_arg{}, xs...);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~
C:\...\MIGraphX\src\api/include\migraphx\migraphx.hpp:130:16: note: in instantiation of function template specialization 'migraphx::interface_base<migraphx::handle_base<migraphx::experimental_custom_op, migraphx_experimental_custom_op, migraphx_status (*)(migraphx_experimental_custom_op *), &migraphx_experimental_custom_op_destroy, migraphx_status (*)(migraphx_experimental_custom_op *, const migraphx_experimental_custom_op *), &migraphx_experimental_custom_op_assign_to>>::set_fp(migraphx_status (*)(migraphx_experimental_custom_op *, migraphx_status (*)(migraphx_shape *, void *, char *, unsigned long long, migraphx_shapes *)), (lambda at C:\...\MIGraphX\src\api\include\migraphx\migraphx.hpp:465:13), out_params<1>)::(anonymous class)::operator()<migraphx_shape *, migraphx_shapes *>' requested here
  130 |     auto e = f(std::forward<Ts>(xs)...);
      |                ^
C:\...\MIGraphX\src\api\include\migraphx\migraphx.hpp:438:9: note: in instantiation of function template specialization 'migraphx::call<migraphx_status (*)(migraphx_experimental_custom_op *, migraphx_status (*)(migraphx_shape *, void *, char *, unsigned long long, migraphx_shapes *)), migraphx_experimental_custom_op *, (lambda at C:\...\MIGraphX\src\api\include\migraphx\migraphx.hpp:440:14)>' requested here
  438 |         call(setter,
      |         ^
C:\...\MIGraphX\src\api\include\migraphx\migraphx.hpp:463:16: note: in instantiation of function template specialization 'migraphx::interface_base<migraphx::handle_base<migraphx::experimental_custom_op, migraphx_experimental_custom_op, migraphx_status (*)(migraphx_experimental_custom_op *), &migraphx_experimental_custom_op_destroy, migraphx_status (*)(migraphx_experimental_custom_op *, const migraphx_experimental_custom_op *), &migraphx_experimental_custom_op_assign_to>>::set_fp<sigmoid_custom_op, migraphx_status (*)(migraphx_experimental_custom_op *, migraphx_status (*)(migraphx_shape *, void *, char *, unsigned long long, migraphx_shapes *)), (lambda at C:\...\MIGraphX\src\api\include\migraphx\migraphx.hpp:465:13)>' requested here
  463 |         return set_fp<T>(
      |                ^
C:\...\MIGraphX\src\api\include\migraphx\migraphx.hpp:1568:9: note: in instantiation of function template specialization 'migraphx::interface_base<migraphx::handle_base<migraphx::experimental_custom_op, migraphx_experimental_custom_op, migraphx_status (*)(migraphx_experimental_custom_op *), &migraphx_experimental_custom_op_destroy, migraphx_status (*)(migraphx_experimental_custom_op *, const migraphx_experimental_custom_op *), &migraphx_experimental_custom_op_assign_to>>::set_auto_fp<sigmoid_custom_op, migraphx_status (*)(migraphx_experimental_custom_op *, migraphx_status (*)(migraphx_shape *, void *, char *, unsigned long long, migraphx_shapes *)), (lambda at C:\...\MIGraphX\src\api\include\migraphx\migraphx.hpp:1568:9), migraphx::out_params<1>>' requested here
 1568 |         MIGRAPHX_INTERFACE_LIFT(1, T, experimental_custom_op, compute_shape);
      |         ^
C:\...\MIGraphX\src\api\include\migraphx\migraphx.hpp:565:11: note: expanded from macro 'MIGRAPHX_INTERFACE_LIFT'
  565 |     this->set_auto_fp<T>(                               \
      |           ^
C:\...\MIGraphX\src\api\include\migraphx\migraphx.hpp:1580:28: note: in instantiation of function template specialization 'migraphx::experimental_custom_op::experimental_custom_op<sigmoid_custom_op>' requested here
 1580 |     experimental_custom_op op{obj};
      |                            ^
C:\...\MIGraphX\test\api\test_custom_op.cpp:73:15: note: in instantiation of function template specialization 'migraphx::register_experimental_custom_op<sigmoid_custom_op, void>' requested here
   73 |     migraphx::register_experimental_custom_op(sigmoid_op);
```
Changing to `static_cast` resolves the problem.