### PR TITLE
Use string_value to see if the variable is set for gfx_default_rocblas()

### DIFF
--- a/src/targets/gpu/device_name.cpp
+++ b/src/targets/gpu/device_name.cpp
@@ -80,7 +80,9 @@ bool gfx_default_rocblas()
 {
     const auto device_name = trim(split_string(get_device_name(), ':').front());
     // Default to rocBLAS for gfx90a.
-    return (not enabled(MIGRAPHX_SET_GEMM_PROVIDER{}) ? (device_name == "gfx90a") : false);
+    return ((string_value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == "hipblaslt")
+                ? false
+                : (device_name == "gfx90a"));
 }
 #endif
 


### PR DESCRIPTION
Use string_value instead of enabled to see if the variable is set for gfx_default_rocblas().

This fixes an issue where we always default to rocblas for gfx90a, even when
MIGRAPHX_SET_GEMM_PROVIDER is set to hipblaslt.