### PR TITLE
Optimize checking for interdependencies

### DIFF
--- a/src/include/migraphx/instruction.hpp
+++ b/src/include/migraphx/instruction.hpp
@@ -49,7 +49,9 @@ MIGRAPHX_EXPORT bool reaches(instruction_ref start, instruction_ref end);
 
 MIGRAPHX_EXPORT bool reaches(instruction_ref start, instruction_ref end, const_module_ref m);
 
-MIGRAPHX_EXPORT bool is_interdependent(const std::vector<instruction_ref>& instructions, const_module_ref m, instruction_ref root);
+MIGRAPHX_EXPORT bool is_interdependent(const std::vector<instruction_ref>& instructions,
+                                       const_module_ref m,
+                                       instruction_ref root);
 
 struct MIGRAPHX_EXPORT instruction
 {

--- a/src/include/migraphx/instruction.hpp
+++ b/src/include/migraphx/instruction.hpp
@@ -49,6 +49,8 @@ MIGRAPHX_EXPORT bool reaches(instruction_ref start, instruction_ref end);
 
 MIGRAPHX_EXPORT bool reaches(instruction_ref start, instruction_ref end, const_module_ref m);
 
+MIGRAPHX_EXPORT bool is_interdependent(const std::vector<instruction_ref>& instructions, const_module_ref m, instruction_ref root);
+
 struct MIGRAPHX_EXPORT instruction
 {
     instruction() {}

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -640,7 +640,8 @@ bool is_interdependent(const std::vector<instruction_ref>& instructions,
     return all_of(instructions, [&](instruction_ref ins) {
         if(ins == start)
             return true;
-        return reaches(start, ins, m, [&](instruction_ref i) { return i != ins and loc.count(i) > 0; });
+        return reaches(
+            start, ins, m, [&](instruction_ref i) { return i != ins and loc.count(i) > 0; });
     });
 }
 

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -555,11 +555,11 @@ const migraphx::instruction* as_address(const std::list<instruction>::const_iter
     return iterator_address(ins);
 }
 
-template <class F>
+template<class F>
 static auto track_visits(instruction_ref start, instruction_ref end, F f)
 {
-    const std::size_t small = 64;
-    std::size_t n           = std::distance(start, end);
+    const std::size_t small = 16;
+    std::size_t n = std::distance(start, end);
     if(n < small)
     {
         std::bitset<small> visited;
@@ -579,7 +579,7 @@ static auto track_visits(instruction_ref start, instruction_ref end, F f)
         std::unordered_set<instruction_ref> visited;
         visited.reserve(n);
         auto stop = [&](auto ins) {
-            if(not visited.insert(ins).second)
+            if (not visited.insert(ins).second)
                 return true;
             if(std::distance(ins, end) > n)
                 return true;
@@ -588,6 +588,7 @@ static auto track_visits(instruction_ref start, instruction_ref end, F f)
         return f(stop);
     }
 }
+
 
 // DFS through inputs of `end` to find `start`.
 // `start` must be positioned before `end`.

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -555,11 +555,11 @@ const migraphx::instruction* as_address(const std::list<instruction>::const_iter
     return iterator_address(ins);
 }
 
-template<class F>
+template <class F>
 static auto track_visits(instruction_ref start, instruction_ref end, F f)
 {
     const std::size_t small = 64;
-    std::size_t n = std::distance(start, end);
+    std::size_t n           = std::distance(start, end);
     if(n < small)
     {
         std::bitset<small> visited;
@@ -579,7 +579,7 @@ static auto track_visits(instruction_ref start, instruction_ref end, F f)
         std::unordered_set<instruction_ref> visited;
         visited.reserve(n);
         auto stop = [&](auto ins) {
-            if (not visited.insert(ins).second)
+            if(not visited.insert(ins).second)
                 return true;
             if(std::distance(ins, end) > n)
                 return true;
@@ -588,7 +588,6 @@ static auto track_visits(instruction_ref start, instruction_ref end, F f)
         return f(stop);
     }
 }
-
 
 // DFS through inputs of `end` to find `start`.
 // `start` must be positioned before `end`.

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -640,7 +640,7 @@ bool is_interdependent(const std::vector<instruction_ref>& instructions,
     return all_of(instructions, [&](instruction_ref ins) {
         if(ins == start)
             return true;
-        return reaches(start, ins, m, [&](instruction_ref i) { return loc.count(i) > 0; });
+        return reaches(start, ins, m, [&](instruction_ref i) { return i != ins and loc.count(i) > 0; });
     });
 }
 

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -617,12 +617,13 @@ bool is_interdependent(const std::vector<instruction_ref>& instructions,
                        loc.begin(),
                        [&](instruction_ref ins) { return std::distance(root, ins); });
         auto min_it = std::min_element(loc.begin(), loc.end());
-        auto start = instructions[std::distance(loc.begin(), min_it)];
+        auto start  = instructions[std::distance(loc.begin(), min_it)];
         return all_of(instructions, [&](instruction_ref ins) {
             if(ins == start)
                 return true;
-            return reaches(
-                start, ins, m, [&](instruction_ref i) { return i != ins and contains(instructions, i); });
+            return reaches(start, ins, m, [&](instruction_ref i) {
+                return i != ins and contains(instructions, i);
+            });
         });
     }
     std::unordered_map<instruction_ref, std::size_t> loc;

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -555,11 +555,11 @@ const migraphx::instruction* as_address(const std::list<instruction>::const_iter
     return iterator_address(ins);
 }
 
-template<class F>
+template <class F>
 static auto track_visits(instruction_ref start, instruction_ref end, F f)
 {
     const std::size_t small = 16;
-    std::size_t n = std::distance(start, end);
+    std::size_t n           = std::distance(start, end);
     if(n < small)
     {
         std::bitset<small> visited;
@@ -579,7 +579,7 @@ static auto track_visits(instruction_ref start, instruction_ref end, F f)
         std::unordered_set<instruction_ref> visited;
         visited.reserve(n);
         auto stop = [&](auto ins) {
-            if (not visited.insert(ins).second)
+            if(not visited.insert(ins).second)
                 return true;
             if(std::distance(ins, end) > n)
                 return true;
@@ -588,7 +588,6 @@ static auto track_visits(instruction_ref start, instruction_ref end, F f)
         return f(stop);
     }
 }
-
 
 // DFS through inputs of `end` to find `start`.
 // `start` must be positioned before `end`.

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -574,7 +574,8 @@ bool reaches(instruction_ref start, instruction_ref end)
 // `reaches` version that checks if instructions are in the module `m`
 // Additional condition that stops if DFS instruction's distance to `end`
 // is greater than the distance between `start` and `end`.
-bool reaches(instruction_ref start, instruction_ref end, const_module_ref m)
+template<class P>
+bool reaches(instruction_ref start, instruction_ref end, const_module_ref m, P predicate)
 {
     if(start == end)
         return true;
@@ -586,7 +587,7 @@ bool reaches(instruction_ref start, instruction_ref end, const_module_ref m)
     return fix<bool>([&](auto self, auto ins) -> bool {
         if(not m->has_instruction(ins))
             return false;
-        if(ins == start)
+        if(ins == start or predicate(ins))
             return true;
         if(not visited.insert(ins).second)
             return false;
@@ -594,6 +595,55 @@ bool reaches(instruction_ref start, instruction_ref end, const_module_ref m)
             return false;
         return std::any_of(ins->inputs().begin(), ins->inputs().end(), self);
     })(end);
+}
+
+bool reaches(instruction_ref start, instruction_ref end, const_module_ref m)
+{
+    return reaches(start, end, m, [](auto) { return false; });
+}
+
+bool is_interdependent(const std::vector<instruction_ref>& instructions, const_module_ref m, instruction_ref root)
+{
+    if(instructions.size() < 2)
+        return true;
+    const std::size_t small_size = 5;
+    if(instructions.size() <= small_size)
+    {
+        std::array<std::size_t, small_size> loc;
+        std::transform(instructions.begin(),
+                       instructions.end(),
+                       loc.begin(),
+                       [&](instruction_ref ins) { return std::distance(root, ins); });
+        return all_of(range(instructions.size()), [&](std::size_t i) {
+            auto ins_i = instructions[i];
+            return all_of(range(instructions.size()), [&](std::size_t j) {
+                auto ins_j = instructions[j];
+                if(loc[i] < loc[j])
+                    return reaches(ins_i, ins_j, m);
+                else
+                    return reaches(ins_j, ins_i, m);
+            });
+        });
+    }
+    std::unordered_map<instruction_ref, std::size_t> loc;
+    std::transform(instructions.begin(),
+                   instructions.end(),
+                   std::inserter(loc, loc.end()),
+                   [&](instruction_ref ins) { return std::make_pair(ins, std::distance(root, ins)); });
+    auto min_it = std::min_element(loc.begin(),
+                                       loc.end(),
+                                       [](const auto& x, const auto& y) {
+                                           return x.second < y.second;
+                                       });
+    auto start = min_it->first;
+
+    return all_of(instructions, [&](instruction_ref ins) {
+        if(ins == start)
+            return true;
+        return reaches(start, ins, m, [&](instruction_ref i) {
+            return loc.count(i) > 0;
+        });
+    });
 }
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -574,7 +574,7 @@ bool reaches(instruction_ref start, instruction_ref end)
 // `reaches` version that checks if instructions are in the module `m`
 // Additional condition that stops if DFS instruction's distance to `end`
 // is greater than the distance between `start` and `end`.
-template<class P>
+template <class P>
 bool reaches(instruction_ref start, instruction_ref end, const_module_ref m, P predicate)
 {
     if(start == end)
@@ -602,7 +602,9 @@ bool reaches(instruction_ref start, instruction_ref end, const_module_ref m)
     return reaches(start, end, m, [](auto) { return false; });
 }
 
-bool is_interdependent(const std::vector<instruction_ref>& instructions, const_module_ref m, instruction_ref root)
+bool is_interdependent(const std::vector<instruction_ref>& instructions,
+                       const_module_ref m,
+                       instruction_ref root)
 {
     if(instructions.size() < 2)
         return true;
@@ -626,23 +628,19 @@ bool is_interdependent(const std::vector<instruction_ref>& instructions, const_m
         });
     }
     std::unordered_map<instruction_ref, std::size_t> loc;
-    std::transform(instructions.begin(),
-                   instructions.end(),
-                   std::inserter(loc, loc.end()),
-                   [&](instruction_ref ins) { return std::make_pair(ins, std::distance(root, ins)); });
-    auto min_it = std::min_element(loc.begin(),
-                                       loc.end(),
-                                       [](const auto& x, const auto& y) {
-                                           return x.second < y.second;
-                                       });
+    std::transform(
+        instructions.begin(),
+        instructions.end(),
+        std::inserter(loc, loc.end()),
+        [&](instruction_ref ins) { return std::make_pair(ins, std::distance(root, ins)); });
+    auto min_it = std::min_element(
+        loc.begin(), loc.end(), [](const auto& x, const auto& y) { return x.second < y.second; });
     auto start = min_it->first;
 
     return all_of(instructions, [&](instruction_ref ins) {
         if(ins == start)
             return true;
-        return reaches(start, ins, m, [&](instruction_ref i) {
-            return loc.count(i) > 0;
-        });
+        return reaches(start, ins, m, [&](instruction_ref i) { return loc.count(i) > 0; });
     });
 }
 

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -1197,15 +1197,10 @@ struct find_splits
                 assert((*it)->name() != "slice");
                 group.push_back(*it);
             }
-            // There should be no dependency between instructions in the group
-            if(std::any_of(group.begin(), group.end() - 1, [&](auto i) {
-                   return is_dependent(m, root, group.back(), i) or
-                          is_dependent(m, root, i, group.back());
-               }))
-            {
-                return {};
-            }
         }
+        // There should be no dependency between instructions in the group
+        if(is_interdependent(group, &m, root))
+            return {};
         return group;
     }
 


### PR DESCRIPTION
On some models that have 500 or so splits the current algorithm is very slow. Instead this uses a different algorithm where it will check an instruction will reach any of the other instructions. 