### PR TITLE
Add flags to EnableControlFlowGuard due to BinSkim errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,6 +133,8 @@ if(WIN32)
     # Due to compilation crashing, we need to use type-erased matchers on Windows.
     target_compile_definitions(migraphx PUBLIC MIGRAPHX_USE_TYPE_ERASED_MATCHERS=1)
     target_compile_options(migraphx PUBLIC "-mno-ms-bitfields")
+    # Due to BinSkim errors EnableControlFlowGuard
+    target_compile_options(migraphx PUBLIC "SHELL:-Xclang -cfguard")
 endif()
 
 configure_file(config.h.in include/migraphx/config.h)


### PR DESCRIPTION
MS pipelines are failing with BinSkim errors due to bins built without CFG enabled. This change adds flag to enable cfc for compilation
See:
https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard

