### PR TITLE
Gather operator: 4D tensor tests with multi-dimensional indices.

### DIFF
--- a/test/verify/test_gather_4d.cpp
+++ b/test/verify/test_gather_4d.cpp
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "verify_program.hpp"
+#include <migraphx/program.hpp>
+#include <migraphx/generate.hpp>
+#include <migraphx/make_op.hpp>
+
+struct test_gather_4d_index_0 : verify_program<test_gather_4d_index_0>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        migraphx::shape s{migraphx::shape::int8_type, {4, 2, 2, 1}};
+        migraphx::shape s_indices{migraphx::shape::int32_type, {2, 4}};
+        std::vector<int> indices{3, 2, 1, 0, 0, 1, 2, 3};
+        auto a0 = mm->add_parameter("data", s);
+        auto a1 = mm->add_literal(migraphx::literal{s_indices, indices});
+        mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), a0, a1);
+        return p;
+    }
+};
+
+struct test_gather_4d_index_2 : verify_program<test_gather_4d_index_2>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        migraphx::shape s{migraphx::shape::int8_type, {4, 2, 2, 2}};
+        migraphx::shape s_indices{migraphx::shape::int32_type, {1, 5}};
+        std::vector<int> indices{1, 1, 0, 0, 1};
+        auto a0 = mm->add_parameter("data", s);
+        auto a1 = mm->add_literal(migraphx::literal{s_indices, indices});
+        mm->add_instruction(migraphx::make_op("gather", {{"axis", 2}}), a0, a1);
+        return p;
+    }
+};
+
+struct test_gather_4d_index_3 : verify_program<test_gather_4d_index_3>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        migraphx::shape s{migraphx::shape::int8_type, {4, 2, 2, 1}};
+        migraphx::shape s_indices{migraphx::shape::int32_type, {2, 2}};
+        std::vector<int> indices{0, 0, 0, 0};
+        auto a0 = mm->add_parameter("data", s);
+        auto a1 = mm->add_literal(migraphx::literal{s_indices, indices});
+        mm->add_instruction(migraphx::make_op("gather", {{"axis", -1}}), a0, a1);
+        return p;
+    }
+};


### PR DESCRIPTION
## Motivation

1. Verify tests for `gather` operator with a higher tensor size: 4D. 
2. To test with multi-dimensional `indices`. 
3. To test with a unit-dimension.
4. To test with an increased dimension.
