### PR TITLE
Add python API for returning serialized bytes

### DIFF
--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -46,6 +46,7 @@
 #include <migraphx/pass_manager.hpp>
 #include <migraphx/version.h>
 #include <migraphx/iterator_for.hpp>
+#include <migraphx/msgpack.hpp>
 #ifdef HAVE_GPU
 #include <migraphx/gpu/hip.hpp>
 #endif
@@ -561,6 +562,8 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
                  p.print_py(ss);
                  return ss.str();
              })
+        .def("to_value", &migraphx::program::to_value)
+        .def("from_value", &migraphx::program::from_value)
         .def("sort", &migraphx::program::sort)
         .def("print", [](const migraphx::program& p) { std::cout << p << std::endl; })
         .def("__eq__", std::equal_to<migraphx::program>{})
@@ -580,6 +583,8 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         .def("values", [](const migraphx::operation& operation) -> py::object {
             return to_py_object(operation.to_value());
         });
+    
+    py::class_<migraphx::value>(m, "value");
 
     py::enum_<migraphx::op::pooling_mode>(op, "pooling_mode")
         .value("average", migraphx::op::pooling_mode::average)
@@ -706,6 +711,8 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         py::arg("filename"),
         py::arg("format") = "msgpack");
 
+    m.def("to_msgpack", py::overload_cast<const migraphx::value&>(&migraphx::to_msgpack));
+    m.def("from_msgpack", py::overload_cast<const std::vector<char>&>(&migraphx::from_msgpack));
     m.def("get_target", &migraphx::make_target);
     m.def("create_argument", [](const migraphx::shape& s, const std::vector<double>& values) {
         if(values.size() != s.elements())

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -583,7 +583,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         .def("values", [](const migraphx::operation& operation) -> py::object {
             return to_py_object(operation.to_value());
         });
-    
+
     py::class_<migraphx::value>(m, "value");
 
     py::enum_<migraphx::op::pooling_mode>(op, "pooling_mode")

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -46,7 +46,6 @@
 #include <migraphx/pass_manager.hpp>
 #include <migraphx/version.h>
 #include <migraphx/iterator_for.hpp>
-#include <migraphx/msgpack.hpp>
 #ifdef HAVE_GPU
 #include <migraphx/gpu/hip.hpp>
 #endif

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -707,7 +707,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         py::arg("format") = "msgpack");
 
     m.def(
-        "serialize",
+        "save_buffer",
         [](const migraphx::program& p) {
             auto buffer = migraphx::save_buffer(p);
             return py::bytes(buffer.data(), buffer.size());
@@ -716,9 +716,9 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         py::arg("p"));
 
     m.def(
-        "deserialize",
+        "load_buffer",
         [](const py::bytes& b) {
-            std::string byte_str = static_cast<std::string>(b);
+            std::string_view byte_str{b};
             std::vector<char> char_arr(byte_str.begin(), byte_str.end());
             return migraphx::load_buffer(char_arr);
         },

--- a/test/py/test_save_load.py
+++ b/test/py/test_save_load.py
@@ -40,6 +40,22 @@ def test_conv_relu(format):
         assert s1 == s2
         assert p1.sort() == p2.sort()
 
+def test_save_load_buffer():
+    p1 = migraphx.parse_onnx("conv_relu_maxpool_test.onnx")
+    print(p1)
+
+    s1 = p1.get_output_shapes()[-1]
+
+    p1_bytes = migraphx.save_buffer(p1)
+    assert isinstance(p1_bytes, bytes)
+
+    p2 = migraphx.load_buffer(p1_bytes)
+    print(p2)
+    s2 = p2.get_output_shapes()[-1]
+
+    assert s1 == s2
+    assert p1.sort() == p2.sort()
+
 
 def create_buffer(t, data, shape):
     a = array.array(t, data)
@@ -62,3 +78,4 @@ if __name__ == "__main__":
     test_load_save_arg()
     test_conv_relu('msgpack')
     test_conv_relu('json')
+    test_save_load_buffer()


### PR DESCRIPTION
Use Case:
Currently torch-migraphx has to use the load-save api to obtain serialized bytes which requires read write from file system. The msgpack bytearray is used to save migraphx program as part of the MGXModule saved using the torch.save api.

This PR allows directly encoding and decoding a program to bytearray without needing to save to disk.