### PR TITLE
Changes for targeting SPIR-V

### DIFF
--- a/docs/dev/contributing-to-migraphx.rst
+++ b/docs/dev/contributing-to-migraphx.rst
@@ -56,7 +56,7 @@ Adding Parameters
 ----------------------------
 
 While the ``add_two_literals()`` function above demonstrates add operation on constant values ``1`` and ``2``,
-the following program demonstrates how to pass a parameter (``x``) to a module using ``add_parameter()`` function .
+the following program demonstrates how to pass a parameter (``x``) to a module using ``add_parameter()`` function::
 
     migraphx::program p;
     auto* mm = p.get_main_module();

--- a/docs/dev/env_vars.rst
+++ b/docs/dev/env_vars.rst
@@ -381,6 +381,15 @@ hipBLASLt vars
 Set to "1", "enable", "enabled", "yes", or "true" to use.
 Performs exhaustive tuning for hipBLASLt.
 
+
+SPIR-V vars
+------------
+
+.. envvar:: MIRGRAPHX_GEN_SPIRV
+
+Set to '1', 'enable', "enabled", "yes", or "true" to use.
+When used with abuild where ``-DMIGRAPHX_USE_HIPRTC=FALSE``, it will target ``SPIR-V``
+
 Testing 
 ------------
 

--- a/src/targets/gpu/compile_hip_code_object.cpp
+++ b/src/targets/gpu/compile_hip_code_object.cpp
@@ -198,7 +198,9 @@ compile_hip_code_object(context& ctx, const std::string& content, hip_compile_op
     options.params.insert(options.params.end(), warnings.begin(), warnings.end());
     options.emplace_param("-ftemplate-backtrace-limit=0");
     options.emplace_param("-Werror");
-    auto cos = compile_hip_src(srcs, options.params, get_device_name());
+    auto cos = enabled(MIGRAPHX_GEN_SPIRV{}) 
+                ? compile_hip_src(srcs, options.params, "amdgcnspirv") 
+                : compile_hip_src(srcs, options.params, get_device_name());
     if(cos.size() != 1)
         MIGRAPHX_THROW("No code object");
     return code_object_op{value::binary{cos.front()},

--- a/src/targets/gpu/compile_hip_code_object.cpp
+++ b/src/targets/gpu/compile_hip_code_object.cpp
@@ -203,15 +203,13 @@ compile_hip_code_object(context& ctx, const std::string& content, hip_compile_op
                    : compile_hip_src(srcs, options.params, get_device_name());
     if(cos.size() != 1)
         MIGRAPHX_THROW("No code object");
-
-    code_object_op cop{value::binary{cos.front()},
-                       options.kernel_name,
-                       options.global,
-                       options.local,
-                       options.inputs,
-                       options.output,
-                       options.output_arg};
-    return cop;
+    return code_object_op{value::binary{cos.front()},
+                          options.kernel_name,
+                          options.global,
+                          options.local,
+                          options.inputs,
+                          options.output,
+                          options.output_arg};
 }
 
 } // namespace gpu

--- a/src/targets/gpu/include/migraphx/gpu/compile_hip_code_object.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/compile_hip_code_object.hpp
@@ -28,9 +28,13 @@
 #include <migraphx/operation.hpp>
 #include <migraphx/compile_src.hpp>
 #include <migraphx/stringutils.hpp>
+#include <migraphx/env.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
+
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GEN_SPIRV);
+
 namespace gpu {
 
 struct context;


### PR DESCRIPTION
Done:
* Added `MIGRAPHX_GEN_SPIRV` flag for generating SPIR-V
* Updated `env_vars.rst` to reflect this
* Small change with tutorial doc

Needs:
* Further tests
* BF16, complex kernel support