### PR TITLE
Reduce nested visits in ref operators to improve compilation time

### DIFF
--- a/src/argument.cpp
+++ b/src/argument.cpp
@@ -153,13 +153,10 @@ argument argument::reshape(const shape& s) const
     return {s, this->m_data};
 }
 
-
 argument argument::convert(shape::type_t t) const
 {
     argument result{this->get_shape().with_type(t)};
-    this->visit([&](auto x) {
-        result.fill(x.begin(), x.end());
-    });
+    this->visit([&](auto x) { result.fill(x.begin(), x.end()); });
     return result;
 }
 

--- a/src/argument.cpp
+++ b/src/argument.cpp
@@ -153,6 +153,16 @@ argument argument::reshape(const shape& s) const
     return {s, this->m_data};
 }
 
+
+argument argument::convert(shape::type_t t) const
+{
+    argument result{this->get_shape().with_type(t)};
+    this->visit([&](auto x) {
+        result.fill(x.begin(), x.end());
+    });
+    return result;
+}
+
 argument::data_t argument::data_t::share() const
 {
     data_t result;

--- a/src/include/migraphx/argument.hpp
+++ b/src/include/migraphx/argument.hpp
@@ -103,6 +103,8 @@ struct MIGRAPHX_EXPORT argument : raw_data<argument>
         });
     }
 
+    argument convert(shape::type_t t) const;
+
     private:
     void assign_buffer(std::function<char*()> d);
     struct data_t
@@ -125,6 +127,17 @@ MIGRAPHX_EXPORT void migraphx_from_value(const value& v, argument& a);
 
 MIGRAPHX_EXPORT void save_argument(const argument& a, const std::string& filename);
 MIGRAPHX_EXPORT argument load_argument(const std::string& filename);
+
+// Visit-like function but just converts argument to double
+template<class T, class... Ts>
+auto get_all(Ts&&... xs)
+{
+    return [&](auto v) {
+        [&](auto&&... xs) {
+            v(xs.template get<T>()...);
+        }(xs.convert(shape::get_type<T>{})...);
+    };
+}
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/include/migraphx/op/gathernd.hpp
+++ b/src/include/migraphx/op/gathernd.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/op/gathernd.hpp
+++ b/src/include/migraphx/op/gathernd.hpp
@@ -146,7 +146,7 @@ struct gathernd
     {
         argument result{dyn_out.computed_shape};
         visit_all(result, args[0])([&](auto output, auto data) {
-            args[1].visit([&](auto indices) {
+            get_all<int64_t>(args[1])([&](auto indices) {
                 auto indices_shape        = indices.get_shape();
                 auto indices_shape_lens   = indices_shape.lens();
                 auto data_shape           = data.get_shape();

--- a/src/include/migraphx/op/group_query_attention.hpp
+++ b/src/include/migraphx/op/group_query_attention.hpp
@@ -494,7 +494,7 @@ struct group_query_attention
                                        auto present_k,
                                        auto present_v,
                                        auto attn_probs) {
-            visit_all(args[5])([&](auto seqlens_k) {
+            get_all<double>(args[5])([&](auto seqlens_k) {
                 par_for(kv_shape.elements(), [&](auto i) {
                     present_k[i] = past_key[i];
                     present_v[i] = past_value[i];

--- a/src/include/migraphx/op/multinomial.hpp
+++ b/src/include/migraphx/op/multinomial.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/op/multinomial.hpp
+++ b/src/include/migraphx/op/multinomial.hpp
@@ -118,7 +118,7 @@ struct multinomial
         size_t class_size  = args[0].get_shape().lens().back();
         size_t sample_size = dyn_out.computed_shape.lens().back();
 
-        visit_all(args[0], args[1])([&](auto cdf, auto dist) {
+        get_all<double>(args[0], args[1])([&](auto cdf, auto dist) {
             result.visit([&](auto output) {
                 par_for(batch_size * sample_size, [&](auto i) {
                     auto idx       = args[1].get_shape().multi(i);

--- a/src/include/migraphx/op/nonmaxsuppression.hpp
+++ b/src/include/migraphx/op/nonmaxsuppression.hpp
@@ -389,7 +389,7 @@ struct nonmaxsuppression
         std::size_t num_selected = 0;
 
         result.visit([&](auto output) {
-            visit_all(args[0], args[1])([&](auto boxes, auto scores) {
+            get_all<double>(args[0], args[1])([&](auto boxes, auto scores) {
                 num_selected = compute_nms(output,
                                            boxes,
                                            scores,

--- a/src/include/migraphx/op/quant_convolution.hpp
+++ b/src/include/migraphx/op/quant_convolution.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/op/quant_convolution.hpp
+++ b/src/include/migraphx/op/quant_convolution.hpp
@@ -128,7 +128,7 @@ struct quant_convolution
     {
         argument result{output_shape};
         result.visit([&](auto output) {
-            visit_all(args[0], args[1])([&](auto input, auto weights) {
+            get_all<double>(args[0], args[1])([&](auto input, auto weights) {
                 migraphx::convolution(output, input, weights, padding, stride, dilation, group);
             });
         });

--- a/src/include/migraphx/op/rnn_variable_seq_lens.hpp
+++ b/src/include/migraphx/op/rnn_variable_seq_lens.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/op/rnn_variable_seq_lens.hpp
+++ b/src/include/migraphx/op/rnn_variable_seq_lens.hpp
@@ -63,7 +63,7 @@ struct rnn_var_sl_shift_output
         int64_t max_len = output_shape.lens()[0];
         visit_all(result, args[0])([&](auto output, auto input) {
             using value_type = typename decltype(output)::value_type;
-            args[1].visit([&](auto seq_lens) {
+            get_all<int64_t>(args[1])([&](auto seq_lens) {
                 par_for(output_shape.elements(), [&](auto i) {
                     auto idx       = output_shape.multi(i);
                     auto batch_id  = idx[2];


### PR DESCRIPTION
This gets rid of nested visits in some places and replaces them with the new `get_all` function which converts the arguments to a single type rather than use another switch statement. Nested switch statements can lead to an explosion of different combinations and for larger functions this can take a lot of time. 