### PR TITLE
Use rocBLAS by default for gfx90a instead of hipBLASLt

### DIFF
--- a/docs/dev/env_vars.rst
+++ b/docs/dev/env_vars.rst
@@ -135,13 +135,10 @@ Use it in conjunction with ``MIGRAPHX_DISABLE_MLIR=1``.
 Set to "1", "enable", "enabled", "yes", or "true" to use.
 Disables use of the rocMLIR library.
 
-.. envvar:: MIGRAPHX_ENABLE_HIPBLASLT_GEMM
-Set to "1", "enable", "enabled", "yes", or "true" to use.
-Enables use of hipBLASLt for all architectures.
+.. envvar:: MIGRAPHX_SET_GEMM_PROVIDER
 
-.. envvar:: MIGRAPHX_DISABLE_HIPBLASLT_GEMM
-Set to "1", "enable", "enabled", "yes", or "true" to use.
-Disables use of hipBLASLt.
+Set to "1" to use hipBLASLt.
+Set to "2" to use rocBLAS.
 
 .. envvar:: MIGRAPHX_COPY_LITERALS
 

--- a/docs/dev/env_vars.rst
+++ b/docs/dev/env_vars.rst
@@ -136,12 +136,10 @@ Set to "1", "enable", "enabled", "yes", or "true" to use.
 Disables use of the rocMLIR library.
 
 .. envvar:: MIGRAPHX_ENABLE_HIPBLASLT_GEMM
-Set to "1", "enable", "enabled", "yes", or "true" to use.
-Enables use of hipBLASLt for all architectures.
+Set to ``1`` or ``true`` to enable use of hipBLASLt GEMM on all architectures.
 
 .. envvar:: MIGRAPHX_DISABLE_HIPBLASLT_GEMM
-Set to "1", "enable", "enabled", "yes", or "true" to use.
-Disables use of hipBLASLt.
+Set to ``1`` or ``true`` to disable use of hipBLASLt GEMM on all architectures.
 
 .. envvar:: MIGRAPHX_COPY_LITERALS
 

--- a/docs/dev/env_vars.rst
+++ b/docs/dev/env_vars.rst
@@ -135,6 +135,10 @@ Use it in conjunction with ``MIGRAPHX_DISABLE_MLIR=1``.
 Set to "1", "enable", "enabled", "yes", or "true" to use.
 Disables use of the rocMLIR library.
 
+.. envvar:: MIGRAPHX_ENABLE_HIPBLASLT_GEMM
+Set to "1", "enable", "enabled", "yes", or "true" to use.
+Enables use of hipBLASLt for all architectures.
+
 .. envvar:: MIGRAPHX_DISABLE_HIPBLASLT_GEMM
 Set to "1", "enable", "enabled", "yes", or "true" to use.
 Disables use of hipBLASLt.

--- a/docs/dev/env_vars.rst
+++ b/docs/dev/env_vars.rst
@@ -136,10 +136,12 @@ Set to "1", "enable", "enabled", "yes", or "true" to use.
 Disables use of the rocMLIR library.
 
 .. envvar:: MIGRAPHX_ENABLE_HIPBLASLT_GEMM
-Set to ``1`` or ``true`` to enable use of hipBLASLt GEMM on all architectures.
+Set to "1", "enable", "enabled", "yes", or "true" to use.
+Enables use of hipBLASLt for all architectures.
 
 .. envvar:: MIGRAPHX_DISABLE_HIPBLASLT_GEMM
-Set to ``1`` or ``true`` to disable use of hipBLASLt GEMM on all architectures.
+Set to "1", "enable", "enabled", "yes", or "true" to use.
+Disables use of hipBLASLt.
 
 .. envvar:: MIGRAPHX_COPY_LITERALS
 

--- a/docs/dev/env_vars.rst
+++ b/docs/dev/env_vars.rst
@@ -137,8 +137,8 @@ Disables use of the rocMLIR library.
 
 .. envvar:: MIGRAPHX_SET_GEMM_PROVIDER
 
-Set to "1" to use hipBLASLt.
-Set to "2" to use rocBLAS.
+Set to "hipblaslt" to use hipBLASLt.
+Set to "rocblas" to use rocBLAS.
 
 .. envvar:: MIGRAPHX_COPY_LITERALS
 

--- a/src/targets/gpu/device_name.cpp
+++ b/src/targets/gpu/device_name.cpp
@@ -23,6 +23,7 @@
  */
 #include <migraphx/env.hpp>
 #include <migraphx/gpu/device_name.hpp>
+#include <migraphx/gpu/hipblaslt.hpp>
 #include <migraphx/gpu/rocblas.hpp>
 #include <migraphx/errors.hpp>
 #include <migraphx/rank.hpp>
@@ -33,6 +34,7 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_HIPBLASLT_GEMM);
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_DISABLE_HIPBLASLT_GEMM)
 
 int get_device_id()
@@ -71,6 +73,14 @@ bool gfx_has_fp8fnuz_support()
 {
     return (enabled(MIGRAPHX_DISABLE_HIPBLASLT_GEMM{}) ? gpu::rocblas_fp8_available()
                                                        : gfx_has_fp8fnuz_intrinsics());
+}
+
+bool gfx_default_rocblas()
+{
+    const auto device_name = trim(split_string(get_device_name(), ':').front());
+    // Default to rocBLAS for gfx90a.
+    return (enabled(MIGRAPHX_ENABLE_HIPBLASLT_GEMM{}) ? not gpu::hipblaslt_supported()
+                                                      : (device_name == "gfx90a"));
 }
 
 } // namespace gpu

--- a/src/targets/gpu/device_name.cpp
+++ b/src/targets/gpu/device_name.cpp
@@ -34,8 +34,7 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
-MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_HIPBLASLT_GEMM);
-MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_DISABLE_HIPBLASLT_GEMM)
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_SET_GEMM_PROVIDER)
 
 int get_device_id()
 {
@@ -71,8 +70,8 @@ bool gfx_has_fp8ocp_intrinsics()
 
 bool gfx_has_fp8fnuz_support()
 {
-    return (enabled(MIGRAPHX_DISABLE_HIPBLASLT_GEMM{}) ? gpu::rocblas_fp8_available()
-                                                       : gfx_has_fp8fnuz_intrinsics());
+    return (value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == 2 ? gpu::rocblas_fp8_available()
+                                                        : gfx_has_fp8fnuz_intrinsics());
 }
 
 #if MIGRAPHX_USE_HIPBLASLT
@@ -80,8 +79,7 @@ bool gfx_default_rocblas()
 {
     const auto device_name = trim(split_string(get_device_name(), ':').front());
     // Default to rocBLAS for gfx90a.
-    return (enabled(MIGRAPHX_ENABLE_HIPBLASLT_GEMM{}) ? not gpu::hipblaslt_supported()
-                                                      : (device_name == "gfx90a"));
+    return (not enabled(MIGRAPHX_SET_GEMM_PROVIDER{}) ? (device_name == "gfx90a") : false);
 }
 #endif
 

--- a/src/targets/gpu/device_name.cpp
+++ b/src/targets/gpu/device_name.cpp
@@ -70,8 +70,9 @@ bool gfx_has_fp8ocp_intrinsics()
 
 bool gfx_has_fp8fnuz_support()
 {
-    return (value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == 2 ? gpu::rocblas_fp8_available()
-                                                        : gfx_has_fp8fnuz_intrinsics());
+    return (string_value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == "rocblas"
+                ? gpu::rocblas_fp8_available()
+                : gfx_has_fp8fnuz_intrinsics());
 }
 
 #if MIGRAPHX_USE_HIPBLASLT

--- a/src/targets/gpu/device_name.cpp
+++ b/src/targets/gpu/device_name.cpp
@@ -75,15 +75,15 @@ bool gfx_has_fp8fnuz_support()
                                                        : gfx_has_fp8fnuz_intrinsics());
 }
 
+#if MIGRAPHX_USE_HIPBLASLT
 bool gfx_default_rocblas()
 {
     const auto device_name = trim(split_string(get_device_name(), ':').front());
     // Default to rocBLAS for gfx90a.
-#if MIGRAPHX_USE_HIPBLASLT
     return (enabled(MIGRAPHX_ENABLE_HIPBLASLT_GEMM{}) ? not gpu::hipblaslt_supported()
                                                       : (device_name == "gfx90a"));
-#endif
 }
+#endif
 
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/targets/gpu/device_name.cpp
+++ b/src/targets/gpu/device_name.cpp
@@ -23,7 +23,6 @@
  */
 #include <migraphx/env.hpp>
 #include <migraphx/gpu/device_name.hpp>
-#include <migraphx/gpu/hipblaslt.hpp>
 #include <migraphx/gpu/rocblas.hpp>
 #include <migraphx/errors.hpp>
 #include <migraphx/rank.hpp>
@@ -76,6 +75,7 @@ bool gfx_has_fp8fnuz_support()
 }
 
 #if MIGRAPHX_USE_HIPBLASLT
+// Archs that support hipBLASLt but are defaulted to use rocBLAS.
 bool gfx_default_rocblas()
 {
     const auto device_name = trim(split_string(get_device_name(), ':').front());

--- a/src/targets/gpu/device_name.cpp
+++ b/src/targets/gpu/device_name.cpp
@@ -79,8 +79,10 @@ bool gfx_default_rocblas()
 {
     const auto device_name = trim(split_string(get_device_name(), ':').front());
     // Default to rocBLAS for gfx90a.
+#if MIGRAPHX_USE_HIPBLASLT
     return (enabled(MIGRAPHX_ENABLE_HIPBLASLT_GEMM{}) ? not gpu::hipblaslt_supported()
                                                       : (device_name == "gfx90a"));
+#endif
 }
 
 } // namespace gpu

--- a/src/targets/gpu/include/migraphx/gpu/device_name.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/device_name.hpp
@@ -43,6 +43,8 @@ MIGRAPHX_GPU_EXPORT bool gfx_has_fp8ocp_intrinsics();
 
 MIGRAPHX_GPU_EXPORT bool gfx_has_fp8fnuz_support();
 
+MIGRAPHX_GPU_EXPORT bool gfx_default_rocblas();
+
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/targets/gpu/lowering.cpp
+++ b/src/targets/gpu/lowering.cpp
@@ -55,7 +55,7 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
-MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_DISABLE_HIPBLASLT_GEMM);
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_SET_GEMM_PROVIDER)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_DISABLE_MIOPEN_POOLING)
 
 struct miopen_apply
@@ -253,8 +253,9 @@ struct miopen_apply
             assert(refs.size() == 2);
             auto output = insert_allocation(ins, ins->get_shape());
             refs.push_back(output);
+
 #if MIGRAPHX_USE_HIPBLASLT
-            if(enabled(MIGRAPHX_DISABLE_HIPBLASLT_GEMM{}) or not hipblaslt_supported() or
+            if((value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == 2) or not hipblaslt_supported() or
                gpu::gfx_default_rocblas())
             {
 #endif

--- a/src/targets/gpu/lowering.cpp
+++ b/src/targets/gpu/lowering.cpp
@@ -254,7 +254,8 @@ struct miopen_apply
             auto output = insert_allocation(ins, ins->get_shape());
             refs.push_back(output);
 #if MIGRAPHX_USE_HIPBLASLT
-            if(enabled(MIGRAPHX_DISABLE_HIPBLASLT_GEMM{}) or not hipblaslt_supported())
+            if(enabled(MIGRAPHX_DISABLE_HIPBLASLT_GEMM{}) or not hipblaslt_supported() or
+               gpu::gfx_default_rocblas())
             {
 #endif
                 return mod->replace_instruction(

--- a/src/targets/gpu/lowering.cpp
+++ b/src/targets/gpu/lowering.cpp
@@ -255,8 +255,8 @@ struct miopen_apply
             refs.push_back(output);
 
 #if MIGRAPHX_USE_HIPBLASLT
-            if((value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == 2) or not hipblaslt_supported() or
-               gpu::gfx_default_rocblas())
+            if((string_value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == "rocblas") or
+               not hipblaslt_supported() or gpu::gfx_default_rocblas())
             {
 #endif
                 return mod->replace_instruction(

--- a/src/targets/gpu/lowering.cpp
+++ b/src/targets/gpu/lowering.cpp
@@ -255,6 +255,9 @@ struct miopen_apply
             refs.push_back(output);
 
 #if MIGRAPHX_USE_HIPBLASLT
+            // Check if user explicitly sets rocBLAS as GEMM provider, or
+            // if the hardware cannot support hipblaslt, or
+            // if the hardware is defaulted to use rocBLAS (such as gfx90).
             if((string_value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == "rocblas") or
                not hipblaslt_supported() or gpu::gfx_default_rocblas())
             {

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -134,7 +134,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
 
     std::set<std::string> unsupported_fp8e5m2fnuz_ops = unsupported_fp8e4m3fnuz_ops;
     // disable gemm for fp8e5m2fnuz if rocBLAS is being used
-    if(value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == 2)
+    if(string_value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == "rocblas")
     {
         unsupported_fp8e5m2fnuz_ops.insert("dot");
         unsupported_fp8e5m2fnuz_ops.insert("quant_dot");

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -82,7 +82,7 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_NHWC)
 #ifndef _WIN32
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_CK)
 #endif
-MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_DISABLE_HIPBLASLT_GEMM)
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_SET_GEMM_PROVIDER)
 
 std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_options& options) const
 {
@@ -134,7 +134,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
 
     std::set<std::string> unsupported_fp8e5m2fnuz_ops = unsupported_fp8e4m3fnuz_ops;
     // disable gemm for fp8e5m2fnuz if rocBLAS is being used
-    if(enabled(MIGRAPHX_DISABLE_HIPBLASLT_GEMM{}))
+    if(value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == 2)
     {
         unsupported_fp8e5m2fnuz_ops.insert("dot");
         unsupported_fp8e5m2fnuz_ops.insert("quant_dot");

--- a/test/gpu/compile_hipblaslt.cpp
+++ b/test/gpu/compile_hipblaslt.cpp
@@ -44,7 +44,7 @@ void run_lowering(migraphx::module& m, bool offload_copy = false)
 TEST_CASE(hipblaslt_op)
 {
     if(not migraphx::disabled(MIGRAPHX_ENABLE_HIPBLASLT_GEMM{}) and
-       migraphx::gpu::hipblaslt_supported())
+       migraphx::gpu::hipblaslt_supported() and not migraphx::gpu::gfx_default_rocblas())
     {
         migraphx::module m1;
         {

--- a/test/gpu/compile_hipblaslt.cpp
+++ b/test/gpu/compile_hipblaslt.cpp
@@ -43,7 +43,7 @@ void run_lowering(migraphx::module& m, bool offload_copy = false)
 #if MIGRAPHX_USE_HIPBLASLT
 TEST_CASE(hipblaslt_op)
 {
-    if(not(migraphx::value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == 2) and
+    if(not(migraphx::string_value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == "rocblas") and
        migraphx::gpu::hipblaslt_supported() and not migraphx::gpu::gfx_default_rocblas())
     {
         migraphx::module m1;

--- a/test/gpu/compile_hipblaslt.cpp
+++ b/test/gpu/compile_hipblaslt.cpp
@@ -32,7 +32,7 @@
 #include <migraphx/register_op.hpp>
 #include <test.hpp>
 
-MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_HIPBLASLT_GEMM);
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_SET_GEMM_PROVIDER)
 
 void run_lowering(migraphx::module& m, bool offload_copy = false)
 {
@@ -43,7 +43,7 @@ void run_lowering(migraphx::module& m, bool offload_copy = false)
 #if MIGRAPHX_USE_HIPBLASLT
 TEST_CASE(hipblaslt_op)
 {
-    if(not migraphx::disabled(MIGRAPHX_ENABLE_HIPBLASLT_GEMM{}) and
+    if(not(migraphx::value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == 2) and
        migraphx::gpu::hipblaslt_supported() and not migraphx::gpu::gfx_default_rocblas())
     {
         migraphx::module m1;

--- a/test/gpu/fuse_gemm.cpp
+++ b/test/gpu/fuse_gemm.cpp
@@ -82,7 +82,7 @@ TEST_CASE(gemm_pointwise_add)
 
         auto output = mm->add_instruction(migraphx::op::allocate{s, std::nullopt});
 
-        if(not(migraphx::value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == 2) and
+        if(not(migraphx::string_value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == "rocblas") and
            migraphx::gpu::hipblaslt_supported() and not migraphx::gpu::gfx_default_rocblas())
         {
             migraphx::op::dot dot_instance;

--- a/test/gpu/fuse_gemm.cpp
+++ b/test/gpu/fuse_gemm.cpp
@@ -83,7 +83,7 @@ TEST_CASE(gemm_pointwise_add)
         auto output = mm->add_instruction(migraphx::op::allocate{s, std::nullopt});
 
         if(not migraphx::disabled(MIGRAPHX_ENABLE_HIPBLASLT_GEMM{}) and
-           migraphx::gpu::hipblaslt_supported())
+           migraphx::gpu::hipblaslt_supported() and not migraphx::gpu::gfx_default_rocblas())
         {
             migraphx::op::dot dot_instance;
             migraphx::gpu::hipblaslt_op hipblaslt_operator;

--- a/test/gpu/fuse_gemm.cpp
+++ b/test/gpu/fuse_gemm.cpp
@@ -41,7 +41,7 @@
 #include <pointwise.hpp>
 #include <test.hpp>
 
-MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_HIPBLASLT_GEMM)
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_SET_GEMM_PROVIDER)
 
 void run_lowering(migraphx::program& p, bool offload_copy = false)
 {
@@ -82,7 +82,7 @@ TEST_CASE(gemm_pointwise_add)
 
         auto output = mm->add_instruction(migraphx::op::allocate{s, std::nullopt});
 
-        if(not migraphx::disabled(MIGRAPHX_ENABLE_HIPBLASLT_GEMM{}) and
+        if(not(migraphx::value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == 2) and
            migraphx::gpu::hipblaslt_supported() and not migraphx::gpu::gfx_default_rocblas())
         {
             migraphx::op::dot dot_instance;


### PR DESCRIPTION
This PR makes the following changes:

    - Use rocBLAS as default for gfx90a instead of hipBLASLt.

    - Introduced env variable: MIGRAPHX_SET_GEMM_PROVIDER
      Set to "hipblaslt" to use hipBLASLt.
      Set to "rocblas" to use rocBLAS.
      
    - Remove MIGRAPHX_DISABLE_HIPBLASLT_GEMM env var