### PR TITLE
Fix Windows compiler warnings

### DIFF
--- a/cmake/EnableCompilerWarnings.cmake
+++ b/cmake/EnableCompilerWarnings.cmake
@@ -109,6 +109,8 @@ else()
             if(WIN32 AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19")
                 list(APPEND CMAKE_COMPILER_WARNINGS
                     -Wno-missing-include-dirs
+                    -Wno-switch-default
+                    -Wno-deprecated-pragma
                 )
             endif()
         else()


### PR DESCRIPTION
Two warnings were detected while building MGX with the new compiler on Windows.

1. The first warning is related to a switch statement. For example, in the file srx/include/migraphx/value.hpp at line 354, there is no default case, which triggers a compiler warning. Adding a default case results in another warning: "default label in switch which covers all enumeration values." This is expected behavior with -Weverything (you can see https://github.com/llvm/llvm-project/issues/81354), so we need to disable the switch-default warning.

2. The second warning point to the macro __AMDGCN_WAVEFRONT_SIZE, which has been marked as deprecated: "compile-time-constant access to the wavefront size will be removed in a future release [-Werror,-Wdeprecated-pragma]." There is currently no fix for this issue, as indicated in https://github.com/ROCm/ROCm/issues/4121, so we need to disable this warning as well.