### PR TITLE
Netron Output Param Name

### DIFF
--- a/src/netron_output.cpp
+++ b/src/netron_output.cpp
@@ -206,6 +206,10 @@ std::unordered_map<instruction_ref, std::string> make_ins_uids(const module& mod
         var_name = mod.name() + ":";
         var_name.append(ins->name() + ":");
         var_name.append("@" + std::to_string(count));
+        if(ins->name() == "@param")
+        {
+            var_name.append(any_cast<builtin::param>(ins->get_operator()).parameter);
+        }
         count++;
         ret.emplace(ins, var_name);
     }

--- a/src/netron_output.cpp
+++ b/src/netron_output.cpp
@@ -205,11 +205,11 @@ std::unordered_map<instruction_ref, std::string> make_ins_uids(const module& mod
         std::string var_name;
         var_name = mod.name() + ":";
         var_name.append(ins->name() + ":");
-        var_name.append("@" + std::to_string(count));
         if(ins->name() == "@param")
         {
             var_name.append(any_cast<builtin::param>(ins->get_operator()).parameter);
         }
+        var_name.append(":@" + std::to_string(count));
         count++;
         ret.emplace(ins, var_name);
     }

--- a/src/netron_output.cpp
+++ b/src/netron_output.cpp
@@ -207,9 +207,9 @@ std::unordered_map<instruction_ref, std::string> make_ins_uids(const module& mod
         var_name.append(ins->name() + ":");
         if(ins->name() == "@param")
         {
-            var_name.append(any_cast<builtin::param>(ins->get_operator()).parameter);
+            var_name.append(any_cast<builtin::param>(ins->get_operator()).parameter + ":");
         }
-        var_name.append(":@" + std::to_string(count));
+        var_name.append("@" + std::to_string(count));
         count++;
         ret.emplace(ins, var_name);
     }


### PR DESCRIPTION
Use the parameter's name in the Netron node name so it's searchable by that.