### PR TITLE
Adding back memory check

### DIFF
--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -81,12 +81,6 @@ if(NOT MIGRAPHX_USE_COMPOSABLEKERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}/kernels/include/migraphx/kernels/ck.hpp)
 endif()
 
-option(MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK "" OFF)
-if(MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK)
-    message(STATUS "HipMemGetInfo check is disabled")
-    target_compile_definitions(migraphx_gpu PUBLIC MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK)
-endif()
-
 add_embed_library(migraphx_kernels ${KERNEL_FILES} RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/kernels/include/)
 
 configure_file(device/targets.hpp.in include/migraphx/gpu/device/targets.hpp)
@@ -254,6 +248,14 @@ if (MIGRAPHX_USE_MIOPEN)
 endif()
 rocm_set_soversion(migraphx_gpu ${MIGRAPHX_SO_VERSION})
 rocm_clang_tidy_check(migraphx_gpu)
+
+option(MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK "" OFF)
+
+if(MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK)
+    message(STATUS "HipMemGetInfo check is disabled")
+    target_compile_definitions(migraphx_gpu PUBLIC MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK)
+endif()
+
 
 set(MIGRAPHX_ENABLE_MLIR ON CACHE BOOL "")
 

--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -81,6 +81,12 @@ if(NOT MIGRAPHX_USE_COMPOSABLEKERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}/kernels/include/migraphx/kernels/ck.hpp)
 endif()
 
+option(MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK "" OFF)
+if(MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK)
+    message(STATUS "HipMemGetInfo check is disabled")
+    target_compile_definitions(migraphx_gpu PUBLIC MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK)
+endif()
+
 add_embed_library(migraphx_kernels ${KERNEL_FILES} RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/kernels/include/)
 
 configure_file(device/targets.hpp.in include/migraphx/gpu/device/targets.hpp)

--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -249,14 +249,6 @@ endif()
 rocm_set_soversion(migraphx_gpu ${MIGRAPHX_SO_VERSION})
 rocm_clang_tidy_check(migraphx_gpu)
 
-option(MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK "" OFF)
-
-if(MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK)
-    message(STATUS "HipMemGetInfo check is disabled")
-    target_compile_definitions(migraphx_gpu PUBLIC MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK)
-endif()
-
-
 set(MIGRAPHX_ENABLE_MLIR ON CACHE BOOL "")
 
 if(MIGRAPHX_ENABLE_MLIR)

--- a/src/targets/gpu/hip.cpp
+++ b/src/targets/gpu/hip.cpp
@@ -60,7 +60,7 @@ static bool is_device_ptr(const void* ptr)
         return false;
     return attr.type == hipMemoryTypeDevice;
 }
-
+#ifndef MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK
 static std::size_t get_available_gpu_memory()
 {
     size_t free;
@@ -70,7 +70,7 @@ static std::size_t get_available_gpu_memory()
         MIGRAPHX_THROW("Failed getting available memory: " + hip_error(status));
     return free;
 }
-
+#endif
 static void* get_device_ptr(void* hptr)
 {
     void* result = nullptr;

--- a/src/targets/gpu/hip.cpp
+++ b/src/targets/gpu/hip.cpp
@@ -108,8 +108,10 @@ static host_ptr_cache& get_host_ptr_cache()
 
 static std::shared_ptr<void> allocate_gpu(std::size_t sz, bool host = false)
 {
-    if(sz > get_available_gpu_memory())
-        MIGRAPHX_THROW("Memory not available to allocate buffer: " + std::to_string(sz));
+    #ifndef MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK
+        if(sz > get_available_gpu_memory())
+            MIGRAPHX_THROW("Memory not available to allocate buffer: " + std::to_string(sz));
+    #endif
     void* alloc_ptr = nullptr;
     auto status     = host ? hipHostMalloc(&alloc_ptr, sz) : hipMalloc(&alloc_ptr, sz);
     if(status != hipSuccess)

--- a/src/targets/gpu/hip.cpp
+++ b/src/targets/gpu/hip.cpp
@@ -60,17 +60,7 @@ static bool is_device_ptr(const void* ptr)
         return false;
     return attr.type == hipMemoryTypeDevice;
 }
-#ifndef MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK
-static std::size_t get_available_gpu_memory()
-{
-    size_t free;
-    size_t total;
-    auto status = hipMemGetInfo(&free, &total);
-    if(status != hipSuccess)
-        MIGRAPHX_THROW("Failed getting available memory: " + hip_error(status));
-    return free;
-}
-#endif
+
 static void* get_device_ptr(void* hptr)
 {
     void* result = nullptr;
@@ -108,10 +98,6 @@ static host_ptr_cache& get_host_ptr_cache()
 
 static std::shared_ptr<void> allocate_gpu(std::size_t sz, bool host = false)
 {
-#ifndef MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK
-    if(sz > get_available_gpu_memory())
-        MIGRAPHX_THROW("Memory not available to allocate buffer: " + std::to_string(sz));
-#endif
     void* alloc_ptr = nullptr;
     auto status     = host ? hipHostMalloc(&alloc_ptr, sz) : hipMalloc(&alloc_ptr, sz);
     if(status != hipSuccess)

--- a/src/targets/gpu/hip.cpp
+++ b/src/targets/gpu/hip.cpp
@@ -108,10 +108,10 @@ static host_ptr_cache& get_host_ptr_cache()
 
 static std::shared_ptr<void> allocate_gpu(std::size_t sz, bool host = false)
 {
-    #ifndef MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK
-        if(sz > get_available_gpu_memory())
-            MIGRAPHX_THROW("Memory not available to allocate buffer: " + std::to_string(sz));
-    #endif
+#ifndef MIGRAPHX_DISABLE_AVAILABLE_GPU_MEMORY_CHECK
+    if(sz > get_available_gpu_memory())
+        MIGRAPHX_THROW("Memory not available to allocate buffer: " + std::to_string(sz));
+#endif
     void* alloc_ptr = nullptr;
     auto status     = host ? hipHostMalloc(&alloc_ptr, sz) : hipMalloc(&alloc_ptr, sz);
     if(status != hipSuccess)


### PR DESCRIPTION
Added an option to disable the hipMemGetInfo memory check on Windows when building MGX. By default, the check is enabled, but it can be turned off if desired.