### PR TITLE
Rearrange driver prints

### DIFF
--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -626,9 +626,10 @@ struct compiler
             }
 
             std::cout << "Program is already compiled, skipping compilation ..." << std::endl;
-            if (to_fp16 or to_bf16 or to_int8 or to_fp8 or to_int4)
+            if(to_fp16 or to_bf16 or to_int8 or to_fp8 or to_int4)
             {
-                std::cerr << "[WARNING]: Quantization options are ignored as program is already compiled.\n";
+                std::cerr << "[WARNING]: Quantization options are ignored as program is already "
+                             "compiled.\n";
             }
             return p;
         }
@@ -770,10 +771,7 @@ struct compile : command<compile>
     compiler c;
     void parse(argument_parser& ap) { c.parse(ap); }
 
-    void run()
-    {
-        c.compile();
-    }
+    void run() { c.compile(); }
 };
 
 struct run_cmd : command<run_cmd>

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -625,29 +625,40 @@ struct compiler
                 }
             }
 
+            std::cout << "Program is already compiled, skipping compilation ..." << std::endl;
+            if (to_fp16 or to_bf16 or to_int8 or to_fp8 or to_int4)
+            {
+                std::cerr << "[WARNING]: Quantization options are ignored as program is already compiled.\n";
+            }
             return p;
         }
         auto t = ct.get_target();
         if(to_fp16)
         {
+            std::cout << "Quantizing to fp16 ... " << std::endl;
             quantize_fp16(p);
         }
         if(to_bf16)
         {
+            std::cout << "Quantizing to bf16 ... " << std::endl;
             quantize_bf16(p);
         }
         if(to_int8)
         {
+            std::cout << "Quantizing to int8 ... " << std::endl;
             quantize_int8(p, t, {host_params(p)});
         }
         if(to_fp8)
         {
+            std::cout << "Quantizing to fp8 ... " << std::endl;
             quantize_fp8(p, t, {host_params(p)});
         }
         if(to_int4)
         {
+            std::cout << "Quantizing to int4 ... " << std::endl;
             quantize_int4_weights(p);
         }
+        std::cout << "Compiling ... " << std::endl;
         p.compile(t, co);
         l.save(p);
         return p;
@@ -761,7 +772,6 @@ struct compile : command<compile>
 
     void run()
     {
-        std::cout << "Compiling ... " << std::endl;
         c.compile();
     }
 };
@@ -773,7 +783,6 @@ struct run_cmd : command<run_cmd>
 
     void run()
     {
-        std::cout << "Compiling ... " << std::endl;
         auto p = c.compile();
         std::cout << "Allocating params ... " << std::endl;
         auto m = c.params(p);
@@ -794,7 +803,6 @@ struct time_cmd : command<time_cmd>
 
     void run()
     {
-        std::cout << "Compiling ... " << std::endl;
         auto p = c.compile();
         std::cout << "Allocating params ... " << std::endl;
         auto m = c.params(p);
@@ -821,7 +829,6 @@ struct perf : command<perf>
 
     void run()
     {
-        std::cout << "Compiling ... " << std::endl;
         auto p = c.compile();
         std::cout << "Allocating params ... " << std::endl;
         auto m = c.params(p);
@@ -837,7 +844,6 @@ struct roctx : command<roctx>
 
     void run()
     {
-        std::cout << "Compiling ... " << std::endl;
         auto p = c.compile();
         std::cout << "Allocating params ... " << std::endl;
         auto m = c.params(p);


### PR DESCRIPTION
Swaps the read and compile prints so that read will come first. Also adds additional prints for quantization and for precompiled programs.
e.g. Old:
```
Running [ MIGraphX Version: 2.13.0.fc8f6ffee-dirty ]: ./build/bin/driver run /code/nas/migraphx/models/resnet50-v2-7.onnx
[2025-07-21 23:35:05]
Compiling ...
Reading: /code/nas/migraphx/models/resnet50-v2-7.onnx

module: "main"
@0 = check_context::migraphx::gpu::context -> float_type, {}, {}
@1 = hip::hip_allocate_memory[shape=int8_type, {268443648}, {1},id=main:scratch] -> int8_type, {268443648}, {1}
@2 = hip::hip_copy_literal[id=main:@literal:72] -> float_type, {64, 3, 7, 7}, {147, 49, 7, 1}
@3 = hip::hip_copy_literal[id=main:@literal:71] -> float_type, {1, 64, 112, 112}, {1, 12544, 112, 1}
...
```
New:
```
Running [ MIGraphX Version: 2.13.0.fc8f6ffee-dirty ]: ./build/bin/driver run /code/nas/migraphx/models/resnet50-v2-7.onnx
[2025-07-21 23:35:05]
Reading: /code/nas/migraphx/models/resnet50-v2-7.onnx
Compiling ... 

module: "main"
@0 = check_context::migraphx::gpu::context -> float_type, {}, {}
@1 = hip::hip_allocate_memory[shape=int8_type, {268443648}, {1},id=main:scratch] -> int8_type, {268443648}, {1}
@2 = hip::hip_copy_literal[id=main:@literal:72] -> float_type, {64, 3, 7, 7}, {147, 49, 7, 1}
@3 = hip::hip_copy_literal[id=main:@literal:71] -> float_type, {1, 64, 112, 112}, {1, 12544, 112, 1}
```

For precompiled models:
Old:
```
Running [ MIGraphX Version: 2.13.0.fc8f6ffee-dirty ]: ./build/bin/driver run mnist.mxr --fp16
[2025-07-21 23:38:16]
Reading: mnist.mxr
Allocating params ... 
module: "main"
@0 = check_context::migraphx::gpu::context -> float_type, {}, {}
@1 = hip::hip_allocate_memory[shape=int8_type, {31360}, {1},id=main:scratch] -> int8_type, {31360}, {1}
@2 = hip::hip_copy_literal[id=main:@literal:3] -> float_type, {8, 1, 1}, {1, 1, 1}
...
```
New:
```
Running [ MIGraphX Version: 2.13.0.fc8f6ffee-dirty ]: ./build/bin/driver run mnist.mxr --fp16
[2025-07-21 23:38:16]
Reading: mnist.mxr
Program is already compiled, skipping compilation ...
[WARNING]: Quantization options are ignored as program is already compiled.
Allocating params ... 
module: "main"
@0 = check_context::migraphx::gpu::context -> float_type, {}, {}
@1 = hip::hip_allocate_memory[shape=int8_type, {31360}, {1},id=main:scratch] -> int8_type, {31360}, {1}
@2 = hip::hip_copy_literal[id=main:@literal:3] -> float_type, {8, 1, 1}, {1, 1, 1}
...
```