### PR TITLE
represent BF16::max by its encoding, rather than the expected value

### DIFF
--- a/src/targets/gpu/kernels/include/migraphx/kernels/type_traits.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/type_traits.hpp
@@ -263,7 +263,10 @@ constexpr T numeric_max()
     else if constexpr(is_same<T, migraphx::half>{})
         return __FLT16_MAX__;
     else if constexpr(is_same<T, migraphx::bf16>{})
-        return 338953138925153547590470800371487866880.000000;
+    {
+        unsigned short us = 0x7f7f; // Max +ve number encoding in BF16
+        return __builtin_bit_cast(T, us);
+    }
     else
         return 0;
 }


### PR DESCRIPTION
Hardcoding a large 47 digit number (338953138925153547590470800371487866880.000000) to represent something of just 16 bits is a very iffy guess. How does someone ever come up with this number? 