### PR TITLE
Rewrite transpose/reshape/broadcast between pointwise/reduce operators

### DIFF
--- a/src/include/migraphx/matcher.hpp
+++ b/src/include/migraphx/matcher.hpp
@@ -31,6 +31,7 @@
 #include <migraphx/module.hpp>
 #include <migraphx/optional.hpp>
 #include <migraphx/iterator_for.hpp>
+#include <migraphx/stringutils.hpp>
 #include <migraphx/type_name.hpp>
 #include <migraphx/source_location.hpp>
 #include <migraphx/config.hpp>
@@ -534,7 +535,7 @@ struct match_fold_f
     template <class... Ts>
     auto operator()(Ts... ms) const
     {
-        return make_bf_matcher(
+        return make_basic_fun_matcher(
             [=](matcher_context& ctx, instruction_ref ins) -> optional<instruction_ref> {
                 bool matches = match_fold_f::fold_matchers(ctx, ins, ms...);
                 if(matches == Matches)
@@ -549,7 +550,7 @@ struct match_fold_f
         return [=](auto... ms) {
             // Workaround ICE on gcc by packing matchers into an object
             auto mpack = pack(ms...);
-            return make_bf_matcher(
+            return make_basic_fun_matcher(
                 [=](matcher_context& ctx, instruction_ref start) -> optional<instruction_ref> {
                     Op op;
                     bool matches = Start;
@@ -1002,6 +1003,8 @@ auto pointwise(Ms... ms)
 {
     return match::has_attribute("pointwise")(ms...);
 }
+
+MIGRAPHX_PRED_MATCHER(reduce, instruction_ref ins) { return starts_with(ins->name(), "reduce_"); }
 
 } // namespace match
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/include/migraphx/rewrite_reshapes.hpp
+++ b/src/include/migraphx/rewrite_reshapes.hpp
@@ -162,6 +162,12 @@ struct rewrite_reshapes
                 shape_transform_descriptor::create(x_ins->get_shape().lens(), ops).rebase(dims2);
             if(desc.empty())
                 return;
+
+            // std::cout << "***************************************************************\n";
+            // std::cout << "ops: " << to_string_range(ops) << "\n";
+            // mpm.get_module().debug_print({x_ins, input_ins, ins});
+            // std::cout << "desc: " << desc << std::endl;
+
             auto cdims         = desc.common_dims();
             auto reshape_input = [&](const auto& ins_to_insert, auto generate) {
                 return [&, generate](auto input) {

--- a/src/include/migraphx/shape_transform_descriptor.hpp
+++ b/src/include/migraphx/shape_transform_descriptor.hpp
@@ -77,7 +77,7 @@ struct MIGRAPHX_EXPORT shape_transform_descriptor
     static shape_transform_descriptor create(const std::vector<std::size_t>& dims,
                                              const std::vector<operation>& ops);
 
-    shape_transform_descriptor rebase(const std::vector<std::size_t>& dims) const;
+    shape_transform_descriptor rebase(const std::vector<std::size_t>& dims, bool broadcast = false) const;
 
     bool apply(const std::vector<operation>& ops);
     bool apply_reshape(const std::vector<std::size_t>& rdims);

--- a/src/include/migraphx/shape_transform_descriptor.hpp
+++ b/src/include/migraphx/shape_transform_descriptor.hpp
@@ -77,7 +77,8 @@ struct MIGRAPHX_EXPORT shape_transform_descriptor
     static shape_transform_descriptor create(const std::vector<std::size_t>& dims,
                                              const std::vector<operation>& ops);
 
-    shape_transform_descriptor rebase(const std::vector<std::size_t>& dims, bool broadcast = false) const;
+    shape_transform_descriptor rebase(const std::vector<std::size_t>& dims,
+                                      bool broadcast = false) const;
 
     bool apply(const std::vector<operation>& ops);
     bool apply_reshape(const std::vector<std::size_t>& rdims);

--- a/src/include/migraphx/shape_transform_descriptor.hpp
+++ b/src/include/migraphx/shape_transform_descriptor.hpp
@@ -99,6 +99,8 @@ struct MIGRAPHX_EXPORT shape_transform_descriptor
     generate_common_from_dst(const std::vector<std::size_t>& input_dims = {}) const;
     std::vector<operation>
     generate_dst_from_common(const std::vector<std::size_t>& input_dims = {}) const;
+    std::vector<operation>
+    generate_src_from_common(const std::vector<std::size_t>& input_dims = {}) const;
     std::vector<std::vector<std::size_t>> common_axes_map_from_src() const;
     std::vector<std::vector<std::size_t>> common_axes_map_from_dst() const;
 

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -1063,6 +1063,9 @@ std::vector<operation> shape_transform_descriptor::generate_common_from_dst(
     for(std::size_t i : range(dimensions.size()))
     {
         const auto& d = dimensions[i];
+        // Bool if the dimensions match the input_dims. If they dont match
+        // then we want to keep the hidden axis, so there len can be replaced
+        // in make_reshape_unsqueeze.
         bool is_equal = true;
         if(i < input_dims.size())
             is_equal = (input_dims[i] == d.len());

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -1122,7 +1122,7 @@ std::vector<operation> shape_transform_descriptor::generate_src_from_common(
     // Need transpose
     if(not std::is_sorted(permutation.begin(), permutation.end()))
     {
-        result.push_back(make_op("transpose", {{"permutation", invert_permutation(permutation)}}));
+        result.push_back(make_op("transpose", {{"permutation", permutation}}));
         subs = reorder_dims(subs, permutation);
     }
 

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -163,11 +163,8 @@ shape_transform_descriptor::rebase(const std::vector<std::size_t>& dims) const
                                               std::multiplies<>{},
                                               [](const dimension::sub* s) { return s->len; });
         if(dim == final_dim)
-        {
-            for(auto* sub : subs)
-                sub->expose();
-        }
-        else if(dim == 1)
+            continue;
+        if(dim == 1)
         {
             for(auto* sub : subs)
             {
@@ -178,7 +175,7 @@ shape_transform_descriptor::rebase(const std::vector<std::size_t>& dims) const
         else if(subs.size() == 1)
         {
             subs.front()->len = dim;
-            subs.front()->expose();
+            subs.front()->hide();
         }
         else
             MIGRAPHX_THROW("Invalid rebase");
@@ -1056,16 +1053,34 @@ std::vector<operation> shape_transform_descriptor::generate_common_from_dst(
     for(std::size_t i : range(dimensions.size()))
     {
         const auto& d = dimensions[i];
+        const std::size_t nhidden = std::count_if(
+            d.subdimensions.begin(), d.subdimensions.end(), [](const dimension::sub& s) {
+                return s.has_hidden_axis();
+            });
+        const bool split_dimension = d.subdimensions.size() > (nhidden + 1);
         std::transform(d.subdimensions.begin(),
                        d.subdimensions.end(),
                        range(d.subdimensions.size()).begin(),
                        std::back_inserter(subs),
                        [&](dimension::sub s, auto j) {
+                        if(s.has_hidden_axis())
+                        {
+                            s.hidden_axis = {i};
+                            s.add_split_axis(j);
+                        }
+                        else
+                        {
                            s.axis = {i};
-                           if(d.subdimensions.size() > 1)
-                               s.axis.push_back(j);
+                           if(split_dimension)
+                               s.add_split_axis(j);
+                        }
                            return s;
                        });
+        if(nhidden == d.subdimensions.size())
+        {
+            for(auto& s:subs)
+                s.expose();
+        }
     }
     return {make_reshape_unsqueeze(subs, input_dims)};
 }

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -1139,9 +1139,7 @@ std::vector<operation> shape_transform_descriptor::generate_dst_from_common(
     std::vector<dimension> new_dims = dimensions;
     if(input_dims.empty())
     {
-        for_each_subdimension(new_dims, [&](auto& s) {
-            s.expose();
-        });
+        for_each_subdimension(new_dims, [&](auto& s) { s.expose(); });
     }
     else
     {

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -175,8 +175,8 @@ shape_transform_descriptor shape_transform_descriptor::create(const std::vector<
     return result;
 }
 
-shape_transform_descriptor
-shape_transform_descriptor::rebase(const std::vector<std::size_t>& dims, bool broadcast) const
+shape_transform_descriptor shape_transform_descriptor::rebase(const std::vector<std::size_t>& dims,
+                                                              bool broadcast) const
 {
     auto result   = *this;
     for(auto& [axis, subs] : group_axes(result.dimensions))
@@ -205,7 +205,7 @@ shape_transform_descriptor::rebase(const std::vector<std::size_t>& dims, bool br
             subs.front()->len = dim;
             if(broadcast)
                 subs.front()->hide();
-            else 
+            else
                 subs.front()->expose();
         }
         else

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -918,7 +918,6 @@ static std::vector<int64_t> find_permutation(std::vector<dimension::sub> tsubs)
     return sort_permutation(tsubs, compare_sub(std::less<>{}));
 }
 
-
 static void generate_from_subdimensions(operation_list& result,
                                         std::vector<dimension::sub> subs,
                                         const std::vector<std::size_t>& input_dims = {})
@@ -1095,7 +1094,7 @@ std::vector<operation> shape_transform_descriptor::generate_src_from_common(
     std::vector<operation> result;
 
     auto subs = get_all_subdimensions(dimensions);
-    for(auto i:range(subs.size()))
+    for(auto i : range(subs.size()))
     {
         auto& s = subs[i];
         if(i < input_dims.size())
@@ -1113,11 +1112,15 @@ std::vector<operation> shape_transform_descriptor::generate_src_from_common(
     }
 
     std::vector<dimension> new_dims;
-    group_by(subs.begin(), subs.end(), [&](auto start, auto last) { new_dims.push_back({{start, last}}); }, [&](const auto& x, const auto& y) { 
-        if(x.axis.empty() or y.axis.empty())
-            return x.axis.empty() == y.axis.empty();
-        return x.axis.front() == y.axis.front();
-    });
+    group_by(
+        subs.begin(),
+        subs.end(),
+        [&](auto start, auto last) { new_dims.push_back({{start, last}}); },
+        [&](const auto& x, const auto& y) {
+            if(x.axis.empty() or y.axis.empty())
+                return x.axis.empty() == y.axis.empty();
+            return x.axis.front() == y.axis.front();
+        });
 
     // Need squeeze reshape
     if(std::any_of(new_dims.begin(), new_dims.end(), [](const dimension& d) {

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -716,6 +716,15 @@ void shape_transform_descriptor::simplify()
     collapse_1_dims(dimensions);
 }
 
+static void expose(std::vector<dimension::sub>& subs)
+{
+    for(auto& s : subs)
+    {
+        if(s.has_hidden_axis())
+            s.expose();
+    }
+}
+
 static std::size_t get_len(const dimension::sub& s, const std::vector<std::size_t>& input_dims)
 {
     if(input_dims.empty())
@@ -1037,6 +1046,7 @@ std::vector<operation> shape_transform_descriptor::generate_common_from_src(
 {
     operation_list result;
     auto subs = get_all_subdimensions(dimensions);
+    expose(subs);
     generate_from_subdimensions(result, subs, input_dims);
     return std::move(result).to_vector();
 }
@@ -1074,13 +1084,10 @@ std::vector<operation> shape_transform_descriptor::generate_common_from_dst(
                                if(split_dimension)
                                    s.add_split_axis(j);
                            }
+                            if(nhidden == d.subdimensions.size())
+                                s.expose();
                            return s;
                        });
-        if(nhidden == d.subdimensions.size())
-        {
-            for(auto& s : subs)
-                s.expose();
-        }
     }
     return {make_reshape_unsqueeze(subs, input_dims)};
 }

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -77,7 +77,8 @@ shape_transform_descriptor::shape_transform_descriptor(const std::vector<std::si
 }
 
 template <class Dimensions, class F>
-static auto for_each_subdimension(Dimensions&& dimensions, F f) -> decltype(dimensions.begin()->subdimensions, void())
+static auto for_each_subdimension(Dimensions&& dimensions,
+                                  F f) -> decltype(dimensions.begin()->subdimensions, void())
 {
     for(auto& dim : dimensions)
     {
@@ -89,7 +90,8 @@ static auto for_each_subdimension(Dimensions&& dimensions, F f) -> decltype(dime
 }
 
 template <class SubDimensions, class F>
-static auto for_each_subdimension(SubDimensions&& subdimensions, F f) -> decltype(subdimensions.begin()->axis, void())
+static auto for_each_subdimension(SubDimensions&& subdimensions,
+                                  F f) -> decltype(subdimensions.begin()->axis, void())
 {
     for(auto& s : subdimensions)
     {
@@ -126,9 +128,8 @@ static void for_each_subdimension(Dimensions&& dimensions, Range&& r, F f)
 
 // Group all axes into a map with a key of the axis and the value is vector of
 // all subdimensions that have that axis.
-template<class Dimensions>
-static std::map<std::size_t, std::vector<dimension::sub*>>
-group_axes(Dimensions& dimensions)
+template <class Dimensions>
+static std::map<std::size_t, std::vector<dimension::sub*>> group_axes(Dimensions& dimensions)
 {
     std::map<std::size_t, std::vector<dimension::sub*>> axes_map;
     for_each_subdimension(dimensions, [&](auto& s) {
@@ -141,13 +142,11 @@ group_axes(Dimensions& dimensions)
 
 static std::size_t len(const std::vector<dimension::sub*>& subs)
 {
-    return transform_accumulate(subs.begin(),
-                                 subs.end(),
-                                 std::size_t{1},
-                                 std::multiplies<>{},
-                                 [](const dimension::sub* s) { return s->len; });
+    return transform_accumulate(
+        subs.begin(), subs.end(), std::size_t{1}, std::multiplies<>{}, [](const dimension::sub* s) {
+            return s->len;
+        });
 }
-
 
 static std::vector<std::size_t> compute_dims(const operation& op,
                                              const std::vector<std::size_t>& idims)
@@ -1077,10 +1076,9 @@ std::vector<operation> shape_transform_descriptor::generate_common_from_src(
             auto dim = len(gsubs);
             if(dim == input_dims.at(axis))
             {
-                for(auto& s:gsubs)
+                for(auto& s : gsubs)
                     s->expose();
             }
-
         }
     }
     generate_from_subdimensions(result, subs, input_dims);

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -1137,11 +1137,21 @@ std::vector<operation> shape_transform_descriptor::generate_dst_from_common(
 {
     std::vector<operation> result;
     std::vector<dimension> new_dims = dimensions;
-    if(not input_dims.empty())
-        for_each_subdimension(new_dims, input_dims, [&](auto& s, auto dim) {
-            s.len = dim;
+    if(input_dims.empty())
+    {
+        for_each_subdimension(new_dims, [&](auto& s) {
             s.expose();
         });
+    }
+    else
+    {
+        for_each_subdimension(new_dims, input_dims, [&](auto& s, auto dim) {
+            if(s.len == dim)
+                s.expose();
+            else
+                s.len = dim;
+        });
+    }
 
     // Need squeeze reshape
     if(std::any_of(new_dims.begin(), new_dims.end(), [](const dimension& d) {

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -1053,32 +1053,32 @@ std::vector<operation> shape_transform_descriptor::generate_common_from_dst(
     for(std::size_t i : range(dimensions.size()))
     {
         const auto& d = dimensions[i];
-        const std::size_t nhidden = std::count_if(
-            d.subdimensions.begin(), d.subdimensions.end(), [](const dimension::sub& s) {
-                return s.has_hidden_axis();
-            });
+        const std::size_t nhidden =
+            std::count_if(d.subdimensions.begin(),
+                          d.subdimensions.end(),
+                          [](const dimension::sub& s) { return s.has_hidden_axis(); });
         const bool split_dimension = d.subdimensions.size() > (nhidden + 1);
         std::transform(d.subdimensions.begin(),
                        d.subdimensions.end(),
                        range(d.subdimensions.size()).begin(),
                        std::back_inserter(subs),
                        [&](dimension::sub s, auto j) {
-                        if(s.has_hidden_axis())
-                        {
-                            s.hidden_axis = {i};
-                            s.add_split_axis(j);
-                        }
-                        else
-                        {
-                           s.axis = {i};
-                           if(split_dimension)
+                           if(s.has_hidden_axis())
+                           {
+                               s.hidden_axis = {i};
                                s.add_split_axis(j);
-                        }
+                           }
+                           else
+                           {
+                               s.axis = {i};
+                               if(split_dimension)
+                                   s.add_split_axis(j);
+                           }
                            return s;
                        });
         if(nhidden == d.subdimensions.size())
         {
-            for(auto& s:subs)
+            for(auto& s : subs)
                 s.expose();
         }
     }

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -1066,22 +1066,23 @@ std::vector<operation> shape_transform_descriptor::generate_common_from_dst(
         bool is_equal = true;
         if(i < input_dims.size())
             is_equal = (input_dims[i] == d.len());
-        const std::size_t nhidden = is_equal ? 0 :
-            std::count_if(d.subdimensions.begin(),
-                          d.subdimensions.end(),
-                          [](const dimension::sub& s) { return s.has_hidden_axis(); });
-        const bool split_dimension = (d.subdimensions.size()-nhidden) > 1;
+        const std::size_t nhidden =
+            is_equal ? 0
+                     : std::count_if(d.subdimensions.begin(),
+                                     d.subdimensions.end(),
+                                     [](const dimension::sub& s) { return s.has_hidden_axis(); });
+        const bool split_dimension = (d.subdimensions.size() - nhidden) > 1;
         std::transform(d.subdimensions.begin(),
                        d.subdimensions.end(),
                        range(d.subdimensions.size()).begin(),
                        std::back_inserter(subs),
                        [&](dimension::sub s, auto j) {
                            if(is_equal)
-                            s.expose();
+                               s.expose();
                            if(s.has_hidden_axis())
                            {
                                s.hidden_axis = {i};
-                                s.add_split_axis(j);
+                               s.add_split_axis(j);
                            }
                            else
                            {
@@ -1100,7 +1101,10 @@ std::vector<operation> shape_transform_descriptor::generate_dst_from_common(
     std::vector<operation> result;
     std::vector<dimension> new_dims = dimensions;
     if(not input_dims.empty())
-        for_each_subdimension(new_dims, input_dims, [&](auto& s, auto dim) { s.len = dim; s.expose(); });
+        for_each_subdimension(new_dims, input_dims, [&](auto& s, auto dim) {
+            s.len = dim;
+            s.expose();
+        });
 
     // Need squeeze reshape
     if(std::any_of(new_dims.begin(), new_dims.end(), [](const dimension& d) {

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -1084,8 +1084,8 @@ std::vector<operation> shape_transform_descriptor::generate_common_from_dst(
                                if(split_dimension)
                                    s.add_split_axis(j);
                            }
-                            if(nhidden == d.subdimensions.size())
-                                s.expose();
+                           if(nhidden == d.subdimensions.size())
+                               s.expose();
                            return s;
                        });
     }

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -271,9 +271,9 @@ struct find_op_shape_transform_op
         assert(x_ins->get_shape().lens() == new_x_ins->get_shape().lens());
         m.replace_instruction(x_ins, new_x_ins);
         // Replace final instruction
-        auto pw   = insert(m, ins, inputs, output_desc.common_axes_map_from_dst());
+        auto pw   = insert(m, ins, inputs, input_desc.common_axes_map_from_dst());
         auto rins = reshape_input(
-            ins, &shape_transform_descriptor::generate_dst_from_common, output_desc)(pw);
+            ins, &shape_transform_descriptor::generate_dst_from_common, input_desc)(pw);
         assert(ins->get_shape().lens() == rins->get_shape().lens());
         m.replace_instruction(ins, rins);
     }

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -246,14 +246,14 @@ struct find_op_shape_transform_op
                                      &shape_transform_descriptor::generate_common_from_src,
                                      input_desc));
         auto new_input_ins = insert(m, x_ins, x_inputs, input_desc.common_axes_map_from_src());
-        auto new_x_ins = reshape_input(
-            x_ins, &shape_transform_descriptor::generate_src_from_common, input_desc)(new_input_ins);
+        auto new_x_ins     = reshape_input(x_ins,
+                                       &shape_transform_descriptor::generate_src_from_common,
+                                       input_desc)(new_input_ins);
         if(new_input_ins->get_shape().elements() != input_ins->get_shape().elements())
         {
             new_input_ins = m.insert_instruction(
                 x_ins, make_op("multibroadcast", {{"out_lens", cdims}}), new_input_ins);
         }
-
 
         auto inputs = ins->inputs();
         std::transform(inputs.begin(), inputs.end(), inputs.begin(), [&](auto input) {

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -225,7 +225,7 @@ struct find_op_shape_transform_op
         auto input_desc = output_desc.rebase(x_ins->inputs().front()->get_shape().lens());
         if(input_desc.empty())
             return;
-        
+
         // std::cout << "***************************************************************\n";
         // std::cout << "ops: " << to_string_range(ops) << "\n";
         // m.debug_print({x_ins, input_ins, ins});

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -254,7 +254,6 @@ struct find_op_shape_transform_op
             new_input_ins = m.insert_instruction(
                 x_ins, make_op("multibroadcast", {{"out_lens", cdims}}), new_input_ins);
         }
-
         auto inputs = ins->inputs();
         std::transform(inputs.begin(), inputs.end(), inputs.begin(), [&](auto input) {
             if(input == input_ins)

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -125,7 +125,7 @@ struct find_op_shape_transform_op
 {
     auto matcher() const
     {
-        auto reshapes          = match::name("reshape",
+        auto reshapes      = match::name("reshape",
                                     "squeeze",
                                     "unsqueeze",
                                     "flatten",
@@ -133,131 +133,124 @@ struct find_op_shape_transform_op
                                     "contiguous",
                                     "multibroadcast",
                                     "broadcast")(match::used_once());
-        auto match_op = match::any_of(match::reduce(), match::pointwise());
-        auto x_op         = match_op(match::used_once());
-        auto reshapes_x_op =
-            reshapes(match::arg(0)(match::skip(reshapes())(x_op.bind("x"))));
-        return match_op(
-            match::any_of[match::inputs()](reshapes_x_op.bind("input")));
+        auto match_op      = match::any_of(match::reduce(), match::pointwise());
+        auto x_op          = match_op(match::used_once());
+        auto reshapes_x_op = reshapes(match::arg(0)(match::skip(reshapes())(x_op.bind("x"))));
+        return match_op(match::any_of[match::inputs()](reshapes_x_op.bind("input")));
     }
 
-    static bool is_reduce(instruction_ref ins)
+    static bool is_reduce(instruction_ref ins) { return starts_with(ins->name(), "reduce_"); }
+
+    template <class F>
+    static instruction_ref find_input_if(instruction_ref start, instruction_ref last, F f)
     {
-        return starts_with(ins->name(), "reduce_");
+        while(start != last)
+        {
+            if(f(start))
+                return start;
+            if(start->inputs().size() != 1)
+                return last;
+            start = start->inputs().front();
+        }
+        return last;
     }
 
     template <class F>
-        static instruction_ref find_input_if(instruction_ref start, instruction_ref last, F f)
+    static bool any_input_of(instruction_ref start, instruction_ref last, F f)
+    {
+        return find_input_if(start, last, f) != last;
+    }
+
+    template <class AxesMap>
+    static instruction_ref insert(module& m,
+                                  instruction_ref ins,
+                                  const std::vector<instruction_ref>& inputs,
+                                  const AxesMap& am)
+    {
+        if(is_reduce(ins))
         {
-            while(start != last)
+            auto v       = ins->get_operator().to_value();
+            auto op_axes = v.at("axes").to_vector<std::size_t>();
+            std::vector<int64_t> axes;
+            for(auto axis : op_axes)
             {
-                if(f(start))
-                    return start;
-                if(start->inputs().size() != 1)
-                    return last;
-                start = start->inputs().front();
+                auto new_axes = am.at(axis);
+                axes.insert(axes.end(), new_axes.begin(), new_axes.end());
             }
-            return last;
+            std::sort(axes.begin(), axes.end());
+            v["axes"] = axes;
+            m.insert_instruction(ins, make_op(ins->name(), v), inputs, ins->module_inputs());
         }
+        return m.insert_instruction(ins, ins->get_operator(), inputs, ins->module_inputs());
+    }
 
-        template <class F>
-        static bool any_input_of(instruction_ref start, instruction_ref last, F f)
+    void apply(module& m, const match::matcher_result& r) const
+    {
+        auto ins       = r.result;
+        auto x_ins     = r.instructions["x"];
+        auto input_ins = r.instructions["input"];
+
+        // If its just a broadcast then skip
+        if(not any_input_of(input_ins, x_ins, [](instruction_ref x) {
+               return not contains({"multibroadcast", "broadcast", "contiguous"}, x->name());
+           }))
+            return;
+
+        std::vector<operation> ops;
+        auto next_ins = input_ins;
+        while(next_ins != x_ins)
         {
-            return find_input_if(start, last, f) != last;
+            ops.push_back(next_ins->get_operator());
+            next_ins = next_ins->inputs().front();
         }
+        assert(next_ins == x_ins);
+        std::reverse(ops.begin(), ops.end());
 
-        template <class AxesMap>
-        static instruction_ref insert(module& m,
-                                      instruction_ref ins,
-                                      const std::vector<instruction_ref>& inputs,
-                                      const AxesMap& am)
-        {
-            if(is_reduce(ins))
-            {
-                auto v = ins->get_operator().to_value();
-                auto op_axes = v.at("axes").to_vector<std::size_t>();
-                std::vector<int64_t> axes;
-                for(auto axis : op_axes)
+        auto output_desc = shape_transform_descriptor::create(x_ins->get_shape().lens(), ops);
+        if(output_desc.empty())
+            return;
+        auto input_desc = output_desc.rebase(x_ins->inputs().front()->get_shape().lens());
+        if(input_desc.empty())
+            return;
+
+        auto cdims         = input_desc.common_dims();
+        auto reshape_input = [&](const auto& ins_to_insert, auto generate, const auto& desc) {
+            return [&, generate](auto input) {
+                auto gops  = std::invoke(generate, desc, input->get_shape().lens());
+                auto start = input;
+                for(const auto& op : gops)
                 {
-                    auto new_axes = am.at(axis);
-                    axes.insert(axes.end(), new_axes.begin(), new_axes.end());
+                    start = m.insert_instruction(ins_to_insert, op, start);
                 }
-                std::sort(axes.begin(), axes.end());
-                v["axes"] = axes;
-                m.insert_instruction(ins, make_op(ins->name(), v), inputs, ins->module_inputs());
-            }
-            return m.insert_instruction(
-                ins, ins->get_operator(), inputs, ins->module_inputs());
-        }
-
-        void apply(module& m, const match::matcher_result& r) const
-        {
-            auto ins         = r.result;
-            auto x_ins       = r.instructions["x"];
-            auto input_ins   = r.instructions["input"];
-
-
-            // If its just a broadcast then skip
-            if(not any_input_of(input_ins, x_ins, [](instruction_ref x) {
-                   return not contains({"multibroadcast", "broadcast", "contiguous"}, x->name());
-               }))
-                return;
-
-            std::vector<operation> ops;
-            auto next_ins = input_ins;
-            while(next_ins != x_ins)
-            {
-                ops.push_back(next_ins->get_operator());
-                next_ins = next_ins->inputs().front();
-            }
-            assert(next_ins == x_ins);
-            std::reverse(ops.begin(), ops.end());
-
-            auto output_desc = shape_transform_descriptor::create(x_ins->get_shape().lens(), ops);
-            if(output_desc.empty())
-                return;
-            auto input_desc = output_desc.rebase(x_ins->inputs().front()->get_shape().lens());
-            if(input_desc.empty())
-                return;
-
-            auto cdims         = input_desc.common_dims();
-            auto reshape_input = [&](const auto& ins_to_insert, auto generate, const auto& desc) {
-                return [&, generate](auto input) {
-                    auto gops  = std::invoke(generate, desc, input->get_shape().lens());
-                    auto start = input;
-                    for(const auto& op : gops)
-                    {
-                        start = m.insert_instruction(ins_to_insert, op, start);
-                    }
-                    return start;
-                };
+                return start;
             };
-            auto x_inputs = x_ins->inputs();
-            std::transform(
-                x_inputs.begin(),
-                x_inputs.end(),
-                x_inputs.begin(),
-                reshape_input(x_ins, &shape_transform_descriptor::generate_common_from_src, input_desc));
-            auto new_x_ins = insert(m, x_ins, x_inputs, input_desc.common_axes_map_from_src());
-            if(new_x_ins->get_shape().elements() != x_ins->get_shape().elements())
-            {
-                new_x_ins = m.insert_instruction(
-                    x_ins, make_op("multibroadcast", {{"out_lens", cdims}}), new_x_ins);
-            }
-
-            auto inputs = ins->inputs();
-            std::transform(inputs.begin(), inputs.end(), inputs.begin(), [&](auto input) {
-                if(input == input_ins)
-                    return new_x_ins;
-                return reshape_input(ins,
-                                     &shape_transform_descriptor::generate_common_from_dst, output_desc)(input);
-            });
-            auto pw = insert(m, ins, inputs, output_desc.common_axes_map_from_dst());
-            auto rins =
-                reshape_input(ins, &shape_transform_descriptor::generate_dst_from_common, output_desc)(pw);
-            m.replace_instruction(ins, rins);
+        };
+        auto x_inputs = x_ins->inputs();
+        std::transform(x_inputs.begin(),
+                       x_inputs.end(),
+                       x_inputs.begin(),
+                       reshape_input(x_ins,
+                                     &shape_transform_descriptor::generate_common_from_src,
+                                     input_desc));
+        auto new_x_ins = insert(m, x_ins, x_inputs, input_desc.common_axes_map_from_src());
+        if(new_x_ins->get_shape().elements() != x_ins->get_shape().elements())
+        {
+            new_x_ins = m.insert_instruction(
+                x_ins, make_op("multibroadcast", {{"out_lens", cdims}}), new_x_ins);
         }
 
+        auto inputs = ins->inputs();
+        std::transform(inputs.begin(), inputs.end(), inputs.begin(), [&](auto input) {
+            if(input == input_ins)
+                return new_x_ins;
+            return reshape_input(
+                ins, &shape_transform_descriptor::generate_common_from_dst, output_desc)(input);
+        });
+        auto pw   = insert(m, ins, inputs, output_desc.common_axes_map_from_dst());
+        auto rins = reshape_input(
+            ins, &shape_transform_descriptor::generate_dst_from_common, output_desc)(pw);
+        m.replace_instruction(ins, rins);
+    }
 };
 
 struct find_nop_reshapes

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -219,16 +219,18 @@ struct find_op_shape_transform_op
         assert(next_ins == x_ins);
         std::reverse(ops.begin(), ops.end());
 
-        // std::cout << "*********************\n";
-        // std::cout << "ops: " << to_string_range(ops) << "\n";
-        // m.debug_print({x_ins, input_ins, ins});
-
         auto output_desc = shape_transform_descriptor::create(x_ins->get_shape().lens(), ops);
         if(output_desc.empty())
             return;
         auto input_desc = output_desc.rebase(x_ins->inputs().front()->get_shape().lens());
         if(input_desc.empty())
             return;
+        
+        // std::cout << "***************************************************************\n";
+        // std::cout << "ops: " << to_string_range(ops) << "\n";
+        // m.debug_print({x_ins, input_ins, ins});
+        // std::cout << "input_desc: " << input_desc << std::endl;
+        // std::cout << "output_desc: " << output_desc << std::endl;
 
         auto cdims         = input_desc.common_dims();
         auto reshape_input = [&](const auto& ins_to_insert, auto generate, const auto& desc) {

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -125,7 +125,7 @@ struct find_op_shape_transform_op
 {
     auto matcher() const
     {
-        auto reshapes      = match::name("reshape",
+        auto reshapes          = match::name("reshape",
                                     "squeeze",
                                     "unsqueeze",
                                     "flatten",
@@ -133,124 +133,144 @@ struct find_op_shape_transform_op
                                     "contiguous",
                                     "multibroadcast",
                                     "broadcast")(match::used_once());
-        auto match_op      = match::any_of(match::reduce(), match::pointwise());
-        auto x_op          = match_op(match::used_once());
-        auto reshapes_x_op = reshapes(match::arg(0)(match::skip(reshapes())(x_op.bind("x"))));
-        return match_op(match::any_of[match::inputs()](reshapes_x_op.bind("input")));
+        auto match_op = match::any_of(match::reduce(), match::pointwise());
+        auto x_op         = match_op(match::used_once());
+        auto reshapes_x_op =
+            reshapes(match::arg(0)(match::skip(reshapes())(x_op.bind("x"))));
+        return match_op(
+            match::any_of[match::inputs()](reshapes_x_op.bind("input")));
     }
 
-    static bool is_reduce(instruction_ref ins) { return starts_with(ins->name(), "reduce_"); }
-
-    template <class F>
-    static instruction_ref find_input_if(instruction_ref start, instruction_ref last, F f)
+    static bool is_reduce(instruction_ref ins)
     {
-        while(start != last)
-        {
-            if(f(start))
-                return start;
-            if(start->inputs().size() != 1)
-                return last;
-            start = start->inputs().front();
-        }
-        return last;
+        return starts_with(ins->name(), "reduce_");
     }
 
     template <class F>
-    static bool any_input_of(instruction_ref start, instruction_ref last, F f)
-    {
-        return find_input_if(start, last, f) != last;
-    }
-
-    template <class AxesMap>
-    static instruction_ref insert(module& m,
-                                  instruction_ref ins,
-                                  const std::vector<instruction_ref>& inputs,
-                                  const AxesMap& am)
-    {
-        if(is_reduce(ins))
+        static instruction_ref find_input_if(instruction_ref start, instruction_ref last, F f)
         {
-            auto v       = ins->get_operator().to_value();
-            auto op_axes = v.at("axes").to_vector<std::size_t>();
-            std::vector<int64_t> axes;
-            for(auto axis : op_axes)
+            while(start != last)
             {
-                auto new_axes = am.at(axis);
-                axes.insert(axes.end(), new_axes.begin(), new_axes.end());
+                if(f(start))
+                    return start;
+                if(start->inputs().size() != 1)
+                    return last;
+                start = start->inputs().front();
             }
-            std::sort(axes.begin(), axes.end());
-            v["axes"] = axes;
-            m.insert_instruction(ins, make_op(ins->name(), v), inputs, ins->module_inputs());
+            return last;
         }
-        return m.insert_instruction(ins, ins->get_operator(), inputs, ins->module_inputs());
-    }
 
-    void apply(module& m, const match::matcher_result& r) const
-    {
-        auto ins       = r.result;
-        auto x_ins     = r.instructions["x"];
-        auto input_ins = r.instructions["input"];
-
-        // If its just a broadcast then skip
-        if(not any_input_of(input_ins, x_ins, [](instruction_ref x) {
-               return not contains({"multibroadcast", "broadcast", "contiguous"}, x->name());
-           }))
-            return;
-
-        std::vector<operation> ops;
-        auto next_ins = input_ins;
-        while(next_ins != x_ins)
+        template <class F>
+        static bool any_input_of(instruction_ref start, instruction_ref last, F f)
         {
-            ops.push_back(next_ins->get_operator());
-            next_ins = next_ins->inputs().front();
+            return find_input_if(start, last, f) != last;
         }
-        assert(next_ins == x_ins);
-        std::reverse(ops.begin(), ops.end());
 
-        auto output_desc = shape_transform_descriptor::create(x_ins->get_shape().lens(), ops);
-        if(output_desc.empty())
-            return;
-        auto input_desc = output_desc.rebase(x_ins->inputs().front()->get_shape().lens());
-        if(input_desc.empty())
-            return;
-
-        auto cdims         = input_desc.common_dims();
-        auto reshape_input = [&](const auto& ins_to_insert, auto generate, const auto& desc) {
-            return [&, generate](auto input) {
-                auto gops  = std::invoke(generate, desc, input->get_shape().lens());
-                auto start = input;
-                for(const auto& op : gops)
+        template <class AxesMap>
+        static instruction_ref insert(module& m,
+                                      instruction_ref ins,
+                                      const std::vector<instruction_ref>& inputs,
+                                      const AxesMap& am)
+        {
+            if(is_reduce(ins))
+            {
+                auto v = ins->get_operator().to_value();
+                auto op_axes = v.at("axes").to_vector<std::size_t>();
+                std::vector<int64_t> axes;
+                for(auto axis : op_axes)
                 {
-                    start = m.insert_instruction(ins_to_insert, op, start);
+                    auto new_axes = am.at(axis);
+                    axes.insert(axes.end(), new_axes.begin(), new_axes.end());
                 }
-                return start;
-            };
-        };
-        auto x_inputs = x_ins->inputs();
-        std::transform(x_inputs.begin(),
-                       x_inputs.end(),
-                       x_inputs.begin(),
-                       reshape_input(x_ins,
-                                     &shape_transform_descriptor::generate_common_from_src,
-                                     input_desc));
-        auto new_x_ins = insert(m, x_ins, x_inputs, input_desc.common_axes_map_from_src());
-        if(new_x_ins->get_shape().elements() != x_ins->get_shape().elements())
-        {
-            new_x_ins = m.insert_instruction(
-                x_ins, make_op("multibroadcast", {{"out_lens", cdims}}), new_x_ins);
+                std::sort(axes.begin(), axes.end());
+                v["axes"] = axes;
+                return m.insert_instruction(ins, make_op(ins->name(), v), inputs, ins->module_inputs());
+            }
+            if(ins->name() == "layout")
+            {
+                auto v = ins->get_operator().to_value();
+                auto op_permutation = v.at("permutation").to_vector<std::int64_t>();
+                std::vector<int64_t> permutation;
+                for(auto axis : op_permutation)
+                {
+                    auto new_axes = am.at(axis);
+                    permutation.insert(permutation.end(), new_axes.begin(), new_axes.end());
+                }
+                v["permutation"] = permutation;
+                return m.insert_instruction(ins, make_op(ins->name(), v), inputs, ins->module_inputs());
+            }
+            return m.insert_instruction(
+                ins, ins->get_operator(), inputs, ins->module_inputs());
         }
 
-        auto inputs = ins->inputs();
-        std::transform(inputs.begin(), inputs.end(), inputs.begin(), [&](auto input) {
-            if(input == input_ins)
-                return new_x_ins;
-            return reshape_input(
-                ins, &shape_transform_descriptor::generate_common_from_dst, output_desc)(input);
-        });
-        auto pw   = insert(m, ins, inputs, output_desc.common_axes_map_from_dst());
-        auto rins = reshape_input(
-            ins, &shape_transform_descriptor::generate_dst_from_common, output_desc)(pw);
-        m.replace_instruction(ins, rins);
-    }
+        void apply(module& m, const match::matcher_result& r) const
+        {
+            auto ins         = r.result;
+            auto x_ins       = r.instructions["x"];
+            auto input_ins   = r.instructions["input"];
+
+
+            // If its just a broadcast then skip
+            if(not any_input_of(input_ins, x_ins, [](instruction_ref x) {
+                   return not contains({"multibroadcast", "broadcast", "contiguous"}, x->name());
+               }))
+                return;
+
+            std::vector<operation> ops;
+            auto next_ins = input_ins;
+            while(next_ins != x_ins)
+            {
+                ops.push_back(next_ins->get_operator());
+                next_ins = next_ins->inputs().front();
+            }
+            assert(next_ins == x_ins);
+            std::reverse(ops.begin(), ops.end());
+
+            auto output_desc = shape_transform_descriptor::create(x_ins->get_shape().lens(), ops);
+            if(output_desc.empty())
+                return;
+            auto input_desc = output_desc.rebase(x_ins->inputs().front()->get_shape().lens());
+            if(input_desc.empty())
+                return;
+
+            auto cdims         = input_desc.common_dims();
+            auto reshape_input = [&](const auto& ins_to_insert, auto generate, const auto& desc) {
+                return [&, generate](auto input) {
+                    auto gops  = std::invoke(generate, desc, input->get_shape().lens());
+                    auto start = input;
+                    for(const auto& op : gops)
+                    {
+                        start = m.insert_instruction(ins_to_insert, op, start);
+                    }
+                    return start;
+                };
+            };
+            auto x_inputs = x_ins->inputs();
+            std::transform(
+                x_inputs.begin(),
+                x_inputs.end(),
+                x_inputs.begin(),
+                reshape_input(x_ins, &shape_transform_descriptor::generate_common_from_src, input_desc));
+            auto new_x_ins = insert(m, x_ins, x_inputs, input_desc.common_axes_map_from_src());
+            if(new_x_ins->get_shape().elements() != x_ins->get_shape().elements())
+            {
+                new_x_ins = m.insert_instruction(
+                    x_ins, make_op("multibroadcast", {{"out_lens", cdims}}), new_x_ins);
+            }
+
+            auto inputs = ins->inputs();
+            std::transform(inputs.begin(), inputs.end(), inputs.begin(), [&](auto input) {
+                if(input == input_ins)
+                    return new_x_ins;
+                return reshape_input(ins,
+                                     &shape_transform_descriptor::generate_common_from_dst, output_desc)(input);
+            });
+            auto pw = insert(m, ins, inputs, output_desc.common_axes_map_from_dst());
+            auto rins =
+                reshape_input(ins, &shape_transform_descriptor::generate_dst_from_common, output_desc)(pw);
+            m.replace_instruction(ins, rins);
+        }
+
 };
 
 struct find_nop_reshapes

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -219,6 +219,10 @@ struct find_op_shape_transform_op
         assert(next_ins == x_ins);
         std::reverse(ops.begin(), ops.end());
 
+        // std::cout << "*********************\n";
+        // std::cout << "ops: " << to_string_range(ops) << "\n";
+        // m.debug_print({x_ins, input_ins, ins});
+
         auto output_desc = shape_transform_descriptor::create(x_ins->get_shape().lens(), ops);
         if(output_desc.empty())
             return;

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -121,6 +121,145 @@ struct find_nested_shape_transforms
     }
 };
 
+struct find_op_shape_transform_op
+{
+    auto matcher() const
+    {
+        auto reshapes          = match::name("reshape",
+                                    "squeeze",
+                                    "unsqueeze",
+                                    "flatten",
+                                    "transpose",
+                                    "contiguous",
+                                    "multibroadcast",
+                                    "broadcast")(match::used_once());
+        auto match_op = match::any_of(match::reduce(), match::pointwise());
+        auto x_op         = match_op(match::used_once());
+        auto reshapes_x_op =
+            reshapes(match::arg(0)(match::skip(reshapes())(x_op.bind("x"))));
+        return match_op(
+            match::any_of[match::inputs()](reshapes_x_op.bind("input")));
+    }
+
+    static bool is_reduce(instruction_ref ins)
+    {
+        return starts_with(ins->name(), "reduce_");
+    }
+
+    template <class F>
+        static instruction_ref find_input_if(instruction_ref start, instruction_ref last, F f)
+        {
+            while(start != last)
+            {
+                if(f(start))
+                    return start;
+                if(start->inputs().size() != 1)
+                    return last;
+                start = start->inputs().front();
+            }
+            return last;
+        }
+
+        template <class F>
+        static bool any_input_of(instruction_ref start, instruction_ref last, F f)
+        {
+            return find_input_if(start, last, f) != last;
+        }
+
+        template <class AxesMap>
+        static instruction_ref insert(module& m,
+                                      instruction_ref ins,
+                                      const std::vector<instruction_ref>& inputs,
+                                      const AxesMap& am)
+        {
+            if(is_reduce(ins))
+            {
+                auto v = ins->get_operator().to_value();
+                auto op_axes = v.at("axes").to_vector<std::size_t>();
+                std::vector<int64_t> axes;
+                for(auto axis : op_axes)
+                {
+                    auto new_axes = am.at(axis);
+                    axes.insert(axes.end(), new_axes.begin(), new_axes.end());
+                }
+                std::sort(axes.begin(), axes.end());
+                v["axes"] = axes;
+                m.insert_instruction(ins, make_op(ins->name(), v), inputs, ins->module_inputs());
+            }
+            return m.insert_instruction(
+                ins, ins->get_operator(), inputs, ins->module_inputs());
+        }
+
+        void apply(module& m, const match::matcher_result& r) const
+        {
+            auto ins         = r.result;
+            auto x_ins       = r.instructions["x"];
+            auto input_ins   = r.instructions["input"];
+
+
+            // If its just a broadcast then skip
+            if(not any_input_of(input_ins, x_ins, [](instruction_ref x) {
+                   return not contains({"multibroadcast", "broadcast", "contiguous"}, x->name());
+               }))
+                return;
+
+            std::vector<operation> ops;
+            auto next_ins = input_ins;
+            while(next_ins != x_ins)
+            {
+                ops.push_back(next_ins->get_operator());
+                next_ins = next_ins->inputs().front();
+            }
+            assert(next_ins == x_ins);
+            std::reverse(ops.begin(), ops.end());
+
+            auto output_desc = shape_transform_descriptor::create(x_ins->get_shape().lens(), ops);
+            if(output_desc.empty())
+                return;
+            auto input_desc = output_desc.rebase(x_ins->inputs().front()->get_shape().lens());
+            if(input_desc.empty())
+                return;
+
+            auto cdims         = input_desc.common_dims();
+            auto reshape_input = [&](const auto& ins_to_insert, auto generate, const auto& desc) {
+                return [&, generate](auto input) {
+                    auto gops  = std::invoke(generate, desc, input->get_shape().lens());
+                    auto start = input;
+                    for(const auto& op : gops)
+                    {
+                        start = m.insert_instruction(ins_to_insert, op, start);
+                    }
+                    return start;
+                };
+            };
+            auto x_inputs = x_ins->inputs();
+            std::transform(
+                x_inputs.begin(),
+                x_inputs.end(),
+                x_inputs.begin(),
+                reshape_input(x_ins, &shape_transform_descriptor::generate_common_from_src, input_desc));
+            auto new_x_ins = insert(m, x_ins, x_inputs, input_desc.common_axes_map_from_src());
+            if(new_x_ins->get_shape().elements() != x_ins->get_shape().elements())
+            {
+                new_x_ins = m.insert_instruction(
+                    x_ins, make_op("multibroadcast", {{"out_lens", cdims}}), new_x_ins);
+            }
+
+            auto inputs = ins->inputs();
+            std::transform(inputs.begin(), inputs.end(), inputs.begin(), [&](auto input) {
+                if(input == input_ins)
+                    return new_x_ins;
+                return reshape_input(ins,
+                                     &shape_transform_descriptor::generate_common_from_dst, output_desc)(input);
+            });
+            auto pw = insert(m, ins, inputs, output_desc.common_axes_map_from_dst());
+            auto rins =
+                reshape_input(ins, &shape_transform_descriptor::generate_dst_from_common, output_desc)(pw);
+            m.replace_instruction(ins, rins);
+        }
+
+};
+
 struct find_nop_reshapes
 {
     auto matcher() const
@@ -1180,7 +1319,8 @@ void simplify_reshapes::apply(module& m) const
                             find_slice_transpose{},
                             find_unary_shape_transforms{},
                             find_reshape_dot{},
-                            find_mul_add_shape_op_dot{});
+                            find_mul_add_shape_op_dot{},
+                            find_op_shape_transform_op{});
         dead_code_elimination{}.apply(m);
     });
 }

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -222,7 +222,7 @@ struct find_op_shape_transform_op
         auto output_desc = shape_transform_descriptor::create(x_ins->get_shape().lens(), ops);
         if(output_desc.empty())
             return;
-        auto input_desc = output_desc.rebase(x_ins->inputs().front()->get_shape().lens());
+        auto input_desc = output_desc.rebase(x_ins->inputs().front()->get_shape().lens(), true);
         if(input_desc.empty())
             return;
 

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -2352,9 +2352,10 @@ TEST_CASE(reduce_broadcast_reshape_pointwise2)
         auto broadcast = m2.add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", s3.lens()}}), reduce_sum);
         auto reshape1 = m2.add_instruction(migraphx::make_op("reshape", {{"dims", s3.lens()}}), y);
-        auto add  = m2.add_instruction(migraphx::make_op("add"), broadcast, reshape1);
-        auto relu = m2.add_instruction(migraphx::make_op("relu"), add);
-        auto reshape2 = m2.add_instruction(migraphx::make_op("reshape", {{"dims", s2.lens()}}), relu);
+        auto add      = m2.add_instruction(migraphx::make_op("add"), broadcast, reshape1);
+        auto relu     = m2.add_instruction(migraphx::make_op("relu"), add);
+        auto reshape2 =
+            m2.add_instruction(migraphx::make_op("reshape", {{"dims", s2.lens()}}), relu);
         m2.add_return({reshape2});
     }
     EXPECT(m1.sort() == m2.sort());

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -2106,12 +2106,12 @@ TEST_CASE(pointwise_transpose_pointwise)
     auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 4, 4, 64}};
     migraphx::module m1;
     {
-        auto x          = m1.add_parameter("x", s1);
-        auto y          = m1.add_parameter("y", s1);
-        auto z          = m1.add_parameter("z", s2);
-        auto mul = m1.add_instruction(migraphx::make_op("mul"), x, y);
-        auto transpose =
-            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
+        auto x         = m1.add_parameter("x", s1);
+        auto y         = m1.add_parameter("y", s1);
+        auto z         = m1.add_parameter("z", s2);
+        auto mul       = m1.add_instruction(migraphx::make_op("mul"), x, y);
+        auto transpose = m1.add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
         auto add  = m1.add_instruction(migraphx::make_op("add"), transpose, z);
         auto relu = m1.add_instruction(migraphx::make_op("relu"), add);
         m1.add_return({relu});
@@ -2119,12 +2119,14 @@ TEST_CASE(pointwise_transpose_pointwise)
     run_pass(m1);
     migraphx::module m2;
     {
-        auto x          = m2.add_parameter("x", s1);
-        auto y          = m2.add_parameter("y", s1);
-        auto z          = m2.add_parameter("z", s2);
-        auto transposex = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
-        auto transposey = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
-        auto mul = m2.add_instruction(migraphx::make_op("mul"), transposex, transposey);
+        auto x = m2.add_parameter("x", s1);
+        auto y = m2.add_parameter("y", s1);
+        auto z = m2.add_parameter("z", s2);
+        auto transposex =
+            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
+        auto transposey =
+            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
+        auto mul  = m2.add_instruction(migraphx::make_op("mul"), transposex, transposey);
         auto add  = m2.add_instruction(migraphx::make_op("add"), mul, z);
         auto relu = m2.add_instruction(migraphx::make_op("relu"), add);
         m2.add_return({relu});
@@ -2138,12 +2140,12 @@ TEST_CASE(pointwise_transpose_pointwise_used_twice1)
     auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 4, 4, 64}};
     migraphx::module m1;
     {
-        auto x          = m1.add_parameter("x", s1);
-        auto y          = m1.add_parameter("y", s1);
-        auto z          = m1.add_parameter("z", s2);
-        auto mul = m1.add_instruction(migraphx::make_op("mul"), x, y);
-        auto transpose =
-            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
+        auto x         = m1.add_parameter("x", s1);
+        auto y         = m1.add_parameter("y", s1);
+        auto z         = m1.add_parameter("z", s2);
+        auto mul       = m1.add_instruction(migraphx::make_op("mul"), x, y);
+        auto transpose = m1.add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
         auto add  = m1.add_instruction(migraphx::make_op("add"), transpose, z);
         auto relu = m1.add_instruction(migraphx::make_op("relu"), add);
         m1.add_return({relu, mul});
@@ -2151,13 +2153,16 @@ TEST_CASE(pointwise_transpose_pointwise_used_twice1)
     run_pass(m1);
     migraphx::module m2;
     {
-        auto x          = m2.add_parameter("x", s1);
-        auto y          = m2.add_parameter("y", s1);
-        auto z          = m2.add_parameter("z", s2);
-        auto transposex = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
-        auto transposey = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
-        auto mul = m2.add_instruction(migraphx::make_op("mul"), transposex, transposey);
-        auto transposemul = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), mul);
+        auto x = m2.add_parameter("x", s1);
+        auto y = m2.add_parameter("y", s1);
+        auto z = m2.add_parameter("z", s2);
+        auto transposex =
+            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
+        auto transposey =
+            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
+        auto mul          = m2.add_instruction(migraphx::make_op("mul"), transposex, transposey);
+        auto transposemul = m2.add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), mul);
         auto add  = m2.add_instruction(migraphx::make_op("add"), mul, z);
         auto relu = m2.add_instruction(migraphx::make_op("relu"), add);
         m2.add_return({relu, transposemul});
@@ -2171,13 +2176,13 @@ TEST_CASE(pointwise_transpose_pointwise_used_twice2)
     auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 4, 4, 64}};
     migraphx::module m1;
     {
-        auto x          = m1.add_parameter("x", s1);
-        auto y          = m1.add_parameter("y", s1);
-        auto z          = m1.add_parameter("z", s2);
-        auto mul = m1.add_instruction(migraphx::make_op("mul"), x, y);
-        auto transpose =
-            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
-        auto add1  = m1.add_instruction(migraphx::make_op("add"), transpose, z);
+        auto x         = m1.add_parameter("x", s1);
+        auto y         = m1.add_parameter("y", s1);
+        auto z         = m1.add_parameter("z", s2);
+        auto mul       = m1.add_instruction(migraphx::make_op("mul"), x, y);
+        auto transpose = m1.add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
+        auto add1 = m1.add_instruction(migraphx::make_op("add"), transpose, z);
         auto relu = m1.add_instruction(migraphx::make_op("relu"), add1);
         auto add2 = m1.add_instruction(migraphx::make_op("add"), relu, mul);
         m1.add_return({add2});

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -2106,12 +2106,12 @@ TEST_CASE(pointwise_transpose_pointwise)
     auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 4, 4, 64}};
     migraphx::module m1;
     {
-        auto x          = m1.add_parameter("x", s1);
-        auto y          = m1.add_parameter("y", s1);
-        auto z          = m1.add_parameter("z", s2);
-        auto mul = m1.add_instruction(migraphx::make_op("mul"), x, y);
-        auto transpose =
-            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
+        auto x         = m1.add_parameter("x", s1);
+        auto y         = m1.add_parameter("y", s1);
+        auto z         = m1.add_parameter("z", s2);
+        auto mul       = m1.add_instruction(migraphx::make_op("mul"), x, y);
+        auto transpose = m1.add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
         auto add  = m1.add_instruction(migraphx::make_op("add"), transpose, z);
         auto relu = m1.add_instruction(migraphx::make_op("relu"), add);
         m1.add_return({relu});
@@ -2119,12 +2119,14 @@ TEST_CASE(pointwise_transpose_pointwise)
     run_pass(m1);
     migraphx::module m2;
     {
-        auto x          = m2.add_parameter("x", s1);
-        auto y          = m2.add_parameter("y", s1);
-        auto z          = m2.add_parameter("z", s2);
-        auto transposex = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
-        auto transposey = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
-        auto mul = m2.add_instruction(migraphx::make_op("mul"), transposex, transposey);
+        auto x = m2.add_parameter("x", s1);
+        auto y = m2.add_parameter("y", s1);
+        auto z = m2.add_parameter("z", s2);
+        auto transposex =
+            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
+        auto transposey =
+            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
+        auto mul  = m2.add_instruction(migraphx::make_op("mul"), transposex, transposey);
         auto add  = m2.add_instruction(migraphx::make_op("add"), mul, z);
         auto relu = m2.add_instruction(migraphx::make_op("relu"), add);
         m2.add_return({relu});
@@ -2138,12 +2140,12 @@ TEST_CASE(pointwise_transpose_pointwise_used_twice1)
     auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 4, 4, 64}};
     migraphx::module m1;
     {
-        auto x          = m1.add_parameter("x", s1);
-        auto y          = m1.add_parameter("y", s1);
-        auto z          = m1.add_parameter("z", s2);
-        auto mul = m1.add_instruction(migraphx::make_op("mul"), x, y);
-        auto transpose =
-            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
+        auto x         = m1.add_parameter("x", s1);
+        auto y         = m1.add_parameter("y", s1);
+        auto z         = m1.add_parameter("z", s2);
+        auto mul       = m1.add_instruction(migraphx::make_op("mul"), x, y);
+        auto transpose = m1.add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
         auto add  = m1.add_instruction(migraphx::make_op("add"), transpose, z);
         auto relu = m1.add_instruction(migraphx::make_op("relu"), add);
         m1.add_return({relu, mul});
@@ -2151,13 +2153,16 @@ TEST_CASE(pointwise_transpose_pointwise_used_twice1)
     run_pass(m1);
     migraphx::module m2;
     {
-        auto x          = m2.add_parameter("x", s1);
-        auto y          = m2.add_parameter("y", s1);
-        auto z          = m2.add_parameter("z", s2);
-        auto transposex = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
-        auto transposey = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
-        auto mul = m2.add_instruction(migraphx::make_op("mul"), transposex, transposey);
-        auto transposemul = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), mul);
+        auto x = m2.add_parameter("x", s1);
+        auto y = m2.add_parameter("y", s1);
+        auto z = m2.add_parameter("z", s2);
+        auto transposex =
+            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
+        auto transposey =
+            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
+        auto mul          = m2.add_instruction(migraphx::make_op("mul"), transposex, transposey);
+        auto transposemul = m2.add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), mul);
         auto add  = m2.add_instruction(migraphx::make_op("add"), mul, z);
         auto relu = m2.add_instruction(migraphx::make_op("relu"), add);
         m2.add_return({relu, transposemul});
@@ -2171,13 +2176,13 @@ TEST_CASE(pointwise_transpose_pointwise_used_twice2)
     auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 4, 4, 64}};
     migraphx::module m1;
     {
-        auto x          = m1.add_parameter("x", s1);
-        auto y          = m1.add_parameter("y", s1);
-        auto z          = m1.add_parameter("z", s2);
-        auto mul = m1.add_instruction(migraphx::make_op("mul"), x, y);
-        auto transpose =
-            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
-        auto add1  = m1.add_instruction(migraphx::make_op("add"), transpose, z);
+        auto x         = m1.add_parameter("x", s1);
+        auto y         = m1.add_parameter("y", s1);
+        auto z         = m1.add_parameter("z", s2);
+        auto mul       = m1.add_instruction(migraphx::make_op("mul"), x, y);
+        auto transpose = m1.add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
+        auto add1 = m1.add_instruction(migraphx::make_op("add"), transpose, z);
         auto relu = m1.add_instruction(migraphx::make_op("relu"), add1);
         auto add2 = m1.add_instruction(migraphx::make_op("add"), relu, mul);
         m1.add_return({add2});
@@ -2290,12 +2295,13 @@ TEST_CASE(reduce_broadcast_reshape_pointwise)
     auto s2 = migraphx::shape{migraphx::shape::float_type, {8, 8, 2, 2}};
     migraphx::module m1;
     {
-        auto x = m1.add_parameter("x", s1);
-        auto y = m1.add_parameter("y", s2);
-        auto reduce_sum =
-            m1.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {1}}}), x);
-        auto broadcast = m1.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s1.lens()}}), reduce_sum);
-        auto reshape = m1.add_instruction(migraphx::make_op("reshape", {{"dims", s2.lens()}}), broadcast);
+        auto x          = m1.add_parameter("x", s1);
+        auto y          = m1.add_parameter("y", s2);
+        auto reduce_sum = m1.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {1}}}), x);
+        auto broadcast  = m1.add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", s1.lens()}}), reduce_sum);
+        auto reshape =
+            m1.add_instruction(migraphx::make_op("reshape", {{"dims", s2.lens()}}), broadcast);
         auto add  = m1.add_instruction(migraphx::make_op("add"), reshape, y);
         auto relu = m1.add_instruction(migraphx::make_op("relu"), add);
         m1.add_return({relu});
@@ -2303,15 +2309,15 @@ TEST_CASE(reduce_broadcast_reshape_pointwise)
     run_pass(m1);
     migraphx::module m2;
     {
-        auto x = m2.add_parameter("x", s1);
-        auto y = m2.add_parameter("y", s2);
+        auto x        = m2.add_parameter("x", s1);
+        auto y        = m2.add_parameter("y", s2);
         auto reshapex = m2.add_instruction(migraphx::make_op("reshape", {{"dims", s1.lens()}}), x);
         auto reduce_sum =
             m2.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {1}}}), reshapex);
         auto broadcast = m2.add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", s2.lens()}}), reduce_sum);
-        auto add      = m2.add_instruction(migraphx::make_op("add"), broadcast, y);
-        auto relu     = m2.add_instruction(migraphx::make_op("relu"), add);
+        auto add  = m2.add_instruction(migraphx::make_op("add"), broadcast, y);
+        auto relu = m2.add_instruction(migraphx::make_op("relu"), add);
         auto reshape =
             m2.add_instruction(migraphx::make_op("reshape", {{"dims", s2.lens()}}), relu);
         m2.add_return({reshape});

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -2311,16 +2311,14 @@ TEST_CASE(reduce_broadcast_reshape_pointwise)
     {
         auto x        = m2.add_parameter("x", s1);
         auto y        = m2.add_parameter("y", s2);
-        auto reshapex = m2.add_instruction(migraphx::make_op("reshape", {{"dims", s1.lens()}}), x);
+        auto reshapex = m2.add_instruction(migraphx::make_op("reshape", {{"dims", s2.lens()}}), x);
         auto reduce_sum =
-            m2.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {1}}}), reshapex);
+            m2.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {2, 3}}}), reshapex);
         auto broadcast = m2.add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", s2.lens()}}), reduce_sum);
         auto add  = m2.add_instruction(migraphx::make_op("add"), broadcast, y);
         auto relu = m2.add_instruction(migraphx::make_op("relu"), add);
-        auto reshape =
-            m2.add_instruction(migraphx::make_op("reshape", {{"dims", s2.lens()}}), relu);
-        m2.add_return({reshape});
+        m2.add_return({relu});
     }
     EXPECT(m1.sort() == m2.sort());
 }

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -2106,12 +2106,12 @@ TEST_CASE(pointwise_transpose_pointwise)
     auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 4, 4, 64}};
     migraphx::module m1;
     {
-        auto x         = m1.add_parameter("x", s1);
-        auto y         = m1.add_parameter("y", s1);
-        auto z         = m1.add_parameter("z", s2);
-        auto mul       = m1.add_instruction(migraphx::make_op("mul"), x, y);
-        auto transpose = m1.add_instruction(
-            migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
+        auto x          = m1.add_parameter("x", s1);
+        auto y          = m1.add_parameter("y", s1);
+        auto z          = m1.add_parameter("z", s2);
+        auto mul = m1.add_instruction(migraphx::make_op("mul"), x, y);
+        auto transpose =
+            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
         auto add  = m1.add_instruction(migraphx::make_op("add"), transpose, z);
         auto relu = m1.add_instruction(migraphx::make_op("relu"), add);
         m1.add_return({relu});
@@ -2119,14 +2119,12 @@ TEST_CASE(pointwise_transpose_pointwise)
     run_pass(m1);
     migraphx::module m2;
     {
-        auto x = m2.add_parameter("x", s1);
-        auto y = m2.add_parameter("y", s1);
-        auto z = m2.add_parameter("z", s2);
-        auto transposex =
-            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
-        auto transposey =
-            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
-        auto mul  = m2.add_instruction(migraphx::make_op("mul"), transposex, transposey);
+        auto x          = m2.add_parameter("x", s1);
+        auto y          = m2.add_parameter("y", s1);
+        auto z          = m2.add_parameter("z", s2);
+        auto transposex = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
+        auto transposey = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
+        auto mul = m2.add_instruction(migraphx::make_op("mul"), transposex, transposey);
         auto add  = m2.add_instruction(migraphx::make_op("add"), mul, z);
         auto relu = m2.add_instruction(migraphx::make_op("relu"), add);
         m2.add_return({relu});
@@ -2140,12 +2138,12 @@ TEST_CASE(pointwise_transpose_pointwise_used_twice1)
     auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 4, 4, 64}};
     migraphx::module m1;
     {
-        auto x         = m1.add_parameter("x", s1);
-        auto y         = m1.add_parameter("y", s1);
-        auto z         = m1.add_parameter("z", s2);
-        auto mul       = m1.add_instruction(migraphx::make_op("mul"), x, y);
-        auto transpose = m1.add_instruction(
-            migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
+        auto x          = m1.add_parameter("x", s1);
+        auto y          = m1.add_parameter("y", s1);
+        auto z          = m1.add_parameter("z", s2);
+        auto mul = m1.add_instruction(migraphx::make_op("mul"), x, y);
+        auto transpose =
+            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
         auto add  = m1.add_instruction(migraphx::make_op("add"), transpose, z);
         auto relu = m1.add_instruction(migraphx::make_op("relu"), add);
         m1.add_return({relu, mul});
@@ -2153,16 +2151,13 @@ TEST_CASE(pointwise_transpose_pointwise_used_twice1)
     run_pass(m1);
     migraphx::module m2;
     {
-        auto x = m2.add_parameter("x", s1);
-        auto y = m2.add_parameter("y", s1);
-        auto z = m2.add_parameter("z", s2);
-        auto transposex =
-            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
-        auto transposey =
-            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
-        auto mul          = m2.add_instruction(migraphx::make_op("mul"), transposex, transposey);
-        auto transposemul = m2.add_instruction(
-            migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), mul);
+        auto x          = m2.add_parameter("x", s1);
+        auto y          = m2.add_parameter("y", s1);
+        auto z          = m2.add_parameter("z", s2);
+        auto transposex = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
+        auto transposey = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
+        auto mul = m2.add_instruction(migraphx::make_op("mul"), transposex, transposey);
+        auto transposemul = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), mul);
         auto add  = m2.add_instruction(migraphx::make_op("add"), mul, z);
         auto relu = m2.add_instruction(migraphx::make_op("relu"), add);
         m2.add_return({relu, transposemul});
@@ -2176,13 +2171,13 @@ TEST_CASE(pointwise_transpose_pointwise_used_twice2)
     auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 4, 4, 64}};
     migraphx::module m1;
     {
-        auto x         = m1.add_parameter("x", s1);
-        auto y         = m1.add_parameter("y", s1);
-        auto z         = m1.add_parameter("z", s2);
-        auto mul       = m1.add_instruction(migraphx::make_op("mul"), x, y);
-        auto transpose = m1.add_instruction(
-            migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
-        auto add1 = m1.add_instruction(migraphx::make_op("add"), transpose, z);
+        auto x          = m1.add_parameter("x", s1);
+        auto y          = m1.add_parameter("y", s1);
+        auto z          = m1.add_parameter("z", s2);
+        auto mul = m1.add_instruction(migraphx::make_op("mul"), x, y);
+        auto transpose =
+            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), mul);
+        auto add1  = m1.add_instruction(migraphx::make_op("add"), transpose, z);
         auto relu = m1.add_instruction(migraphx::make_op("relu"), add1);
         auto add2 = m1.add_instruction(migraphx::make_op("add"), relu, mul);
         m1.add_return({add2});
@@ -2285,6 +2280,41 @@ TEST_CASE(reduce_squeeze_broadcast_pointwise)
         auto reshape2 =
             m2.add_instruction(migraphx::make_op("reshape", {{"dims", s2.lens()}}), relu);
         m2.add_return({reshape2});
+    }
+    EXPECT(m1.sort() == m2.sort());
+}
+
+TEST_CASE(reduce_broadcast_reshape_pointwise)
+{
+    auto s1 = migraphx::shape{migraphx::shape::float_type, {64, 4}};
+    auto s2 = migraphx::shape{migraphx::shape::float_type, {8, 8, 2, 2}};
+    migraphx::module m1;
+    {
+        auto x = m1.add_parameter("x", s1);
+        auto y = m1.add_parameter("y", s2);
+        auto reduce_sum =
+            m1.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {1}}}), x);
+        auto broadcast = m1.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s1.lens()}}), reduce_sum);
+        auto reshape = m1.add_instruction(migraphx::make_op("reshape", {{"dims", s2.lens()}}), broadcast);
+        auto add  = m1.add_instruction(migraphx::make_op("add"), reshape, y);
+        auto relu = m1.add_instruction(migraphx::make_op("relu"), add);
+        m1.add_return({relu});
+    }
+    run_pass(m1);
+    migraphx::module m2;
+    {
+        auto x = m2.add_parameter("x", s1);
+        auto y = m2.add_parameter("y", s2);
+        auto reshapex = m2.add_instruction(migraphx::make_op("reshape", {{"dims", s1.lens()}}), x);
+        auto reduce_sum =
+            m2.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {1}}}), reshapex);
+        auto broadcast = m2.add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", s2.lens()}}), reduce_sum);
+        auto add      = m2.add_instruction(migraphx::make_op("add"), broadcast, y);
+        auto relu     = m2.add_instruction(migraphx::make_op("relu"), add);
+        auto reshape =
+            m2.add_instruction(migraphx::make_op("reshape", {{"dims", s2.lens()}}), relu);
+        m2.add_return({reshape});
     }
     EXPECT(m1.sort() == m2.sort());
 }

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -2106,24 +2106,25 @@ TEST_CASE(reduce_squeeze_pointwise1)
     auto s2 = migraphx::shape{migraphx::shape::float_type, {1, 1024, 1280}};
     migraphx::module m1;
     {
-        auto x   = m1.add_parameter("x", s1);
-        auto y   = m1.add_parameter("y", s2);
+        auto x          = m1.add_parameter("x", s1);
+        auto y          = m1.add_parameter("y", s2);
         auto reduce_sum = m1.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {1}}}), x);
-        auto squeeze = m1.add_instruction(migraphx::make_op("squeeze", {{"axes", {1}}}), reduce_sum);
-        auto add = m1.add_instruction(migraphx::make_op("add"), squeeze, y);
+        auto squeeze =
+            m1.add_instruction(migraphx::make_op("squeeze", {{"axes", {1}}}), reduce_sum);
+        auto add  = m1.add_instruction(migraphx::make_op("add"), squeeze, y);
         auto relu = m1.add_instruction(migraphx::make_op("relu"), add);
         m1.add_return({relu});
     }
     run_pass(m1);
     migraphx::module m2;
     {
-        auto x   = m2.add_parameter("x", s1);
-        auto y   = m2.add_parameter("y", s2);
+        auto x          = m2.add_parameter("x", s1);
+        auto y          = m2.add_parameter("y", s2);
         auto reduce_sum = m2.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {1}}}), x);
-        auto unsqueeze = m2.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1}}}), y);
-        auto add = m2.add_instruction(migraphx::make_op("add"), reduce_sum, unsqueeze);
-        auto relu = m2.add_instruction(migraphx::make_op("relu"), add);
-        auto squeeze = m2.add_instruction(migraphx::make_op("squeeze", {{"axes", {1}}}), relu);
+        auto unsqueeze  = m2.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1}}}), y);
+        auto add        = m2.add_instruction(migraphx::make_op("add"), reduce_sum, unsqueeze);
+        auto relu       = m2.add_instruction(migraphx::make_op("relu"), add);
+        auto squeeze    = m2.add_instruction(migraphx::make_op("squeeze", {{"axes", {1}}}), relu);
         m2.add_return({squeeze});
     }
     EXPECT(m1.sort() == m2.sort());
@@ -2135,24 +2136,25 @@ TEST_CASE(reduce_squeeze_pointwise2)
     auto s2 = migraphx::shape{migraphx::shape::float_type, {1, 1024, 1280}};
     migraphx::module m1;
     {
-        auto x   = m1.add_parameter("x", s1);
-        auto y   = m1.add_parameter("y", s2);
+        auto x          = m1.add_parameter("x", s1);
+        auto y          = m1.add_parameter("y", s2);
         auto reduce_sum = m1.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {1}}}), x);
-        auto squeeze = m1.add_instruction(migraphx::make_op("squeeze", {{"axes", {1}}}), reduce_sum);
-        auto add = m1.add_instruction(migraphx::make_op("add"), squeeze, y);
+        auto squeeze =
+            m1.add_instruction(migraphx::make_op("squeeze", {{"axes", {1}}}), reduce_sum);
+        auto add  = m1.add_instruction(migraphx::make_op("add"), squeeze, y);
         auto relu = m1.add_instruction(migraphx::make_op("relu"), add);
         m1.add_return({relu});
     }
     run_pass(m1);
     migraphx::module m2;
     {
-        auto x   = m2.add_parameter("x", s1);
-        auto y   = m2.add_parameter("y", s2);
+        auto x          = m2.add_parameter("x", s1);
+        auto y          = m2.add_parameter("y", s2);
         auto reduce_sum = m2.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {1}}}), x);
-        auto unsqueeze = m2.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1}}}), y);
-        auto add = m2.add_instruction(migraphx::make_op("add"), reduce_sum, unsqueeze);
-        auto relu = m2.add_instruction(migraphx::make_op("relu"), add);
-        auto squeeze = m2.add_instruction(migraphx::make_op("squeeze", {{"axes", {1}}}), relu);
+        auto unsqueeze  = m2.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1}}}), y);
+        auto add        = m2.add_instruction(migraphx::make_op("add"), reduce_sum, unsqueeze);
+        auto relu       = m2.add_instruction(migraphx::make_op("relu"), add);
+        auto squeeze    = m2.add_instruction(migraphx::make_op("squeeze", {{"axes", {1}}}), relu);
         m2.add_return({squeeze});
     }
     EXPECT(m1.sort() == m2.sort());
@@ -2164,26 +2166,32 @@ TEST_CASE(reduce_squeeze_broadcast_pointwise)
     auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 32, 40960}};
     migraphx::module m1;
     {
-        auto x   = m1.add_parameter("x", s1);
-        auto y   = m1.add_parameter("y", s2);
-        auto reduce_sum = m1.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {2, 3, 4}}}), x);
-        auto squeeze = m1.add_instruction(migraphx::make_op("squeeze", {{"axes", {3, 4}}}), reduce_sum);
-        auto broadcast = m1.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s2.lens()}}), squeeze);
-        auto add = m1.add_instruction(migraphx::make_op("add"), broadcast, y);
+        auto x = m1.add_parameter("x", s1);
+        auto y = m1.add_parameter("y", s2);
+        auto reduce_sum =
+            m1.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {2, 3, 4}}}), x);
+        auto squeeze =
+            m1.add_instruction(migraphx::make_op("squeeze", {{"axes", {3, 4}}}), reduce_sum);
+        auto broadcast = m1.add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", s2.lens()}}), squeeze);
+        auto add  = m1.add_instruction(migraphx::make_op("add"), broadcast, y);
         auto relu = m1.add_instruction(migraphx::make_op("relu"), add);
         m1.add_return({relu});
     }
     run_pass(m1);
     migraphx::module m2;
     {
-        auto x   = m2.add_parameter("x", s1);
-        auto y   = m2.add_parameter("y", s2);
-        auto reduce_sum = m2.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {2, 3, 4}}}), x);
-        auto broadcast = m2.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s1.lens()}}), reduce_sum);
+        auto x = m2.add_parameter("x", s1);
+        auto y = m2.add_parameter("y", s2);
+        auto reduce_sum =
+            m2.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {2, 3, 4}}}), x);
+        auto broadcast = m2.add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", s1.lens()}}), reduce_sum);
         auto reshape1 = m2.add_instruction(migraphx::make_op("reshape", {{"dims", s1.lens()}}), y);
-        auto add = m2.add_instruction(migraphx::make_op("add"), broadcast, reshape1);
-        auto relu = m2.add_instruction(migraphx::make_op("relu"), add);
-        auto reshape2 = m2.add_instruction(migraphx::make_op("reshape", {{"dims", s2.lens()}}), relu);
+        auto add      = m2.add_instruction(migraphx::make_op("add"), broadcast, reshape1);
+        auto relu     = m2.add_instruction(migraphx::make_op("relu"), add);
+        auto reshape2 =
+            m2.add_instruction(migraphx::make_op("reshape", {{"dims", s2.lens()}}), relu);
         m2.add_return({reshape2});
     }
     EXPECT(m1.sort() == m2.sort());


### PR DESCRIPTION
This will rewrite transpose/reshape/broadcast so they will not be between pointwise and reduction using the shape_transform_descriptor. This is similiar to the `rewrite_reshapes` that is used for pointwise/reduce fusion, however this is done before fusions in simplify_reshapes. It also supports more cases such as reduce->squeeze->pointwise.

This could be expanded in the future to support other operators like argmin/argmax/concat etc. 