### PR TITLE
Convolution_backwards group compute shape fix

### DIFF
--- a/src/include/migraphx/op/convolution_backwards.hpp
+++ b/src/include/migraphx/op/convolution_backwards.hpp
@@ -80,7 +80,7 @@ struct convolution_backwards
         }
 
         if(not x_shape.dynamic() and not w_shape.dynamic() and
-           x_shape.lens().at(1) != (w_shape.lens().at(0) * group))
+           x_shape.lens().at(1) != (w_shape.lens().at(0)))
         {
             MIGRAPHX_THROW("CONVOLUTION_BACKWARDS: mismatched channel numbers");
         }
@@ -116,7 +116,7 @@ struct convolution_backwards
     {
         std::vector<shape::dynamic_dimension> output_dyn_dims = {};
         output_dyn_dims.push_back(x_shape.to_dynamic().dyn_dims().at(0));
-        output_dyn_dims.push_back(w_shape.to_dynamic().dyn_dims().at(1));
+        output_dyn_dims.push_back(w_shape.to_dynamic().dyn_dims().at(1) * group);
         const std::size_t num_spatial_dims = x_shape.ndim() - 2;
         // Does not compute for optimals
         auto min_spatial_dims = calc_spatial_lens(x_shape.min_lens(), w_shape.min_lens());
@@ -131,7 +131,7 @@ struct convolution_backwards
 
     shape static_compute_shape(shape x_shape, shape w_shape) const
     {
-        std::vector<size_t> output_lens{x_shape.lens()[0], w_shape.lens()[1]};
+        std::vector<size_t> output_lens{x_shape.lens()[0], w_shape.lens()[1] * group};
         auto spatial_lens = calc_spatial_lens(x_shape.lens(), w_shape.lens());
         std::for_each(spatial_lens.begin(), spatial_lens.end(), [&output_lens](auto x) {
             output_lens.push_back(x);

--- a/src/include/migraphx/shape.hpp
+++ b/src/include/migraphx/shape.hpp
@@ -134,15 +134,20 @@ struct MIGRAPHX_EXPORT shape
         MIGRAPHX_EXPORT friend bool operator!=(const dynamic_dimension& x, const std::size_t& y);
         MIGRAPHX_EXPORT friend bool operator!=(const std::size_t& x, const dynamic_dimension& y);
 
-        // add and subtract fixed std::size_t dimension
+        // add, subtract, multiply fixed std::size_t dimension
         dynamic_dimension& operator+=(const std::size_t& x);
         dynamic_dimension& operator-=(const std::size_t& x);
+        dynamic_dimension& operator*=(const std::size_t& x);
         MIGRAPHX_EXPORT friend dynamic_dimension operator+(const dynamic_dimension& x,
                                                            const std::size_t& y);
         MIGRAPHX_EXPORT friend dynamic_dimension operator+(const std::size_t& x,
                                                            const dynamic_dimension& y);
         MIGRAPHX_EXPORT friend dynamic_dimension operator-(const dynamic_dimension& x,
                                                            const std::size_t& y);
+        MIGRAPHX_EXPORT friend dynamic_dimension operator*(const dynamic_dimension& x,
+                                                           const std::size_t& y);
+        MIGRAPHX_EXPORT friend dynamic_dimension operator*(const std::size_t& x,
+                                                           const dynamic_dimension& y);
     };
 
     static std::string to_sizes_string(const std::vector<shape>& shapes);

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -693,6 +693,19 @@ shape::dynamic_dimension& shape::dynamic_dimension::operator-=(const std::size_t
     return *this;
 }
 
+shape::dynamic_dimension& shape::dynamic_dimension::operator*=(const std::size_t& x)
+{
+    this->min *= x;
+    this->max *= x;
+    std::set<std::size_t> new_optimals;
+    std::transform(this->optimals.begin(),
+                   this->optimals.end(),
+                   std::inserter(new_optimals, new_optimals.begin()),
+                   [&x](const auto& opt) { return (opt * x); });
+    this->optimals = new_optimals;
+    return *this;
+}
+
 bool operator==(const shape::dynamic_dimension& x, const shape::dynamic_dimension& y)
 {
     // don't check optimals if both are fixed
@@ -733,6 +746,17 @@ shape::dynamic_dimension operator-(const shape::dynamic_dimension& x, const std:
 {
     auto dd = x;
     return dd -= y;
+}
+
+shape::dynamic_dimension operator*(const shape::dynamic_dimension& x, const std::size_t& y)
+{
+    auto dd = x;
+    return dd *= y;
+}
+
+shape::dynamic_dimension operator*(const std::size_t& x, const shape::dynamic_dimension& y)
+{
+    return y * x;
 }
 
 bool operator==(const shape& x, const shape& y)

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -593,6 +593,19 @@ TEST_CASE(convolution_backwards_2dilation)
                  weights);
 }
 
+TEST_CASE(convolution_backwards_2group)
+{
+    migraphx::shape input{migraphx::shape::float_type, {4, 4, 4, 4}};
+    migraphx::shape weights{migraphx::shape::float_type, {4, 2, 4, 4}};
+    migraphx::shape output{migraphx::shape::float_type, {4, 4, 7, 7}};
+    expect_shape(output,
+                 migraphx::make_op(
+                     "convolution_backwards",
+                     {{"padding", {0, 0}}, {"stride", {1, 1}}, {"dilation", {1, 1}}, {"group", 2}}),
+                 input,
+                 weights);
+}
+
 TEST_CASE(convolution_backwards_3d)
 {
     migraphx::shape input_3d{migraphx::shape::float_type, {4, 4, 1, 1, 1}};
@@ -619,6 +632,15 @@ TEST_CASE(convolution_backwards_dyn_batch_2d)
     migraphx::shape weights{migraphx::shape::float_type, {4, 3, 3, 3}};
     migraphx::shape output{migraphx::shape::float_type, {{1, 4}, {3, 3}, {3, 3}, {3, 3}}};
     expect_shape(output, migraphx::make_op("convolution_backwards"), input, weights);
+}
+
+TEST_CASE(convolution_backwards_dyn_batch_2dgroup)
+{
+    migraphx::shape input{migraphx::shape::float_type, {{1, 4}, {4, 4}, {4, 4}, {4, 4}}};
+    migraphx::shape weights{migraphx::shape::float_type, {4, 2, 4, 4}};
+    migraphx::shape output{migraphx::shape::float_type, {{1, 4}, {4, 4}, {7, 7}, {7, 7}}};
+    expect_shape(
+        output, migraphx::make_op("convolution_backwards", {{"group", 2}}), input, weights);
 }
 
 TEST_CASE(convolution_backwards_dyn_img_2d)

--- a/test/ref/convolution_backwards.cpp
+++ b/test/ref/convolution_backwards.cpp
@@ -222,6 +222,35 @@ TEST_CASE(convolution_backwards_2dilation)
     EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
 }
 
+TEST_CASE(convolution_backwards_2d_group)
+{
+    migraphx::shape activations_shape{migraphx::shape::float_type, {1, 2, 3, 3}};
+    migraphx::shape weights_shape{migraphx::shape::float_type, {2, 2, 3, 3}};
+    std::vector<float> x_data{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17};
+    std::vector<float> w_data(36, 1.0);
+
+    std::vector<float> gold{
+        0.,  1.,  3.,   3.,  2.,  3.,  8.,  15., 12., 7.,  9.,  21.,  36., 27., 15., 9.,  20.,
+        33., 24., 13.,  6.,  13., 21., 15., 8.,  0.,  1.,  3.,  3.,   2.,  3.,  8.,  15., 12.,
+        7.,  9.,  21.,  36., 27., 15., 9.,  20., 33., 24., 13., 6.,   13., 21., 15., 8.,  9.,
+        19., 30., 21.,  11., 21., 44., 69., 48., 25., 36., 75., 117., 81., 42., 27., 56., 87.,
+        60., 31., 15.,  31., 48., 33., 17., 9.,  19., 30., 21., 11.,  21., 44., 69., 48., 25.,
+        36., 75., 117., 81., 42., 27., 56., 87., 60., 31., 15., 31.,  48., 33., 17.};
+
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    auto x   = mm->add_literal(migraphx::literal{activations_shape, x_data});
+    auto w   = mm->add_literal(migraphx::literal{weights_shape, w_data});
+
+    mm->add_instruction(migraphx::make_op("convolution_backwards", {{"group", 2}}), x, w);
+    p.compile(migraphx::make_target("ref"));
+    auto result = p.eval({}).back();
+
+    std::vector<float> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+}
+
 TEST_CASE(convolution_backwards_dyn_batch1)
 {
     migraphx::program p;

--- a/test/ref/convolution_backwards.cpp
+++ b/test/ref/convolution_backwards.cpp
@@ -78,6 +78,7 @@ TEST_CASE(convolution_backwards_2d)
     EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
 }
 
+// test values from pytorch
 TEST_CASE(convolution_backwards_3d)
 {
     migraphx::shape s_1{migraphx::shape::float_type, {1, 1, 1, 2, 3}};
@@ -222,6 +223,7 @@ TEST_CASE(convolution_backwards_2dilation)
     EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
 }
 
+// test values from pytorch
 TEST_CASE(convolution_backwards_2d_group)
 {
     migraphx::shape activations_shape{migraphx::shape::float_type, {1, 2, 3, 3}};

--- a/test/verify/test_convolution_backwards_2d_group.cpp
+++ b/test/verify/test_convolution_backwards_2d_group.cpp
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "verify_program.hpp"
+#include <migraphx/program.hpp>
+#include <migraphx/generate.hpp>
+#include <migraphx/make_op.hpp>
+
+struct test_convolution_backwards_2d_group : verify_program<test_convolution_backwards_2d_group>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        auto input =
+            mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 2, 10, 10}});
+        auto weights =
+            mm->add_parameter("w", migraphx::shape{migraphx::shape::float_type, {2, 4, 3, 3}});
+        mm->add_instruction(
+            migraphx::make_op("convolution_backwards", {{"group", 2}}), input, weights);
+        return p;
+    }
+};


### PR DESCRIPTION
Multiplied by number of groups at the wrong place for this operation. Added tests to cover the group convolution backwards case.