### PR TITLE
Add skip layer normalization

### DIFF
--- a/src/onnx/parse_skip_layer_normalization.cpp
+++ b/src/onnx/parse_skip_layer_normalization.cpp
@@ -138,8 +138,7 @@ struct parse_skip_simplified_layer_normalization
         // Get the mean of input and squared of the expectation (for variance calc later)
         // Var = E( (x - E[x])) ^2)
         auto exp_x  = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), float_x);
-        auto pr_var = info.add_common_op("sub", float_x, exp_x);
-        pr_var      = info.add_common_op("mul", pr_var, pr_var);
+        pr_var      = info.add_common_op("sqdiff", {float_x, exp_x});
         auto var    = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), pr_var);
         var         = info.add_instruction(make_op("convert", {{"target_type", x_dtype}}), var);
         auto mean   = info.add_instruction(make_op("convert", {{"target_type", x_dtype}}), exp_x);

--- a/src/onnx/parse_skip_layer_normalization.cpp
+++ b/src/onnx/parse_skip_layer_normalization.cpp
@@ -140,19 +140,19 @@ struct parse_skip_simplified_layer_normalization
         auto exp_x  = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), float_x);
         auto pr_var = info.add_common_op("sqdiff", {float_x, exp_x});
         auto var    = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), pr_var);
-        var         = info.add_instruction(make_op("convert", {{"target_type", x_dtype}}), var);
         auto mean   = info.add_instruction(make_op("convert", {{"target_type", x_dtype}}), exp_x);
 
         epsilon =
             (x_dtype == migraphx::shape::half_type and std::abs(epsilon) < 1e-7) ? 1e-7 : epsilon;
-        auto eps    = info.add_literal(migraphx::literal{migraphx::shape{x_dtype}, {epsilon}});
+        auto eps    = info.add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {epsilon}});
         auto var_ep = info.add_common_op("add", var, eps);
 
         // reciprical sqrt here on resulting variance + epsilon offset to avoid div by zero
-        auto r_var  = info.add_instruction(make_op("rsqrt"), var_ep);
+        auto r_var_fp32  = info.add_instruction(make_op("rsqrt"), var_ep);
+        auto r_var       = info.add_instruction(make_op("convert", {{"target_type", x_dtype}}), r_var_fp32);
 
         // Output is  (x - E[x]) * gamma / (sqrt(var(x) - epsilon)) + beta
-        auto result = info.add_common_op("sub", x, exp_x);
+        auto result = info.add_common_op("sub", x, mean);
         result      = info.add_common_op("mul", result, r_var);
         result      = info.add_common_op("mul", result, gamma);
 
@@ -172,8 +172,7 @@ struct parse_skip_simplified_layer_normalization
         // exists)with shape (batch_size, sequence_length, hidden_size) or (token_count,
         // hidden_size).
 
-        result->debug_print();
-        return {result, mean, r_var, x};
+        return {result, exp_x, r_var_fp32, x};
     }
 };
 

--- a/src/onnx/parse_skip_layer_normalization.cpp
+++ b/src/onnx/parse_skip_layer_normalization.cpp
@@ -1,0 +1,149 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/onnx/op_parser.hpp>
+#include <migraphx/ranges.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/instruction.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace onnx {
+
+// com.microsoft.SkipSimplifiedLayerNormalization
+// Skip and Root Mean Square Layer Normalization
+
+// Version
+// This version of the operator has been available since version 1 of the 'com.microsoft' operator
+// set.
+
+// Type Constraints
+// T : tensor(float), tensor(float16)
+// Constrain input and output types to float or half tensors.
+// U : tensor(float)
+// Constrain mean and inv_std_var to float tensors.
+
+struct parse_skip_simplified_layer_normalization
+    : op_parser<parse_skip_simplified_layer_normalization>
+{
+    std::vector<op_desc> operators() const { return {{"SkipLayerNormalization"}}; }
+
+    std::vector<instruction_ref> parse(const op_desc& /*opd*/,
+                                       const onnx_parser& parser,
+                                       const onnx_parser::node_info& info,
+                                       std::vector<instruction_ref> args) const
+    {
+        // Attributes
+        // epsilon : float
+        // The epsilon value to use to avoid division by zero.
+        float epsilon = 1e-5f;
+        if(contains(info.attributes, "epsilon"))
+        {
+            epsilon = parser.parse_value(info.attributes.at("epsilon")).at<float>();
+        }
+
+        // Inputs (3 - 4)
+        // input : T
+        // 3D input tensor with shape (batch_size, sequence_length, hidden_size) Or 2D input tensor
+        // with shape (token_count, hidden_size)
+        // skip : T
+        // 3D input tensor with shape (batch_size, sequence_length, hidden_size)
+        // Or 2D input tensor with shape (token_count, hidden_size)
+        // gamma : T
+        // 1D input tensor with shape (hidden_size)
+        // bias (optional) : T
+        // 1D bias tensor with shape (hidden_size) - not used by ORT
+
+        if(args.size() < 3 or args.size() > 4)
+        {
+            MIGRAPHX_THROW("PARSE_SKIPSIMPLIFIEDLAYERNORMALIZATION: invalid input count");
+        }
+
+        auto x     = args.at(0);
+        auto skip  = args.at(1);
+        auto gamma = args.at(2);
+        instruction_ref beta;
+        instruction_ref bias;
+        if(args.size() >= 4)
+        {
+            beta = args.at(3);
+        }
+        if(args.size() == 5)
+        {
+            bias = args.at(4);
+        }
+
+        auto x_shape       = x->get_shape();
+        auto x_dtype       = x_shape.type();
+        int64_t x_rank     = x_shape.ndim();
+        int64_t skip_rank  = skip->get_shape().ndim();
+        int64_t gamma_rank = gamma->get_shape().ndim();
+        // axis = hidden_size dim
+        int64_t axis = x_rank - 1;
+
+        if(x_rank < 2 or x_rank > 3 or x_rank != skip_rank or gamma_rank != 1)
+        {
+            MIGRAPHX_THROW("PARSE_SKIPLAYERNORMALIZATION: invalid input shape");
+        }
+
+        x         = info.add_common_op("add", x, skip);
+        // Convert to float before reduce_mean
+        // Fp16 reduce_mean on GPU causes loss of accuracy
+        auto float_x = info.add_instruction(
+            make_op("convert", {{"target_type", migraphx::shape::float_type}}), x);
+        auto x_sq = info.add_common_op("mul", float_x, float_x);
+        auto rms  = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), x_sq);
+        rms       = info.add_instruction(make_op("convert", {{"target_type", x_dtype}}), rms);
+        auto mean = rms;
+        epsilon =
+            (x_dtype == migraphx::shape::half_type and std::abs(epsilon) < 1e-7) ? 1e-7 : epsilon;
+        auto eps    = info.add_literal(migraphx::literal{migraphx::shape{x_dtype}, {epsilon}});
+        rms         = info.add_common_op("add", rms, eps);
+        auto rrms   = info.add_instruction(make_op("rsqrt"), rms);
+        auto result = info.add_common_op("mul", x, rrms);
+        result      = info.add_common_op("mul", result, gamma);
+        if(args.size() == 4)
+        {
+            result = info.add_common_op("add", result, bias);
+            x      = info.add_common_op("add", x, bias);
+        }
+
+        // Outputs (1 - 4)
+        // output : T
+        // 3D output tensor with shape (batch_size, sequence_length, hidden_size)Or 2D output tensor
+        // with shape (token_count, hidden_size)
+        // mean (optional) : U Saved mean used during training
+        // to speed up gradient computation
+        // inv_std_var (optional) : U Saved inverse standard
+        // variance used during training to speed up gradient computation.
+        // input_skip_bias_sum (optional) : T Sum of the input and skip inputs (and bias if it
+        // exists)with shape (batch_size, sequence_length, hidden_size) or (token_count,
+        // hidden_size).
+
+        return {result, mean, rrms, x};
+    }
+};
+
+} // namespace onnx
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx

--- a/src/onnx/parse_skip_layer_normalization.cpp
+++ b/src/onnx/parse_skip_layer_normalization.cpp
@@ -92,7 +92,7 @@ struct parse_skip_simplified_layer_normalization
         // axis = hidden_size dim
         int64_t axis = x_rank - 1;
 
-        if(x_rank > 3 or (x_rank != skip_rank and skip_rank != 2) or gamma_rank != 1)
+        if(x_rank != 3 or (x_rank != skip_rank and skip_rank != 2) or gamma_rank != 1)
         {
             MIGRAPHX_THROW("PARSE_SKIPLAYERNORMALIZATION: invalid input shape");
         }
@@ -138,7 +138,7 @@ struct parse_skip_simplified_layer_normalization
         // Get the mean of input and squared of the expectation (for variance calc later)
         // Var = E( (x - E[x])) ^2)
         auto exp_x  = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), float_x);
-        pr_var      = info.add_common_op("sqdiff", {float_x, exp_x});
+        auto pr_var = info.add_common_op("sqdiff", {float_x, exp_x});
         auto var    = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), pr_var);
         var         = info.add_instruction(make_op("convert", {{"target_type", x_dtype}}), var);
         auto mean   = info.add_instruction(make_op("convert", {{"target_type", x_dtype}}), exp_x);

--- a/src/onnx/parse_skip_layer_normalization.cpp
+++ b/src/onnx/parse_skip_layer_normalization.cpp
@@ -85,7 +85,6 @@ struct parse_skip_simplified_layer_normalization
         auto skip  = args.at(1);
         auto gamma = args.at(2);
 
-
         auto x_shape       = x->get_shape();
         auto x_dtype       = x_shape.type();
         int64_t x_rank     = x_shape.ndim();
@@ -103,7 +102,7 @@ struct parse_skip_simplified_layer_normalization
         instruction_ref beta;
         if(args.size() >= 4)
         {
-            beta = args.at(3);
+            beta            = args.at(3);
             auto beta_shape = beta->get_shape();
             auto beta_len   = beta_shape.lens();
             if(beta_shape.type() != x_dtype or beta_len.size() > 1)
@@ -116,7 +115,7 @@ struct parse_skip_simplified_layer_normalization
         instruction_ref bias;
         if(args.size() == 5)
         {
-            bias = args.at(4);
+            bias            = args.at(4);
             auto bias_shape = bias->get_shape();
             auto bias_len   = bias_shape.lens();
             if(bias_shape.type() != x_dtype or bias_len.size() > 1)
@@ -133,18 +132,18 @@ struct parse_skip_simplified_layer_normalization
 
         // Get the mean of input and squared of the expectation (for variance calc later)
         // Var = E( (x - E[x])) ^2)
-        auto mean  = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), x);
+        auto mean   = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), x);
         auto pr_var = info.add_common_op("sqdiff", {x, mean});
         auto var    = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), pr_var);
 
         epsilon =
-        (x_dtype == migraphx::shape::half_type and std::abs(epsilon) < 1e-7) ? 1e-7 : epsilon;
-        auto eps    = info.add_literal(migraphx::literal{shape{x_dtype}, {epsilon}});
+            (x_dtype == migraphx::shape::half_type and std::abs(epsilon) < 1e-7) ? 1e-7 : epsilon;
+        auto eps = info.add_literal(migraphx::literal{shape{x_dtype}, {epsilon}});
 
         auto var_ep = info.add_common_op("add", var, eps);
 
         // reciprical sqrt here on resulting variance + epsilon offset to avoid div by zero
-        auto r_var  = info.add_instruction(make_op("rsqrt"), var_ep);
+        auto r_var = info.add_instruction(make_op("rsqrt"), var_ep);
 
         // Output is  (x - E[x]) * gamma / (sqrt(var(x) - epsilon)) + beta
         auto result = info.add_common_op("sub", x, mean);

--- a/src/onnx/parse_skip_layer_normalization.cpp
+++ b/src/onnx/parse_skip_layer_normalization.cpp
@@ -137,12 +137,12 @@ struct parse_skip_simplified_layer_normalization
 
         // Get the mean of input and squared of the expectation (for variance calc later)
         // Var = E( (x - E[x])) ^2)
-        auto exp_x     = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), float_x);
-        auto pre_var   = info.add_common_op("sub", float_x, exp_x);
-        pre_var        = info.add_common_op("mul", pre_var, pre_var);
-        auto var       = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), pre_var);
-        var            = info.add_instruction(make_op("convert", {{"target_type", x_dtype}}), var);
-        auto mean      = info.add_instruction(make_op("convert", {{"target_type", x_dtype}}), exp_x);
+        auto exp_x  = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), float_x);
+        auto pr_var = info.add_common_op("sub", float_x, exp_x);
+        pr_var      = info.add_common_op("mul", pr_var, pr_var);
+        auto var    = info.add_instruction(make_op("reduce_mean", {{"axes", {axis}}}), pr_var);
+        var         = info.add_instruction(make_op("convert", {{"target_type", x_dtype}}), var);
+        auto mean   = info.add_instruction(make_op("convert", {{"target_type", x_dtype}}), exp_x);
 
         epsilon =
             (x_dtype == migraphx::shape::half_type and std::abs(epsilon) < 1e-7) ? 1e-7 : epsilon;
@@ -173,6 +173,7 @@ struct parse_skip_simplified_layer_normalization
         // exists)with shape (batch_size, sequence_length, hidden_size) or (token_count,
         // hidden_size).
 
+        result->debug_print();
         return {result, mean, r_var, x};
     }
 };

--- a/src/onnx/parse_skip_layer_normalization.cpp
+++ b/src/onnx/parse_skip_layer_normalization.cpp
@@ -62,7 +62,7 @@ struct parse_skip_simplified_layer_normalization
             epsilon = parser.parse_value(info.attributes.at("epsilon")).at<float>();
         }
 
-        // Inputs (3 - 4)
+        // Inputs (3 - 5)
         // input : T
         // 3D input tensor with shape (batch_size, sequence_length, hidden_size) Or 2D input tensor
         // with shape (token_count, hidden_size)
@@ -97,10 +97,8 @@ struct parse_skip_simplified_layer_normalization
             MIGRAPHX_THROW("PARSE_SKIPLAYERNORMALIZATION: invalid input shape");
         }
 
-        instruction_ref beta;
-        instruction_ref bias;
-
         // Beta always applied at the end result as an affine offset
+        instruction_ref beta;
         if(args.size() >= 4)
         {
             beta = args.at(3);
@@ -113,6 +111,7 @@ struct parse_skip_simplified_layer_normalization
         }
 
         // Bias is always applied to the input along with any skip input
+        instruction_ref bias;
         if(args.size() == 5)
         {
             bias = args.at(4);
@@ -125,7 +124,7 @@ struct parse_skip_simplified_layer_normalization
         }
 
         x = info.add_common_op("add", x, skip);
-        if(args.size() >= 4)
+        if(args.size() >= 5)
         {
             x = info.add_common_op("add", x, bias);
         }
@@ -156,7 +155,7 @@ struct parse_skip_simplified_layer_normalization
         result      = info.add_common_op("mul", result, r_var);
         result      = info.add_common_op("mul", result, gamma);
 
-        if(args.size() == 5)
+        if(args.size() >= 4)
         {
             result = info.add_common_op("add", result, beta);
         }

--- a/src/onnx/parse_skip_layer_normalization.cpp
+++ b/src/onnx/parse_skip_layer_normalization.cpp
@@ -71,6 +71,8 @@ struct parse_skip_simplified_layer_normalization
         // Or 2D input tensor with shape (token_count, hidden_size)
         // gamma : T
         // 1D input tensor with shape (hidden_size)
+        // beta (optional) : T
+        // 1D skip tensor with shape (hidden_size)
         // bias (optional) : T
         // 1D bias tensor with shape (hidden_size) - not used by ORT
 

--- a/test/onnx/gen_onnx.py
+++ b/test/onnx/gen_onnx.py
@@ -12753,7 +12753,7 @@ def skip_layer_normalization_beta_bias_test():
         epsilon=1e-5,
         domain="com.microsoft")
 
-    return ([node], [x, skip, gamma,
+    return ([node], [x, skip, gamma, beta,
                      bias], [y, mean, inv_std_var, input_skip_bias_sum])
 
 
@@ -12779,7 +12779,7 @@ def skip_layer_normalization_bad_bias_test():
         epsilon=1e-5,
         domain="com.microsoft")
 
-    return ([node], [x, skip, gamma,
+    return ([node], [x, skip, gamma, beta,
                      bias], [y, mean, inv_std_var, input_skip_bias_sum])
 
 

--- a/test/onnx/gen_onnx.py
+++ b/test/onnx/gen_onnx.py
@@ -12658,6 +12658,165 @@ def skip_simplified_layer_normalization_invalid_input_test():
 
 
 @onnx_test()
+def skip_layer_normalization_test():
+    x = helper.make_tensor_value_info('x', TensorProto.FLOAT16, [2, 2, 4])
+    skip = helper.make_tensor_value_info('skip', TensorProto.FLOAT16,
+                                         [2, 2, 4])
+    gamma = helper.make_tensor_value_info('gamma', TensorProto.FLOAT16, [4])
+    y = helper.make_tensor_value_info('y', TensorProto.FLOAT16, [2, 2, 4])
+    mean = helper.make_tensor_value_info('mean', TensorProto.FLOAT, [2, 2, 1])
+    inv_std_var = helper.make_tensor_value_info('inv_std_var',
+                                                TensorProto.FLOAT, [2, 2, 1])
+    input_skip_bias_sum = helper.make_tensor_value_info(
+        'input_skip_bias_sum', TensorProto.FLOAT16, [2, 2, 4])
+
+    node = onnx.helper.make_node(
+        'SkipLayerNormalization',
+        inputs=['x', 'skip', 'gamma'],
+        outputs=['y', 'mean', 'inv_std_var', 'input_skip_bias_sum'],
+        epsilon=1e-5,
+        domain="com.microsoft")
+
+    return ([node], [x, skip,
+                     gamma], [y, mean, inv_std_var, input_skip_bias_sum])
+
+
+@onnx_test()
+def skip_layer_normalization_beta_test():
+    x = helper.make_tensor_value_info('x', TensorProto.FLOAT16, [2, 2, 4])
+    skip = helper.make_tensor_value_info('skip', TensorProto.FLOAT16,
+                                         [2, 2, 4])
+    gamma = helper.make_tensor_value_info('gamma', TensorProto.FLOAT16, [4])
+    beta = helper.make_tensor_value_info('beta', TensorProto.FLOAT16, [4])
+    y = helper.make_tensor_value_info('y', TensorProto.FLOAT16, [2, 2, 4])
+    mean = helper.make_tensor_value_info('mean', TensorProto.FLOAT, [2, 2, 1])
+    inv_std_var = helper.make_tensor_value_info('inv_std_var',
+                                                TensorProto.FLOAT, [2, 2, 1])
+    input_skip_bias_sum = helper.make_tensor_value_info(
+        'input_skip_bias_sum', TensorProto.FLOAT16, [2, 2, 4])
+
+    node = onnx.helper.make_node(
+        'SkipLayerNormalization',
+        inputs=['x', 'skip', 'gamma', 'beta'],
+        outputs=['y', 'mean', 'inv_std_var', 'input_skip_bias_sum'],
+        epsilon=1e-5,
+        domain="com.microsoft")
+
+    return ([node], [x, skip, gamma,
+                     beta], [y, mean, inv_std_var, input_skip_bias_sum])
+
+
+@onnx_test()
+def skip_layer_normalization_bad_beta_test():
+    x = helper.make_tensor_value_info('x', TensorProto.FLOAT16, [2, 2, 4])
+    skip = helper.make_tensor_value_info('skip', TensorProto.FLOAT16,
+                                         [2, 2, 4])
+    gamma = helper.make_tensor_value_info('gamma', TensorProto.FLOAT16, [4])
+    beta = helper.make_tensor_value_info('beta', TensorProto.FLOAT16, [4, 4])
+    y = helper.make_tensor_value_info('y', TensorProto.FLOAT16, [2, 2, 4])
+    mean = helper.make_tensor_value_info('mean', TensorProto.FLOAT, [2, 2, 1])
+    inv_std_var = helper.make_tensor_value_info('inv_std_var',
+                                                TensorProto.FLOAT, [2, 2, 1])
+    input_skip_bias_sum = helper.make_tensor_value_info(
+        'input_skip_bias_sum', TensorProto.FLOAT16, [2, 2, 4])
+
+    node = onnx.helper.make_node(
+        'SkipLayerNormalization',
+        inputs=['x', 'skip', 'gamma', 'beta'],
+        outputs=['y', 'mean', 'inv_std_var', 'input_skip_bias_sum'],
+        epsilon=1e-5,
+        domain="com.microsoft")
+
+    return ([node], [x, skip, gamma,
+                     beta], [y, mean, inv_std_var, input_skip_bias_sum])
+
+
+@onnx_test()
+def skip_layer_normalization_beta_bias_test():
+    x = helper.make_tensor_value_info('x', TensorProto.FLOAT16, [2, 2, 4])
+    skip = helper.make_tensor_value_info('skip', TensorProto.FLOAT16,
+                                         [2, 2, 4])
+    gamma = helper.make_tensor_value_info('gamma', TensorProto.FLOAT16, [4])
+    beta = helper.make_tensor_value_info('beta', TensorProto.FLOAT16, [4])
+    bias = helper.make_tensor_value_info('bias', TensorProto.FLOAT16, [4])
+    y = helper.make_tensor_value_info('y', TensorProto.FLOAT16, [2, 2, 4])
+    mean = helper.make_tensor_value_info('mean', TensorProto.FLOAT, [2, 2, 1])
+    inv_std_var = helper.make_tensor_value_info('inv_std_var',
+                                                TensorProto.FLOAT, [2, 2, 1])
+    input_skip_bias_sum = helper.make_tensor_value_info(
+        'input_skip_bias_sum', TensorProto.FLOAT16, [2, 2, 4])
+
+    node = onnx.helper.make_node(
+        'SkipLayerNormalization',
+        inputs=['x', 'skip', 'gamma', 'beta', 'bias'],
+        outputs=['y', 'mean', 'inv_std_var', 'input_skip_bias_sum'],
+        epsilon=1e-5,
+        domain="com.microsoft")
+
+    return ([node], [x, skip, gamma,
+                     bias], [y, mean, inv_std_var, input_skip_bias_sum])
+
+
+@onnx_test()
+def skip_layer_normalization_bad_bias_test():
+    x = helper.make_tensor_value_info('x', TensorProto.FLOAT16, [2, 2, 4])
+    skip = helper.make_tensor_value_info('skip', TensorProto.FLOAT16,
+                                         [2, 2, 4])
+    gamma = helper.make_tensor_value_info('gamma', TensorProto.FLOAT16, [4])
+    beta = helper.make_tensor_value_info('beta', TensorProto.FLOAT16, [4])
+    bias = helper.make_tensor_value_info('bias', TensorProto.FLOAT, [4])
+    y = helper.make_tensor_value_info('y', TensorProto.FLOAT16, [2, 2, 4])
+    mean = helper.make_tensor_value_info('mean', TensorProto.FLOAT, [2, 2, 1])
+    inv_std_var = helper.make_tensor_value_info('inv_std_var',
+                                                TensorProto.FLOAT, [2, 2, 1])
+    input_skip_bias_sum = helper.make_tensor_value_info(
+        'input_skip_bias_sum', TensorProto.FLOAT16, [2, 2, 4])
+
+    node = onnx.helper.make_node(
+        'SkipLayerNormalization',
+        inputs=['x', 'skip', 'gamma', 'beta', 'bias'],
+        outputs=['y', 'mean', 'inv_std_var', 'input_skip_bias_sum'],
+        epsilon=1e-5,
+        domain="com.microsoft")
+
+    return ([node], [x, skip, gamma,
+                     bias], [y, mean, inv_std_var, input_skip_bias_sum])
+
+
+@onnx_test()
+def skip_layer_normalization_invalid_n_args_test():
+    x = helper.make_tensor_value_info('x', TensorProto.FLOAT16, [2, 2, 4])
+    skip = helper.make_tensor_value_info('skip', TensorProto.FLOAT16,
+                                         [2, 2, 4])
+    y = helper.make_tensor_value_info('y', TensorProto.FLOAT16, [2, 2, 4])
+
+    node = onnx.helper.make_node('SkipLayerNormalization',
+                                 inputs=['x', 'skip'],
+                                 outputs=['y'],
+                                 epsilon=1e-5,
+                                 domain="com.microsoft")
+
+    return ([node], [x, skip], [y])
+
+
+@onnx_test()
+def skip_layer_normalization_invalid_input_test():
+    x = helper.make_tensor_value_info('x', TensorProto.FLOAT16, [2, 2, 2, 4])
+    skip = helper.make_tensor_value_info('skip', TensorProto.FLOAT16,
+                                         [2, 2, 4])
+    gamma = helper.make_tensor_value_info('gamma', TensorProto.FLOAT16, [2, 4])
+    y = helper.make_tensor_value_info('y', TensorProto.FLOAT16, [2, 2, 2, 4])
+
+    node = onnx.helper.make_node('SkipLayerNormalization',
+                                 inputs=['x', 'skip', 'gamma'],
+                                 outputs=['y'],
+                                 epsilon=1e-5,
+                                 domain="com.microsoft")
+
+    return ([node], [x, skip, gamma], [y])
+
+
+@onnx_test()
 def slice_test():
     x = helper.make_tensor_value_info('0', TensorProto.FLOAT, [3, 2])
     y = helper.make_tensor_value_info('1', TensorProto.FLOAT, [1, 2])

--- a/test/onnx/include/onnx_test_utils.hpp
+++ b/test/onnx/include/onnx_test_utils.hpp
@@ -203,6 +203,64 @@ make_layer_norm(const std::vector<int64_t>& input_shape,
 }
 
 inline migraphx::program
+make_skip_layer_norm(const std::vector<int64_t>& input_shape,
+                           const std::vector<int64_t>& skip_shape,
+                           const std::vector<int64_t>& gamma_shape,
+                           const std::vector<int64_t>& beta_shape,
+                           const std::vector<int64_t>& bias_shape,
+                           const int axes,
+                           const float eps_value               = 1e-5f,
+                           const migraphx::shape::type_t dtype = migraphx::shape::half_type)
+{
+    migraphx::program p;
+    auto* mm   = p.get_main_module();
+    auto x     = mm->add_parameter("x", {dtype, input_shape});
+    auto skip = mm->add_parameter("skip", {dtype, skip_shape});
+    auto scale = mm->add_parameter("gamma", {dtype, gamma_shape});
+
+    migraphx::instruction_ref beta;
+    migraphx::instruction_ref bias;
+    if(beta_shape.size() > 0)
+    {
+        beta = mm->add_parameter("beta", {dtype, beta_shape});
+    }
+
+    if(bias_shape.size() > 0)
+    {
+        bias = mm->add_parameter("bias", {dtype, bias_shape});
+    }
+
+    x = add_common_op(*mm, migraphx::make_op("add"), {x, skip});
+    if(bias_shape.size() > 0)
+        x = add_common_op(*mm, migraphx::make_op("add"), {x, bias});
+
+    auto float_x = mm->add_instruction(
+        migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), x);
+
+    auto eps  = mm->add_literal(migraphx::literal{dtype, {eps_value}});
+    auto mean = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {axes}}}), float_x);
+    auto x_sqdiff_mean = add_common_op(*mm, migraphx::make_op("sqdiff"), {x, mean});
+    auto var  = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {axes}}}),
+                                   x_sqdiff_mean);
+    var  = mm->add_instruction(migraphx::make_op("convert", {{"target_type", dtype}}), var);
+    mean = mm->add_instruction(migraphx::make_op("convert", {{"target_type", dtype}}), mean);
+
+    auto var_eps = add_common_op(*mm, migraphx::make_op("add"), {var, eps});
+    auto rsqrt   = mm->add_instruction(migraphx::make_op("rsqrt"), {var_eps});
+
+    auto x_sub_mean    = add_common_op(*mm, migraphx::make_op("sub"), {x, mean});
+    auto result  = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, rsqrt});
+    result = add_common_op(*mm, migraphx::make_op("mul"), {result, scale});
+
+    if(beta_shape.size() > 0)
+    {   
+        result = add_common_op(*mm, migraphx::make_op("add"), {result, beta});
+    }
+
+    return p;
+}
+
+inline migraphx::program
 make_simplified_layer_norm(const std::vector<int64_t>& input_shape,
                            const std::vector<int64_t>& skip_shape,
                            const std::vector<int64_t>& scale_shape,

--- a/test/onnx/parse/skip_layer_normalization_beta_bias_test.cpp
+++ b/test/onnx/parse/skip_layer_normalization_beta_bias_test.cpp
@@ -25,11 +25,11 @@
 #include <onnx_test.hpp>
 #include <onnx_test_utils.hpp>
 
-TEST_CASE(skip_layer_normalization_test)
+TEST_CASE(skip_layer_normalization_beta_bias_test)
 {
     migraphx::program p = make_skip_layer_norm(
-        {2, 2, 4}, {2, 2, 4}, {4}, {}, {}, 2, 1e-5f, migraphx::shape::half_type);
+        {2, 2, 4}, {2, 2, 4}, {4}, {4}, {4}, 2, 1e-5f, migraphx::shape::half_type);
 
-    auto prog = optimize_onnx("skip_layer_normalization_test.onnx");
+    auto prog = optimize_onnx("skip_layer_normalization_beta_bias_test.onnx");
     EXPECT(p == prog);
 }

--- a/test/onnx/parse/skip_layer_normalization_beta_test.cpp
+++ b/test/onnx/parse/skip_layer_normalization_beta_test.cpp
@@ -25,11 +25,11 @@
 #include <onnx_test.hpp>
 #include <onnx_test_utils.hpp>
 
-TEST_CASE(skip_layer_normalization_test)
+TEST_CASE(skip_layer_normalization_beta_test)
 {
     migraphx::program p = make_skip_layer_norm(
-        {2, 2, 4}, {2, 2, 4}, {4}, {}, {}, 2, 1e-5f, migraphx::shape::half_type);
+        {2, 2, 4}, {2, 2, 4}, {4}, {4}, {}, 2, 1e-5f, migraphx::shape::half_type);
 
-    auto prog = optimize_onnx("skip_layer_normalization_test.onnx");
+    auto prog = optimize_onnx("skip_layer_normalization_beta_test.onnx");
     EXPECT(p == prog);
 }

--- a/test/onnx/parse/skip_layer_normalization_invalid_beta_test.cpp
+++ b/test/onnx/parse/skip_layer_normalization_invalid_beta_test.cpp
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <onnx_test.hpp>
+
+TEST_CASE(skip_layer_normalization_invalid_beta_test)
+{
+    EXPECT(test::throws([&] {
+        migraphx::parse_onnx("skip_layer_normalization_invalid_beta_test.onnx");
+    }));
+}

--- a/test/onnx/parse/skip_layer_normalization_invalid_beta_test.cpp
+++ b/test/onnx/parse/skip_layer_normalization_invalid_beta_test.cpp
@@ -26,7 +26,6 @@
 
 TEST_CASE(skip_layer_normalization_invalid_beta_test)
 {
-    EXPECT(test::throws([&] {
-        migraphx::parse_onnx("skip_layer_normalization_invalid_beta_test.onnx");
-    }));
+    EXPECT(test::throws(
+        [&] { migraphx::parse_onnx("skip_layer_normalization_invalid_beta_test.onnx"); }));
 }

--- a/test/onnx/parse/skip_layer_normalization_invalid_bias_test.cpp
+++ b/test/onnx/parse/skip_layer_normalization_invalid_bias_test.cpp
@@ -26,7 +26,6 @@
 
 TEST_CASE(skip_layer_normalization_invalid_bias_test)
 {
-    EXPECT(test::throws([&] {
-        migraphx::parse_onnx("skip_layer_normalization_invalid_bias_test.onnx");
-    }));
+    EXPECT(test::throws(
+        [&] { migraphx::parse_onnx("skip_layer_normalization_invalid_bias_test.onnx"); }));
 }

--- a/test/onnx/parse/skip_layer_normalization_invalid_bias_test.cpp
+++ b/test/onnx/parse/skip_layer_normalization_invalid_bias_test.cpp
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <onnx_test.hpp>
+
+TEST_CASE(skip_layer_normalization_invalid_bias_test)
+{
+    EXPECT(test::throws([&] {
+        migraphx::parse_onnx("skip_layer_normalization_invalid_bias_test.onnx");
+    }));
+}

--- a/test/onnx/parse/skip_layer_normalization_invalid_input_test.cpp
+++ b/test/onnx/parse/skip_layer_normalization_invalid_input_test.cpp
@@ -26,7 +26,6 @@
 
 TEST_CASE(skip_layer_normalization_invalid_input_test)
 {
-    EXPECT(test::throws([&] {
-        migraphx::parse_onnx("skip_layer_normalization_invalid_input_test.onnx");
-    }));
+    EXPECT(test::throws(
+        [&] { migraphx::parse_onnx("skip_layer_normalization_invalid_input_test.onnx"); }));
 }

--- a/test/onnx/parse/skip_layer_normalization_invalid_input_test.cpp
+++ b/test/onnx/parse/skip_layer_normalization_invalid_input_test.cpp
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <onnx_test.hpp>
+
+TEST_CASE(skip_layer_normalization_invalid_input_test)
+{
+    EXPECT(test::throws([&] {
+        migraphx::parse_onnx("skip_layer_normalization_invalid_input_test.onnx");
+    }));
+}

--- a/test/onnx/parse/skip_layer_normalization_invalid_n_args_test.cpp
+++ b/test/onnx/parse/skip_layer_normalization_invalid_n_args_test.cpp
@@ -26,7 +26,6 @@
 
 TEST_CASE(skip_layer_normalization_invalid_n_args_test)
 {
-    EXPECT(test::throws([&] {
-        migraphx::parse_onnx("skip_layer_normalization_invalid_n_args_test.onnx");
-    }));
+    EXPECT(test::throws(
+        [&] { migraphx::parse_onnx("skip_layer_normalization_invalid_n_args_test.onnx"); }));
 }

--- a/test/onnx/parse/skip_layer_normalization_invalid_n_args_test.cpp
+++ b/test/onnx/parse/skip_layer_normalization_invalid_n_args_test.cpp
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <onnx_test.hpp>
+
+TEST_CASE(skip_layer_normalization_invalid_n_args_test)
+{
+    EXPECT(test::throws([&] {
+        migraphx::parse_onnx("skip_layer_normalization_invalid_n_args_test.onnx");
+    }));
+}

--- a/test/onnx/parse/skip_layer_normalization_test.cpp
+++ b/test/onnx/parse/skip_layer_normalization_test.cpp
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <onnx_test.hpp>
+#include <onnx_test_utils.hpp>
+
+TEST_CASE(skip_layer_normalization_test)
+{
+    migraphx::program p = make_layer_norm(
+        {2, 2, 4}, {2, 2, 4}, {4}, -1, 1e-5f, migraphx::shape::half_type);
+
+    auto prog = optimize_onnx("skip_layer_normalization_test.onnx");
+    EXPECT(p == prog);
+}

--- a/test/onnx/parse/skip_layer_normalization_test.cpp
+++ b/test/onnx/parse/skip_layer_normalization_test.cpp
@@ -27,8 +27,8 @@
 
 TEST_CASE(skip_layer_normalization_test)
 {
-    migraphx::program p = make_layer_norm(
-        {2, 2, 4}, {2, 2, 4}, {4}, -1, 1e-5f, migraphx::shape::half_type);
+    migraphx::program p = make_skip_layer_norm(
+        {2, 2, 4}, {2, 2, 4}, {2}, {}, {}, 2, 1e-5f, migraphx::shape::half_type);
 
     auto prog = optimize_onnx("skip_layer_normalization_test.onnx");
     EXPECT(p == prog);

--- a/test/onnx/parse/skip_layer_normalization_test.cpp
+++ b/test/onnx/parse/skip_layer_normalization_test.cpp
@@ -28,7 +28,7 @@
 TEST_CASE(skip_layer_normalization_test)
 {
     migraphx::program p = make_skip_layer_norm(
-        {2, 2, 4}, {2, 2, 4}, {2}, {}, {}, 2, 1e-5f, migraphx::shape::half_type);
+        {2, 2, 4}, {2, 2, 4}, {4}, {}, {}, 2, 1e-5f, migraphx::shape::half_type);
 
     auto prog = optimize_onnx("skip_layer_normalization_test.onnx");
     EXPECT(p == prog);

--- a/test/onnx/skip_layer_normalization_bad_beta_test.onnx
+++ b/test/onnx/skip_layer_normalization_bad_beta_test.onnx
@@ -1,0 +1,52 @@
+
+&skip_layer_normalization_bad_beta_test:Š
+{
+x
+skip
+gamma
+betaymeaninv_std_varinput_skip_bias_sum"SkipLayerNormalization*
+epsilon¬Å'7 :com.microsoft&skip_layer_normalization_bad_beta_testZ
+x
+
+
+
+
+Z
+skip
+
+
+
+
+Z
+gamma
+
+
+
+Z
+beta
+
+
+
+b
+y
+
+
+
+
+b
+mean
+
+
+
+b!
+inv_std_var
+
+
+
+b)
+input_skip_bias_sum
+
+
+
+
+B

--- a/test/onnx/skip_layer_normalization_bad_bias_test.onnx
+++ b/test/onnx/skip_layer_normalization_bad_bias_test.onnx
@@ -1,0 +1,52 @@
+
+&skip_layer_normalization_bad_bias_test:ç
+Å
+x
+skip
+gamma
+beta
+biasymeaninv_std_varinput_skip_bias_sum"SkipLayerNormalization*
+epsilon¨≈'7†:com.microsoft&skip_layer_normalization_bad_bias_testZ
+x
+
+
+
+
+Z
+skip
+
+
+
+
+Z
+gamma
+
+
+
+Z
+bias
+
+
+b
+y
+
+
+
+
+b
+mean
+
+
+
+b!
+inv_std_var
+
+
+
+b)
+input_skip_bias_sum
+
+
+
+
+B

--- a/test/onnx/skip_layer_normalization_bad_bias_test.onnx
+++ b/test/onnx/skip_layer_normalization_bad_bias_test.onnx
@@ -1,5 +1,5 @@
 
-&skip_layer_normalization_bad_bias_test:ç
+&skip_layer_normalization_bad_bias_test:°
 Å
 x
 skip
@@ -20,6 +20,11 @@
 
 Z
 gamma
+
+
+
+Z
+beta
 
 
 

--- a/test/onnx/skip_layer_normalization_beta_bias_test.onnx
+++ b/test/onnx/skip_layer_normalization_beta_bias_test.onnx
@@ -1,0 +1,53 @@
+
+'skip_layer_normalization_beta_bias_test:é
+Å
+x
+skip
+gamma
+beta
+biasymeaninv_std_varinput_skip_bias_sum"SkipLayerNormalization*
+epsilon¨≈'7†:com.microsoft'skip_layer_normalization_beta_bias_testZ
+x
+
+
+
+
+Z
+skip
+
+
+
+
+Z
+gamma
+
+
+
+Z
+bias
+
+
+
+b
+y
+
+
+
+
+b
+mean
+
+
+
+b!
+inv_std_var
+
+
+
+b)
+input_skip_bias_sum
+
+
+
+
+B

--- a/test/onnx/skip_layer_normalization_beta_bias_test.onnx
+++ b/test/onnx/skip_layer_normalization_beta_bias_test.onnx
@@ -1,5 +1,5 @@
 
-'skip_layer_normalization_beta_bias_test:é
+'skip_layer_normalization_beta_bias_test:¢
 Å
 x
 skip
@@ -20,6 +20,11 @@
 
 Z
 gamma
+
+
+
+Z
+beta
 
 
 

--- a/test/onnx/skip_layer_normalization_beta_test.onnx
+++ b/test/onnx/skip_layer_normalization_beta_test.onnx
@@ -1,0 +1,52 @@
+
+"skip_layer_normalization_beta_test:‚
+{
+x
+skip
+gamma
+betaymeaninv_std_varinput_skip_bias_sum"SkipLayerNormalization*
+epsilon¬Å'7 :com.microsoft"skip_layer_normalization_beta_testZ
+x
+
+
+
+
+Z
+skip
+
+
+
+
+Z
+gamma
+
+
+
+Z
+beta
+
+
+
+b
+y
+
+
+
+
+b
+mean
+
+
+
+b!
+inv_std_var
+
+
+
+b)
+input_skip_bias_sum
+
+
+
+
+B

--- a/test/onnx/skip_layer_normalization_invalid_input_test.onnx
+++ b/test/onnx/skip_layer_normalization_invalid_input_test.onnx
@@ -1,0 +1,32 @@
+
++skip_layer_normalization_invalid_input_test:ë
+M
+x
+skip
+gammay"SkipLayerNormalization*
+epsilon¬Å'7 :com.microsoft+skip_layer_normalization_invalid_input_testZ
+x
+
+
+
+
+
+Z
+skip
+
+
+
+
+Z
+gamma
+
+
+
+b
+y
+
+
+
+
+
+B

--- a/test/onnx/skip_layer_normalization_invalid_n_args_test.onnx
+++ b/test/onnx/skip_layer_normalization_invalid_n_args_test.onnx
@@ -1,0 +1,24 @@
+
+,skip_layer_normalization_invalid_n_args_test:Ä
+F
+x
+skipy"SkipLayerNormalization*
+epsilon¬Å'7 :com.microsoft,skip_layer_normalization_invalid_n_args_testZ
+x
+
+
+
+
+Z
+skip
+
+
+
+
+b
+y
+
+
+
+
+B

--- a/test/onnx/skip_layer_normalization_test.onnx
+++ b/test/onnx/skip_layer_normalization_test.onnx
@@ -1,0 +1,46 @@
+
+skip_layer_normalization_test:ã
+u
+x
+skip
+gammaymeaninv_std_varinput_skip_bias_sum"SkipLayerNormalization*
+epsilon¬Å'7 :com.microsoftskip_layer_normalization_testZ
+x
+
+
+
+
+Z
+skip
+
+
+
+
+Z
+gamma
+
+
+
+b
+y
+
+
+
+
+b
+mean
+
+
+
+b!
+inv_std_var
+
+
+
+b)
+input_skip_bias_sum
+
+
+
+
+B

--- a/test/onnx/verify/skip_layer_normalization.cpp
+++ b/test/onnx/verify/skip_layer_normalization.cpp
@@ -1,0 +1,357 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <migraphx/register_target.hpp>
+#include <migraphx/verify.hpp>
+#include <onnx_test.hpp>
+#include <onnx_verify_utils.hpp>
+
+TEST_CASE(skip_layer_normalization_test)
+{
+    using migraphx::half;
+    std::vector<half> x{half{0.8},
+                        half{-0.5},
+                        half{0.0},
+                        half{1.0},
+                        half{0.5},
+                        half{0.2},
+                        half{0.3},
+                        half{-0.6},
+                        half{10.0},
+                        half{-1.0},
+                        half{0.0},
+                        half{1.0},
+                        half{1.2},
+                        half{3.2},
+                        half{-4.1},
+                        half{5.3}};
+    std::vector<half> skip{half{1.2},
+                           half{-1.0},
+                           half{2.0},
+                           half{1.0},
+                           half{1.5},
+                           half{2.2},
+                           half{-3.3},
+                           half{2.6},
+                           half{1.0},
+                           half{-10.0},
+                           half{-1.0},
+                           half{2.0},
+                           half{-1.2},
+                           half{1.6},
+                           half{-1.1},
+                           half{1.3}};
+    std::vector<half> scale{half{0.1}, half{0.2}, half{4.0}, half{-2.2}};
+
+    auto p = read_onnx("skip_layer_normalization_test.onnx");
+    p.compile(migraphx::make_target("ref"));
+
+    migraphx::shape s_x{migraphx::shape::half_type, {2, 2, 4}};
+    migraphx::shape s_s{migraphx::shape::half_type, {4}};
+
+    migraphx::parameter_map pp;
+    pp["x"]     = migraphx::argument(s_x, x.data());
+    pp["skip"]  = migraphx::argument(s_x, skip.data());
+    pp["gamma"] = migraphx::argument(s_s, scale.data());
+
+    auto results             = p.eval(pp);
+    auto output              = results.at(0);
+    auto mean                = results.at(1);
+    auto inv_std_var         = results.at(2);
+    auto input_skip_bias_sum = results.at(3);
+
+    std::vector<half> result_vector;
+    std::vector<half> mean_vector;
+    std::vector<half> inv_std_var_vector;
+    std::vector<half> input_skip_bias_sum_vector;
+
+    output.visit([&](auto vals) { result_vector.assign(vals.begin(), vals.end()); });
+    mean.visit([&](auto vals) { mean_vector.assign(vals.begin(), vals.end()); });
+    inv_std_var.visit([&](auto vals) { inv_std_var_vector.assign(vals.begin(), vals.end()); });
+    input_skip_bias_sum.visit(
+        [&](auto vals) { input_skip_bias_sum_vector.assign(vals.begin(), vals.end()); });
+
+    std::vector<half> gold = {half{1.02076491},
+                              half{0.89526127},
+                              half{1.83059639},
+                              half{0.54317199},
+                              half{1.02076491},
+                              half{1.05824622},
+                              half{-2.34850493},
+                              half{0.54317199},
+                              half{1.20882447},
+                              half{0.49824664},
+                              half{-0.6768644},
+                              half{-0.08347084},
+                              half{0.9789739},
+                              half{1.15854466},
+                              half{-4.1873095},
+                              half{-1.57145328}};
+    std::vector<half> gold_mean{half{1.125}, half{0.85}, half{0.5}, half{1.55}};
+    std::vector<half> gold_inv_std_var{half{0.65982744}, half{0.44867371}, half{0.12623887}, half{0.21817888}};
+    std::vector<half> gold_input_skip_bias_sum = {half{2.0},
+                                                  half{-1.5},
+                                                  half{2.0},
+                                                  half{2.0},
+                                                  half{2.0},
+                                                  half{2.3984375},
+                                                  half{-3.0},
+                                                  half{2.0},
+                                                  half{11.0},
+                                                  half{-11.0},
+                                                  half{-1.0},
+                                                  half{3.0},
+                                                  half{0.0},
+                                                  half{4.796875},
+                                                  half{-5.203125},
+                                                  half{6.6015625}};
+
+    EXPECT(migraphx::verify::verify_rms_range(result_vector, gold));
+    EXPECT(migraphx::verify::verify_rms_range(mean_vector, gold_mean));
+    EXPECT(migraphx::verify::verify_rms_range(inv_std_var_vector, gold_inv_std_var));
+    EXPECT(
+        migraphx::verify::verify_rms_range(input_skip_bias_sum_vector, gold_input_skip_bias_sum));
+}
+
+TEST_CASE(skip_layer_normalization_beta_test)
+{
+    using migraphx::half;
+    std::vector<half> x{half{0.8},
+                        half{-0.5},
+                        half{0.0},
+                        half{1.0},
+                        half{0.5},
+                        half{0.2},
+                        half{0.3},
+                        half{-0.6},
+                        half{10.0},
+                        half{-1.0},
+                        half{0.0},
+                        half{1.0},
+                        half{1.2},
+                        half{3.2},
+                        half{-4.1},
+                        half{5.3}};
+    std::vector<half> skip{half{1.2},
+                           half{-1.0},
+                           half{2.0},
+                           half{1.0},
+                           half{1.5},
+                           half{2.2},
+                           half{-3.3},
+                           half{2.6},
+                           half{1.0},
+                           half{-10.0},
+                           half{-1.0},
+                           half{2.0},
+                           half{-1.2},
+                           half{1.6},
+                           half{-1.1},
+                           half{1.3}};
+    std::vector<half> scale{half{0.1}, half{0.2}, half{4.0}, half{-2.2}};
+    std::vector<half> beta{half{1.0}, half{1.0}, half{1.0}, half{1.0}};
+
+    auto p = read_onnx("skip_layer_normalization_beta_test.onnx");
+    p.compile(migraphx::make_target("ref"));
+
+    migraphx::shape s_x{migraphx::shape::half_type, {2, 2, 4}};
+    migraphx::shape s_s{migraphx::shape::half_type, {4}};
+
+    migraphx::parameter_map pp;
+    pp["x"]     = migraphx::argument(s_x, x.data());
+    pp["skip"]  = migraphx::argument(s_x, skip.data());
+    pp["gamma"] = migraphx::argument(s_s, scale.data());
+    pp["beta"]  = migraphx::argument(s_s, beta.data());
+
+    auto results             = p.eval(pp);
+    auto output              = results.at(0);
+    auto mean                = results.at(1);
+    auto inv_std_var         = results.at(2);
+    auto input_skip_bias_sum = results.at(3);
+
+    std::vector<half> result_vector;
+    std::vector<half> mean_vector;
+    std::vector<half> inv_std_var_vector;
+    std::vector<half> input_skip_bias_sum_vector;
+
+    output.visit([&](auto vals) { result_vector.assign(vals.begin(), vals.end()); });
+    mean.visit([&](auto vals) { mean_vector.assign(vals.begin(), vals.end()); });
+    inv_std_var.visit([&](auto vals) { inv_std_var_vector.assign(vals.begin(), vals.end()); });
+    input_skip_bias_sum.visit(
+        [&](auto vals) { input_skip_bias_sum_vector.assign(vals.begin(), vals.end()); });
+
+    std::vector<half> gold = {half{1.10596},
+                              half{0.8411},
+                              half{5.24},
+                              half{-1.33},
+                              half{1.0838},
+                              half{1.2012},
+                              half{-4.03},
+                              half{-0.844},
+                              half{1.1385},
+                              half{0.723},
+                              half{0.496},
+                              half{0.169},
+                              half{1.0},
+                              half{1.1984},
+                              half{-3.3},
+                              half{-2.0}};
+
+    std::vector<half> gold_mean{half{3.5625}, half{5.6875}, half{63.0}, half{23.421875}};
+    std::vector<half> gold_inv_std_var{half{0.5298}, half{0.4194}, half{0.1260}, half{0.2067}};
+    std::vector<half> gold_input_skip_bias_sum = {half{3.0},
+                                                  half{-0.5},
+                                                  half{3.0},
+                                                  half{3.0},
+                                                  half{3.0},
+                                                  half{3.3984375},
+                                                  half{-2.0},
+                                                  half{3.0},
+                                                  half{12.0},
+                                                  half{-10.0},
+                                                  half{0.0},
+                                                  half{4.0},
+                                                  half{1.0},
+                                                  half{5.796875},
+                                                  half{-4.203125},
+                                                  half{7.6015625}};
+
+    EXPECT(migraphx::verify::verify_rms_range(result_vector, gold));
+    EXPECT(migraphx::verify::verify_rms_range(mean_vector, gold_mean));
+    EXPECT(migraphx::verify::verify_rms_range(inv_std_var_vector, gold_inv_std_var));
+    EXPECT(
+        migraphx::verify::verify_rms_range(input_skip_bias_sum_vector, gold_input_skip_bias_sum));
+}
+
+TEST_CASE(skip_layer_normalization_beta_bias_test)
+{
+    using migraphx::half;
+    std::vector<half> x{half{0.8},
+                        half{-0.5},
+                        half{0.0},
+                        half{1.0},
+                        half{0.5},
+                        half{0.2},
+                        half{0.3},
+                        half{-0.6},
+                        half{10.0},
+                        half{-1.0},
+                        half{0.0},
+                        half{1.0},
+                        half{1.2},
+                        half{3.2},
+                        half{-4.1},
+                        half{5.3}};
+    std::vector<half> skip{half{1.2},
+                           half{-1.0},
+                           half{2.0},
+                           half{1.0},
+                           half{1.5},
+                           half{2.2},
+                           half{-3.3},
+                           half{2.6},
+                           half{1.0},
+                           half{-10.0},
+                           half{-1.0},
+                           half{2.0},
+                           half{-1.2},
+                           half{1.6},
+                           half{-1.1},
+                           half{1.3}};
+    std::vector<half> scale{half{0.1}, half{0.2}, half{4.0}, half{-2.2}};
+    std::vector<half> beta{half{1.0}, half{1.0}, half{1.0}, half{1.0}};
+    std::vector<half> bias{half{1.0}, half{1.0}, half{1.0}, half{1.0}};
+
+    auto p = read_onnx("skip_layer_normalization_beta_test.onnx");
+    p.compile(migraphx::make_target("ref"));
+
+    migraphx::shape s_x{migraphx::shape::half_type, {2, 2, 4}};
+    migraphx::shape s_s{migraphx::shape::half_type, {4}};
+
+    migraphx::parameter_map pp;
+    pp["x"]     = migraphx::argument(s_x, x.data());
+    pp["skip"]  = migraphx::argument(s_x, skip.data());
+    pp["gamma"] = migraphx::argument(s_s, scale.data());
+    pp["beta"]  = migraphx::argument(s_s, beta.data());
+    pp["bias"]  = migraphx::argument(s_s, bias.data());
+
+    auto results             = p.eval(pp);
+    auto output              = results.at(0);
+    auto mean                = results.at(1);
+    auto inv_std_var         = results.at(2);
+    auto input_skip_bias_sum = results.at(3);
+
+    std::vector<half> result_vector;
+    std::vector<half> mean_vector;
+    std::vector<half> inv_std_var_vector;
+    std::vector<half> input_skip_bias_sum_vector;
+
+    output.visit([&](auto vals) { result_vector.assign(vals.begin(), vals.end()); });
+    mean.visit([&](auto vals) { mean_vector.assign(vals.begin(), vals.end()); });
+    inv_std_var.visit([&](auto vals) { inv_std_var_vector.assign(vals.begin(), vals.end()); });
+    input_skip_bias_sum.visit(
+        [&](auto vals) { input_skip_bias_sum_vector.assign(vals.begin(), vals.end()); });
+
+    std::vector<half> gold = {half{1.10596},
+                              half{0.8411},
+                              half{5.24},
+                              half{-1.33},
+                              half{1.0838},
+                              half{1.2012},
+                              half{-4.03},
+                              half{-0.844},
+                              half{1.1385},
+                              half{0.723},
+                              half{0.496},
+                              half{0.169},
+                              half{1.0},
+                              half{1.1984},
+                              half{-3.3},
+                              half{-2.0}};
+
+    std::vector<half> gold_mean{half{3.5625}, half{5.6875}, half{63.0}, half{23.421875}};
+    std::vector<half> gold_inv_std_var{half{0.5298}, half{0.4194}, half{0.1260}, half{0.2067}};
+    std::vector<half> gold_input_skip_bias_sum = {half{3.0},
+                                                  half{-0.5},
+                                                  half{3.0},
+                                                  half{3.0},
+                                                  half{3.0},
+                                                  half{3.3984375},
+                                                  half{-2.0},
+                                                  half{3.0},
+                                                  half{12.0},
+                                                  half{-10.0},
+                                                  half{0.0},
+                                                  half{4.0},
+                                                  half{1.0},
+                                                  half{5.796875},
+                                                  half{-4.203125},
+                                                  half{7.6015625}};
+
+    EXPECT(migraphx::verify::verify_rms_range(result_vector, gold));
+    EXPECT(migraphx::verify::verify_rms_range(mean_vector, gold_mean));
+    EXPECT(migraphx::verify::verify_rms_range(inv_std_var_vector, gold_inv_std_var));
+    EXPECT(
+        migraphx::verify::verify_rms_range(input_skip_bias_sum_vector, gold_input_skip_bias_sum));
+}

--- a/test/onnx/verify/skip_layer_normalization.cpp
+++ b/test/onnx/verify/skip_layer_normalization.cpp
@@ -92,40 +92,42 @@ TEST_CASE(skip_layer_normalization_test)
     input_skip_bias_sum.visit(
         [&](auto vals) { input_skip_bias_sum_vector.assign(vals.begin(), vals.end()); });
 
-    std::vector<half> gold = {half{1.02076491},
-                              half{0.89526127},
-                              half{1.83059639},
-                              half{0.54317199},
-                              half{1.02076491},
-                              half{1.05824622},
-                              half{-2.34850493},
-                              half{0.54317199},
-                              half{1.20882447},
-                              half{0.49824664},
-                              half{-0.6768644},
-                              half{-0.08347084},
-                              half{0.9789739},
-                              half{1.15854466},
-                              half{-4.1873095},
-                              half{-1.57145328}};
-    std::vector<half> gold_mean{half{1.125}, half{0.85}, half{0.5}, half{1.55}};
-    std::vector<half> gold_inv_std_var{half{0.65982744}, half{0.44867371}, half{0.12623887}, half{0.21817888}};
-    std::vector<half> gold_input_skip_bias_sum = {half{2.0},
-                                                  half{-1.5},
-                                                  half{2.0},
-                                                  half{2.0},
-                                                  half{2.0},
-                                                  half{2.3984375},
-                                                  half{-3.0},
-                                                  half{2.0},
-                                                  half{11.0},
-                                                  half{-11.0},
-                                                  half{-1.0},
-                                                  half{3.0},
-                                                  half{0.0},
-                                                  half{4.796875},
-                                                  half{-5.203125},
-                                                  half{6.6015625}};
+    std::vector<half> gold      = {half{0.05770874},
+                                   half{-0.34619141},
+                                   half{2.30859375},
+                                   half{-1.26953125},
+                                   half{0.05160522},
+                                   half{0.13891602},
+                                   half{-6.91015625},
+                                   half{-1.13476562},
+                                   half{0.13244629},
+                                   half{-0.29028320},
+                                   half{-0.75732422},
+                                   half{-0.69384766},
+                                   half{-0.03375244},
+                                   half{0.14160156},
+                                   half{-5.88671875},
+                                   half{-2.42187500}};
+    std::vector<half> gold_mean = {
+        half{1.12500000}, half{0.84960938}, half{0.50000000}, half{1.54882812}};
+    std::vector<half> gold_inv_std_var = {
+        half{0.65966797}, half{0.44873047}, half{0.12622070}, half{0.21801758}};
+    std::vector<half> gold_input_skip_bias_sum = {half{2.00000000},
+                                                  half{-1.50000000},
+                                                  half{2.00000000},
+                                                  half{2.00000000},
+                                                  half{2.00000000},
+                                                  half{2.39843750},
+                                                  half{-3.00000000},
+                                                  half{2.00000000},
+                                                  half{11.00000000},
+                                                  half{-11.00000000},
+                                                  half{-1.00000000},
+                                                  half{3.00000000},
+                                                  half{0.00000000},
+                                                  half{4.79687500},
+                                                  half{-5.20312500},
+                                                  half{6.60156250}};
 
     EXPECT(migraphx::verify::verify_rms_range(result_vector, gold));
     EXPECT(migraphx::verify::verify_rms_range(mean_vector, gold_mean));
@@ -201,41 +203,42 @@ TEST_CASE(skip_layer_normalization_beta_test)
     input_skip_bias_sum.visit(
         [&](auto vals) { input_skip_bias_sum_vector.assign(vals.begin(), vals.end()); });
 
-    std::vector<half> gold = {half{1.10596},
-                              half{0.8411},
-                              half{5.24},
-                              half{-1.33},
-                              half{1.0838},
-                              half{1.2012},
-                              half{-4.03},
-                              half{-0.844},
-                              half{1.1385},
-                              half{0.723},
-                              half{0.496},
-                              half{0.169},
-                              half{1.0},
-                              half{1.1984},
-                              half{-3.3},
-                              half{-2.0}};
-
-    std::vector<half> gold_mean{half{3.5625}, half{5.6875}, half{63.0}, half{23.421875}};
-    std::vector<half> gold_inv_std_var{half{0.5298}, half{0.4194}, half{0.1260}, half{0.2067}};
-    std::vector<half> gold_input_skip_bias_sum = {half{3.0},
-                                                  half{-0.5},
-                                                  half{3.0},
-                                                  half{3.0},
-                                                  half{3.0},
-                                                  half{3.3984375},
-                                                  half{-2.0},
-                                                  half{3.0},
-                                                  half{12.0},
-                                                  half{-10.0},
-                                                  half{0.0},
-                                                  half{4.0},
-                                                  half{1.0},
-                                                  half{5.796875},
-                                                  half{-4.203125},
-                                                  half{7.6015625}};
+    std::vector<half> gold      = {half{1.05761719},
+                                   half{0.65380859},
+                                   half{3.30859375},
+                                   half{-0.26953125},
+                                   half{1.05175781},
+                                   half{1.13867188},
+                                   half{-5.91015625},
+                                   half{-0.13476562},
+                                   half{1.13281250},
+                                   half{0.70996094},
+                                   half{0.24267578},
+                                   half{0.30615234},
+                                   half{0.96630859},
+                                   half{1.14160156},
+                                   half{-4.88671875},
+                                   half{-1.42187500}};
+    std::vector<half> gold_mean = {
+        half{1.12500000}, half{0.84960938}, half{0.50000000}, half{1.54882812}};
+    std::vector<half> gold_inv_std_var = {
+        half{0.65966797}, half{0.44873047}, half{0.12622070}, half{0.21801758}};
+    std::vector<half> gold_input_skip_bias_sum = {half{2.00000000},
+                                                  half{-1.50000000},
+                                                  half{2.00000000},
+                                                  half{2.00000000},
+                                                  half{2.00000000},
+                                                  half{2.39843750},
+                                                  half{-3.00000000},
+                                                  half{2.00000000},
+                                                  half{11.00000000},
+                                                  half{-11.00000000},
+                                                  half{-1.00000000},
+                                                  half{3.00000000},
+                                                  half{0.00000000},
+                                                  half{4.79687500},
+                                                  half{-5.20312500},
+                                                  half{6.60156250}};
 
     EXPECT(migraphx::verify::verify_rms_range(result_vector, gold));
     EXPECT(migraphx::verify::verify_rms_range(mean_vector, gold_mean));
@@ -313,41 +316,60 @@ TEST_CASE(skip_layer_normalization_beta_bias_test)
     input_skip_bias_sum.visit(
         [&](auto vals) { input_skip_bias_sum_vector.assign(vals.begin(), vals.end()); });
 
-    std::vector<half> gold = {half{1.10596},
-                              half{0.8411},
-                              half{5.24},
-                              half{-1.33},
-                              half{1.0838},
-                              half{1.2012},
-                              half{-4.03},
-                              half{-0.844},
-                              half{1.1385},
-                              half{0.723},
-                              half{0.496},
-                              half{0.169},
-                              half{1.0},
-                              half{1.1984},
-                              half{-3.3},
-                              half{-2.0}};
+    std::vector<half> gold      = {half{1.05761719},
+                                   half{0.65380859},
+                                   half{3.30859375},
+                                   half{-0.26953125},
+                                   half{1.05175781},
+                                   half{1.13867188},
+                                   half{-5.91015625},
+                                   half{-0.13476562},
+                                   half{1.13281250},
+                                   half{0.70996094},
+                                   half{0.24267578},
+                                   half{0.30615234},
+                                   half{0.96630859},
+                                   half{1.14160156},
+                                   half{-4.88671875},
+                                   half{-1.42187500}};
+    std::vector<half> gold_mean = {
+        half{2.12500000}, half{1.84960938}, half{1.50000000}, half{2.54882812}};
+    std::vector<half> gold_inv_std_var = {
+        half{0.65966797}, half{0.44873047}, half{0.12622070}, half{0.21801758}};
+    std::vector<half> gold_input_skip_bias_sum = {half{3.00000000},
+                                                  half{-0.50000000},
+                                                  half{3.00000000},
+                                                  half{3.00000000},
+                                                  half{3.00000000},
+                                                  half{3.39843750},
+                                                  half{-2.00000000},
+                                                  half{3.00000000},
+                                                  half{12.00000000},
+                                                  half{-10.00000000},
+                                                  half{0.00000000},
+                                                  half{4.00000000},
+                                                  half{1.00000000},
+                                                  half{5.79687500},
+                                                  half{-4.20312500},
+                                                  half{7.60156250}};
 
-    std::vector<half> gold_mean{half{3.5625}, half{5.6875}, half{63.0}, half{23.421875}};
-    std::vector<half> gold_inv_std_var{half{0.5298}, half{0.4194}, half{0.1260}, half{0.2067}};
-    std::vector<half> gold_input_skip_bias_sum = {half{3.0},
-                                                  half{-0.5},
-                                                  half{3.0},
-                                                  half{3.0},
-                                                  half{3.0},
-                                                  half{3.3984375},
-                                                  half{-2.0},
-                                                  half{3.0},
-                                                  half{12.0},
-                                                  half{-10.0},
-                                                  half{0.0},
-                                                  half{4.0},
-                                                  half{1.0},
-                                                  half{5.796875},
-                                                  half{-4.203125},
-                                                  half{7.6015625}};
+    // print values of result_vector, mean_vector, inv_std_var_vector, input_skip_bias_sum_vector
+    std::cout << "result_vector" << std::endl;
+    for(auto i : result_vector)
+        std::cout << i << " ";
+    std::cout << std::endl;
+    std::cout << "mean_vector" << std::endl;
+    for(auto i : mean_vector)
+        std::cout << i << " ";
+    std::cout << std::endl;
+    std::cout << "inv_std_var_vector" << std::endl;
+    for(auto i : inv_std_var_vector)
+        std::cout << i << " ";
+    std::cout << std::endl;
+    std::cout << "input_skip_bias_sum_vector" << std::endl;
+    for(auto i : input_skip_bias_sum_vector)
+        std::cout << i << " ";
+    std::cout << std::endl;
 
     EXPECT(migraphx::verify::verify_rms_range(result_vector, gold));
     EXPECT(migraphx::verify::verify_rms_range(mean_vector, gold_mean));

--- a/test/onnx/verify/skip_layer_normalization.cpp
+++ b/test/onnx/verify/skip_layer_normalization.cpp
@@ -283,7 +283,7 @@ TEST_CASE(skip_layer_normalization_beta_bias_test)
     std::vector<half> beta{half{1.0}, half{1.0}, half{1.0}, half{1.0}};
     std::vector<half> bias{half{1.0}, half{1.0}, half{1.0}, half{1.0}};
 
-    auto p = read_onnx("skip_layer_normalization_beta_test.onnx");
+    auto p = read_onnx("skip_layer_normalization_beta_bias_test.onnx");
     p.compile(migraphx::make_target("ref"));
 
     migraphx::shape s_x{migraphx::shape::half_type, {2, 2, 4}};


### PR DESCRIPTION
Needed to support customer models. Seen in optimized versions of BERT or optimizations using the Onnxruntime toolset

Currently built off the add_attention_contrib_op branch as this is used to parse in an optimized bert model

official Doc here: https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.SkipLayerNormalization

Other useful descriptions (this vs say simplified case)

https://pytorch.org/docs/stable/generated/torch.nn.RMSNorm.html#torch.nn.RMSNorm (also known as simplified)

https://sh-tsang.medium.com/review-layer-normalization-ln-6c2ae88bae47

