### PR TITLE
Add TF AddN op support

### DIFF
--- a/src/tf/parse_addn.cpp
+++ b/src/tf/parse_addn.cpp
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/tf/op_parser.hpp>
+#include <migraphx/ranges.hpp>
+#include <migraphx/instruction.hpp>
+#include <migraphx/make_op.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace tf {
+
+struct parse_addn : op_parser<parse_addn>
+{
+    bool transpose() const { return true; }
+    std::vector<op_desc> operators() const { return {{"AddN"}}; }
+
+    instruction_ref parse(const op_desc& /*opd*/,
+                          const tf_parser& /*parser*/,
+                          const tf_parser::node_info& info,
+                          std::vector<instruction_ref> args) const
+    {
+        instruction_ref sum = args[0];
+        for(auto i = 1; i < args.size(); i++)
+        {
+            sum = info.add_instruction(make_op("add"), sum, args[i]);
+        }
+        return sum;
+    }
+};
+
+} // namespace tf
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx

--- a/test/tf/gen_tf_pb.py
+++ b/test/tf/gen_tf_pb.py
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/test/tf/gen_tf_pb.py
+++ b/test/tf/gen_tf_pb.py
@@ -72,6 +72,24 @@ def add_bcast_test(g1):
 
 
 @tf_test
+def addn_test(g1):
+    with g1.as_default():
+        g1_input = tf.compat.v1.placeholder(tf.float32, shape=(2, 3), name='0')
+        g2_input = tf.compat.v1.placeholder(tf.float32, shape=(2, 3), name='1')
+        g3_input = tf.compat.v1.placeholder(tf.float32, shape=(2, 3), name='2')
+
+        tf.math.add_n([g1_input, g2_input, g3_input], name='addn1')        
+
+
+@tf_test
+def addn_single_test(g1):
+    with g1.as_default():
+        g1_input = tf.compat.v1.placeholder(tf.float32, shape=(2, 3), name='0')
+
+        tf.math.add_n([g1_input], name='addn1')
+
+
+@tf_test
 def argmax_test(g1):
     with g1.as_default():
         g1_input = tf.compat.v1.placeholder(tf.float32,

--- a/test/tf/models/addn_single_test.pb
+++ b/test/tf/models/addn_single_test.pb
@@ -1,0 +1,9 @@
+
+2
+0Placeholder*
+dtype0*
+shape
+:
+
+addn1Identity0*
+T0"Ñ

--- a/test/tf/models/addn_test.pb
+++ b/test/tf/models/addn_test.pb
@@ -1,0 +1,20 @@
+
+2
+0Placeholder*
+dtype0*
+shape
+:
+2
+1Placeholder*
+dtype0*
+shape
+:
+2
+2Placeholder*
+dtype0*
+shape
+:
+(
+addn1AddN012*
+N*
+T0"Ñ

--- a/test/tf/tests/addn_test.cpp
+++ b/test/tf/tests/addn_test.cpp
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <tf_test.hpp>
+
+TEST_CASE(addn_test)
+{
+    migraphx::program p;
+
+    auto* mm = p.get_main_module();
+    auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3}});
+    auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {2, 3}});
+    auto l2  = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {2, 3}});
+    auto add1 = mm->add_instruction(migraphx::make_op("add"), l0, l1);
+    mm->add_instruction(migraphx::make_op("add"), add1, l2);
+    auto prog = optimize_tf("addn_test.pb", false);
+
+    EXPECT(p == prog);
+}
+
+TEST_CASE(addn_single_test)
+{
+    migraphx::program p;
+
+    auto* mm = p.get_main_module();
+    auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3}});
+    mm->add_instruction(migraphx::make_op("identity"), l0);
+    auto prog = optimize_tf("addn_single_test.pb", false);
+
+    EXPECT(p == prog);
+}

--- a/test/tf/tests/addn_test.cpp
+++ b/test/tf/tests/addn_test.cpp
@@ -29,10 +29,10 @@ TEST_CASE(addn_test)
 {
     migraphx::program p;
 
-    auto* mm = p.get_main_module();
-    auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3}});
-    auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {2, 3}});
-    auto l2  = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {2, 3}});
+    auto* mm  = p.get_main_module();
+    auto l0   = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3}});
+    auto l1   = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {2, 3}});
+    auto l2   = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {2, 3}});
     auto add1 = mm->add_instruction(migraphx::make_op("add"), l0, l1);
     mm->add_instruction(migraphx::make_op("add"), add1, l2);
     auto prog = optimize_tf("addn_test.pb", false);


### PR DESCRIPTION
* added parser for AddN op
* added some unit tests
* according to the spec, AddN inputs must all have the same shape. Otherwise, I can't create the protobuf. That's why I don't have any error checking in the parser. We would through an exception though on our Add op if there was a shape mismatch.