### PR TITLE
Print Kernel/Module in Compile Failure

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -146,7 +146,12 @@ struct compile_plan
                 ctx->get_problem_cache().mark(preop.name(), problem);
                 const auto& solutions = config->solutions;
                 if(solutions.empty())
-                    MIGRAPHX_THROW("No solutions provided for " + preop.name() + " with " + problem_string() + (not config->mlir_kernel.empty() ? ("\nMLIR Fused Kernel:\n" + config->mlir_kernel) : "") +"\nMIGraphX Module:\n" + to_string(*mod));
+                    MIGRAPHX_THROW("No solutions provided for " + preop.name() + " with " +
+                                   problem_string() +
+                                   (not config->mlir_kernel.empty()
+                                        ? ("\nMLIR Fused Kernel:\n" + config->mlir_kernel)
+                                        : "") +
+                                   "\nMIGraphX Module:\n" + to_string(*mod));
                 results.resize(solutions.size());
                 for(auto i : range(solutions.size()))
                 {
@@ -177,11 +182,20 @@ struct compile_plan
                       << std::endl;
         }
         if(results.empty())
-            MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " + problem_string() + (not config->mlir_kernel.empty() ? ("\nMLIR Fused Kernel:\n" + config->mlir_kernel) : "") +"\nMIGraphX Module:\n" + to_string(*mod));
+            MIGRAPHX_THROW(
+                "No valid tuned compilation for " + preop.name() + " with " + problem_string() +
+                (not config->mlir_kernel.empty() ? ("\nMLIR Fused Kernel:\n" + config->mlir_kernel)
+                                                 : "") +
+                "\nMIGraphX Module:\n" + to_string(*mod));
         if(results.size() == 1)
         {
             if(not results.front().has_value())
-                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " + problem_string() + (not config->mlir_kernel.empty() ? ("\nMLIR Fused Kernel:\n" + config->mlir_kernel) : "") +"\nMIGraphX Module:\n" + to_string(*mod));
+                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
+                               problem_string() +
+                               (not config->mlir_kernel.empty()
+                                    ? ("\nMLIR Fused Kernel:\n" + config->mlir_kernel)
+                                    : "") +
+                               "\nMIGraphX Module:\n" + to_string(*mod));
             return *results.front();
         }
         if(not config)
@@ -243,7 +257,11 @@ struct compile_plan
             ctx->get_problem_cache().save();
         }
         if(not results[i].has_value())
-            MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " + problem_string() + (not config->mlir_kernel.empty() ? ("\nMLIR Fused Kernel:\n" + config->mlir_kernel) : "") +"\nMIGraphX Module:\n" + to_string(*mod));
+            MIGRAPHX_THROW(
+                "No valid tuned compilation for " + preop.name() + " with " + problem_string() +
+                (not config->mlir_kernel.empty() ? ("\nMLIR Fused Kernel:\n" + config->mlir_kernel)
+                                                 : "") +
+                "\nMIGraphX Module:\n" + to_string(*mod));
         auto skipped = std::count_if(
             results.begin(), results.end(), [](const auto& cr) { return not cr.has_value(); });
         if(skipped > 0)

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -146,17 +146,7 @@ struct compile_plan
                 ctx->get_problem_cache().mark(preop.name(), problem);
                 const auto& solutions = config->solutions;
                 if(solutions.empty())
-                {
-                    if(config->mlir_kernel.empty())
-                        MIGRAPHX_THROW("No solutions provided for " + preop.name() + " with " +
-                                       to_string(problem) + "\nMIGraphX Module:\n" +
-                                       to_string(*mod));
-                    else
-                        MIGRAPHX_THROW("No solutions provided for " + preop.name() + " with " +
-                                       to_string(problem) + "\nMLIR Fused Kernel:\n" +
-                                       config->mlir_kernel + "\nMIGraphX Module:\n" +
-                                       to_string(*mod));
-                }
+                    MIGRAPHX_THROW("No solutions provided for " + preop.name() + " with " + problem_string() + (not config->mlir_kernel.empty() ? ("\nMLIR Fused Kernel:\n" + config->mlir_kernel) : "") +"\nMIGraphX Module:\n" + to_string(*mod));
                 results.resize(solutions.size());
                 for(auto i : range(solutions.size()))
                 {
@@ -187,27 +177,11 @@ struct compile_plan
                       << std::endl;
         }
         if(results.empty())
-        {
-            if(not config or config->mlir_kernel.empty())
-                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
-                               problem_string() + "\nMIGraphX Module:\n" + to_string(*mod));
-            else
-                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
-                               problem_string() + "\nMLIR Fused Kernel:\n" + config->mlir_kernel +
-                               "\nMIGraphX Module:\n" + to_string(*mod));
-        }
+            MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " + problem_string() + (not config->mlir_kernel.empty() ? ("\nMLIR Fused Kernel:\n" + config->mlir_kernel) : "") +"\nMIGraphX Module:\n" + to_string(*mod));
         if(results.size() == 1)
         {
             if(not results.front().has_value())
-            {
-                if(not config or config->mlir_kernel.empty())
-                    MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
-                                   problem_string() + "\nMIGraphX Module:\n" + to_string(*mod));
-                else
-                    MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
-                                   problem_string() + "\nMLIR Fused Kernel:\n" +
-                                   config->mlir_kernel + "\nMIGraphX Module:\n" + to_string(*mod));
-            }
+                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " + problem_string() + (not config->mlir_kernel.empty() ? ("\nMLIR Fused Kernel:\n" + config->mlir_kernel) : "") +"\nMIGraphX Module:\n" + to_string(*mod));
             return *results.front();
         }
         if(not config)
@@ -269,15 +243,7 @@ struct compile_plan
             ctx->get_problem_cache().save();
         }
         if(not results[i].has_value())
-        {
-            if(config->mlir_kernel.empty())
-                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
-                               problem_string() + "\nMIGraphX Module:\n" + to_string(*mod));
-            else
-                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
-                               problem_string() + "\nMLIR Fused Kernel:\n" + config->mlir_kernel +
-                               "\nMIGraphX Module:\n" + to_string(*mod));
-        }
+            MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " + problem_string() + (not config->mlir_kernel.empty() ? ("\nMLIR Fused Kernel:\n" + config->mlir_kernel) : "") +"\nMIGraphX Module:\n" + to_string(*mod));
         auto skipped = std::count_if(
             results.begin(), results.end(), [](const auto& cr) { return not cr.has_value(); });
         if(skipped > 0)

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -145,12 +145,17 @@ struct compile_plan
             {
                 ctx->get_problem_cache().mark(preop.name(), problem);
                 const auto& solutions = config->solutions;
-                if(solutions.empty()) 
+                if(solutions.empty())
                 {
-                    if (config->mlir_kernel.empty())
-                        MIGRAPHX_THROW("No solutions provided for " + preop.name() + " with " + to_string(problem) + "\nMIGraphX Module:\n" + to_string(*mod));
+                    if(config->mlir_kernel.empty())
+                        MIGRAPHX_THROW("No solutions provided for " + preop.name() + " with " +
+                                       to_string(problem) + "\nMIGraphX Module:\n" +
+                                       to_string(*mod));
                     else
-                        MIGRAPHX_THROW("No solutions provided for " + preop.name() + " with " + to_string(problem) + "\nMLIR Fused Kernel:\n" + config->mlir_kernel + "\nMIGraphX Module:\n" + to_string(*mod));
+                        MIGRAPHX_THROW("No solutions provided for " + preop.name() + " with " +
+                                       to_string(problem) + "\nMLIR Fused Kernel:\n" +
+                                       config->mlir_kernel + "\nMIGraphX Module:\n" +
+                                       to_string(*mod));
                 }
                 results.resize(solutions.size());
                 for(auto i : range(solutions.size()))
@@ -183,19 +188,25 @@ struct compile_plan
         }
         if(results.empty())
         {
-            if (not config or config->mlir_kernel.empty())
-                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " + problem_string() + "\nMIGraphX Module:\n" + to_string(*mod));
+            if(not config or config->mlir_kernel.empty())
+                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
+                               problem_string() + "\nMIGraphX Module:\n" + to_string(*mod));
             else
-                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " + problem_string() + "\nMLIR Fused Kernel:\n" + config->mlir_kernel + "\nMIGraphX Module:\n" + to_string(*mod));
+                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
+                               problem_string() + "\nMLIR Fused Kernel:\n" + config->mlir_kernel +
+                               "\nMIGraphX Module:\n" + to_string(*mod));
         }
         if(results.size() == 1)
         {
             if(not results.front().has_value())
             {
-                if (not config or config->mlir_kernel.empty())
-                    MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " + problem_string() + "\nMIGraphX Module:\n" + to_string(*mod));
+                if(not config or config->mlir_kernel.empty())
+                    MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
+                                   problem_string() + "\nMIGraphX Module:\n" + to_string(*mod));
                 else
-                    MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " + problem_string() + "\nMLIR Fused Kernel:\n" + config->mlir_kernel + "\nMIGraphX Module:\n" + to_string(*mod));
+                    MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
+                                   problem_string() + "\nMLIR Fused Kernel:\n" +
+                                   config->mlir_kernel + "\nMIGraphX Module:\n" + to_string(*mod));
             }
             return *results.front();
         }
@@ -259,10 +270,13 @@ struct compile_plan
         }
         if(not results[i].has_value())
         {
-            if (config->mlir_kernel.empty())
-                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " + problem_string() + "\nMIGraphX Module:\n" + to_string(*mod));
+            if(config->mlir_kernel.empty())
+                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
+                               problem_string() + "\nMIGraphX Module:\n" + to_string(*mod));
             else
-                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " + problem_string() + "\nMLIR Fused Kernel:\n" + config->mlir_kernel + "\nMIGraphX Module:\n" + to_string(*mod));
+                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
+                               problem_string() + "\nMLIR Fused Kernel:\n" + config->mlir_kernel +
+                               "\nMIGraphX Module:\n" + to_string(*mod));
         }
         auto skipped = std::count_if(
             results.begin(), results.end(), [](const auto& cr) { return not cr.has_value(); });

--- a/src/targets/gpu/include/migraphx/gpu/tuning_config.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/tuning_config.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/include/migraphx/gpu/tuning_config.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/tuning_config.hpp
@@ -35,6 +35,7 @@ struct tuning_config
 {
     value problem;
     std::vector<value> solutions;
+    std::string mlir_kernel;
 };
 
 } // namespace gpu

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -849,6 +849,7 @@ struct mlir_program
     tuning_config get_tuning_config(bool exhaustive)
     {
         tuning_config tc;
+        tc.mlir_kernel = mlir_print(&mlirOperationPrint, mlirModuleGetOperation(mmodule.get()));
         run_high_level_pipeline();
         auto tuning_mode =
             exhaustive ? RocmlirTuningParamSetKindFull : RocmlirTuningParamSetKindQuick;
@@ -878,7 +879,6 @@ struct mlir_program
             MIGRAPHX_THROW("Tuning table key was " + std::to_string(tuning_key_bytes) +
                            " bytes and thus too long");
         tc.problem = std::string(tuning_key.begin(), tuning_key.begin() + tuning_key_bytes);
-        tc.mlir_kernel = mlir_print(&mlirOperationPrint, mlirModuleGetOperation(mmodule.get()));
         return tc;
     }
 

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -878,6 +878,7 @@ struct mlir_program
             MIGRAPHX_THROW("Tuning table key was " + std::to_string(tuning_key_bytes) +
                            " bytes and thus too long");
         tc.problem = std::string(tuning_key.begin(), tuning_key.begin() + tuning_key_bytes);
+        tc.mlir_kernel = mlir_print(&mlirOperationPrint, mlirModuleGetOperation(mmodule.get()));
         return tc;
     }
 


### PR DESCRIPTION
Currently, when `compile_ops` fails, we print out the name of the failing operator and occasionally the problem config. An example of this is the following:
```
terminate called after throwing an instance of 'migraphx::version_2_13_0::exception'
  what():  /code/AMDMIGraphX/src/targets/gpu/compile_ops.cpp:153: add_compiles: No solutions provided for gpu::mlir_op with gfx1100     48      -t f32 -transQ false -transK true -transV false -transO false -g 2 -seq_len_q 2 -seq_len_k 2 -head_dim_qk 2 -head_dim_v 2
```
This PR aims to add more detail to the failure in the hopes of making debugging easier. For instance, the MLIR kernel should hopefully reduce the need to re-create the issue before MLIR team can begin debugging. In cases where there is no MLIR kernel (i.e. MLIR is disabled), then it simply prints the MIGraphX module. An example of the updated error message is as follows:
```
terminate called after throwing an instance of 'migraphx::version_2_13_0::exception'
  what():  /code/AMDMIGraphX/src/targets/gpu/compile_ops.cpp:153: add_compiles: No solutions provided for gpu::mlir_op with gfx1100     48      -t f32 -transQ false -transK true -transV false -transO false -g 2 -seq_len_q 2 -seq_len_k 2 -head_dim_qk 2 -head_dim_v 2
MLIR Fused Kernel:
module {
  func.func @mlir_reshape_transpose_reshape_transpose_dot_mul_softmax_reshape_transpose_dot(%arg0: memref<8xf32>, %arg1: memref<8xf32>, %arg2: memref<8xf32>, %arg3: memref<8xf32>) attributes {arch = "gfx1100", kernel = "mixr", num_cu = 48 : i64} {
    %cst = arith.constant 0.707106769 : f32
    %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2, d3) -> ((d1 * 2 + d2) * 2 + d3)> by [<Unmerge{2, 2, 2} ["exp1", "exp2", "exp3"] at [1, 2, 3] -> ["dim0"] at [0]>, <AddDim{1} ["unit0"] at [0] -> [] at []>] bounds = [1, 2, 2, 2] -> [8]> : memref<8xf32> to memref<1x2x2x2xf32>
    %1 = rock.transform %0 by <affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)> by [<PassThrough ["dim0", "dim2", "dim1", "dim3"] at [0, 1, 2, 3] -> ["dim0", "dim2", "dim1", "dim3"] at [0, 2, 1, 3]>] bounds = [1, 2, 2, 2] -> [1, 2, 2, 2]> : memref<1x2x2x2xf32> to memref<1x2x2x2xf32>
    %2 = rock.transform %arg1 by <affine_map<(d0, d1, d2, d3) -> ((d1 * 2 + d2) * 2 + d3)> by [<Unmerge{2, 2, 2} ["exp1", "exp2", "exp3"] at [1, 2, 3] -> ["dim0"] at [0]>, <AddDim{1} ["unit0"] at [0] -> [] at []>] bounds = [1, 2, 2, 2] -> [8]> : memref<8xf32> to memref<1x2x2x2xf32>
    %3 = rock.transform %2 by <affine_map<(d0, d1, d2, d3) -> (d0, d3, d1, d2)> by [<PassThrough ["dim0", "dim2", "dim3", "dim1"] at [0, 1, 2, 3] -> ["dim0", "dim2", "dim3", "dim1"] at [0, 2, 3, 1]>] bounds = [1, 2, 2, 2] -> [1, 2, 2, 2]> : memref<1x2x2x2xf32> to memref<1x2x2x2xf32>
    %4 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (0, d0, d1, d2)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>, <PassThrough ["dim2"] at [2] -> ["dim2"] at [3]>] bounds = [2, 2, 2] -> [1, 2, 2, 2]> : memref<1x2x2x2xf32> to memref<2x2x2xf32>
    %5 = rock.transform %3 by <affine_map<(d0, d1, d2) -> (0, d0, d1, d2)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>, <PassThrough ["dim2"] at [2] -> ["dim2"] at [3]>] bounds = [2, 2, 2] -> [1, 2, 2, 2]> : memref<1x2x2x2xf32> to memref<2x2x2xf32>
    %6 = rock.transform %arg2 by <affine_map<(d0, d1, d2, d3) -> ((d1 * 2 + d2) * 2 + d3)> by [<Unmerge{2, 2, 2} ["exp1", "exp2", "exp3"] at [1, 2, 3] -> ["dim0"] at [0]>, <AddDim{1} ["unit0"] at [0] -> [] at []>] bounds = [1, 2, 2, 2] -> [8]> : memref<8xf32> to memref<1x2x2x2xf32>
    %7 = rock.transform %6 by <affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)> by [<PassThrough ["dim0", "dim2", "dim1", "dim3"] at [0, 1, 2, 3] -> ["dim0", "dim2", "dim1", "dim3"] at [0, 2, 1, 3]>] bounds = [1, 2, 2, 2] -> [1, 2, 2, 2]> : memref<1x2x2x2xf32> to memref<1x2x2x2xf32>
    %8 = rock.transform %7 by <affine_map<(d0, d1, d2) -> (0, d0, d1, d2)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>, <PassThrough ["dim2"] at [2] -> ["dim2"] at [3]>] bounds = [2, 2, 2] -> [1, 2, 2, 2]> : memref<1x2x2x2xf32> to memref<2x2x2xf32>
    %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x2x2xf32>
    %9 = rock.transform %4 by <affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["dim1", "dim0", "dim2"] at [0, 1, 2] -> ["dim1", "dim0", "dim2"] at [1, 0, 2]>] bounds = [2, 2, 2] -> [2, 2, 2]> : memref<2x2x2xf32> to memref<2x2x2xf32>
    %10 = rock.transform %5 by <affine_map<(d0, d1, d2) -> (d1, d2, d0)> by [<PassThrough ["dim2", "dim0", "dim1"] at [0, 1, 2] -> ["dim2", "dim0", "dim1"] at [2, 0, 1]>] bounds = [2, 2, 2] -> [2, 2, 2]> : memref<2x2x2xf32> to memref<2x2x2xf32>
    %11 = rock.transform %8 by <affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["dim1", "dim0", "dim2"] at [0, 1, 2] -> ["dim1", "dim0", "dim2"] at [1, 0, 2]>] bounds = [2, 2, 2] -> [2, 2, 2]> : memref<2x2x2xf32> to memref<2x2x2xf32>
    %12 = rock.transform %9 by <affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["dim1", "dim0", "dim2"] at [0, 1, 2] -> ["dim1", "dim0", "dim2"] at [1, 0, 2]>] bounds = [2, 2, 2] -> [2, 2, 2]> : memref<2x2x2xf32> to memref<2x2x2xf32>
    %13 = rock.transform %10 by <affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["dim1", "dim0", "dim2"] at [0, 1, 2] -> ["dim1", "dim0", "dim2"] at [1, 0, 2]>] bounds = [2, 2, 2] -> [2, 2, 2]> : memref<2x2x2xf32> to memref<2x2x2xf32>
    %14 = rock.transform %11 by <affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["dim1", "dim0", "dim2"] at [0, 1, 2] -> ["dim1", "dim0", "dim2"] at [1, 0, 2]>] bounds = [2, 2, 2] -> [2, 2, 2]> : memref<2x2x2xf32> to memref<2x2x2xf32>
    rock.attention{
     qk = %12 * tr %13 : memref<2x2x2xf32>, memref<2x2x2xf32>
     qk = elementwise {
    ^bb0(%arg4: memref<2x2x2xf32>, %arg5: memref<1x2x2x2xf32>):
      %16 = rock.transform %arg4 by <affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)> by [<Unmerge{2} ["exp1"] at [1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>, <PassThrough ["dim2"] at [3] -> ["dim2"] at [2]>, <AddDim{1} ["unit0"] at [0] -> [] at []>] bounds = [1, 2, 2, 2] -> [2, 2, 2]> : memref<2x2x2xf32> to memref<1x2x2x2xf32>
      %17 = rock.transform %16 by <affine_map<(d0, d1, d2) -> (0, d0, d1, d2)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>, <PassThrough ["dim2"] at [2] -> ["dim2"] at [3]>] bounds = [2, 2, 2] -> [1, 2, 2, 2]> : memref<1x2x2x2xf32> to memref<2x2x2xf32>
      %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x2x2xf32>
      linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%17 : memref<2x2x2xf32>) outs(%alloc_0 : memref<2x2x2xf32>) {
      ^bb0(%in: f32, %out: f32):
        %19 = arith.mulf %in, %cst : f32
        linalg.yield %19 : f32
      }
      %18 = rock.transform %alloc_0 by <affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)> by [<Unmerge{2} ["exp1"] at [1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>, <PassThrough ["dim2"] at [3] -> ["dim2"] at [2]>, <AddDim{1} ["unit0"] at [0] -> [] at []>] bounds = [1, 2, 2, 2] -> [2, 2, 2]> : memref<2x2x2xf32> to memref<1x2x2x2xf32>
      memref.copy %18, %arg5 : memref<1x2x2x2xf32> to memref<1x2x2x2xf32>
      rock.yield
    }
     %alloc = softmax(qk) * %14 : memref<2x2x2xf32> -> memref<2x2x2xf32>
    } {arch = "gfx1100", features = #rock<GemmFeatures dot|atomic_add|atomic_fmax_f32>, firstGemmIdx = 0 : i32, numCU = 48 : i32}
    %15 = rock.transform %alloc by <affine_map<(d0) -> (d0 floordiv 4, (d0 mod 4) floordiv 2, d0 mod 2)> by [<Merge{2, 2, 2} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>] bounds = [8] -> [2, 2, 2]> : memref<2x2x2xf32> to memref<8xf32>
    memref.copy %15, %arg3 : memref<8xf32> to memref<8xf32>
    return
  }
}
MIGraphX Module:
main:#output_0 = @param:main:#output_0 -> float_type, {1, 2, 4}, {8, 4, 1}
v = @param:v -> float_type, {1, 2, 4}, {8, 4, 1}
k = @param:k -> float_type, {1, 2, 4}, {8, 4, 1}
q = @param:q -> float_type, {1, 2, 4}, {8, 4, 1}
@4 = hip::allocate[shape=float_type, {1, 2, 2, 2}, {8, 4, 2, 1}] -> float_type, {1, 2, 2, 2}, {8, 4, 2, 1}
@5 = gpu::precompile_op[op=gpu::mlir_op[op=dot],additional_args=1,ignore_modules=0,output_shape=nullopt](q,k,v,@4), [mlir_attn_main:reduce_sum1:main:pointwise3:main:pointwise0:main:reduce_max0:main:pointwise1] -> float_type, {1, 2, 2, 2}, {8, 4, 2, 1}
@6 = transpose[permutation={0, 2, 1, 3}](@5) -> float_type, {1, 2, 2, 2}, {8, 2, 4, 1}
@7 = hip::allocate[shape=float_type, {1, 2, 2, 2}, {8, 4, 2, 1}] -> float_type, {1, 2, 2, 2}, {8, 4, 2, 1}
@8 = gpu::precompile_op[op=contiguous,additional_args=1,ignore_modules=0,output_shape=nullopt](@6,@7) -> float_type, {1, 2, 2, 2}, {8, 4, 2, 1}
@9 = reshape_lazy[dims={1, 2, 4}](@8) -> float_type, {1, 2, 4}, {8, 4, 1}
@10 = gpu::precompile_op[op=contiguous,additional_args=1,ignore_modules=0,output_shape=nullopt](@9,main:#output_0) -> float_type, {1, 2, 4}, {8, 4, 1}
@11 = @return(@10)
```
I do have potential concerns about the error message becoming too large, but I'm not sure if this is something people are worried about. In particular, large models may cause the MIGraphX module output to be not useful; maybe there is a way to trim it down to a specific area of interest? Alternative is to have the verbose output enabled through an env var, although that may negate the purpose of reducing the need to reproduce the issue before beginning debugging.

Closes https://github.com/ROCm/AMDMIGraphX/issues/4070.