### PR TITLE
Fix Stable Diffusion 2.1 Example

### DIFF
--- a/examples/diffusion/python_stable_diffusion_21/README.md
+++ b/examples/diffusion/python_stable_diffusion_21/README.md
@@ -40,7 +40,7 @@ optimum-cli export onnx --model stabilityai/stable-diffusion-2-1 models/sd21-onn
 Run the text-to-image script with the following example prompt and seed (optionally, you can change the batch size / number of images generated for that prompt)
 
 ```bash
-python txt2img.py --prompt "a photograph of an astronaut riding a horse" --seed 13 --output astro_horse.jpg --batch 1
+MIGRAPHX_MLIR_USE_SPECIFIC_OPS="attention,dot,fused,convolution" python txt2img.py --prompt "a photograph of an astronaut riding a horse" --seed 13 --output astro_horse.jpg --batch 1
 ```
 *Note: The first run will compile the models and cache them to make subsequent runs faster. New batch sizes will result in the models re-compiling.*
 

--- a/examples/diffusion/python_stable_diffusion_21/sd21.ipynb
+++ b/examples/diffusion/python_stable_diffusion_21/sd21.ipynb
@@ -53,7 +53,7 @@
    "source": [
     "# Install dependencies\n",
     "# We need this version to run torch with gpu tensors\n",
-    "!pip install torch==2.1.1 -f https://repo.radeon.com/rocm/manylinux/rocm-rel-6.0/\n",
+    "!pip install torch -f https://download.pytorch.org/whl/rocm6.2.4/\n",
     "!pip install optimum[onnxruntime] transformers diffusers accelerate"
    ]
   },
@@ -168,6 +168,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "There is currently a compilation issue with MIOpen for SD2.1. As such, we can set an environment variable to use MLIR instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%env MIGRAPHX_MLIR_USE_SPECIFIC_OPS=\"attention,dot,fused,convolution\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "With that, we can load the models. This could take several minutes."
    ]
   },
@@ -190,7 +206,7 @@
     "        \"unet\", {\n",
     "            \"sample\": [2, 4, 64, 64],\n",
     "            \"encoder_hidden_states\": [2, 77, 1024],\n",
-    "            \"timestep\": [1],\n",
+    "            \"timestep\": [],\n",
     "        })"
    ]
   },
@@ -259,9 +275,8 @@
     "def allocate_torch_tensors(model):\n",
     "    input_shapes = model.get_parameter_shapes()\n",
     "    data_mapping = {\n",
-    "        name:\n",
-    "        torch.zeros(shape.lens()).to(\n",
-    "            mgx_to_torch_dtype_dict[shape.type_string()]).to(device=\"cuda\")\n",
+    "        name: torch.zeros(shape.lens()).to(\n",
+    "            mgx_to_torch_dtype_dict[shape.type_string()]).to(device=\"cuda\") if not shape.scalar() else torch.tensor(0).to(mgx_to_torch_dtype_dict[shape.type_string()]).to(device=\"cuda\")\n",
     "        for name, shape in input_shapes.items()\n",
     "    }\n",
     "    return data_mapping"
@@ -315,7 +330,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since the tensors won't change, we only need to do this once, an cache it."
+    "Since the tensors won't change, we only need to do this once, and cache it."
    ]
   },
   {
@@ -511,7 +526,7 @@
     "    return scheduler.scale_model_input(latents, t).to(torch.float32).to(device=\"cuda\")\n",
     "\n",
     "def get_timestep(t):\n",
-    "    return torch.atleast_1d(t.to(torch.int64).to(device=\"cuda\"))  # convert 0D -> 1D"
+    "    return t.to(torch.int64).to(device=\"cuda\")"
    ]
   },
   {
@@ -695,7 +710,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "sd_venv",
+   "display_name": "usr",
    "language": "python",
    "name": "python3"
   },
@@ -709,7 +724,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/examples/diffusion/python_stable_diffusion_21/torch_requirements.txt
+++ b/examples/diffusion/python_stable_diffusion_21/torch_requirements.txt
@@ -21,6 +21,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #####################################################################################
---index-url https://download.pytorch.org/whl/rocm6.1/
+--extra-index-url https://download.pytorch.org/whl/rocm6.2.4/
 torch
 

--- a/examples/diffusion/python_stable_diffusion_21/txt2img.py
+++ b/examples/diffusion/python_stable_diffusion_21/txt2img.py
@@ -197,7 +197,7 @@ def allocate_torch_tensors(model):
     input_shapes = model.get_parameter_shapes()
     data_mapping = {
         name: torch.zeros(shape.lens()).to(
-            mgx_to_torch_dtype_dict[shape.type_string()]).to(device="cuda")
+            mgx_to_torch_dtype_dict[shape.type_string()]).to(device="cuda") if not shape.scalar() else torch.tensor(0).to(mgx_to_torch_dtype_dict[shape.type_string()]).to(device="cuda")
         for name, shape in input_shapes.items()
     }
     return data_mapping
@@ -249,7 +249,7 @@ class StableDiffusionMGX():
                 "unet", {
                     "sample": [2 * self.batch, 4, 64, 64],
                     "encoder_hidden_states": [2 * self.batch, 77, 1024],
-                    "timestep": [1],
+                    "timestep": [],
                 },
                 onnx_model_path,
                 compiled_model_path=compiled_model_path,
@@ -441,8 +441,8 @@ class StableDiffusionMGX():
         latents_model_input = torch.cat([latents] * 2)
         latents_model_input = self.scheduler.scale_model_input(
             latents_model_input, t).to(torch.float32).to(device="cuda")
-        timestep = torch.atleast_1d(t.to(torch.int64)).to(
-            device="cuda")  # convert 0D -> 1D
+        timestep = t.to(torch.int64).to(
+            device="cuda")
 
         copy_tensor_sync(self.tensors["unet"]["sample"], latents_model_input)
         copy_tensor_sync(self.tensors["unet"]["encoder_hidden_states"],
@@ -478,7 +478,7 @@ class StableDiffusionMGX():
             self.tensors["unet"]["encoder_hidden_states"],
             torch.randn((2 * self.batch, 77, 1024)).to(torch.float32))
         copy_tensor_sync(self.tensors["unet"]["timestep"],
-                         torch.atleast_1d(torch.randn(1).to(torch.int64)))
+                         torch.tensor(0).to(torch.int64))
         copy_tensor_sync(
             self.tensors["vae"]["latent_sample"],
             torch.randn((self.batch, 4, 64, 64)).to(torch.float32))

--- a/examples/diffusion/python_stable_diffusion_21/txt2img.py
+++ b/examples/diffusion/python_stable_diffusion_21/txt2img.py
@@ -197,7 +197,9 @@ def allocate_torch_tensors(model):
     input_shapes = model.get_parameter_shapes()
     data_mapping = {
         name: torch.zeros(shape.lens()).to(
-            mgx_to_torch_dtype_dict[shape.type_string()]).to(device="cuda") if not shape.scalar() else torch.tensor(0).to(mgx_to_torch_dtype_dict[shape.type_string()]).to(device="cuda")
+            mgx_to_torch_dtype_dict[shape.type_string()]).to(device="cuda")
+        if not shape.scalar() else torch.tensor(0).to(
+            mgx_to_torch_dtype_dict[shape.type_string()]).to(device="cuda")
         for name, shape in input_shapes.items()
     }
     return data_mapping
@@ -441,8 +443,7 @@ class StableDiffusionMGX():
         latents_model_input = torch.cat([latents] * 2)
         latents_model_input = self.scheduler.scale_model_input(
             latents_model_input, t).to(torch.float32).to(device="cuda")
-        timestep = t.to(torch.int64).to(
-            device="cuda")
+        timestep = t.to(torch.int64).to(device="cuda")
 
         copy_tensor_sync(self.tensors["unet"]["sample"], latents_model_input)
         copy_tensor_sync(self.tensors["unet"]["encoder_hidden_states"],


### PR DESCRIPTION
Fixes failures seen when running Stable Diffusion 2.1 example script. Uses MLIR instead of MIOpen to avoid compilation failure. Should work with both new and old onnx export, but probably best to update NAS to newer onnx models as DLM pulls from NAS instead of using optimum to export.

Closes https://github.com/ROCm/AMDMIGraphX/issues/3912.