### PR TITLE
Add --spin-thread flag to driver

### DIFF
--- a/docs/driver/compile.rst
+++ b/docs/driver/compile.rst
@@ -30,6 +30,10 @@ Disable fast math optimization
 
 Perform an exhaustive search to find the fastest version of generated kernels for selected backend
 
+.. option:: --spin-thread
+
+Enable CPU thread to spin while waiting for GPU commands to complete, could potentially improve performance stability on small models
+
 .. option::  --fp16
 
 Quantize for fp16

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -519,7 +519,11 @@ struct compiler
            ap.help("Exhastively search for best tuning parameters for kernels"),
            ap.set_value(true));
 
-        ap(spin_thread, {"--spin-thread"}, ap.help("Enable CPU thread to spin while waiting for GPU commands to complete, could potentially improve performance stability on small models"), ap.set_value(true));
+        ap(spin_thread,
+           {"--spin-thread"},
+           ap.help("Enable CPU thread to spin while waiting for GPU commands to complete, could "
+                   "potentially improve performance stability on small models"),
+           ap.set_value(true));
 
         ap(to_fp16, {"--fp16"}, ap.help("Quantize for fp16"), ap.set_value(true));
         ap(to_bf16, {"--bf16"}, ap.help("Quantize for bf16"), ap.set_value(true));
@@ -547,7 +551,7 @@ struct compiler
                 auto status = hipSetDeviceFlags(hipDeviceScheduleSpin);
                 if(status != hipSuccess)
                     MIGRAPHX_THROW("Failed to set device flags to: hipDeviceScheduleSpin");
-            } 
+            }
         }
 
         auto p = l.load();


### PR DESCRIPTION
Added a new flag `--spin-thread` to the MIGraphX driver. This will use the HIP runtime API to set the device to `hipDeviceScheduleSpin` mode. Ideally when enabled, this should help with stability when measuring smaller models and kernels.