### PR TITLE
Detect when parallel stl is not parallel and enable when it is in parallel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,10 +129,9 @@ set(MIGRAPHX_ENABLE_FPGA Off CACHE BOOL "")
 
 set(MIGRAPHX_HAS_EXECUTORS_DEFAULT Off)
 find_package(ParallelSTL QUIET)
-# TODO: resolve parallism issue
-# if(ParallelSTL_FOUND)
-# set(MIGRAPHX_HAS_EXECUTORS_DEFAULT On)
-# endif()
+if(ParallelSTL_FOUND)
+    set(MIGRAPHX_HAS_EXECUTORS_DEFAULT On)
+endif()
 option(MIGRAPHX_HAS_EXECUTORS "C++ supports parallel executors" ${MIGRAPHX_HAS_EXECUTORS_DEFAULT})
 if(MIGRAPHX_HAS_EXECUTORS AND ParallelSTL_USES_TBB)
     list(APPEND PACKAGE_DEPENDS libtbb2)

--- a/cmake/FindParallelSTL.cmake
+++ b/cmake/FindParallelSTL.cmake
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/cmake/FindParallelSTL.cmake
+++ b/cmake/FindParallelSTL.cmake
@@ -35,6 +35,10 @@ function(find_parallel_stl_check RESULT)
     set(_source "
 #include <execution>
 
+#ifdef _PSTL_PAR_BACKEND_SERIAL
+#error \"Using serial backend\"
+#endif
+
 int main() {
     int* i = nullptr;
     std::sort(std::execution::par, i, i);

--- a/src/include/migraphx/par.hpp
+++ b/src/include/migraphx/par.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/par.hpp
+++ b/src/include/migraphx/par.hpp
@@ -27,13 +27,18 @@
 #include <migraphx/config.hpp>
 #if MIGRAPHX_HAS_EXECUTORS
 #include <execution>
-#else
+// Warn if paralle stl is not parallel
+#ifdef _PSTL_PAR_BACKEND_SERIAL
+#warning "Using serial backend for parallel stl"
+#endif
+#else // MIGRAPHX_HAS_EXECUTORS
 #include <migraphx/simple_par_for.hpp>
 #endif
 #include <algorithm>
 #include <mutex>
 #include <vector>
 #include <exception>
+
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {

--- a/src/include/migraphx/par.hpp
+++ b/src/include/migraphx/par.hpp
@@ -39,7 +39,6 @@
 #include <vector>
 #include <exception>
 
-
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 

--- a/src/include/migraphx/par.hpp
+++ b/src/include/migraphx/par.hpp
@@ -27,7 +27,7 @@
 #include <migraphx/config.hpp>
 #if MIGRAPHX_HAS_EXECUTORS
 #include <execution>
-// Warn if paralle stl is not parallel
+// Warn if parallel stl is not parallel
 #ifdef _PSTL_PAR_BACKEND_SERIAL
 #warning "Using serial backend for parallel stl"
 #endif

--- a/src/include/migraphx/par_for.hpp
+++ b/src/include/migraphx/par_for.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/par_for.hpp
+++ b/src/include/migraphx/par_for.hpp
@@ -25,6 +25,7 @@
 #define MIGRAPHX_GUARD_RTGLIB_PAR_FOR_HPP
 
 #include <migraphx/par.hpp>
+#include <migraphx/simple_par_for.hpp>
 #include <migraphx/ranges.hpp>
 
 namespace migraphx {


### PR DESCRIPTION
When TBB is not found with libstdc++ then the parallel stl will be serial, so we try to detect that by checking the `_PSTL_PAR_BACKEND_SERIAL` macro which gets defined for this case. 

Now that we can detect the parallel stl correctly we can now enable this when its available. 