### PR TITLE
Print MigraphX consumed Env Variables

### DIFF
--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -974,11 +974,8 @@ int main(int argc, const char* argv[], const char* envp[])
             std::cout << k << "=" << v << "\\ \n"; // backslash(s) to facilitate cut-n-paste
 
         auto unused_envs = get_unrecognized_migraphx_envs(envp, mgx_env_map);
-        if(not unused_envs.empty())
-        {
-            for(auto&& e : unused_envs)
-                std::cout << "Unused environment variable: " << e << "\n";
-        }
+        for(auto&& e : unused_envs)
+            std::cout << "Unused environment variable: " << e << "\n";
 
         std::cout << "[ " << get_version() << " ] Complete: " << driver_invocation << std::endl;
     }

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -43,6 +43,7 @@
 #include <migraphx/load_save.hpp>
 #include <migraphx/json.hpp>
 #include <migraphx/version.h>
+#include <migraphx/env.hpp>
 
 #include <migraphx/dead_code_elimination.hpp>
 #include <migraphx/eliminate_identity.hpp>
@@ -914,7 +915,7 @@ struct main_command
 } // namespace migraphx
 
 using namespace migraphx::driver; // NOLINT
-int main(int argc, const char* argv[], const char* envp[])
+int main(int argc, const char* argv[])
 {
     std::vector<std::string> args(argv + 1, argv + argc);
     // no argument, print the help infomration by default
@@ -943,33 +944,13 @@ int main(int argc, const char* argv[], const char* envp[])
             std::string(argv[0]) + " " + migraphx::to_string_range(args, " ");
         std::cout << "Running [ " << get_version() << " ]: " << driver_invocation << std::endl;
 
-        std::string mgx_env_var;
-        for(const char** env = envp; *env != nullptr; ++env)
-        {
-            std::string env_var(*env);
-            size_t pos = env_var.find('=');
-            if(pos != std::string::npos)
-            {
-                std::string key = env_var.substr(0, pos);
-                if(key.find("MIGRAPHX") != std::string::npos)
-                {
-                    mgx_env_var += env_var + " \\ \n";
-                }
-            }
-        }
-
-        if(not mgx_env_var.empty())
-        {
-            std::cout << mgx_env_var;
-        }
-
         m.at(cmd)(argv[0],
                   {args.begin() + 1, args.end()}); // run driver command found in commands map
 
-        if(not mgx_env_var.empty())
-        {
-            std::cout << mgx_env_var;
-        }
+        // Dump all the MIGraphX (consumed) Environment Variables:
+        const auto mgx_env_map = migraphx::get_all_envs();
+        for(auto&& [k, v] : mgx_env_map)
+            std::cout << k << "=" << v << "\\ \n"; // backslash(s) to facilitate cut-n-paste
 
         std::cout << "[ " << get_version() << " ] Complete: " << driver_invocation << std::endl;
     }

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -70,7 +70,7 @@ get_unrecognized_migraphx_envs(const char* envp[],
     for(; *envp != nullptr; ++envp)
     {
         std::string e(*envp);
-        if(e.find("MIGRAPHX_") != 0) // starts with
+        if(not migraphx::starts_with(e, "MIGRAPHX"))
             continue;
         size_t pos = e.find('=');
         if(pos == std::string::npos)

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/env.hpp
+++ b/src/include/migraphx/env.hpp
@@ -27,6 +27,7 @@
 #include <utility>
 #include <vector>
 #include <string>
+#include <map>
 #include <migraphx/config.hpp>
 
 namespace migraphx {
@@ -74,6 +75,8 @@ std::string string_value_of(T, std::string fallback = "")
     static const std::string result = string_value_of(T::value(), std::move(fallback));
     return result;
 }
+
+std::map<std::string, std::string> get_all_envs();
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/include/migraphx/env.hpp
+++ b/src/include/migraphx/env.hpp
@@ -43,10 +43,9 @@ inline namespace MIGRAPHX_INLINE_NS {
 MIGRAPHX_EXPORT bool enabled(const char* name);
 MIGRAPHX_EXPORT bool disabled(const char* name);
 MIGRAPHX_EXPORT std::vector<std::string> env(const char* name);
-
 MIGRAPHX_EXPORT std::size_t value_of(const char* name, std::size_t fallback = 0);
-
 MIGRAPHX_EXPORT std::string string_value_of(const char* name, std::string fallback = "");
+MIGRAPHX_EXPORT std::map<std::string, std::string> get_all_envs();
 
 template <class T>
 bool enabled(T)

--- a/src/include/migraphx/env.hpp
+++ b/src/include/migraphx/env.hpp
@@ -75,8 +75,6 @@ std::string string_value_of(T, std::string fallback = "")
     return result;
 }
 
-std::map<std::string, std::string> get_all_envs();
-
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
 


### PR DESCRIPTION
The prior logic to dump MigraphX related Env variables was simplistic -- just by a string (prefix) match. It didn't matter if there were a mis-spelled string, which won't be consumed by the Driver.

Example, the final output of `MIGRAPHX_Junk_Env_Var=1 driver compile model.onnx` command would list:
`MIGRAPHX_Junk_Env_Var=1 \`  in its output; This variable was never consumed obviously. 

Typos like `MIGRAPHX_SET_GEM_PROVIDER=rocblas` could be easily caught, say for Perf results.

This change is to print only the actual consumed Env variables. Note, it doesn't verify the value of the consumed variable.

This change also guards against any version changes. If an Env variable isn't supported in a particular version, the final dump of the consumed variables will not show it.

Also fixed a bug in `disabled()`.