### PR TITLE
nonmaxsuppression: identical boxes/scores not ordered correctly

### DIFF
--- a/src/include/migraphx/op/nonmaxsuppression.hpp
+++ b/src/include/migraphx/op/nonmaxsuppression.hpp
@@ -305,10 +305,10 @@ struct nonmaxsuppression
                                return std::make_pair(sc, box_idx - 1);
                            });
         }
-        // sort by the higher score, or if equal then the early (i.e. lower) index of the box
+        // Sort by the higher score; or if equal then the early (i.e. lower) index of the box
+        // The tie below compares in effect t2.second > t1.second
         par_sort(boxes_heap.begin(), boxes_heap.end(), [](auto const& t1, auto const& t2) {
-            return std::get<0>(t1) > std::get<0>(t2) or
-                   (not(std::get<0>(t1) < std::get<0>(t2)) and (std::get<1>(t1) < std::get<1>(t2)));
+            return std::tie(t1.first, t2.second) > std::tie(t2.first, t1.second);
         });
         return boxes_heap;
     }

--- a/test/ref/nonmaxsuppression.cpp
+++ b/test/ref/nonmaxsuppression.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
NMS identical boxes: the earliest should be picked. Also added a test case which would otherwise fail.