### PR TITLE
Check for file-write errors

### DIFF
--- a/src/file_buffer.cpp
+++ b/src/file_buffer.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -73,7 +73,11 @@ void write_string(const fs::path& filename, const std::string& buffer)
 void write_buffer(const fs::path& filename, const char* buffer, std::size_t size)
 {
     std::ofstream os(filename, std::ios::out | std::ios::binary);
+    if(!os)
+        MIGRAPHX_THROW("Failure opening file: " + filename);
     os.write(buffer, size);
+    if(os.bad())
+        MIGRAPHX_THROW("Error writing file: " + filename);
 }
 
 void write_buffer(const fs::path& filename, const std::vector<char>& buffer)

--- a/src/file_buffer.cpp
+++ b/src/file_buffer.cpp
@@ -73,7 +73,7 @@ void write_string(const fs::path& filename, const std::string& buffer)
 void write_buffer(const fs::path& filename, const char* buffer, std::size_t size)
 {
     std::ofstream os(filename, std::ios::out | std::ios::binary);
-    if(!os)
+    if(os.fail())
         MIGRAPHX_THROW("Failure opening file: " + filename);
     os.write(buffer, size);
     if(os.bad())


### PR DESCRIPTION
Currently, a write op silently fails.

A commonly occurring example is that of an mxr being dumped, there is no failure notification to the developer if the dump directory were non-existent.