### PR TITLE
Check for hipblaslt workspace size during tuning

### DIFF
--- a/src/targets/gpu/hip_gemm_impl.cpp
+++ b/src/targets/gpu/hip_gemm_impl.cpp
@@ -589,7 +589,7 @@ struct hip_gemm_impl
                                                     algo,
                                                     ret_workspace_size) == HIPBLAS_STATUS_SUCCESS)
             {
-                if(ret_workspace_size <= hipblaslt_workspace_size/2)
+                if(ret_workspace_size <= hipblaslt_workspace_size / 2)
                     solution_indices.push_back(hipblaslt_ext::getIndexFromAlgo(algo));
             }
         }

--- a/src/targets/gpu/hip_gemm_impl.cpp
+++ b/src/targets/gpu/hip_gemm_impl.cpp
@@ -577,17 +577,20 @@ struct hip_gemm_impl
         {
             auto algo                 = result[i].algo;
             size_t ret_workspace_size = 0;
-            auto supporting_args =
-                create_hipblaslt_supporting_args_common(ctx, input_args, algo, ret_workspace_size);
-            try
+
+            if(hipblaslt_ext::matmulIsAlgoSupported(ctx.get_stream().get_hipblaslt(),
+                                                    hipblaslt_desc,
+                                                    get_alpha(),
+                                                    mat_b,
+                                                    mat_a,
+                                                    get_beta(),
+                                                    mat_c,
+                                                    is_3inputs ? mat_d : mat_c,
+                                                    algo,
+                                                    ret_workspace_size) == HIPBLAS_STATUS_SUCCESS)
             {
-                hipblaslt_invoke(&hipblaslt_ext::matmulIsAlgoSupported, supporting_args);
-                solution_indices.push_back(hipblaslt_ext::getIndexFromAlgo(algo));
-            }
-            catch(...)
-            {
-                // algo is not supported, continue in that case
-                continue;
+                if(ret_workspace_size <= hipblaslt_workspace_size/2)
+                    solution_indices.push_back(hipblaslt_ext::getIndexFromAlgo(algo));
             }
         }
 

--- a/src/targets/gpu/hip_gemm_impl.cpp
+++ b/src/targets/gpu/hip_gemm_impl.cpp
@@ -589,6 +589,9 @@ struct hip_gemm_impl
                                                     algo,
                                                     ret_workspace_size) == HIPBLAS_STATUS_SUCCESS)
             {
+                // To balance performance and memory usage, solutions for exhaustive tuning
+                // are only considered if their workspace size is less than or equal to 128MB.
+                // This avoids using excessive memory for potentially minor speed improvements.
                 if(ret_workspace_size <= hipblaslt_workspace_size / 2)
                     solution_indices.push_back(hipblaslt_ext::getIndexFromAlgo(algo));
             }


### PR DESCRIPTION
We used default workspace size of 256 MB during tuning, however, it turns out
that some of the solutions require a workspace size larger than 256MB. 
This causes memory access failures. 

To fix this, we skip over solutions that require more than 128MB of workspace size.
The reason for choosing 128MB is for efficient memory usage.