### PR TITLE
Add Sigmoid Op to TF parser

### DIFF
--- a/src/tf/parse_generic_op.cpp
+++ b/src/tf/parse_generic_op.cpp
@@ -40,8 +40,10 @@ struct parse_generic_op : op_parser<parse_generic_op>
                 {"LessEqual", "identity"},
                 {"Relu", "relu"},
                 {"Rsqrt", "rsqrt"},
-                {"Tanh", "tanh"},
-                {"StopGradient", "identity"}};
+                {"Sigmoid", "sigmoid"},
+                {"StopGradient", "identity"},
+                {"Tanh", "tanh"}
+                };
     }
 
     instruction_ref parse(const op_desc& opd,

--- a/test/tf/gen_tf_pb.py
+++ b/test/tf/gen_tf_pb.py
@@ -575,6 +575,15 @@ def shape_test(g1):
 
 
 @tf_test
+def sigmoid_test(g1):
+    with g1.as_default():
+        g1_input = tf.compat.v1.placeholder(tf.float32,
+                                            shape=(1, 3, 16, 16),
+                                            name='0')
+        tf.math.sigmoid(g1_input, 'sigmoid')
+
+
+@tf_test
 def slice_test(g1):
     with g1.as_default():
         g1_input = tf.compat.v1.placeholder(tf.float32,

--- a/test/tf/models/sigmoid_test.pb
+++ b/test/tf/models/sigmoid_test.pb
@@ -1,0 +1,8 @@
+
+:
+0Placeholder*
+dtype0*
+shape:
+
+sigmoidSigmoid0*
+T0"Ñ

--- a/test/tf/tests/addn_test.cpp
+++ b/test/tf/tests/addn_test.cpp
@@ -29,10 +29,10 @@ TEST_CASE(addn_test)
 {
     migraphx::program p;
 
-    auto* mm  = p.get_main_module();
-    auto l0   = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3}});
-    auto l1   = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {2, 3}});
-    auto l2   = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {2, 3}});
+    auto* mm = p.get_main_module();
+    auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3}});
+    auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {2, 3}});
+    auto l2  = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {2, 3}});
     auto add1 = mm->add_instruction(migraphx::make_op("add"), l0, l1);
     mm->add_instruction(migraphx::make_op("add"), add1, l2);
     auto prog = optimize_tf("addn_test.pb", false);

--- a/test/tf/tests/addn_test.cpp
+++ b/test/tf/tests/addn_test.cpp
@@ -29,10 +29,10 @@ TEST_CASE(addn_test)
 {
     migraphx::program p;
 
-    auto* mm = p.get_main_module();
-    auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3}});
-    auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {2, 3}});
-    auto l2  = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {2, 3}});
+    auto* mm  = p.get_main_module();
+    auto l0   = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3}});
+    auto l1   = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {2, 3}});
+    auto l2   = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {2, 3}});
     auto add1 = mm->add_instruction(migraphx::make_op("add"), l0, l1);
     mm->add_instruction(migraphx::make_op("add"), add1, l2);
     auto prog = optimize_tf("addn_test.pb", false);

--- a/test/tf/tests/sigmoid_test.cpp
+++ b/test/tf/tests/sigmoid_test.cpp
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <tf_test.hpp>
+
+TEST_CASE(sigmoid_test)
+{
+    migraphx::program p;
+
+    auto* mm = p.get_main_module();
+    auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {1, 3, 16, 16}});
+    mm->add_instruction(migraphx::make_op("sigmoid"), l0);
+    auto prog = optimize_tf("sigmoid_test.pb", false);
+
+    EXPECT(p == prog);
+}


### PR DESCRIPTION
* adds sigmoid to `parse_generic_op.cpp` on the tf side
* added unit test