### PR TITLE
Interleave fuse pointwise passes for broadcast rewrite with multi output fusions

### DIFF
--- a/src/fuse_pointwise_reduce.cpp
+++ b/src/fuse_pointwise_reduce.cpp
@@ -51,11 +51,8 @@ void fuse_pointwise_reduce::apply(module_pass_manager& mpm) const
     mpm.run_pass(fuse_pointwise{.enable_rewrite_reshapes = true});
     mpm.run_pass(fuse_reduce{.enable_rewrite_reshapes = true});
     mpm.run_pass(split_reduce{.split_size = get_split_size(split_size)});
-    mpm.run_pass(fuse_pointwise{.enable_rewrite_broadcasts = true});
-    if(not enabled(MIGRAPHX_DISABLE_MULTI_OUTPUT_FUSION{}))
-    {
-        mpm.run_pass(fuse_pointwise{.enable_multi_output = true});
-    }
+    mpm.run_pass(fuse_pointwise{.enable_rewrite_broadcasts = true,
+                                .enable_multi_output = not enabled(MIGRAPHX_DISABLE_MULTI_OUTPUT_FUSION)});
 }
 
 } // namespace MIGRAPHX_INLINE_NS


### PR DESCRIPTION


## Motivation
Fixes an issue I was seeing with multi outptut fusions. Multi output would generate additional outputs and blow up so to speak for certain models and was causing broadcasts to be removed. Ensuring we fuse broadcasts after multioutput fusion pass is complte gives us a more stable run.

During debug I was seeing cases where fuse broadcast was creating a large amount of outputs resulting in a few cases where inputs would be mismatched on check during the fusion for multi output.

I don't see this anymore when allowing a reduce multioutput between broadcasts

## Technical Details

Was hitting a failing case during MIGraphx compile related to multi output fusions being on. 
Seeing about a 2-3 ms boost in perf run on fp16 and 5-6ms on fp32 runs now when I'm able to get multi output fusions running.

## Test Plan

Running customer model with or without the change that generates the errornous case

## Test Result

Pass/fail in this case. 
