### PR TITLE
Update problem cache as configs are benchmarked

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -236,9 +236,12 @@ struct compile_plan
                        });
         std::this_thread::sleep_for(std::chrono::milliseconds{50});
         auto i = std::distance(times.begin(), std::min_element(times.begin(), times.end()));
-        if(trace_level > 0)
-            std::cout << "Fastest solution: " << config->solutions.at(i) << std::endl;
         ctx->get_problem_cache().insert(preop.name(), config->problem, config->solutions.at(i));
+        if(trace_level > 0)
+        {
+            std::cout << "Fastest solution: " << config->solutions.at(i) << std::endl;
+            ctx->get_problem_cache().save();
+        }
         if(not results[i].has_value())
             MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
                            problem_string());

--- a/src/targets/gpu/problem_cache.cpp
+++ b/src/targets/gpu/problem_cache.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/problem_cache.cpp
+++ b/src/targets/gpu/problem_cache.cpp
@@ -44,6 +44,7 @@ void problem_cache::load()
     if(not fs::exists(pc_path))
     {
         std::cout << "Problem cache not found. Creating new file.\n";
+        save();
         return;
     }
     from_value(from_json_string(read_string(pc_path)), cache);


### PR DESCRIPTION
Currently the problem cache gets saved off at the very end of compile. Assuming it was specified with the environment variable `MIGRAPHX_PROBLEM_CACHE=[cache_file_path]`.
* This PR optionally allows the problem cache file to be updated after finding the best solution in `compile_ops()`. It will be enabled if `MIGRAPHX_TRACE_BENCHMARKING>0`
* The problem cache is not getting updated during rocblas/hipblaslt tuning, but I can do that if needed.
* Right now it will write out the whole file again for each config. But we could possibly modify it to append to the end of the file in a future PR. I don't think this file write will add much time to the run at all.
* After the message of creating the problem cache (if it doesn't exist), it will save off and create an empty json file.
