### PR TITLE
NFC: Remove outdated comment

### DIFF
--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -675,7 +675,6 @@ struct find_rocblas_gemm_pointwise : gemm_pointwise
             auto c_ins = r.instructions["c"];
             shape s    = c_ins->get_shape();
             // const-fold input if not standard shape since rocblas can't handle it
-            // Updated for a case where "standard" shape has out-of-sequence strides
             if(not s.standard())
             {
                 auto c = make_op("contiguous");
@@ -736,7 +735,6 @@ struct find_hipblas_gemm_pointwise : gemm_pointwise
             auto c_ins = r.instructions["c"];
             shape s    = c_ins->get_shape();
             // const-fold input if not standard shape
-            // Updated for a case where "standard" shape has out-of-sequence strides
             if(not s.standard())
             {
                 auto c = make_op("contiguous");


### PR DESCRIPTION
The changes associated with the comment were removed in earlier PRs.
The comment is no longer applicable to the code; removing it for clarity.