### PR TITLE
MIGRAPHX_GPU_HIP_FLAGS, to be able to pass in extra hip compile flags…

### DIFF
--- a/docs/reference/MIGraphX-dev-env-vars.rst
+++ b/docs/reference/MIGraphX-dev-env-vars.rst
@@ -574,6 +574,13 @@ Advanced settings
 
       | Default: The hip-clang assembly output isn't written out.
 
+  * - | ``MIGRAPHX_GPU_HIP_FLAGS``
+      | When set, the hip-clang complier appends these extra flags for compilation.
+
+    - | Takes a valid string, a valid hip compile option, e.g. "-Wno-error".
+
+      | Default: The compiler will not append any extra flags for compilation.
+
   * - | ``MIGRAPHX_GPU_OPTIMIZE``
       | Sets the GPU compiler optimization mode. 
   

--- a/src/targets/gpu/compile_hip.cpp
+++ b/src/targets/gpu/compile_hip.cpp
@@ -55,6 +55,7 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GPU_DEBUG_SYM);
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GPU_OPTIMIZE);
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GPU_DUMP_ASM);
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GPU_DUMP_SRC);
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GPU_HIP_FLAGS);
 
 #ifdef MIGRAPHX_USE_HIPRTC
 
@@ -215,6 +216,9 @@ std::vector<std::vector<char>> compile_hip_src_with_hiprtc(std::vector<hiprtc_sr
     options.push_back("-O" + string_value_of(MIGRAPHX_GPU_OPTIMIZE{}, "3"));
     options.push_back("-Wno-cuda-compat");
     options.push_back("--offload-arch=" + arch);
+    std::string extra_flags = string_value_of(MIGRAPHX_GPU_HIP_FLAGS{});
+    if(not extra_flags.empty())
+        options.push_back(extra_flags);
     prog.compile(options);
     return {prog.get_code_obj()};
 }
@@ -352,6 +356,9 @@ std::vector<std::vector<char>> compile_hip_src(const std::vector<src_file>& srcs
     compiler.flags.emplace_back("-Wno-unused-command-line-argument");
     compiler.flags.emplace_back("-Wno-cuda-compat");
     compiler.flags.emplace_back(MIGRAPHX_HIP_COMPILER_FLAGS);
+    std::string extra_flags = string_value_of(MIGRAPHX_GPU_HIP_FLAGS{});
+    if(not extra_flags.empty())
+        compiler.flags.push_back(extra_flags);
 
     if(enabled(MIGRAPHX_GPU_DUMP_SRC{}))
     {


### PR DESCRIPTION
… for quick debugging purposes, we need to be able to pass in options like `-Wno-error` or something new, as the tool-chain changes, we are seeing new warnings that are tripping up testing process. This should make debugging _in the field_ much easier, hopefully. 

Right now, I see another team not able to test further, unless a warning is fixed -- which can take a long time to resolve.