### PR TITLE
Bump Doxygen to 1.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN cget -p $PREFIX install facebook/zstd@v1.4.5 -X subdir -DCMAKE_DIR=build/cma
 RUN cget -p $PREFIX install ccache@v4.1 -DENABLE_TESTING=OFF
 RUN cget -p /opt/cmake install kitware/cmake@v3.28.0
 # Install a newer version of doxygen because the one that comes with ubuntu is broken
-RUN cget -p $PREFIX install doxygen@Release_1_9_8
+RUN cget -p $PREFIX install doxygen@Release_1_14_0
 
 COPY ./test/onnx/.onnxrt-commit /
 


### PR DESCRIPTION
Fixing an error with Doxygen 1.9.8 that got generated when using ROCm 7.0 and our Dockerfile