### PR TITLE
Fixes for hip compilation

### DIFF
--- a/src/targets/gpu/compile_hip_code_object.cpp
+++ b/src/targets/gpu/compile_hip_code_object.cpp
@@ -112,6 +112,10 @@ static std::vector<std::string> get_compiler_warnings()
 
     if(hip_has_flags({"-Werror", "-Wunsafe-buffer-usage"}))
         warnings.push_back("-Wno-unsafe-buffer-usage");
+
+    if(hip_has_flags({"-Werror", "-Wnrvo"}))
+        warnings.push_back("-Wno-nrvo");
+
     return warnings;
 }
 

--- a/test/gpu/jit.cpp
+++ b/test/gpu/jit.cpp
@@ -39,7 +39,9 @@
 
 // NOLINTNEXTLINE
 const std::string write_2s = R"__migraphx__(
+#ifndef __HIPCC_RTC__
 #include <hip/hip_runtime.h>
+#endif
 
 extern "C" {
 __global__ void write(char* data) 
@@ -56,7 +58,9 @@ int main() {}
 
 // NOLINTNEXTLINE
 const std::string add_2s_binary = R"__migraphx__(
+#ifndef __HIPCC_RTC__
 #include <hip/hip_runtime.h>
+#endif
 
 extern "C" {
 __global__ void add_2(char* x, char* y) 

--- a/test/gpu/stream_sync.cpp
+++ b/test/gpu/stream_sync.cpp
@@ -44,7 +44,9 @@ constexpr uint32_t stream_sync_test_val = 1337;
 
 // NOLINTNEXTLINE
 const std::string compare_numbers = R"__migraphx__(
+#ifndef __HIPCC_RTC__
 #include <hip/hip_runtime.h>
+#endif
 
 extern "C" {
 __global__ void compare(float* data) 


### PR DESCRIPTION
Newer compiler (version) and their additional warnings relating to `nvro` are explicitly disabled.