### PR TITLE
Set attribute to help bypass the warning about amdgpu_waves_per_eu

### DIFF
--- a/src/targets/gpu/jit/topk.cpp
+++ b/src/targets/gpu/jit/topk.cpp
@@ -43,7 +43,7 @@ static const char* const topk_kernel = R"__migraphx__(
 namespace migraphx {
 
 extern "C" {
-
+__attribute__((amdgpu_waves_per_eu(1,32)))
 MIGRAPHX_GLOBAL void topk_kernel(${params}) 
 {
     transform_args(make_tensors(), rotate_last<2>())(${args})([](auto... xs) {


### PR DESCRIPTION
The upgraded tool chain is giving a new compile warning that needs to be bypassed for the topk test to successfully compile, and run.

> [   RUN    ] test_topk<migraphx::shape::half_type, 1000, 120000>
/tmp/comgr-d7a292/input/main.cpp:11:22: error: failed to meet occupancy target given by 'amdgpu-waves-per-eu' in 'topk_kernel': desired occupancy was 2, final occupancy is 1 [-Werror,-Wpass-failed]