### PR TITLE
Expose some additional methods to the python API

### DIFF
--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -422,7 +422,10 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         .def("shape", [](migraphx::instruction_ref i) { return i->get_shape(); })
         .def("op", [](migraphx::instruction_ref i) { return i->get_operator(); })
         .def("inputs", [](migraphx::instruction_ref i) { return i->inputs(); })
+        .def("outputs", [](migraphx::instruction_ref i) { return i->outputs(); })
         .def("name", [](migraphx::instruction_ref i) { return i->name(); })
+        .def("get_literal",
+             [](migraphx::instruction_ref i) { return i->get_literal().get_argument(); })
         .def(py::hash(py::self))
         .def(py::self == py::self)
         .def(py::self != py::self);
@@ -465,6 +468,12 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             "add_return",
             [](migraphx::module& mm, std::vector<migraphx::instruction_ref>& args) {
                 return mm.add_return(args);
+            },
+            py::arg("args"))
+        .def(
+            "replace_return",
+            [](migraphx::module& mm, std::vector<migraphx::instruction_ref>& args) {
+                return mm.replace_return(args);
             },
             py::arg("args"))
         .def("__repr__", [](const migraphx::module& mm) { return migraphx::to_string(mm); })


### PR DESCRIPTION
This exposes the `outputs` and `get_literal` methods on the instruction and exposes the `replace_return` on the module.