### PR TITLE
Remove old targets

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -2005,7 +2005,7 @@ void simplify_algebra::apply(module& m) const
                             find_double_add_lit_broadcast{},
                             find_add_lit_broadcast{},
                             find_add_convs{},
-                            find_conv_dot_horiz_fusion{},
+                            // find_conv_dot_horiz_fusion{},
                             find_mul_conv{},
                             find_mul_slice_conv{},
                             find_mul_dot{},

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -2005,7 +2005,7 @@ void simplify_algebra::apply(module& m) const
                             find_double_add_lit_broadcast{},
                             find_add_lit_broadcast{},
                             find_add_convs{},
-                            // find_conv_dot_horiz_fusion{},
+                            find_conv_dot_horiz_fusion{},
                             find_mul_conv{},
                             find_mul_slice_conv{},
                             find_mul_dot{},

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -169,7 +169,7 @@ struct fusion
 const std::unordered_set<std::string>& get_supported_archs()
 {
     static std::unordered_set<std::string> supported_archs{
-        "gfx900", "gfx906", "gfx908", "gfx1030", "gfx940"};
+        "gfx900", "gfx906", "gfx908", "gfx1030"};
     return supported_archs;
 }
 #if MIGRAPHX_USE_MIOPEN

--- a/src/targets/gpu/hipblaslt.cpp
+++ b/src/targets/gpu/hipblaslt.cpp
@@ -58,7 +58,7 @@ bool hipblaslt_supported()
     const auto device_name = trim(split_string(get_device_name(), ':').front());
     // hipblaslt is supported for MI200 and above, and Navi3x and above.
     return (device_name == "gfx90a" or
-            (starts_with(device_name, "gfx94") and device_name >= "gfx940") or
+            (starts_with(device_name, "gfx94") and device_name >= "gfx942") or
             (starts_with(device_name, "gfx95") and device_name >= "gfx950") or
             starts_with(device_name, "gfx110") or starts_with(device_name, "gfx120"));
 }

--- a/src/targets/gpu/kernels/include/migraphx/kernels/float8.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/float8.hpp
@@ -71,7 +71,7 @@ struct float8
 
     __device__ explicit constexpr float8(uint8_t bits, from_bits_t) : data(bits) {}
 
-#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+#if defined(__gfx942__)
     // device specific optimized F8 down-conversion code
 
     template <bool stochastic_rounding = false>
@@ -129,10 +129,10 @@ struct float8
 
         return i8data;
     }
-#endif // __gfx940__
+#endif // __gfx942__
 
        // constructor from float
-#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+#if defined(__gfx942__)
 
     // NOTE: ON-DEVICE... always optimal bias
     explicit constexpr __device__
@@ -177,7 +177,7 @@ struct float8
         }
     }
 #else
-    // DEVICE for non-gfx940 using s/w simulation
+    // DEVICE for non-gfx942 using s/w simulation
     explicit constexpr __device__
     float8(const float v,
            migraphx::fp8::rounding_mode rm = migraphx::fp8::rounding_mode::standard,
@@ -208,7 +208,7 @@ struct float8
 #endif // MIGRAPHX_FP8_DOWNCAST_CLIPPING}
         }
     }
-#endif // __gfx940___
+#endif // __gfx942___
 
     // Constructor from half
     explicit constexpr __device__
@@ -245,7 +245,7 @@ struct float8
     {
     }
     // convert to float
-#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) // NOLINT
+#if defined(__gfx942__) // NOLINT
     // upcast using device specific intrinsic
     inline constexpr __device__ operator float() const
     {
@@ -277,7 +277,7 @@ struct float8
         }
     }
 
-#else // non gfx940
+#else // non gfx942
     inline constexpr __device__ operator float() const
     {
         if constexpr(T == migraphx::fp8::f8_type::fp8)


### PR DESCRIPTION
Removes and/or replaces references to gfx940 and gfx941 with gfx942 as the old targets have been removed.