### PR TITLE
Fix generic_float template params

### DIFF
--- a/src/include/migraphx/bf16.hpp
+++ b/src/include/migraphx/bf16.hpp
@@ -31,7 +31,7 @@
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
-using bf16 = migraphx::generic_float<8, 7>;
+using bf16 = migraphx::generic_float<7, 8>;
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/include/migraphx/bf16.hpp
+++ b/src/include/migraphx/bf16.hpp
@@ -31,7 +31,7 @@
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
-using bf16 = migraphx::generic_float<7, 8>;
+using bf16 = migraphx::generic_float<8, 7>;
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/include/migraphx/generic_float.hpp
+++ b/src/include/migraphx/generic_float.hpp
@@ -73,8 +73,8 @@ struct unsigned_type<8>
 
 struct float32_parts
 {
-    unsigned int mantissa : 23;
     unsigned int exponent : 8;
+    unsigned int mantissa : 23;
     unsigned int sign : 1;
 
     static constexpr unsigned int exponent_width() { return 8; }
@@ -90,14 +90,14 @@ struct float32_parts
 
 constexpr float32_parts get_parts(float f) { return migraphx::bit_cast<float32_parts>(f); }
 
-template <unsigned int MantissaSize, unsigned int ExponentSize, unsigned int Flags = 0>
+template <unsigned int ExponentSize, unsigned int MantissaSize, unsigned int Flags = 0>
 struct __attribute__((packed, may_alias)) generic_float
 {
     using type = typename unsigned_type<bit_ceil(
         integer_divide_ceil(MantissaSize + ExponentSize + 1, 8))>::type;
 
-    type mantissa : MantissaSize;
     type exponent : ExponentSize;
+    type mantissa : MantissaSize;
     type sign : 1;
 
     static constexpr int exponent_bias() { return all_ones<ExponentSize - 1>(); }

--- a/src/include/migraphx/generic_float.hpp
+++ b/src/include/migraphx/generic_float.hpp
@@ -73,8 +73,8 @@ struct unsigned_type<8>
 
 struct float32_parts
 {
-    unsigned int exponent : 8;
     unsigned int mantissa : 23;
+    unsigned int exponent : 8;
     unsigned int sign : 1;
 
     static constexpr unsigned int exponent_width() { return 8; }
@@ -90,14 +90,14 @@ struct float32_parts
 
 constexpr float32_parts get_parts(float f) { return migraphx::bit_cast<float32_parts>(f); }
 
-template <unsigned int ExponentSize, unsigned int MantissaSize, unsigned int Flags = 0>
+template <unsigned int MantissaSize, unsigned int ExponentSize, unsigned int Flags = 0>
 struct __attribute__((packed, may_alias)) generic_float
 {
     using type = typename unsigned_type<bit_ceil(
         integer_divide_ceil(MantissaSize + ExponentSize + 1, 8))>::type;
 
-    type exponent : ExponentSize;
     type mantissa : MantissaSize;
+    type exponent : ExponentSize;
     type sign : 1;
 
     static constexpr int exponent_bias() { return all_ones<ExponentSize - 1>(); }
@@ -369,75 +369,75 @@ struct __attribute__((packed, may_alias)) generic_float
 // NOLINTBEGIN(cert-dcl58-cpp)
 namespace std {
 
-template <unsigned int E, unsigned int M, unsigned int F>
-class numeric_limits<migraphx::generic_float<E, M, F>>
+template <unsigned int M, unsigned int E, unsigned int F>
+class numeric_limits<migraphx::generic_float<M, E, F>>
 {
     public:
     static constexpr bool has_infinity = true;
-    static constexpr migraphx::generic_float<E, M, F> epsilon()
+    static constexpr migraphx::generic_float<M, E, F> epsilon()
     {
-        return migraphx::generic_float<E, M, F>::epsilon();
+        return migraphx::generic_float<M, E, F>::epsilon();
     }
 
-    static constexpr migraphx::generic_float<E, M, F> quiet_NaN()
+    static constexpr migraphx::generic_float<M, E, F> quiet_NaN()
     {
-        return migraphx::generic_float<E, M, F>::qnan();
+        return migraphx::generic_float<M, E, F>::qnan();
     }
 
-    static constexpr migraphx::generic_float<E, M, F> signaling_NaN()
+    static constexpr migraphx::generic_float<M, E, F> signaling_NaN()
     {
-        return migraphx::generic_float<E, M, F>::snan();
+        return migraphx::generic_float<M, E, F>::snan();
     }
 
-    static constexpr migraphx::generic_float<E, M, F> max()
+    static constexpr migraphx::generic_float<M, E, F> max()
     {
-        return migraphx::generic_float<E, M, F>::max();
+        return migraphx::generic_float<M, E, F>::max();
     }
 
-    static constexpr migraphx::generic_float<E, M, F> min()
+    static constexpr migraphx::generic_float<M, E, F> min()
     {
-        return migraphx::generic_float<E, M, F>::min();
+        return migraphx::generic_float<M, E, F>::min();
     }
 
-    static constexpr migraphx::generic_float<E, M, F> lowest()
+    static constexpr migraphx::generic_float<M, E, F> lowest()
     {
-        return migraphx::generic_float<E, M, F>::lowest();
+        return migraphx::generic_float<M, E, F>::lowest();
     }
 
-    static constexpr migraphx::generic_float<E, M, F> infinity()
+    static constexpr migraphx::generic_float<M, E, F> infinity()
     {
-        return migraphx::generic_float<E, M, F>::infinity();
+        return migraphx::generic_float<M, E, F>::infinity();
     }
 
-    static constexpr migraphx::generic_float<E, M, F> denorm_min()
+    static constexpr migraphx::generic_float<M, E, F> denorm_min()
     {
-        return migraphx::generic_float<E, M, F>::denorm_min();
+        return migraphx::generic_float<M, E, F>::denorm_min();
     }
 };
 
-template <unsigned int E, unsigned int M, unsigned int F, class T>
-struct common_type<migraphx::generic_float<E, M, F>, T> : std::common_type<float, T>
+template <unsigned int M, unsigned int E, unsigned int F, class T>
+struct common_type<migraphx::generic_float<M, E, F>, T> : std::common_type<float, T>
 {
 };
 
-template <unsigned int E, unsigned int M, unsigned int F, class T>
-struct common_type<T, migraphx::generic_float<E, M, F>> : std::common_type<float, T>
+template <unsigned int M, unsigned int E, unsigned int F, class T>
+struct common_type<T, migraphx::generic_float<M, E, F>> : std::common_type<float, T>
 {
 };
 
-template <unsigned int E, unsigned int M, unsigned int F>
-struct common_type<migraphx::generic_float<E, M, F>, migraphx::generic_float<E, M, F>>
+template <unsigned int M, unsigned int E, unsigned int F>
+struct common_type<migraphx::generic_float<M, E, F>, migraphx::generic_float<M, E, F>>
 {
-    using type = migraphx::generic_float<E, M, F>;
+    using type = migraphx::generic_float<M, E, F>;
 };
 
-template <unsigned int E1,
-          unsigned int M1,
+template <unsigned int M1,
+          unsigned int E1,
           unsigned int F1,
-          unsigned int E2,
           unsigned int M2,
+          unsigned int E2,
           unsigned int F2>
-struct common_type<migraphx::generic_float<E1, M1, F1>, migraphx::generic_float<E2, M2, F2>>
+struct common_type<migraphx::generic_float<M1, E1, F1>, migraphx::generic_float<M2, E2, F2>>
 {
     using type = float;
 };

--- a/src/include/migraphx/half.hpp
+++ b/src/include/migraphx/half.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/half.hpp
+++ b/src/include/migraphx/half.hpp
@@ -26,13 +26,12 @@
 #define MIGRAPHX_GUARD_RTGLIB_HALF_HPP
 
 #include <migraphx/config.hpp>
-#include <migraphx/float8.hpp>
 #include <migraphx/generic_float.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
-using half = migraphx::generic_float<10, 5>;
+using half = migraphx::generic_float<5, 10>;
 
 namespace detail {
 template <class T>

--- a/src/include/migraphx/half.hpp
+++ b/src/include/migraphx/half.hpp
@@ -31,7 +31,7 @@
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
-using half = migraphx::generic_float<5, 10>;
+using half = migraphx::generic_float<10, 5>;
 
 namespace detail {
 template <class T>


### PR DESCRIPTION
The template parameters for the numeric limits were named in a way that's confusing. `generic_float` template parameters are in the order `<MantissaSize, ExponentSize, Flags>`. No logic issue because the template parameters will be deduced correctly either way.