### PR TITLE
Ignore empty strings when checking if onnx graph is sorted

### DIFF
--- a/src/onnx/onnx_parser.cpp
+++ b/src/onnx/onnx_parser.cpp
@@ -509,8 +509,10 @@ static bool check_sorted(const onnx::GraphProto& graph,
     {
         for(auto&& input : node.input())
         {
-            if(not contains(visited_nodes, input))
-                return false;
+            // operators like resize can use empty strings to skip unused inputs
+            if(not input.empty())
+                if(not contains(visited_nodes, input))
+                    return false;
         }
         // node outputs struct is used to keep track of currently visited nodes
         visited_nodes.insert(node.output().begin(), node.output().end());


### PR DESCRIPTION
In operators like resize, optional inputs can be set to empty strings. There is a bug in checking the sorting if there are optional inputs and the graph is sorted, but because the empty string is not found in previously visited nodes, it will return false.
* added condition to skip over empty input strings
* existing resize op test cases will no longer throw warning messages.