### PR TITLE
Fix for MHA in attn refactor

### DIFF
--- a/src/fuse_attention.cpp
+++ b/src/fuse_attention.cpp
@@ -23,6 +23,7 @@
  *
  */
 #include <migraphx/fuse_attention.hpp>
+#include <migraphx/instruction.hpp>
 #include <migraphx/pass_manager.hpp>
 #include <migraphx/matcher.hpp>
 #include <migraphx/match/softmax.hpp>
@@ -82,39 +83,16 @@ struct find_attention
     }
 
     std::vector<instruction_ref>
-    get_attn_instructions(module& m, instruction_ref start, instruction_ref end) const
+    get_attn_instructions(module& m, instruction_ref gemm1, instruction_ref gemm2) const
     {
-        std::queue<instruction_ref> inputs;
-        std::unordered_set<instruction_ref> inss;
-        inputs.push(end);
+        auto attn_inss = find_instructions_between(gemm1, gemm2, m);
 
-        static const std::unordered_set<std::string> valid_attn_ops = {
-            "reshape", "reduce_sum", "reduce_max", "broadcast", "multibroadcast", "@literal"};
-
-        auto is_valid_attn_op = [&](auto i) {
-            return i->get_operator().attributes().get("pointwise", false) or
-                   contains(valid_attn_ops, i->get_operator().name()) or i == start or i == end;
-        };
-
-        while(not inputs.empty())
-        {
-            auto current_inp = inputs.front();
-            inputs.pop();
-
-            if(is_valid_attn_op(current_inp) and inss.insert(current_inp).second and
-               current_inp != start)
-            {
-                for(auto i : current_inp->inputs())
-                {
-                    inputs.push(i);
-                }
-            }
-        }
-        std::vector<instruction_ref> sorted_inss(inss.begin(), inss.end());
+        std::vector<instruction_ref> sorted_inss(attn_inss.begin(), attn_inss.end());
         std::sort(
             sorted_inss.begin(), sorted_inss.end(), [&](instruction_ref x, instruction_ref y) {
                 return std::distance(m.begin(), x) < std::distance(m.begin(), y);
             });
+
         return sorted_inss;
     }
 

--- a/src/include/migraphx/instruction.hpp
+++ b/src/include/migraphx/instruction.hpp
@@ -32,6 +32,7 @@
 #include <migraphx/erase.hpp>
 #include <migraphx/config.hpp>
 #include <string>
+#include <unordered_set>
 #include <utility>
 
 namespace migraphx {
@@ -48,6 +49,9 @@ MIGRAPHX_EXPORT std::vector<shape> try_compute_shape(const operation& op,
 MIGRAPHX_EXPORT bool reaches(instruction_ref start, instruction_ref end);
 
 MIGRAPHX_EXPORT bool reaches(instruction_ref start, instruction_ref end, const_module_ref m);
+
+MIGRAPHX_EXPORT std::unordered_set<instruction_ref>
+find_instructions_between(instruction_ref start, instruction_ref end, module& m);
 
 struct MIGRAPHX_EXPORT instruction
 {
@@ -185,6 +189,7 @@ struct MIGRAPHX_EXPORT instruction
     bool normalized       = false;
     std::size_t target_id = 0;
 };
+
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
 

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -596,5 +596,30 @@ bool reaches(instruction_ref start, instruction_ref end, const_module_ref m)
     })(end);
 }
 
+// Return set of all instructions that are connected to both start and end nodes (inclusive)
+std::unordered_set<instruction_ref>
+find_instructions_between(instruction_ref start, instruction_ref end, module& m)
+{
+    std::queue<instruction_ref> inputs;
+    std::unordered_set<instruction_ref> inss;
+    inputs.push(end);
+
+    while(not inputs.empty())
+    {
+        auto current_inp = inputs.front();
+        inputs.pop();
+
+        if(reaches(start, current_inp, &m) and inss.insert(current_inp).second and
+           current_inp != start)
+        {
+            for(auto i : current_inp->inputs())
+            {
+                inputs.push(i);
+            }
+        }
+    }
+    return inss;
+}
+
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx


### PR DESCRIPTION
Update the algorithm in fuse_attention for finding the attention subgraph. 

- Current implementation was fusing unwanted instructions into the attention subgraph (eg. pointwise instructions that have multiple outputs)
- Implement `find_instructions_between` routine that only gives instructions directly connected to both start and end node
- Any additional fusions are handled already by the fuse_mlir pass
