### PR TITLE
Fix MLIR rewrite_reduce

### DIFF
--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1022,12 +1022,13 @@ static void rewrite_reduce(module& m)
                     new_reduce_axes.push_back(axis);
                 }
             }
-            // If the reshape dimensions are the same as the original, use the original reduce axes to avoid issues with empty axes
-            if (std::vector<int64_t>(in_lens.begin(), in_lens.end()) == new_rsp_dims)
+            // If the reshape dimensions are the same as the original, use the original reduce axes
+            // to avoid issues with empty axes
+            if(std::vector<int64_t>(in_lens.begin(), in_lens.end()) == new_rsp_dims)
                 std::transform(reduce_axes.begin(),
-                                reduce_axes.end(),
-                                std::back_inserter(new_reduce_axes),
-                                [](auto axis) { return static_cast<int64_t>(axis); });
+                               reduce_axes.end(),
+                               std::back_inserter(new_reduce_axes),
+                               [](auto axis) { return static_cast<int64_t>(axis); });
             auto rsp_ins = m.insert_instruction(
                 i, migraphx::make_op("reshape", {{"dims", new_rsp_dims}}), i->inputs().front());
             auto collapsed_reduce = m.insert_instruction(

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -997,7 +997,8 @@ static void rewrite_reduce(module& m)
             auto reduce_op      = i->get_operator().to_value();
             auto reduce_op_name = i->get_operator().name();
             auto reduce_axes    = reduce_op["axes"].to_vector<size_t>();
-            auto reduce_axes_set = std::set<size_t>(reduce_axes.begin(), reduce_axes.end()); // Use a set so that find() is faster
+            auto reduce_axes_set = std::set<size_t>(
+                reduce_axes.begin(), reduce_axes.end()); // Use a set so that find() is faster
             auto reduce_lens    = i->get_shape().lens();
             auto in_shape       = i->inputs().front()->get_shape();
             const auto& in_lens = in_shape.lens();
@@ -1012,7 +1013,8 @@ static void rewrite_reduce(module& m)
             std::vector<int64_t> new_reduce_axes;
             for(const auto axis : range(in_shape.ndim()))
             {
-                if(reduce_lens[axis] == in_lens[axis] and not (reduce_axes_set.find(axis) != reduce_axes_set.end()))
+                if(reduce_lens[axis] == in_lens[axis] and
+                   not(reduce_axes_set.find(axis) != reduce_axes_set.end()))
                 {
                     new_rsp_dims.push_back(in_lens[axis]);
                 }

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1022,6 +1022,12 @@ static void rewrite_reduce(module& m)
                     new_reduce_axes.push_back(axis);
                 }
             }
+            // If the reshape dimensions are the same as the original, use the original reduce axes to avoid issues with empty axes
+            if (std::vector<int64_t>(in_lens.begin(), in_lens.end()) == new_rsp_dims)
+                std::transform(reduce_axes.begin(),
+                                reduce_axes.end(),
+                                std::back_inserter(new_reduce_axes),
+                                [](auto axis) { return static_cast<int64_t>(axis); });
             auto rsp_ins = m.insert_instruction(
                 i, migraphx::make_op("reshape", {{"dims", new_rsp_dims}}), i->inputs().front());
             auto collapsed_reduce = m.insert_instruction(

--- a/test/gpu/mlir.cpp
+++ b/test/gpu/mlir.cpp
@@ -673,26 +673,29 @@ module {
 }
 )__migraphx__";
     migraphx::module m;
-    auto x0 = m.add_parameter("x0", migraphx::shape{migraphx::shape::float_type, {1, 12, 1, 64}});
-    auto x1 = m.add_parameter("x1", migraphx::shape{migraphx::shape::float_type, {1, 12, 64, 1}});
-    auto x2 = m.add_parameter("x2", migraphx::shape{migraphx::shape::float_type, {1, 12, 1, 1}});
-    auto x3 = m.add_parameter("x3", migraphx::shape{migraphx::shape::float_type, {1, 12, 1, 64}});
+    auto x0   = m.add_parameter("x0", migraphx::shape{migraphx::shape::float_type, {1, 12, 1, 64}});
+    auto x1   = m.add_parameter("x1", migraphx::shape{migraphx::shape::float_type, {1, 12, 64, 1}});
+    auto x2   = m.add_parameter("x2", migraphx::shape{migraphx::shape::float_type, {1, 12, 1, 1}});
+    auto x3   = m.add_parameter("x3", migraphx::shape{migraphx::shape::float_type, {1, 12, 1, 64}});
     auto dot0 = m.add_instruction(migraphx::make_op("dot"), x0, x1);
-    auto mul = m.add_instruction(migraphx::make_op("mul"), dot0, x2);
+    auto mul  = m.add_instruction(migraphx::make_op("mul"), dot0, x2);
     auto reduce_max = m.add_instruction(migraphx::make_op("reduce_max", {{"axes", {3}}}), mul);
-    auto broadcast0 = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 12, 1, 1}}}), reduce_max);
-    auto sub = m.add_instruction(migraphx::make_op("sub"), mul, broadcast0);
-    auto exp = m.add_instruction(migraphx::make_op("exp"), sub);
+    auto broadcast0 = m.add_instruction(
+        migraphx::make_op("multibroadcast", {{"out_lens", {1, 12, 1, 1}}}), reduce_max);
+    auto sub        = m.add_instruction(migraphx::make_op("sub"), mul, broadcast0);
+    auto exp        = m.add_instruction(migraphx::make_op("exp"), sub);
     auto reduce_sum = m.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {3}}}), exp);
-    auto broadcast1 = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 12, 1, 1}}}), reduce_sum);
-    auto div = m.add_instruction(migraphx::make_op("div"), exp, broadcast1);
+    auto broadcast1 = m.add_instruction(
+        migraphx::make_op("multibroadcast", {{"out_lens", {1, 12, 1, 1}}}), reduce_sum);
+    auto div  = m.add_instruction(migraphx::make_op("div"), exp, broadcast1);
     auto dot1 = m.add_instruction(migraphx::make_op("dot"), div, x3);
     m.add_return({dot1});
     auto s = migraphx::gpu::dump_mlir(m);
     // Skip test if MLIR is not enabled
     if(s.empty())
         return;
-    auto mlir_output_with_attrs = migraphx::interpolate_string(mlir_output, {{"attrs", get_attrs()}});
+    auto mlir_output_with_attrs =
+        migraphx::interpolate_string(mlir_output, {{"attrs", get_attrs()}});
     CHECK(encode(s) == encode(mlir_output_with_attrs));
     EXPECT(verify_mlir(m));
 }

--- a/test/gpu/mlir.cpp
+++ b/test/gpu/mlir.cpp
@@ -649,4 +649,52 @@ module {
     EXPECT(verify_mlir(m));
 }
 
+TEST_CASE(attention)
+{
+    std::string mlir_output = R"__migraphx__(
+module {
+  func.func @mlir_dot_mul_reshape_reduce_max_reshape_sub_exp_reshape_reduce_sum_reshape_div_dot(%arg0: !migraphx.shaped<1x12x1x64xf32, 768x64x64x1>, %arg1: !migraphx.shaped<1x12x64x1xf32, 768x64x1x1>, %arg2: !migraphx.shaped<1x12x1x1xf32, 12x1x1x1>, %arg3: !migraphx.shaped<1x12x1x64xf32, 768x64x64x1>) -> !migraphx.shaped<1x12x1x64xf32, 768x64x64x1> attributes {arch = "", kernel = "mixr", num_cu = 0 : i64} {
+    %0 = migraphx.dot %arg0, %arg1 : <1x12x1x64xf32, 768x64x64x1>, <1x12x64x1xf32, 768x64x1x1> -> <1x12x1x1xf32, 12x1x1x1>
+    %1 = migraphx.mul %0, %arg2 : <1x12x1x1xf32, 12x1x1x1>, <1x12x1x1xf32, 12x1x1x1> -> <1x12x1x1xf32, 12x1x1x1>
+    %2 = migraphx.reshape %1 {dims = [1, 12, 1, 1]} : <1x12x1x1xf32, 12x1x1x1> -> <1x12x1x1xf32, 12x1x1x1>
+    %3 = migraphx.reduce_max %2 {axes = [3]} : <1x12x1x1xf32, 12x1x1x1> -> <1x12x1x1xf32, 12x1x1x1>
+    %4 = migraphx.reshape %3 {dims = [1, 12, 1, 1]} : <1x12x1x1xf32, 12x1x1x1> -> <1x12x1x1xf32, 12x1x1x1>
+    %5 = migraphx.multibroadcast %4 {out_dyn_dims = [], out_lens = [1, 12, 1, 1]} : <1x12x1x1xf32, 12x1x1x1> -> <1x12x1x1xf32, 12x1x1x1>
+    %6 = migraphx.sub %1, %5 : <1x12x1x1xf32, 12x1x1x1>, <1x12x1x1xf32, 12x1x1x1> -> <1x12x1x1xf32, 12x1x1x1>
+    %7 = migraphx.exp %6 : <1x12x1x1xf32, 12x1x1x1> -> <1x12x1x1xf32, 12x1x1x1>
+    %8 = migraphx.reshape %7 {dims = [1, 12, 1, 1]} : <1x12x1x1xf32, 12x1x1x1> -> <1x12x1x1xf32, 12x1x1x1>
+    %9 = migraphx.reduce_sum %8 {axes = [3]} : <1x12x1x1xf32, 12x1x1x1> -> <1x12x1x1xf32, 12x1x1x1>
+    %10 = migraphx.reshape %9 {dims = [1, 12, 1, 1]} : <1x12x1x1xf32, 12x1x1x1> -> <1x12x1x1xf32, 12x1x1x1>
+    %11 = migraphx.multibroadcast %10 {out_dyn_dims = [], out_lens = [1, 12, 1, 1]} : <1x12x1x1xf32, 12x1x1x1> -> <1x12x1x1xf32, 12x1x1x1>
+    %12 = migraphx.div %7, %11 : <1x12x1x1xf32, 12x1x1x1>, <1x12x1x1xf32, 12x1x1x1> -> <1x12x1x1xf32, 12x1x1x1>
+    %13 = migraphx.dot %12, %arg3 : <1x12x1x1xf32, 12x1x1x1>, <1x12x1x64xf32, 768x64x64x1> -> <1x12x1x64xf32, 768x64x64x1>
+    return %13 : !migraphx.shaped<1x12x1x64xf32, 768x64x64x1>
+  }
+}
+)__migraphx__";
+    migraphx::module m;
+    auto x0 = m.add_parameter("x0", migraphx::shape{migraphx::shape::float_type, {1, 12, 1, 64}});
+    auto x1 = m.add_parameter("x1", migraphx::shape{migraphx::shape::float_type, {1, 12, 64, 1}});
+    auto x2 = m.add_parameter("x2", migraphx::shape{migraphx::shape::float_type, {1, 12, 1, 1}});
+    auto x3 = m.add_parameter("x3", migraphx::shape{migraphx::shape::float_type, {1, 12, 1, 64}});
+    auto dot0 = m.add_instruction(migraphx::make_op("dot"), x0, x1);
+    auto mul = m.add_instruction(migraphx::make_op("mul"), dot0, x2);
+    auto reduce_max = m.add_instruction(migraphx::make_op("reduce_max", {{"axes", {3}}}), mul);
+    auto broadcast0 = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 12, 1, 1}}}), reduce_max);
+    auto sub = m.add_instruction(migraphx::make_op("sub"), mul, broadcast0);
+    auto exp = m.add_instruction(migraphx::make_op("exp"), sub);
+    auto reduce_sum = m.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {3}}}), exp);
+    auto broadcast1 = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 12, 1, 1}}}), reduce_sum);
+    auto div = m.add_instruction(migraphx::make_op("div"), exp, broadcast1);
+    auto dot1 = m.add_instruction(migraphx::make_op("dot"), div, x3);
+    m.add_return({dot1});
+    auto s = migraphx::gpu::dump_mlir(m);
+    // Skip test if MLIR is not enabled
+    if(s.empty())
+        return;
+    auto mlir_output_with_attrs = migraphx::interpolate_string(mlir_output, {{"attrs", get_attrs()}});
+    CHECK(encode(s) == encode(mlir_output_with_attrs));
+    EXPECT(verify_mlir(m));
+}
+
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
Addresses an edge case where if the dimensions to reduce were already 1 then an empty `axes` would be passed into the reduce op.

Closes https://github.com/ROCm/AMDMIGraphX/issues/4203.