### PR TITLE
Only run exhaustive tune for hipblaslt/rocblas when there isnt a solution

### DIFF
--- a/src/targets/gpu/include/migraphx/gpu/gemm.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/gemm.hpp
@@ -131,7 +131,7 @@ struct rocblas_gemm
 #ifdef MIGRAPHX_USE_ROCBLAS_TUNING_API
         if(solution_idx == 0)
             solution_idx = gemm_default_solution(ctx, output_shape, input_shapes);
-        if(enabled(MIGRAPHX_ENABLE_GEMM_TUNING{}) or ctx.get_exhaustive_tune_flag())
+        if(solution_idx == 0 and (enabled(MIGRAPHX_ENABLE_GEMM_TUNING{}) or ctx.get_exhaustive_tune_flag()))
         {
             if(this->name() == "gpu::gemm")
             {

--- a/src/targets/gpu/include/migraphx/gpu/gemm.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/gemm.hpp
@@ -131,7 +131,8 @@ struct rocblas_gemm
 #ifdef MIGRAPHX_USE_ROCBLAS_TUNING_API
         if(solution_idx == 0)
             solution_idx = gemm_default_solution(ctx, output_shape, input_shapes);
-        if(solution_idx == 0 and (enabled(MIGRAPHX_ENABLE_GEMM_TUNING{}) or ctx.get_exhaustive_tune_flag()))
+        if(solution_idx == 0 and
+           (enabled(MIGRAPHX_ENABLE_GEMM_TUNING{}) or ctx.get_exhaustive_tune_flag()))
         {
             if(this->name() == "gpu::gemm")
             {

--- a/src/targets/gpu/include/migraphx/gpu/hip_gemm.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/hip_gemm.hpp
@@ -122,7 +122,8 @@ struct MIGRAPHX_GPU_EXPORT hip_gemm
     {
         if(solution_idx == 0)
             solution_idx = hip_gemm_default_solution(ctx, output_shape, input_shapes);
-        if(solution_idx == 0 and (enabled(MIGRAPHX_ENABLE_HIP_GEMM_TUNING{}) or ctx.get_exhaustive_tune_flag()))
+        if(solution_idx == 0 and
+           (enabled(MIGRAPHX_ENABLE_HIP_GEMM_TUNING{}) or ctx.get_exhaustive_tune_flag()))
         {
             solution_idx =
                 hip_gemm_finalize(ctx, output_shape, input_shapes, alpha, beta, solution_idx);

--- a/src/targets/gpu/include/migraphx/gpu/hip_gemm.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/hip_gemm.hpp
@@ -122,7 +122,7 @@ struct MIGRAPHX_GPU_EXPORT hip_gemm
     {
         if(solution_idx == 0)
             solution_idx = hip_gemm_default_solution(ctx, output_shape, input_shapes);
-        if(enabled(MIGRAPHX_ENABLE_HIP_GEMM_TUNING{}) or ctx.get_exhaustive_tune_flag())
+        if(solution_idx == 0 and (enabled(MIGRAPHX_ENABLE_HIP_GEMM_TUNING{}) or ctx.get_exhaustive_tune_flag()))
         {
             solution_idx =
                 hip_gemm_finalize(ctx, output_shape, input_shapes, alpha, beta, solution_idx);


### PR DESCRIPTION
If the solution is already in the cache, then dont run tuning again. 