### PR TITLE
Remove ROCM_USE_FLOAT8 macro

### DIFF
--- a/src/targets/gpu/hip_gemm_impl.cpp
+++ b/src/targets/gpu/hip_gemm_impl.cpp
@@ -61,8 +61,7 @@ static hipDataType get_type_hipblas(shape::type_t type)
     case shape::int32_type: return HIP_R_32I;
     case shape::uint32_type: return HIP_R_32U;
     case shape::fp8e4m3fnuz_type: return HIP_R_8F_E4M3_FNUZ;
-    case shape::fp8e5m2fnuz_type:
-        return HIP_R_8F_E5M2_FNUZ;
+    case shape::fp8e5m2fnuz_type: return HIP_R_8F_E5M2_FNUZ;
     case shape::fp8e4m3fn_type: return HIP_R_8F_E4M3;
     case shape::fp8e5m2_type: return HIP_R_8F_E5M2;
     case shape::tuple_type:


### PR DESCRIPTION
Remove `ROCM_USE_FLOAT8` macro. This macro has been removed from hipblaslt (in this [PR](https://github.com/ROCm/hipBLASLt/pull/2165)) and the check no longer needed for rocm-7.0. 