### PR TITLE
Fix compilation with hiBLASLt on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,18 +62,17 @@ option(MIGRAPHX_ENABLE_PYTHON "Enable python bindings" ON)
 endif()
 
 if(WIN32)
-option(MIGRAPHX_USE_ROCBLAS "Enable MIGraphX to use rocBLAS" OFF)
-else()
-option(MIGRAPHX_USE_ROCBLAS "Enable MIGraphX to use rocBLAS" ON)
-endif()
-
-if(WIN32)
 option(MIGRAPHX_USE_MIOPEN "Enable MIGraphX to use MIOpen" OFF)
 else()
 option(MIGRAPHX_USE_MIOPEN "Enable MIGraphX to use MIOpen" ON)
 endif()
 
+option(MIGRAPHX_USE_ROCBLAS "Enable MIGraphX to use rocBLAS" ON)
 option(MIGRAPHX_USE_HIPBLASLT "Enable MIGraphX to use hipBLASLt" ON)
+
+if(MIGRAPHX_USE_HIPBLASLT AND NOT MIGRAPHX_USE_ROCBLAS)
+    message(FATAL_ERROR "hipBLASLt requires rocBLAS, but MIGRAPHX_USE_ROCBLAS is OFF")
+endif()
 
 # By default build shared libraries
 option(BUILD_SHARED_LIBS "Create shared libraries" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,11 +73,7 @@ else()
 option(MIGRAPHX_USE_MIOPEN "Enable MIGraphX to use MIOpen" ON)
 endif()
 
-if(WIN32)
-option(MIGRAPHX_USE_HIPBLASLT "Enable MIGraphX to use hipBLASLt" OFF)
-else()
 option(MIGRAPHX_USE_HIPBLASLT "Enable MIGraphX to use hipBLASLt" ON)
-endif()
 
 # By default build shared libraries
 option(BUILD_SHARED_LIBS "Create shared libraries" ON)

--- a/src/targets/gpu/include/migraphx/gpu/hip_gemm.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/hip_gemm.hpp
@@ -42,7 +42,7 @@ namespace gpu {
 struct context;
 
 template <class Op>
-struct hip_gemm
+struct MIGRAPHX_GPU_EXPORT hip_gemm
 {
     Op op;
     float alpha          = 1;

--- a/src/targets/gpu/include/migraphx/gpu/hip_gemm_impl.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/hip_gemm_impl.hpp
@@ -68,7 +68,6 @@ int32_t hip_gemm_finalize(context& ctx,
                           float beta,
                           int32_t solution_idx);
 
-
 MIGRAPHX_GPU_EXPORT int32_t hip_gemm_default_solution(context& ctx,
                                                       const shape& output_shape,
                                                       const std::vector<shape>& input_shapes);

--- a/src/targets/gpu/include/migraphx/gpu/hip_gemm_impl.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/hip_gemm_impl.hpp
@@ -53,13 +53,15 @@ shape transpose_batch_hip(const shape& s, unsigned trans_batch);
  * @param alpha .
  * @param beta .
  */
-void hip_gemm_compute(context& ctx,
-                      const shape& output_shape,
-                      const std::vector<argument>& args,
-                      float alpha,
-                      float beta,
-                      int32_t solution_idx);
+MIGRAPHX_GPU_EXPORT void
+hip_gemm_compute(context& ctx,
+                 const shape& output_shape,
+                 const std::vector<argument>& args,
+                 float alpha,
+                 float beta,
+                 int32_t solution_idx);
 
+MIGRAPHX_GPU_EXPORT
 int32_t hip_gemm_finalize(context& ctx,
                           const shape& output_shape,
                           const std::vector<shape>& input_shapes,
@@ -67,16 +69,19 @@ int32_t hip_gemm_finalize(context& ctx,
                           float beta,
                           int32_t solution_idx);
 
-int32_t hip_gemm_default_solution(context& ctx,
-                                  const shape& output_shape,
-                                  const std::vector<shape>& input_shapes);
 
-size_t hip_gemm_workspace_size(context& ctx,
-                               const shape& output_shape,
-                               const std::vector<shape>& input_shapes,
-                               float alpha,
-                               float beta,
-                               int32_t solution_idx);
+MIGRAPHX_GPU_EXPORT int32_t
+hip_gemm_default_solution(context& ctx,
+                          const shape& output_shape,
+                          const std::vector<shape>& input_shapes);
+
+MIGRAPHX_GPU_EXPORT size_t
+hip_gemm_workspace_size(context& ctx,
+                        const shape& output_shape,
+                        const std::vector<shape>& input_shapes,
+                        float alpha,
+                        float beta,
+                        int32_t solution_idx);
 
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/targets/gpu/include/migraphx/gpu/hip_gemm_impl.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/hip_gemm_impl.hpp
@@ -53,13 +53,12 @@ shape transpose_batch_hip(const shape& s, unsigned trans_batch);
  * @param alpha .
  * @param beta .
  */
-MIGRAPHX_GPU_EXPORT void
-hip_gemm_compute(context& ctx,
-                 const shape& output_shape,
-                 const std::vector<argument>& args,
-                 float alpha,
-                 float beta,
-                 int32_t solution_idx);
+MIGRAPHX_GPU_EXPORT void hip_gemm_compute(context& ctx,
+                                          const shape& output_shape,
+                                          const std::vector<argument>& args,
+                                          float alpha,
+                                          float beta,
+                                          int32_t solution_idx);
 
 MIGRAPHX_GPU_EXPORT
 int32_t hip_gemm_finalize(context& ctx,
@@ -70,18 +69,16 @@ int32_t hip_gemm_finalize(context& ctx,
                           int32_t solution_idx);
 
 
-MIGRAPHX_GPU_EXPORT int32_t
-hip_gemm_default_solution(context& ctx,
-                          const shape& output_shape,
-                          const std::vector<shape>& input_shapes);
+MIGRAPHX_GPU_EXPORT int32_t hip_gemm_default_solution(context& ctx,
+                                                      const shape& output_shape,
+                                                      const std::vector<shape>& input_shapes);
 
-MIGRAPHX_GPU_EXPORT size_t
-hip_gemm_workspace_size(context& ctx,
-                        const shape& output_shape,
-                        const std::vector<shape>& input_shapes,
-                        float alpha,
-                        float beta,
-                        int32_t solution_idx);
+MIGRAPHX_GPU_EXPORT size_t hip_gemm_workspace_size(context& ctx,
+                                                   const shape& output_shape,
+                                                   const std::vector<shape>& input_shapes,
+                                                   float alpha,
+                                                   float beta,
+                                                   int32_t solution_idx);
 
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/targets/gpu/include/migraphx/gpu/hipblaslt.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/hipblaslt.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/include/migraphx/gpu/hipblaslt.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/hipblaslt.hpp
@@ -100,7 +100,7 @@ using hipblaslt_preference_ptr = MIGRAPHX_MANAGE_PTR(hipblasLtMatmulPreference_t
 
 hipblaslt_handle_ptr create_hipblaslt_handle_ptr();
 hipblaslt_preference_ptr create_hipblaslt_preference_ptr();
-bool hipblaslt_supported();
+MIGRAPHX_GPU_EXPORT bool hipblaslt_supported();
 const size_t hipblaslt_workspace_size = 2 * 128 * 1024 * 1024;
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS


### PR DESCRIPTION
hipBLASLt is avaialble on Windows now. This PR makes it possible to compile MIGraphX with hipBLASLt on Windows.