### PR TITLE
fp8 quantization restricted to dot and convolution operators

### DIFF
--- a/src/quantization.cpp
+++ b/src/quantization.cpp
@@ -194,18 +194,13 @@ void quantize_fp8(program& prog, const target& t, const std::vector<parameter_ma
 {
     std::unordered_set<std::string> supported_ins_names;
     auto* mm = prog.get_main_module();
-    for(auto ins : iterator_for(*mm))
+    for(const auto ins : iterator_for(*mm))
     {
-        if(ins->name() == "convert")
-        {
-            continue;
-        }
-        if(not starts_with(ins->name(), "@"))
-        {
+        if(ins->name() == "convolution" or ins->name() == "dot")
             supported_ins_names.insert(ins->name());
-        }
     }
-    quantize_8bits(prog, t, shape::fp8e4m3fn_type, calibration, supported_ins_names);
+    if(not supported_ins_names.empty())
+        quantize_8bits(prog, t, shape::fp8e4m3fn_type, calibration, supported_ins_names);
 }
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/quantization.cpp
+++ b/src/quantization.cpp
@@ -93,7 +93,7 @@ static void quantize_8bits(program& prog,
 {
     // Run optimize_module() before converting to int8/fp8 to const eval and fold in FP32 to
     // avoid loss of precision.
-    run_passes(prog, {normalize_ops{}, optimize_module{}}, quant_tracer());
+    run_passes(prog, {rewrite_rnn{}, normalize_ops{}, optimize_module{}}, quant_tracer());
 
     std::shared_ptr<std::vector<std::pair<float, float>>> quant_8bit_params =
         std::make_shared<std::vector<std::pair<float, float>>>();
@@ -193,7 +193,6 @@ void quantize_int4_weights(program& prog)
 
 void quantize_fp8(program& prog, const target& t, const std::vector<parameter_map>& calibration)
 {
-    run_passes(prog, {rewrite_rnn{}}, quant_tracer());
     std::unordered_set<std::string> supported_ins_names;
     auto* mm = prog.get_main_module();
     for(auto ins : iterator_for(*mm))


### PR DESCRIPTION
## Motivation
Bugfix: Run rewrite_rnn pass ~~only `dot` and `convolution` operators to be~~ before the graph is quantized for `fp8`.

## Technical Details
Currently, operators like `rnn_**` become candidates for `capture` for fp8 conversion, ~~which should be restricted just to `dot` & `convolution` operators,  similar to the logic for `int8` quantization~~. With this current improper capture, `rnn_**` operators go through `eval` without any prior rewrite, causing an exception.

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- [ ] Added: New functionality.
- [ ] Changed: Changes to existing functionality.
- [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- [ ] Optimized: Component performance that has been optimized or improved.
- [x] Resolved Issues: Known issues from a previous version that have been resolved.
- [ ] Not Applicable: This PR is not to be included in the changelog.
