### PR TITLE
Dont fuse broadcast after conv/gemm in mlir #3863

### DIFF
--- a/src/layout_convolution.cpp
+++ b/src/layout_convolution.cpp
@@ -40,14 +40,17 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace {
 std::vector<int64_t> get_permutation(instruction_ref ins, const layout_convolution& lc)
 {
+    std::vector<int64_t> perm(ins->get_shape().ndim());
     if(lc.channels_last)
     {
-        std::vector<int64_t> perm(ins->get_shape().ndim());
         std::iota(perm.begin() + 1, perm.end() - 1, 2);
         perm.back() = 1;
-        return perm;
     }
-    return find_permutation(ins->inputs().front()->get_shape());
+    else
+    {
+        std::iota(perm.begin(), perm.end(), 0);
+    }
+    return perm;
 }
 
 std::vector<int64_t> get_default_permutation(instruction_ref ins)

--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -205,7 +205,6 @@ const auto& reshaper_names()
 {
     // clang-format off
     static const std::unordered_set<std::string> names = {
-        "slice",
         "transpose",
         "multibroadcast",
         "broadcast",
@@ -220,12 +219,17 @@ const auto& reshaper_names()
     return names;
 }
 
+bool is_fusable_input_op(const std::string& name)
+{
+    return contains(reshaper_names(), name) or contains({"slice"}, name);
+}
+
 std::tuple<instruction_ref, std::vector<operation>>
 get_fusable_input_op_stream(instruction_ref lower_input)
 {
     instruction_ref upper_input = lower_input;
     std::vector<operation> op_stream;
-    while(contains(reshaper_names(), upper_input->name()))
+    while(is_fusable_input_op(upper_input->name()))
     {
         operation op = upper_input->get_operator();
         op_stream.push_back(op);
@@ -362,6 +366,18 @@ create_param_map_with_literals(module_ref mm, const module* pm, const shape& sha
         ins_map[ins] = mbcast;
     }
     return ins_map;
+}
+
+instruction_ref insert_pointwise(module& m,
+                                 instruction_ref ins,
+                                 const operation& op,
+                                 const std::vector<instruction_ref>& inputs,
+                                 const std::vector<module_ref>& mod_args)
+{
+    // Only used in assert
+    (void)mod_args;
+    assert(mod_args.empty());
+    return insert_common_op(m, ins, op, inputs, {.common_type = false});
 }
 
 instruction_ref unroll_pointwise(module& main_mod,
@@ -501,9 +517,7 @@ MIGRAPHX_PRED_MATCHER(mlir_split_reduce, instruction_ref ins)
 {
     if(ins->name() != "split_fused_reduce")
         return false;
-    auto* mod_arg           = ins->module_inputs().front();
-    auto supported_reshapes = reshaper_names();
-    supported_reshapes.erase("slice");
+    auto* mod_arg                            = ins->module_inputs().front();
     std::unordered_set<std::string> builtins = {"@param", "@literal", "@return"};
     for(const auto i : iterator_for(*mod_arg))
     {
@@ -629,10 +643,7 @@ struct find_mlir_fused_ops
     mlir_mode dot_mode  = mlir_mode::none;
     auto matcher() const
     {
-        auto reshapes = reshaper_names();
-        // slice is not supported
-        reshapes.erase("slice");
-        auto dot_or_conv = match::skip(match::name(reshapes))(
+        auto dot_or_conv = match::skip(match::name(reshaper_names()))(
             match::any_of(is_mlir_dot(dot_mode), is_mlir_conv(conv_mode)).bind("gemm_based_op"));
         return mlir_pointwise()(match::any_of[match::inputs()](dot_or_conv.bind("x")));
     }
@@ -650,68 +661,62 @@ struct find_mlir_fused_ops
                return i != x_ins and reaches(gemm_based_op, i);
            }))
             return;
-        auto names = pm->get_parameter_names();
-        std::sort(names.begin(), names.end());
+
+        std::unordered_map<instruction_ref, instruction_ref> map_ins;
         module_ref mm = mpm.create_module("mlir_" + pm->name());
         mm->set_bypass();
-        auto [anchor_op, top_inputs] = fuse_input_ops_and_gemm_based_op(
-            mm, gemm_based_op->inputs(), gemm_based_op->get_operator());
-        std::unordered_map<instruction_ref, instruction_ref> param_map =
-            create_param_map_with_literals(mm, pm, pw_ins->get_shape());
-        auto [upper_input, op_stream] = get_fusable_input_op_stream(x_ins);
-        assert(upper_input == gemm_based_op);
-        auto prev_input = anchor_op;
-        for(const auto& op : reverse(op_stream))
-        {
-            prev_input = mm->add_instruction(op, {prev_input});
-        }
-        assert(prev_input->get_shape().lens() == x_ins->get_shape().lens());
-        param_map[x_ins] = prev_input; // this is to avoid adding parameter for gemm/conv reshaped
-                                       // input to pointwise in new fused module
+        fuse_input_ops(mm, gemm_based_op->inputs(), &map_ins);
+
         bool gemm_has_multi_outs = gemm_based_op->outputs().size() > 1;
-        auto reshaped_gemm       = x_ins;
-        std::vector<instruction_ref> reshapes_vec;
-        while(reshaped_gemm != gemm_based_op)
+        std::vector<instruction_ref> inss_to_insert;
+        auto reshape_ins = x_ins;
+        for(; reshape_ins != gemm_based_op; reshape_ins = reshape_ins->inputs().front())
         {
-            reshapes_vec.push_back(reshaped_gemm);
-            gemm_has_multi_outs = gemm_has_multi_outs or reshaped_gemm->outputs().size() > 1;
-            reshaped_gemm       = reshaped_gemm->inputs().at(0);
+            inss_to_insert.push_back(reshape_ins);
+            gemm_has_multi_outs |= reshape_ins->outputs().size() > 1;
         }
-        reshapes_vec.push_back(reshaped_gemm);
+        inss_to_insert.push_back(gemm_based_op);
+        std::reverse(inss_to_insert.begin(), inss_to_insert.end());
+        mm->add_instructions(inss_to_insert, &map_ins);
 
-        auto return_vals = mm->fuse(*pm, pw_ins->inputs(), &param_map);
+        fuse_input_ops(mm, pw_ins->inputs(), &map_ins);
+        auto rins = mm->fuse(*pm, pw_ins->inputs(), &map_ins, &insert_pointwise);
         if(gemm_has_multi_outs)
         {
-            return_vals.insert(return_vals.begin(), anchor_op);
+            rins.push_back(map_ins.at(gemm_based_op));
         }
-        mm->add_return(return_vals);
+        mm->add_return(rins);
 
-        std::vector<instruction_ref> inputs;
-        std::copy_if(pw_ins->inputs().begin(),
-                     pw_ins->inputs().end(),
-                     std::back_inserter(inputs),
-                     [&](auto input) { return input != x_ins; });
-        inputs.insert(inputs.end(), top_inputs.begin(), top_inputs.end());
+        auto inputs    = find_inputs(map_ins, &mpm.get_module(), mm);
+        auto fused_ins = mpm.get_module().insert_instruction(
+            pw_ins, mlir_op{gemm_based_op->get_operator()}, mlir_contiguous(mpm, inputs), {mm});
         if(gemm_has_multi_outs)
         {
-            auto fused_ins = mpm.get_module().insert_instruction(
-                pw_ins, mlir_op{gemm_based_op->get_operator()}, mlir_contiguous(mpm, inputs), {mm});
-            mpm.get_module().replace_instruction(
-                pw_ins, migraphx::make_op("get_tuple_elem", {{"index", 1}}), fused_ins);
             auto dot_ins = mpm.get_module().insert_instruction(
-                pw_ins, migraphx::make_op("get_tuple_elem", {{"index", 0}}), fused_ins);
-            // move all the reshape instructions and original GEMM instruction after the fused op to
-            // avoid generating invalid migraphx program
-            for(const auto& orig_i : reverse(reshapes_vec))
+                pw_ins,
+                migraphx::make_op("get_tuple_elem", {{"index", rins.size() - 1}}),
+                fused_ins);
+
+            // move all the reshape instructions after the fused op to avoid
+            // generating invalid migraphx program since the reshapes can be
+            // used by the replaced dot_ins
+            for(instruction_ref x : inss_to_insert)
             {
-                mpm.get_module().move_instruction(orig_i, pw_ins);
+                if(x == gemm_based_op)
+                    continue;
+                mpm.get_module().move_instruction(x, pw_ins);
             }
+
             mpm.get_module().replace_instruction(gemm_based_op, dot_ins);
+            if(rins.size() == 2)
+            {
+                mpm.get_module().replace_instruction(
+                    pw_ins, migraphx::make_op("get_tuple_elem", {{"index", 0}}), fused_ins);
+            }
         }
         else
         {
-            mpm.get_module().replace_instruction(
-                pw_ins, mlir_op{gemm_based_op->get_operator()}, mlir_contiguous(mpm, inputs), {mm});
+            mpm.get_module().replace_instruction(pw_ins, fused_ins);
         }
     }
 };
@@ -851,9 +856,8 @@ struct find_mlir_standalone_attention_op
         map_main_to_mattn[fused_reduce] = softmax;
 
         // all preceeding ops should be fusable ops
-        if(not std::all_of(m_gemm1, softmax, [](auto i) {
-               return (is_pointwise_op_supported_by_mlir(i) or
-                       contains(reshaper_names(), i.name()));
+        if(not std::all_of(m_gemm1, softmax, [](const instruction& i) {
+               return (is_pointwise_op_supported_by_mlir(i) or is_fusable_input_op(i.name()));
            }))
             return;
 
@@ -936,18 +940,6 @@ struct find_pointwise_mlir
         if(op_ins != rins)
             return false;
         return contains(op_names, op_ins->name());
-    }
-
-    static instruction_ref insert_pointwise(module& m,
-                                            instruction_ref ins,
-                                            const operation& op,
-                                            const std::vector<instruction_ref>& inputs,
-                                            const std::vector<module_ref>& mod_args)
-    {
-        // Only used in assert
-        (void)mod_args;
-        assert(mod_args.empty());
-        return insert_common_op(m, ins, op, inputs, {.common_type = false});
     }
 
     void apply(module_pass_manager& mpm, const match::matcher_result& r) const

--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -641,9 +641,19 @@ struct find_mlir_fused_ops
 {
     mlir_mode conv_mode = mlir_mode::none;
     mlir_mode dot_mode  = mlir_mode::none;
+
+    static auto make_conv_dot_reshaper_names()
+    {
+        auto names = reshaper_names();
+        names.erase("broadcast");
+        names.erase("multibroadcast");
+        return names;
+    }
+
     auto matcher() const
     {
-        auto dot_or_conv = match::skip(match::name(reshaper_names()))(
+        static const auto conv_dot_reshaper_names = make_conv_dot_reshaper_names();
+        auto dot_or_conv = match::skip(match::name(conv_dot_reshaper_names))(
             match::any_of(is_mlir_dot(dot_mode), is_mlir_conv(conv_mode)).bind("gemm_based_op"));
         return mlir_pointwise()(match::any_of[match::inputs()](dot_or_conv.bind("x")));
     }

--- a/test/gpu/fuse_mlir.cpp
+++ b/test/gpu/fuse_mlir.cpp
@@ -29,6 +29,7 @@
 #include <migraphx/op/common.hpp>
 #include <migraphx/program.hpp>
 #include <migraphx/make_op.hpp>
+#include <migraphx/param_utils.hpp>
 #include <basic_ops.hpp>
 #include <test.hpp>
 #include <pointwise.hpp>
@@ -77,6 +78,19 @@ migraphx::instruction_ref add_mlir(migraphx::program& p,
         migraphx::make_op("gpu::mlir_op", {{"op", migraphx::to_value(root)}}), inputs, {pm});
 }
 
+template <class F>
+migraphx::instruction_ref add_mlir(migraphx::program& p,
+                                   const std::string& name,
+                                   std::vector<migraphx::instruction_ref> inputs,
+                                   F f)
+{
+    std::vector<std::string> arg_names;
+    migraphx::transform(migraphx::range(inputs.size()), std::back_inserter(arg_names), [&](auto i) {
+        return migraphx::param_name(i);
+    });
+    return add_mlir(p, name, std::move(inputs), std::move(arg_names), f);
+}
+
 TEST_CASE(dot_reshapes_add)
 {
     migraphx::shape s{migraphx::shape::float_type, {1, 3, 3}};
@@ -100,17 +114,13 @@ TEST_CASE(dot_reshapes_add)
         auto a     = mm->add_parameter("a", s);
         auto b     = mm->add_parameter("b", s);
         auto x     = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {3, 3}});
-        auto fused = add_mlir(
-            p2,
-            "mlir_main:pointwise0",
-            {x, a, b},
-            {"x2", "y0", "y1"},
-            [=](auto* pm, const auto& inputs) {
-                auto dot = pm->add_instruction(migraphx::make_op("dot"), inputs[1], inputs[2]);
+        auto fused =
+            add_mlir(p2, "mlir_main:pointwise0", {a, b, x}, [=](auto* pm, const auto& inputs) {
+                auto dot = pm->add_instruction(migraphx::make_op("dot"), inputs[0], inputs[1]);
                 auto dot_trans = pm->add_instruction(
                     migraphx::make_op("transpose", {{"permutation", {0, 2, 1}}}), dot);
                 auto dot_rsp = pm->add_instruction(migraphx::make_op("squeeze"), dot_trans);
-                auto add     = pm->add_instruction(migraphx::make_op("add"), dot_rsp, inputs[0]);
+                auto add     = pm->add_instruction(migraphx::make_op("add"), dot_rsp, inputs[2]);
                 return std::make_tuple(dot->get_operator(), add);
             });
         mm->add_return({fused});
@@ -139,16 +149,51 @@ TEST_CASE(dot_add)
         auto b   = mm->add_parameter("b", s);
         auto x   = mm->add_parameter("x", s);
         auto fused =
-            add_mlir(p2,
-                     "mlir_main:pointwise0",
-                     {x, a, b},
-                     {"x2", "y0", "y1"},
-                     [=](auto* pm, const auto& inputs) {
-                         auto dot =
-                             pm->add_instruction(migraphx::make_op("dot"), inputs[1], inputs[2]);
-                         auto add = pm->add_instruction(migraphx::make_op("add"), dot, inputs[0]);
-                         return std::make_tuple(dot->get_operator(), add);
-                     });
+            add_mlir(p2, "mlir_main:pointwise0", {a, b, x}, [=](auto* pm, const auto& inputs) {
+                auto dot = pm->add_instruction(migraphx::make_op("dot"), inputs[0], inputs[1]);
+                auto add = pm->add_instruction(migraphx::make_op("add"), dot, inputs[2]);
+                return std::make_tuple(dot->get_operator(), add);
+            });
+        mm->add_return({fused});
+    }
+    EXPECT(p1.sort() == p2.sort());
+}
+
+TEST_CASE(dot_transpose_reshape_add)
+{
+    migraphx::shape s1{migraphx::shape::float_type, {1, 6, 6}};
+    migraphx::shape s2{migraphx::shape::float_type, {2, 3, 6}};
+    migraphx::program p1;
+    {
+        auto* mm = p1.get_main_module();
+        auto a   = mm->add_parameter("a", s1);
+        auto b   = mm->add_parameter("b", s1);
+        auto x   = mm->add_parameter("x", s1);
+        auto dot = mm->add_instruction(migraphx::make_op("dot"), a, b);
+        auto xtranspose =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), x);
+        auto xreshape =
+            mm->add_instruction(migraphx::make_op("reshape", {{"dims", s1.lens()}}), xtranspose);
+        auto add = add_pointwise(p1, "main:pointwise0", {dot, xreshape}, single_pointwise("add"));
+        mm->add_return({add});
+    }
+    run_pass(p1);
+    migraphx::program p2;
+    {
+        auto* mm = p2.get_main_module();
+        auto a   = mm->add_parameter("a", s1);
+        auto b   = mm->add_parameter("b", s1);
+        auto x   = mm->add_parameter("x", s1);
+        auto fused =
+            add_mlir(p2, "mlir_main:pointwise0", {a, b, x}, [=](auto* pm, const auto& inputs) {
+                auto dot = pm->add_instruction(migraphx::make_op("dot"), inputs[0], inputs[1]);
+                auto xtranspose = pm->add_instruction(
+                    migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), inputs[2]);
+                auto xreshape = pm->add_instruction(
+                    migraphx::make_op("reshape", {{"dims", s1.lens()}}), xtranspose);
+                auto add = pm->add_instruction(migraphx::make_op("add"), dot, xreshape);
+                return std::make_tuple(dot->get_operator(), add);
+            });
         mm->add_return({fused});
     }
     EXPECT(p1.sort() == p2.sort());
@@ -186,22 +231,18 @@ TEST_CASE(multi_use_dot_trans_add_pooling_sub)
         auto a   = mm->add_parameter("a", s1);
         auto b   = mm->add_parameter("b", s2);
         auto x = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 1, 5, 4}});
-        auto fused = add_mlir(
-            p2,
-            "mlir_main:pointwise0",
-            {x, a, b},
-            {"x2", "y0", "y1"},
-            [=](auto* pm, const auto& inputs) {
-                auto dot = pm->add_instruction(migraphx::make_op("dot"), inputs[1], inputs[2]);
+        auto fused =
+            add_mlir(p2, "mlir_main:pointwise0", {a, b, x}, [=](auto* pm, const auto& inputs) {
+                auto dot = pm->add_instruction(migraphx::make_op("dot"), inputs[0], inputs[1]);
                 auto dot_trans = pm->add_instruction(
                     migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), dot);
 
-                auto add = pm->add_instruction(migraphx::make_op("add"), dot_trans, inputs[0]);
+                auto add = pm->add_instruction(migraphx::make_op("add"), dot_trans, inputs[2]);
                 return std::make_tuple(dot->get_operator(),
-                                       std::vector<migraphx::instruction_ref>{dot, add});
+                                       std::vector<migraphx::instruction_ref>{add, dot});
             });
         auto fused_dot_add =
-            mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), fused);
+            mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), fused);
         auto pooling =
             mm->add_instruction(migraphx::make_op("pooling",
                                                   {{"mode", migraphx::op::pooling_mode::lpnorm},
@@ -210,7 +251,7 @@ TEST_CASE(multi_use_dot_trans_add_pooling_sub)
                                                    {"lengths", {2, 1}},
                                                    {"lp_order", 2}}),
                                 fused_dot_add);
-        auto dot = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), fused);
+        auto dot = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), fused);
         auto sub = add_pointwise(p2, "main:pointwise1", {dot, pooling}, single_pointwise("sub"));
         mm->add_return({sub});
     }
@@ -252,23 +293,19 @@ TEST_CASE(dot_multi_use_trans_add_pooling_sub)
         auto a   = mm->add_parameter("a", s1);
         auto b   = mm->add_parameter("b", s2);
         auto x = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 1, 5, 4}});
-        auto fused = add_mlir(
-            p2,
-            "mlir_main:pointwise0",
-            {x, a, b},
-            {"x2", "y0", "y1"},
-            [=](auto* pm, const auto& inputs) {
-                auto dot = pm->add_instruction(migraphx::make_op("dot"), inputs[1], inputs[2]);
+        auto fused =
+            add_mlir(p2, "mlir_main:pointwise0", {a, b, x}, [=](auto* pm, const auto& inputs) {
+                auto dot = pm->add_instruction(migraphx::make_op("dot"), inputs[0], inputs[1]);
                 auto dot_trans = pm->add_instruction(
                     migraphx::make_op("transpose", {{"permutation", {0, 2, 1}}}), dot);
                 auto dot_unsq = pm->add_instruction(
                     migraphx::make_op("reshape", {{"dims", {1, 1, 5, 4}}}), dot_trans);
-                auto add = pm->add_instruction(migraphx::make_op("add"), dot_unsq, inputs[0]);
+                auto add = pm->add_instruction(migraphx::make_op("add"), dot_unsq, inputs[2]);
                 return std::make_tuple(dot->get_operator(),
-                                       std::vector<migraphx::instruction_ref>{dot, add});
+                                       std::vector<migraphx::instruction_ref>{add, dot});
             });
         auto fused_dot_add =
-            mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), fused);
+            mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), fused);
         auto pooling =
             mm->add_instruction(migraphx::make_op("pooling",
                                                   {{"mode", migraphx::op::pooling_mode::lpnorm},
@@ -277,7 +314,7 @@ TEST_CASE(dot_multi_use_trans_add_pooling_sub)
                                                    {"lengths", {2, 1}},
                                                    {"lp_order", 2}}),
                                 fused_dot_add);
-        auto dot = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), fused);
+        auto dot = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), fused);
         auto dot_trans =
             mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 1}}}), dot);
         auto dot_reshape =
@@ -358,16 +395,11 @@ TEST_CASE(dot_dot_pointwise_pointwise)
                 return std::make_tuple(dot->get_operator(), dot);
             });
         auto fused =
-            add_mlir(p2,
-                     "mlir_main:pointwise0",
-                     {x, dot1, c},
-                     {"x2", "y0", "y1"},
-                     [=](auto* pm, const auto& inputs) {
-                         auto dot =
-                             pm->add_instruction(migraphx::make_op("dot"), inputs[1], inputs[2]);
-                         auto add = pm->add_instruction(migraphx::make_op("add"), dot, inputs[0]);
-                         return std::make_tuple(dot->get_operator(), add);
-                     });
+            add_mlir(p2, "mlir_main:pointwise0", {dot1, c, x}, [=](auto* pm, const auto& inputs) {
+                auto dot = pm->add_instruction(migraphx::make_op("dot"), inputs[0], inputs[1]);
+                auto add = pm->add_instruction(migraphx::make_op("add"), dot, inputs[2]);
+                return std::make_tuple(dot->get_operator(), add);
+            });
         auto add2 = add_pointwise(p2, "main:pointwise1", {dot1, fused}, single_pointwise("add"));
         mm->add_return({add2});
     }
@@ -731,8 +763,8 @@ TEST_CASE(int_quant_dot_abs)
         auto* mm   = p2.get_main_module();
         auto a     = mm->add_parameter("a", s_a);
         auto b     = mm->add_parameter("b", s_b);
-        auto fused = add_mlir(
-            p2, "mlir_main:pointwise0", {a, b}, {"y0", "y1"}, [=](auto* pm, const auto& inputs) {
+        auto fused =
+            add_mlir(p2, "mlir_main:pointwise0", {a, b}, [=](auto* pm, const auto& inputs) {
                 auto dot =
                     pm->add_instruction(migraphx::make_op("quant_dot"), inputs[0], inputs[1]);
                 auto abs = pm->add_instruction(migraphx::make_op("abs"), dot);
@@ -811,22 +843,23 @@ TEST_CASE(conv_split_reduce)
         auto x   = mm->add_parameter("x", s_x);
         auto w   = mm->add_parameter("w", s_w);
         auto b   = mm->add_literal(migraphx::generate_literal(s_b));
-        auto mb  = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {2, 32, 10, 64, 64}}}), b);
         auto fused =
             add_mlir(p2,
                      "mlir_main:pointwise0_main:split_reduce0",
-                     {mb, x, w},
-                     {"x2", "y0", "y1"},
+                     {x, w, b},
+                     {"x0", "x1", "x2"},
                      [=](auto* pm, const auto& inputs) {
                          auto conv = pm->add_instruction(
                              migraphx::make_op("convolution", {{"padding", {1, 1, 1, 1}}}),
-                             inputs[1],
-                             inputs[2]);
+                             inputs[0],
+                             inputs[1]);
                          auto reshape = pm->add_instruction(
                              migraphx::make_op("reshape", {{"dims", {2, 32, 10, 64, 64}}}), conv);
-                         auto add =
-                             pm->add_instruction(migraphx::make_op("add"), reshape, inputs[0]);
+                         auto mb = pm->add_instruction(
+                             migraphx::make_op("broadcast",
+                                               {{"axis", 1}, {"out_lens", {2, 32, 10, 64, 64}}}),
+                             inputs[2]);
+                         auto add  = pm->add_instruction(migraphx::make_op("add"), reshape, mb);
                          auto mul  = pm->add_instruction(migraphx::make_op("mul"), add, add);
                          auto mean = pm->add_instruction(
                              migraphx::make_op("reduce_sum", {{"axes", {2, 3, 4}}}), add);
@@ -903,22 +936,23 @@ TEST_CASE(conv_add_split_reduce_multi_use)
         auto x   = mm->add_parameter("x", s_x);
         auto w   = mm->add_parameter("w", s_w);
         auto b   = mm->add_literal(migraphx::generate_literal(s_b));
-        auto mb  = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {2, 32, 10, 64, 64}}}), b);
         auto fused =
             add_mlir(p2,
                      "mlir_main:pointwise0_main:split_reduce0",
-                     {mb, x, w},
-                     {"x2", "y0", "y1"},
+                     {x, w, b},
+                     {"x0", "x1", "x2"},
                      [=](auto* pm, const auto& inputs) {
                          auto conv = pm->add_instruction(
                              migraphx::make_op("convolution", {{"padding", {1, 1, 1, 1}}}),
-                             inputs[1],
-                             inputs[2]);
+                             inputs[0],
+                             inputs[1]);
                          auto reshape = pm->add_instruction(
                              migraphx::make_op("reshape", {{"dims", {2, 32, 10, 64, 64}}}), conv);
-                         auto add =
-                             pm->add_instruction(migraphx::make_op("add"), reshape, inputs[0]);
+                         auto mb = pm->add_instruction(
+                             migraphx::make_op("broadcast",
+                                               {{"axis", 1}, {"out_lens", {2, 32, 10, 64, 64}}}),
+                             inputs[2]);
+                         auto add  = pm->add_instruction(migraphx::make_op("add"), reshape, mb);
                          auto mul  = pm->add_instruction(migraphx::make_op("mul"), add, add);
                          auto mean = pm->add_instruction(
                              migraphx::make_op("reduce_sum", {{"axes", {2, 3, 4}}}), add);
@@ -1017,22 +1051,23 @@ TEST_CASE(conv_add_split_reduce_multi_use_conv)
         auto w1  = mm->add_parameter("w1", s_w1);
         auto w2  = mm->add_parameter("w2", s_w2);
         auto b   = mm->add_literal(migraphx::generate_literal(s_b));
-        auto mb  = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {2, 32, 10, 64, 64}}}), b);
         auto fused =
             add_mlir(p2,
                      "mlir_main:pointwise0_main:split_reduce0",
-                     {mb, x, w1},
-                     {"x2", "y0", "y1"},
+                     {x, w1, b},
+                     {"x0", "x1", "x2"},
                      [=](auto* pm, const auto& inputs) {
                          auto conv = pm->add_instruction(
                              migraphx::make_op("convolution", {{"padding", {1, 1, 1, 1}}}),
-                             inputs[1],
-                             inputs[2]);
+                             inputs[0],
+                             inputs[1]);
                          auto reshape = pm->add_instruction(
                              migraphx::make_op("reshape", {{"dims", {2, 32, 10, 64, 64}}}), conv);
-                         auto add =
-                             pm->add_instruction(migraphx::make_op("add"), reshape, inputs[0]);
+                         auto mb = pm->add_instruction(
+                             migraphx::make_op("broadcast",
+                                               {{"axis", 1}, {"out_lens", {2, 32, 10, 64, 64}}}),
+                             inputs[2]);
+                         auto add  = pm->add_instruction(migraphx::make_op("add"), reshape, mb);
                          auto mul  = pm->add_instruction(migraphx::make_op("mul"), add, add);
                          auto mean = pm->add_instruction(
                              migraphx::make_op("reduce_sum", {{"axes", {2, 3, 4}}}), add);

--- a/test/gpu/fuse_mlir.cpp
+++ b/test/gpu/fuse_mlir.cpp
@@ -199,6 +199,44 @@ TEST_CASE(dot_transpose_reshape_add)
     EXPECT(p1.sort() == p2.sort());
 }
 
+TEST_CASE(conv_broadcast_mul)
+{
+    migraphx::shape os{migraphx::shape::float_type, {4, 56, 122, 122}};
+    migraphx::shape is{migraphx::shape::float_type, {4, 14, 1, 1}};
+    migraphx::shape ws{migraphx::shape::float_type, {56, 14, 1, 1}};
+    migraphx::program p1;
+    {
+        auto* mm   = p1.get_main_module();
+        auto x     = mm->add_parameter("x", is);
+        auto y     = mm->add_parameter("y", os);
+        auto w     = mm->add_parameter("w", ws);
+        auto conv  = mm->add_instruction(migraphx::make_op("convolution"), x, w);
+        auto convb = mm->add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", os.lens()}}), conv);
+        auto mul = add_pointwise(p1, "main:pointwise0", {convb, y}, single_pointwise("mul"));
+        mm->add_return({mul});
+    }
+    run_pass(p1);
+    migraphx::program p2;
+    {
+        auto* mm  = p2.get_main_module();
+        auto x    = mm->add_parameter("x", is);
+        auto y    = mm->add_parameter("y", os);
+        auto w    = mm->add_parameter("w", ws);
+        auto conv = add_mlir(
+            p2, "mlir_convolution0", {x, w}, {"y0", "y1"}, [=](auto* pm, const auto& inputs) {
+                auto c =
+                    pm->add_instruction(migraphx::make_op("convolution"), inputs[0], inputs[1]);
+                return std::make_tuple(c->get_operator(), c);
+            });
+        auto convb = mm->add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", os.lens()}}), conv);
+        auto mul = add_pointwise(p2, "main:pointwise0", {convb, y}, single_pointwise("mul"));
+        mm->add_return({mul});
+    }
+    EXPECT(p1.sort() == p2.sort());
+}
+
 TEST_CASE(multi_use_dot_trans_add_pooling_sub)
 {
     migraphx::shape s1{migraphx::shape::float_type, {1, 1, 4, 5}};

--- a/test/layout_convolution.cpp
+++ b/test/layout_convolution.cpp
@@ -49,7 +49,7 @@ migraphx::instruction_ref add_layout_nhwc(migraphx::module& m, migraphx::instruc
 
 migraphx::instruction_ref add_layout_nchw(migraphx::module& m, migraphx::instruction_ref ins)
 {
-    return m.add_instruction(layout(), ins);
+    return m.add_instruction(layout({0, 1, 2, 3}), ins);
 }
 
 TEST_CASE(auto_conv_nchw)
@@ -90,8 +90,22 @@ TEST_CASE(auto_conv_nhwc)
         auto relu = m1.add_instruction(migraphx::make_op("relu"), conv);
         m1.add_return({relu});
     }
-    migraphx::module m2 = m1;
     run_pass(m1);
+    migraphx::module m2;
+    {
+        auto x          = m2.add_parameter("x", {migraphx::shape::float_type, {1, 16, 16, 8}});
+        auto xtranspose = add_layout_nchw(m2, m2.add_instruction(transpose, x));
+        auto w          = m2.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {16, 3, 3, 8}}));
+        auto wtranspose = add_layout_nchw(m2, m2.add_instruction(transpose, w));
+        auto conv       = m2.add_instruction(
+            migraphx::make_op("convolution",
+                                    {{"padding", {1, 1}}, {"stride", {2, 2}}, {"dilation", {1, 1}}}),
+            xtranspose,
+            wtranspose);
+        auto relu = add_layout_nhwc(m2, m2.add_instruction(migraphx::make_op("relu"), conv));
+        m2.add_return({relu});
+    }
     EXPECT(m1.sort() == m2.sort());
 }
 


### PR DESCRIPTION
Resolves mlir rejected Problem Config.  Example...
src/targets/gpu/compile_ops.cpp:242: benchmark: No valid tuned compilation for gpu::mlir_op with gfx1101	27	conv -F 1 -f GNC01 -I NGC01 -O NGC01 -n 1 -c 12 -H 1 -W 1 -k 48 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1
