### PR TITLE
Remove rocblas fp8

### DIFF
--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -319,8 +319,6 @@ if(MIGRAPHX_USE_ROCBLAS)
     target_compile_definitions(migraphx_gpu PUBLIC MIGRAPHX_USE_ROCBLAS=1)
     # Beta API for automated GEMM tuning
     check_library_exists(roc::rocblas "rocblas_gemm_ex_get_solutions" "${ROCBLAS_LOCATION}" HAS_ROCBLAS_TUNING_BETA_FEATURE_API)
-    # rocblas FP8 API
-    check_library_exists(roc::rocblas "rocblas_gemm_strided_batched_ex3" "${ROCBLAS_LOCATION}" HAS_ROCBLAS_FP8_BETA_API)
 else()
     target_compile_definitions(migraphx_gpu PUBLIC MIGRAPHX_USE_ROCBLAS=0)
 endif()

--- a/src/targets/gpu/device_name.cpp
+++ b/src/targets/gpu/device_name.cpp
@@ -29,6 +29,8 @@
 #include <migraphx/stringutils.hpp>
 #include <hip/hip_runtime_api.h>
 
+#include <iostream>
+
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
@@ -71,13 +73,6 @@ bool gfx_has_bf16_intrinsics()
 {
     const auto device_name = trim(split_string(get_device_name(), ':').front());
     return not(starts_with(device_name, "gfx1030"));
-}
-
-bool gfx_has_fp8fnuz_support()
-{
-    return (string_value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == "rocblas"
-                ? gpu::rocblas_fp8_available()
-                : gfx_has_fp8fnuz_intrinsics());
 }
 
 #if MIGRAPHX_USE_HIPBLASLT

--- a/src/targets/gpu/gemm_impl.cpp
+++ b/src/targets/gpu/gemm_impl.cpp
@@ -38,17 +38,15 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 #if MIGRAPHX_USE_ROCBLAS
 /*
-Regular rocBLAS API takes compute_type as `rocblas_datatype` enum value v/s "ex3" BETA API takes it
-as `rocblas_computetype` enum value. `rb_compute_type` is faciliator to implictly cast integer enum
+Regular rocBLAS API takes compute_type as `rocblas_datatype` enum value.
+`rb_compute_type` is faciliator to implictly cast integer enum
 value to required type that can be used inside `common_args` generator.
 */
 struct rb_compute_type
 {
     int type = 0;
     rb_compute_type(rocblas_datatype t) : type(static_cast<int>(t)) {}
-    rb_compute_type(rocblas_computetype t) : type(static_cast<int>(t)) {}
     operator rocblas_datatype() const { return static_cast<rocblas_datatype>(type); }
-    operator rocblas_computetype() const { return static_cast<rocblas_computetype>(type); }
 };
 
 // Convert rocBLAS datatypes to equivalent Migraphx data types

--- a/src/targets/gpu/gemm_impl.cpp
+++ b/src/targets/gpu/gemm_impl.cpp
@@ -38,15 +38,17 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 #if MIGRAPHX_USE_ROCBLAS
 /*
-Regular rocBLAS API takes compute_type as `rocblas_datatype` enum value.
-`rb_compute_type` is faciliator to implictly cast integer enum
+Regular rocBLAS API takes compute_type as `rocblas_datatype` enum value v/s "ex3" BETA API takes it
+as `rocblas_computetype` enum value. `rb_compute_type` is faciliator to implictly cast integer enum
 value to required type that can be used inside `common_args` generator.
 */
 struct rb_compute_type
 {
     int type = 0;
     rb_compute_type(rocblas_datatype t) : type(static_cast<int>(t)) {}
+    rb_compute_type(rocblas_computetype t) : type(static_cast<int>(t)) {}
     operator rocblas_datatype() const { return static_cast<rocblas_datatype>(type); }
+    operator rocblas_computetype() const { return static_cast<rocblas_computetype>(type); }
 };
 
 // Convert rocBLAS datatypes to equivalent Migraphx data types

--- a/src/targets/gpu/gemm_impl.cpp
+++ b/src/targets/gpu/gemm_impl.cpp
@@ -37,11 +37,12 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 #if MIGRAPHX_USE_ROCBLAS
-/*
-Regular rocBLAS API takes compute_type as `rocblas_datatype` enum value v/s "ex3" BETA API takes it
-as `rocblas_computetype` enum value. `rb_compute_type` is faciliator to implictly cast integer enum
-value to required type that can be used inside `common_args` generator.
-*/
+/**
+ * Regular rocBLAS API takes compute_type as `rocblas_datatype` enum value.
+ * `rb_compute_type` is faciliator to implictly cast integer enum value to required type that can be
+ * used inside `common_args` generator. Beta API was removed, so this struct is the same as the enum
+ * directly.
+ */
 struct rb_compute_type
 {
     int type = 0;

--- a/src/targets/gpu/gemm_impl.cpp
+++ b/src/targets/gpu/gemm_impl.cpp
@@ -46,9 +46,7 @@ struct rb_compute_type
 {
     int type = 0;
     rb_compute_type(rocblas_datatype t) : type(static_cast<int>(t)) {}
-    rb_compute_type(rocblas_computetype t) : type(static_cast<int>(t)) {}
     operator rocblas_datatype() const { return static_cast<rocblas_datatype>(type); }
-    operator rocblas_computetype() const { return static_cast<rocblas_computetype>(type); }
 };
 
 // Convert rocBLAS datatypes to equivalent Migraphx data types
@@ -230,11 +228,6 @@ struct gemm_impl
         {
             if(arg_type == rocblas_datatype_f16_r or arg_type == rocblas_datatype_bf16_r)
                 compute_type = rocblas_datatype_f32_r;
-        }
-        if(arg_type == rocblas_datatype_f8_r)
-        {
-            assert(get_type(input_shapes[1].type()) == rocblas_datatype_f8_r);
-            compute_type = rocblas_compute_type_f32;
         }
 
         auto a_lens = input_shapes[0].lens();

--- a/src/targets/gpu/include/migraphx/gpu/rocblas.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/rocblas.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/include/migraphx/gpu/rocblas.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/rocblas.hpp
@@ -43,8 +43,6 @@ struct context;
 
 MIGRAPHX_GPU_EXPORT bool get_compute_fp32_flag();
 
-MIGRAPHX_GPU_EXPORT bool rocblas_fp8_available();
-
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/targets/gpu/rocblas.cpp
+++ b/src/targets/gpu/rocblas.cpp
@@ -31,6 +31,7 @@
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
+
 #if MIGRAPHX_USE_ROCBLAS
 rocblas_handle_ptr create_rocblas_handle_ptr()
 {
@@ -46,23 +47,11 @@ rocblas_handle_ptr create_rocblas_handle_ptr(hipStream_t s)
     return rb;
 }
 #endif
+
 bool get_compute_fp32_flag()
 {
     const auto device_name = trim(split_string(get_device_name(), ':').front());
     return (starts_with(device_name, "gfx9") and device_name >= "gfx908");
-}
-
-bool rocblas_fp8_available()
-{
-#if MIGRAPHX_USE_ROCBLAS
-#ifndef MIGRAPHX_USE_ROCBLAS_FP8_API
-    return false;
-#else
-    return gfx_has_fp8fnuz_intrinsics();
-#endif
-#else
-    return false;
-#endif
 }
 
 } // namespace gpu

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -114,9 +114,8 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
     // whiltelist supported Ops for the FP8 types
     // rocBLAS does not support any FP8 types
     std::set<std::string> unsupported_fp8fnuz_ops = {};
-    if(string_value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == "rocblas")
+    if(string_value_of(MIGRAPHX_SET_GEMM_PROVIDER{}) == "rocblas" or gpu::gfx_default_rocblas())
     {
-        std::cout << "rocBLAS provider selected. rocBLAS does not support FP8 types.\n";
         unsupported_fp8fnuz_ops.insert("dot");
         unsupported_fp8fnuz_ops.insert("quant_dot");
     }


### PR DESCRIPTION
* rocBLAS fp8 beta API support is being removed in the next ROCm release.
* Removing all usage of rocBLAS fp8 and eliminating the datatype when rocBLAS is selected to fp32.
* Checks GEMM provider environment variable and default setting