### PR TITLE
Add fixed_pad op

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -205,6 +205,7 @@ register_migraphx_ops(
     erf
     exp
     fill
+    fixed_pad
     flatten
     floor
     fmod

--- a/src/include/migraphx/op/fixed_pad.hpp
+++ b/src/include/migraphx/op/fixed_pad.hpp
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MIGRAPHX_GUARD_OPERATORS_FIXED_PAD_HPP
+#define MIGRAPHX_GUARD_OPERATORS_FIXED_PAD_HPP
+
+#include <array>
+#include <migraphx/check_shapes.hpp>
+#include <migraphx/stringutils.hpp>
+#include <migraphx/streamutils.hpp>
+#include <migraphx/literal.hpp>
+#include <migraphx/shape_for_each.hpp>
+#include <migraphx/par_for.hpp>
+#include <migraphx/config.hpp>
+#include <cmath>
+#include <utility>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace op {
+
+struct fixed_pad
+{
+    std::vector<size_t> output_lens = {};
+
+    template <class Self, class F>
+    static auto reflect(Self& self, F f)
+    {
+        return pack(f(self.output_lens, "output_lens"));
+    }
+
+    std::string name() const { return "fixed_pad"; }
+    shape compute_shape(std::vector<shape> inputs) const
+    {
+        check_shapes{inputs, *this, true}.has(1);
+        const auto& s0 = inputs.front();
+        if(s0.ndim() != output_lens.size())
+        {
+            MIGRAPHX_THROW("FIXED_PAD: input dimensions should match output_lens size");
+        }
+        return {s0.type(), output_lens};
+    }
+    argument compute(const shape& output_shape, std::vector<argument> args) const
+    {
+        const auto& input_arg = args.front();
+        if(input_arg.get_shape() == output_shape)
+            return input_arg;
+
+        argument out{output_shape};
+        visit_all(out, input_arg)([&](auto output, auto input){
+            par_for(input.get_shape().elements(), [&](auto i) {
+                auto idx = input.get_shape().multi(i);
+                output[idx] = input[idx];
+            });
+        });
+
+        return out;
+    }
+};
+
+} // namespace op
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+
+#endif

--- a/src/include/migraphx/op/fixed_pad.hpp
+++ b/src/include/migraphx/op/fixed_pad.hpp
@@ -40,7 +40,8 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace op {
 
 /**
- * Pads the given input to the dimensions given in the `output_lens` attribute.
+ * Pads an input with dynamic shape to its maximum dimensions.
+ * No-op for a static shape input.
  * The main use for this op versus the standard pad op is that it can
  * accept a dynamic input shape and convert it to a padded static shape.
  */

--- a/src/include/migraphx/op/fixed_pad.hpp
+++ b/src/include/migraphx/op/fixed_pad.hpp
@@ -68,7 +68,8 @@ struct fixed_pad
             for(auto i = 0; i < s0.ndim(); i++)
             {
                 if(output_lens[i] != s0.dyn_dims()[i].max)
-                    MIGRAPHX_THROW("FIXED_PAD: padding to size smaller than max dyn dim is not allowed");
+                    MIGRAPHX_THROW(
+                        "FIXED_PAD: padding to size smaller than max dyn dim is not allowed");
             }
         }
         else

--- a/src/include/migraphx/op/fixed_pad.hpp
+++ b/src/include/migraphx/op/fixed_pad.hpp
@@ -67,10 +67,8 @@ struct fixed_pad
         {
             for(auto i = 0; i < s0.ndim(); i++)
             {
-                if(output_lens[i] < s0.dyn_dims()[i].min)
-                    MIGRAPHX_THROW("FIXED_PAD: padding to size smaller than min dyn dim");
-                if(output_lens[i] > s0.dyn_dims()[i].max)
-                    MIGRAPHX_THROW("FIXED_PAD: padding to size larger than max dyn dim");
+                if(output_lens[i] != s0.dyn_dims()[i].max)
+                    MIGRAPHX_THROW("FIXED_PAD: padding to size smaller than max dyn dim is not allowed");
             }
         }
         else
@@ -93,15 +91,6 @@ struct fixed_pad
         auto input_shape      = input_arg.get_shape();
         if(input_shape == output_shape)
             return input_arg;
-
-        if(std::mismatch(input_shape.lens().begin(),
-                         input_shape.lens().end(),
-                         output_shape.lens().begin(),
-                         [&](auto in_dim, auto out_dim) { return in_dim <= out_dim; })
-               .first != input_shape.lens().end())
-        {
-            MIGRAPHX_THROW("COMPUTE_FIXED_PAD: output lens are smaller than input lens");
-        }
 
         argument out{output_shape};
         visit_all(out, input_arg)([&](auto output, auto input) {

--- a/src/include/migraphx/op/fixed_pad.hpp
+++ b/src/include/migraphx/op/fixed_pad.hpp
@@ -68,7 +68,7 @@ struct fixed_pad
             for(auto i = 0; i < s0.ndim(); i++)
             {
                 if(output_lens[i] < s0.dyn_dims()[i].min)
-                    MIGRAPHX_THROW("FIXED_PAD: padding to size smaller than min dyn dim");    
+                    MIGRAPHX_THROW("FIXED_PAD: padding to size smaller than min dyn dim");
                 if(output_lens[i] > s0.dyn_dims()[i].max)
                     MIGRAPHX_THROW("FIXED_PAD: padding to size larger than max dyn dim");
             }
@@ -76,10 +76,10 @@ struct fixed_pad
         else
         {
             if(std::mismatch(s0.lens().begin(),
-                         s0.lens().end(),
-                         output_lens.begin(),
-                         [&](auto in_dim, auto out_dim) { return in_dim <= out_dim; })
-               .first != s0.lens().end())
+                             s0.lens().end(),
+                             output_lens.begin(),
+                             [&](auto in_dim, auto out_dim) { return in_dim <= out_dim; })
+                   .first != s0.lens().end())
             {
                 MIGRAPHX_THROW("FIXED_PAD: output lens are smaller than input lens");
             }

--- a/src/include/migraphx/op/fixed_pad.hpp
+++ b/src/include/migraphx/op/fixed_pad.hpp
@@ -40,10 +40,10 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace op {
 
 /**
-  * Pads the given input to the dimensions given in the `output_lens` attribute.
-  * The main use for this op versus the standard pad op is that it can
-  * accept a dynamic input shape and convert it to a padded static shape. 
-  */
+ * Pads the given input to the dimensions given in the `output_lens` attribute.
+ * The main use for this op versus the standard pad op is that it can
+ * accept a dynamic input shape and convert it to a padded static shape.
+ */
 struct fixed_pad
 {
     std::vector<size_t> output_lens = {};

--- a/src/include/migraphx/op/fixed_pad.hpp
+++ b/src/include/migraphx/op/fixed_pad.hpp
@@ -39,6 +39,11 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace op {
 
+/**
+  * Pads the given input to the dimensions given in the `output_lens` attribute.
+  * The main use for this op versus the standard pad op is that it can
+  * accept a dynamic input shape and convert it to a padded static shape. 
+  */
 struct fixed_pad
 {
     std::vector<size_t> output_lens = {};
@@ -56,7 +61,7 @@ struct fixed_pad
         const auto& s0 = inputs.front();
         if(s0.ndim() != output_lens.size())
         {
-            MIGRAPHX_THROW("FIXED_PAD: input dimensions should match output_lens size");
+            MIGRAPHX_THROW("FIXED_PAD: input number of dimensions should match output_lens size");
         }
         return {s0.type(), output_lens};
     }

--- a/src/include/migraphx/op/fixed_pad.hpp
+++ b/src/include/migraphx/op/fixed_pad.hpp
@@ -48,7 +48,7 @@ struct fixed_pad
 {
 
     std::string name() const { return "fixed_pad"; }
-    
+
     shape compute_shape(std::vector<shape> inputs) const
     {
         check_shapes{inputs, *this, true}.has(1);

--- a/src/include/migraphx/op/fixed_pad.hpp
+++ b/src/include/migraphx/op/fixed_pad.hpp
@@ -67,9 +67,9 @@ struct fixed_pad
             return input_arg;
 
         argument out{output_shape};
-        visit_all(out, input_arg)([&](auto output, auto input){
+        visit_all(out, input_arg)([&](auto output, auto input) {
             par_for(input.get_shape().elements(), [&](auto i) {
-                auto idx = input.get_shape().multi(i);
+                auto idx    = input.get_shape().multi(i);
                 output[idx] = input[idx];
             });
         });

--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -153,6 +153,7 @@ add_library(migraphx_gpu
     compile_pointwise.cpp
     compiler.cpp
     device_name.cpp
+    fixed_pad.cpp
     fuse_ck.cpp
     fuse_mlir.cpp
     fuse_ops.cpp
@@ -200,6 +201,7 @@ endfunction()
 register_migraphx_gpu_ops(hip_
     argmax
     argmin
+    fixed_pad
     logsoftmax
     loop
     multinomial

--- a/src/targets/gpu/device/fixed_pad.cpp
+++ b/src/targets/gpu/device/fixed_pad.cpp
@@ -35,7 +35,7 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 namespace device {
 
-argument fixed_pad_base_impl(hipStream_t stream, const argument& result, const argument& arg)
+static argument fixed_pad_base_impl(hipStream_t stream, const argument& result, const argument& arg)
 {
     hip_visit_all(result, arg)([&](auto output, auto input) {
         gs_launch(stream, result.get_shape().elements())([=](auto i) __device__ {
@@ -51,7 +51,7 @@ argument fixed_pad_base_impl(hipStream_t stream, const argument& result, const a
     return result;
 }
 
-argument fixed_pad_standard_impl(hipStream_t stream, const argument& result, const argument& arg)
+static argument fixed_pad_standard_impl(hipStream_t stream, const argument& result, const argument& arg)
 {
     index_int nelements = result.get_shape().elements();
     index_int ielements = arg.get_shape().elements();

--- a/src/targets/gpu/device/fixed_pad.cpp
+++ b/src/targets/gpu/device/fixed_pad.cpp
@@ -35,18 +35,15 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 namespace device {
 
-argument
-fixed_pad_base_impl(hipStream_t stream, const argument& result, const argument& arg)
+argument fixed_pad_base_impl(hipStream_t stream, const argument& result, const argument& arg)
 {
     hip_visit_all(result, arg)([&](auto output, auto input) {
-
         gs_launch(stream, result.get_shape().elements())([=](auto i) __device__ {
             auto input_bounds = input.get_shape().lens;
-            auto idx = output.get_shape().multi(i);
+            auto idx          = output.get_shape().multi(i);
 
-            bool in_bounds = sequence(idx.size(), [&](auto... js) {
-                return ((idx[js] < input_bounds[js]) and ...);
-            });
+            bool in_bounds = sequence(
+                idx.size(), [&](auto... js) { return ((idx[js] < input_bounds[js]) and ...); });
 
             output[idx] = in_bounds ? input[idx] : 0;
         });
@@ -54,31 +51,26 @@ fixed_pad_base_impl(hipStream_t stream, const argument& result, const argument& 
     return result;
 }
 
-argument
-fixed_pad_standard_impl(hipStream_t stream, const argument& result, const argument& arg)
+argument fixed_pad_standard_impl(hipStream_t stream, const argument& result, const argument& arg)
 {
     index_int nelements = result.get_shape().elements();
     index_int ielements = arg.get_shape().elements();
     hip_pointer_visit_all(result, arg)([&](auto output, auto input) {
-        gs_launch(stream, nelements)([=](auto i) __device__ {
-            output[i] = (i < ielements) ? input[i] : 0;
-        });
+        gs_launch(stream, nelements)(
+            [=](auto i) __device__ { output[i] = (i < ielements) ? input[i] : 0; });
     });
     return result;
 }
 
-
-argument
-fixed_pad(hipStream_t stream, const argument& result, const argument& arg)
+argument fixed_pad(hipStream_t stream, const argument& result, const argument& arg)
 {
     if(result.get_shape().standard() and arg.get_shape().standard())
     {
-        auto ilens = arg.get_shape().lens();
-        auto olens = result.get_shape().lens();
+        auto ilens            = arg.get_shape().lens();
+        auto olens            = result.get_shape().lens();
         auto [istart, ostart] = std::mismatch(ilens.begin(), ilens.end(), olens.begin());
         if(std::equal(istart, ilens.end(), ostart, olens.end()))
             return fixed_pad_standard_impl(stream, result, arg);
-
     }
     return fixed_pad_base_impl(stream, result, arg);
 }

--- a/src/targets/gpu/device/fixed_pad.cpp
+++ b/src/targets/gpu/device/fixed_pad.cpp
@@ -51,7 +51,8 @@ static argument fixed_pad_base_impl(hipStream_t stream, const argument& result, 
     return result;
 }
 
-static argument fixed_pad_standard_impl(hipStream_t stream, const argument& result, const argument& arg)
+static argument
+fixed_pad_standard_impl(hipStream_t stream, const argument& result, const argument& arg)
 {
     index_int nelements = result.get_shape().elements();
     index_int ielements = arg.get_shape().elements();

--- a/src/targets/gpu/device/fixed_pad.cpp
+++ b/src/targets/gpu/device/fixed_pad.cpp
@@ -1,0 +1,89 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/shape.hpp>
+#include <migraphx/argument.hpp>
+#include <migraphx/gpu/device/nary.hpp>
+#include <migraphx/gpu/device/fixed_pad.hpp>
+#include <migraphx/gpu/device/tensor.hpp>
+#include <migraphx/gpu/device/launch.hpp>
+#include <migraphx/float_equal.hpp>
+#include <migraphx/functional.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
+namespace device {
+
+argument
+fixed_pad_base_impl(hipStream_t stream, const argument& result, const argument& arg)
+{
+    hip_visit_all(result, arg)([&](auto output, auto input) {
+
+        gs_launch(stream, result.get_shape().elements())([=](auto i) __device__ {
+            auto input_bounds = input.get_shape().lens;
+            auto idx = output.get_shape().multi(i);
+
+            bool in_bounds = sequence(idx.size(), [&](auto... js) {
+                return ((idx[js] < input_bounds[js]) and ...);
+            });
+
+            output[idx] = in_bounds ? input[idx] : 0;
+        });
+    });
+    return result;
+}
+
+argument
+fixed_pad_standard_impl(hipStream_t stream, const argument& result, const argument& arg)
+{
+    index_int nelements = result.get_shape().elements();
+    index_int ielements = arg.get_shape().elements();
+    hip_pointer_visit_all(result, arg)([&](auto output, auto input) {
+        gs_launch(stream, nelements)([=](auto i) __device__ {
+            output[i] = (i < ielements) ? input[i] : 0;
+        });
+    });
+    return result;
+}
+
+
+argument
+fixed_pad(hipStream_t stream, const argument& result, const argument& arg)
+{
+    if(result.get_shape().standard() and arg.get_shape().standard())
+    {
+        auto ilens = arg.get_shape().lens();
+        auto olens = result.get_shape().lens();
+        auto [istart, ostart] = std::mismatch(ilens.begin(), ilens.end(), olens.begin());
+        if(std::equal(istart, ilens.end(), ostart, olens.end()))
+            return fixed_pad_standard_impl(stream, result, arg);
+
+    }
+    return fixed_pad_base_impl(stream, result, arg);
+}
+
+} // namespace device
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx

--- a/src/targets/gpu/fixed_pad.cpp
+++ b/src/targets/gpu/fixed_pad.cpp
@@ -40,6 +40,16 @@ argument hip_fixed_pad::compute(context& ctx, const shape&, const std::vector<ar
 {
     if(args.front().get_shape() == args.back().get_shape())
         return args.front();
+    auto input_shape = args.front().get_shape();
+    auto output_shape = args.back().get_shape();
+    if(std::mismatch(input_shape.lens().begin(),
+                         input_shape.lens().end(),
+                         output_shape.lens().begin(),
+                         [&](auto in_dim, auto out_dim) { return in_dim <= out_dim; })
+               .first != input_shape.lens().end())
+    {
+        MIGRAPHX_THROW("COMPUTE_HIP_FIXED_PAD: output lens are smaller than input lens");
+    }
     return device::fixed_pad(ctx.get_stream().get(), args.back(), args.front());
 }
 

--- a/src/targets/gpu/fixed_pad.cpp
+++ b/src/targets/gpu/fixed_pad.cpp
@@ -40,13 +40,13 @@ argument hip_fixed_pad::compute(context& ctx, const shape&, const std::vector<ar
 {
     if(args.front().get_shape() == args.back().get_shape())
         return args.front();
-    auto input_shape = args.front().get_shape();
+    auto input_shape  = args.front().get_shape();
     auto output_shape = args.back().get_shape();
     if(std::mismatch(input_shape.lens().begin(),
-                         input_shape.lens().end(),
-                         output_shape.lens().begin(),
-                         [&](auto in_dim, auto out_dim) { return in_dim <= out_dim; })
-               .first != input_shape.lens().end())
+                     input_shape.lens().end(),
+                     output_shape.lens().begin(),
+                     [&](auto in_dim, auto out_dim) { return in_dim <= out_dim; })
+           .first != input_shape.lens().end())
     {
         MIGRAPHX_THROW("COMPUTE_HIP_FIXED_PAD: output lens are smaller than input lens");
     }

--- a/src/targets/gpu/fixed_pad.cpp
+++ b/src/targets/gpu/fixed_pad.cpp
@@ -42,14 +42,7 @@ argument hip_fixed_pad::compute(context& ctx, const shape&, const std::vector<ar
         return args.front();
     auto input_shape  = args.front().get_shape();
     auto output_shape = args.back().get_shape();
-    if(std::mismatch(input_shape.lens().begin(),
-                     input_shape.lens().end(),
-                     output_shape.lens().begin(),
-                     [&](auto in_dim, auto out_dim) { return in_dim <= out_dim; })
-           .first != input_shape.lens().end())
-    {
-        MIGRAPHX_THROW("COMPUTE_HIP_FIXED_PAD: output lens are smaller than input lens");
-    }
+    
     return device::fixed_pad(ctx.get_stream().get(), args.back(), args.front());
 }
 

--- a/src/targets/gpu/fixed_pad.cpp
+++ b/src/targets/gpu/fixed_pad.cpp
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/gpu/fixed_pad.hpp>
+#include <migraphx/gpu/context.hpp>
+#include <migraphx/gpu/device/fixed_pad.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
+
+shape hip_fixed_pad::compute_shape(std::vector<shape> inputs) const
+{
+    inputs.pop_back();
+    check_shapes{inputs, *this, true}.has(1);
+    return op.compute_shape(inputs);
+}
+
+argument hip_fixed_pad::compute(context& ctx, const shape&, const std::vector<argument>& args) const
+{
+    if(args.front().get_shape() == args.back().get_shape())
+        return args.front();
+    return device::fixed_pad(ctx.get_stream().get(), args.back(), args.front());
+}
+
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx

--- a/src/targets/gpu/fixed_pad.cpp
+++ b/src/targets/gpu/fixed_pad.cpp
@@ -42,7 +42,7 @@ argument hip_fixed_pad::compute(context& ctx, const shape&, const std::vector<ar
         return args.front();
     auto input_shape  = args.front().get_shape();
     auto output_shape = args.back().get_shape();
-    
+
     return device::fixed_pad(ctx.get_stream().get(), args.back(), args.front());
 }
 

--- a/src/targets/gpu/fixed_pad.cpp
+++ b/src/targets/gpu/fixed_pad.cpp
@@ -40,8 +40,6 @@ argument hip_fixed_pad::compute(context& ctx, const shape&, const std::vector<ar
 {
     if(args.front().get_shape() == args.back().get_shape())
         return args.front();
-    auto input_shape  = args.front().get_shape();
-    auto output_shape = args.back().get_shape();
 
     return device::fixed_pad(ctx.get_stream().get(), args.back(), args.front());
 }

--- a/src/targets/gpu/include/migraphx/gpu/device/fixed_pad.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/device/fixed_pad.hpp
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MIGRAPHX_GUARD_RTGLIB_DEVICE_FIXED_PAD_HPP
+#define MIGRAPHX_GUARD_RTGLIB_DEVICE_FIXED_PAD_HPP
+
+#include <migraphx/argument.hpp>
+#include <migraphx/gpu/device/config.hpp>
+#include <hip/hip_runtime_api.h>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
+namespace device {
+
+argument MIGRAPHX_DEVICE_EXPORT fixed_pad(hipStream_t stream, const argument& result, const argument& arg);
+
+} // namespace device
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+
+#endif

--- a/src/targets/gpu/include/migraphx/gpu/device/fixed_pad.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/device/fixed_pad.hpp
@@ -33,7 +33,9 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 namespace device {
 
-argument MIGRAPHX_DEVICE_EXPORT fixed_pad(hipStream_t stream, const argument& result, const argument& arg);
+argument MIGRAPHX_DEVICE_EXPORT fixed_pad(hipStream_t stream,
+                                          const argument& result,
+                                          const argument& arg);
 
 } // namespace device
 } // namespace gpu

--- a/src/targets/gpu/include/migraphx/gpu/fixed_pad.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/fixed_pad.hpp
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MIGRAPHX_GUARD_RTGLIB_FIXED_PAD_HPP
+#define MIGRAPHX_GUARD_RTGLIB_FIXED_PAD_HPP
+
+#include <migraphx/argument.hpp>
+#include <migraphx/reflect.hpp>
+#include <migraphx/op/fixed_pad.hpp>
+#include <migraphx/gpu/device/fixed_pad.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
+
+struct context;
+
+struct hip_fixed_pad
+{
+    op::fixed_pad op;
+
+    template <class Self, class F>
+    static auto reflect(Self& self, F f)
+    {
+        return migraphx::reflect(self.op, f);
+    }
+
+    std::string name() const { return "gpu::fixed_pad"; }
+    shape compute_shape(std::vector<shape> inputs) const;
+    argument compute(context& ctx, const shape&, const std::vector<argument>& args) const;
+    std::ptrdiff_t output_alias(const std::vector<shape>& shapes) const
+    {
+        return shapes.size() - 1;
+    }
+};
+
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+
+#endif

--- a/src/targets/gpu/lowering.cpp
+++ b/src/targets/gpu/lowering.cpp
@@ -94,6 +94,7 @@ struct miopen_apply
 
         add_extend_op("argmax");
         add_extend_op("argmin");
+        add_extend_op("fixed_pad");
         add_extend_op("logsoftmax");
         add_extend_op("multinomial");
         add_extend_op("nonzero");

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -1043,7 +1043,7 @@ TEST_CASE(fixed_pad)
     shape output{migraphx::shape::float_type, {4, 3}};
     expect_shape(output, migraphx::make_op("fixed_pad", {{"output_lens", {4, 3}}}), input);
     expect_shape(output, migraphx::make_op("fixed_pad", {{"output_lens", {4, 3}}}), input_static);
-    
+
     throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), input_mismatched);
     throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), input);
     throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {5, 3}}}), input);

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -1033,6 +1033,19 @@ TEST_CASE(broadcast_with_dims2)
                  s1);
 }
 
+TEST_CASE(fixed_pad)
+{
+    using migraphx::shape;
+    shape input{migraphx::shape::float_type, {{1, 4, {3}}, {3, 3}}};
+    shape output_mid{migraphx::shape::float_type, {2, 3}};
+    shape output_opt{migraphx::shape::float_type, {3, 3}};
+    shape output_max{migraphx::shape::float_type, {4, 3}};
+    expect_shape(output_mid, migraphx::make_op("fixed_pad", {{"output_lens", {2, 3}}}), input);
+    expect_shape(output_opt, migraphx::make_op("fixed_pad", {{"output_lens", {3, 3}}}), input);
+    expect_shape(output_max, migraphx::make_op("fixed_pad", {{"output_lens", {4, 3}}}), input);
+    throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {5, 3}}}), input);   
+}
+
 TEST_CASE(flatten_shape)
 {
     migraphx::shape input{migraphx::shape::float_type, {2, 4, 6, 8}};

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -1036,14 +1036,10 @@ TEST_CASE(broadcast_with_dims2)
 TEST_CASE(fixed_pad)
 {
     using migraphx::shape;
-    shape input{migraphx::shape::float_type, {{2, 4, {3}}, {3, 3}}};
+    shape input{migraphx::shape::float_type, {{2, 4, {}}, {3, 3}}};
     shape input_static{migraphx::shape::float_type, {2, 3}};
-    shape output_min{migraphx::shape::float_type, {2, 3}};
-    shape output_opt{migraphx::shape::float_type, {3, 3}};
-    shape output_max{migraphx::shape::float_type, {4, 3}};
-    expect_shape(output_min, migraphx::make_op("fixed_pad", {{"output_lens", {2, 3}}}), input);
-    expect_shape(output_opt, migraphx::make_op("fixed_pad", {{"output_lens", {3, 3}}}), input);
-    expect_shape(output_max, migraphx::make_op("fixed_pad", {{"output_lens", {4, 3}}}), input);
+    shape output{migraphx::shape::float_type, {4, 3}};
+    expect_shape(output, migraphx::make_op("fixed_pad", {{"output_lens", {4, 3}}}), input);
     throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), input);
     throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {5, 3}}}), input);
     throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), input_static);

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -1036,14 +1036,17 @@ TEST_CASE(broadcast_with_dims2)
 TEST_CASE(fixed_pad)
 {
     using migraphx::shape;
-    shape input{migraphx::shape::float_type, {{1, 4, {3}}, {3, 3}}};
-    shape output_mid{migraphx::shape::float_type, {2, 3}};
+    shape input{migraphx::shape::float_type, {{2, 4, {3}}, {3, 3}}};
+    shape input_static{migraphx::shape::float_type, {2, 3}};
+    shape output_min{migraphx::shape::float_type, {2, 3}};
     shape output_opt{migraphx::shape::float_type, {3, 3}};
     shape output_max{migraphx::shape::float_type, {4, 3}};
-    expect_shape(output_mid, migraphx::make_op("fixed_pad", {{"output_lens", {2, 3}}}), input);
+    expect_shape(output_min, migraphx::make_op("fixed_pad", {{"output_lens", {2, 3}}}), input);
     expect_shape(output_opt, migraphx::make_op("fixed_pad", {{"output_lens", {3, 3}}}), input);
     expect_shape(output_max, migraphx::make_op("fixed_pad", {{"output_lens", {4, 3}}}), input);
-    throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {5, 3}}}), input);   
+    throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), input);
+    throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {5, 3}}}), input);
+    throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), input_static);
 }
 
 TEST_CASE(flatten_shape)

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -1038,8 +1038,13 @@ TEST_CASE(fixed_pad)
     using migraphx::shape;
     shape input{migraphx::shape::float_type, {{2, 4, {}}, {3, 3}}};
     shape input_static{migraphx::shape::float_type, {2, 3}};
+    shape input_mismatched{migraphx::shape::float_type, {2}};
+
     shape output{migraphx::shape::float_type, {4, 3}};
     expect_shape(output, migraphx::make_op("fixed_pad", {{"output_lens", {4, 3}}}), input);
+    expect_shape(output, migraphx::make_op("fixed_pad", {{"output_lens", {4, 3}}}), input_static);
+    
+    throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), input_mismatched);
     throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), input);
     throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {5, 3}}}), input);
     throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), input_static);

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -1038,16 +1038,10 @@ TEST_CASE(fixed_pad)
     using migraphx::shape;
     shape input{migraphx::shape::float_type, {{2, 4, {}}, {3, 3}}};
     shape input_static{migraphx::shape::float_type, {2, 3}};
-    shape input_mismatched{migraphx::shape::float_type, {2}};
 
     shape output{migraphx::shape::float_type, {4, 3}};
-    expect_shape(output, migraphx::make_op("fixed_pad", {{"output_lens", {4, 3}}}), input);
-    expect_shape(output, migraphx::make_op("fixed_pad", {{"output_lens", {4, 3}}}), input_static);
-
-    throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), input_mismatched);
-    throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), input);
-    throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {5, 3}}}), input);
-    throws_shape(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), input_static);
+    expect_shape(output, migraphx::make_op("fixed_pad"), input);
+    expect_shape(input_static, migraphx::make_op("fixed_pad"), input_static); // effectively no-op
 }
 
 TEST_CASE(flatten_shape)

--- a/test/ref/fixed_pad.cpp
+++ b/test/ref/fixed_pad.cpp
@@ -48,6 +48,24 @@ TEST_CASE(fixed_pad_test)
     EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
 }
 
+TEST_CASE(fixed_pad_max_test)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape s{migraphx::shape::float_type, {{1, 4, {3}}, {3, 3}}};
+    auto x = mm->add_parameter("x", s);
+    mm->add_instruction(migraphx::make_op("fixed_pad", {{"output_lens", {4, 3}}}), x);
+    p.compile(migraphx::make_target("ref"));
+    std::vector<float> data = {-3, -2, -1, 0, 1, 2};
+    migraphx::shape s2{migraphx::shape::float_type, {2, 3}};
+    migraphx::argument arg(s2, data.data());
+    auto result = p.eval({{"x", arg}}).back();
+    std::vector<float> results_vector(9);
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    std::vector<float> gold = {-3, -2, -1, 0, 1, 2, 0, 0, 0, 0, 0, 0};
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+}
+
 TEST_CASE(fixed_pad_same_shape_test)
 {
     migraphx::program p;

--- a/test/ref/fixed_pad.cpp
+++ b/test/ref/fixed_pad.cpp
@@ -66,6 +66,20 @@ TEST_CASE(fixed_pad_max_test)
     EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
 }
 
+TEST_CASE(fixed_pad_smaller_test)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape s{migraphx::shape::float_type, {{1, 4, {3}}, {3, 3}}};
+    auto x = mm->add_parameter("x", s);
+    mm->add_instruction(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), x);
+    p.compile(migraphx::make_target("ref"));
+    std::vector<float> data = {-3, -2, -1, 0, 1, 2};
+    migraphx::shape s2{migraphx::shape::float_type, {2, 3}};
+    migraphx::argument arg(s2, data.data());
+    EXPECT(test::throws([&] { p.eval({{"x", arg}}).back(); }));
+}
+
 TEST_CASE(fixed_pad_same_shape_test)
 {
     migraphx::program p;

--- a/test/ref/fixed_pad.cpp
+++ b/test/ref/fixed_pad.cpp
@@ -36,7 +36,7 @@ TEST_CASE(fixed_pad_test)
     auto* mm = p.get_main_module();
     migraphx::shape s{migraphx::shape::float_type, {{1, 3}, {3, 3}}};
     auto x = mm->add_parameter("x", s);
-    mm->add_instruction(migraphx::make_op("fixed_pad", {{"output_lens", {3, 3}}}), x);
+    mm->add_instruction(migraphx::make_op("fixed_pad"), x);
     p.compile(migraphx::make_target("ref"));
     std::vector<float> data = {-3, -2, -1, 0, 1, 2};
     migraphx::shape s2{migraphx::shape::float_type, {2, 3}};
@@ -54,7 +54,7 @@ TEST_CASE(fixed_pad_same_shape_test)
     auto* mm = p.get_main_module();
     migraphx::shape s{migraphx::shape::float_type, {{1, 2}, {3, 3}}};
     auto x = mm->add_parameter("x", s);
-    mm->add_instruction(migraphx::make_op("fixed_pad", {{"output_lens", {2, 3}}}), x);
+    mm->add_instruction(migraphx::make_op("fixed_pad"), x);
     p.compile(migraphx::make_target("ref"));
     std::vector<float> data = {-3, -2, -1, 0, 1, 2};
     migraphx::shape s2{migraphx::shape::float_type, {2, 3}};

--- a/test/ref/fixed_pad.cpp
+++ b/test/ref/fixed_pad.cpp
@@ -34,7 +34,7 @@ TEST_CASE(fixed_pad_test)
 {
     migraphx::program p;
     auto* mm = p.get_main_module();
-    migraphx::shape s{migraphx::shape::float_type, {{1, 4, {3}}, {3, 3}}};
+    migraphx::shape s{migraphx::shape::float_type, {{1, 3}, {3, 3}}};
     auto x = mm->add_parameter("x", s);
     mm->add_instruction(migraphx::make_op("fixed_pad", {{"output_lens", {3, 3}}}), x);
     p.compile(migraphx::make_target("ref"));
@@ -48,43 +48,11 @@ TEST_CASE(fixed_pad_test)
     EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
 }
 
-TEST_CASE(fixed_pad_max_test)
-{
-    migraphx::program p;
-    auto* mm = p.get_main_module();
-    migraphx::shape s{migraphx::shape::float_type, {{1, 4, {3}}, {3, 3}}};
-    auto x = mm->add_parameter("x", s);
-    mm->add_instruction(migraphx::make_op("fixed_pad", {{"output_lens", {4, 3}}}), x);
-    p.compile(migraphx::make_target("ref"));
-    std::vector<float> data = {-3, -2, -1, 0, 1, 2};
-    migraphx::shape s2{migraphx::shape::float_type, {2, 3}};
-    migraphx::argument arg(s2, data.data());
-    auto result = p.eval({{"x", arg}}).back();
-    std::vector<float> results_vector(9);
-    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
-    std::vector<float> gold = {-3, -2, -1, 0, 1, 2, 0, 0, 0, 0, 0, 0};
-    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
-}
-
-TEST_CASE(fixed_pad_smaller_test)
-{
-    migraphx::program p;
-    auto* mm = p.get_main_module();
-    migraphx::shape s{migraphx::shape::float_type, {{1, 4, {3}}, {3, 3}}};
-    auto x = mm->add_parameter("x", s);
-    mm->add_instruction(migraphx::make_op("fixed_pad", {{"output_lens", {1, 3}}}), x);
-    p.compile(migraphx::make_target("ref"));
-    std::vector<float> data = {-3, -2, -1, 0, 1, 2};
-    migraphx::shape s2{migraphx::shape::float_type, {2, 3}};
-    migraphx::argument arg(s2, data.data());
-    EXPECT(test::throws([&] { p.eval({{"x", arg}}).back(); }));
-}
-
 TEST_CASE(fixed_pad_same_shape_test)
 {
     migraphx::program p;
     auto* mm = p.get_main_module();
-    migraphx::shape s{migraphx::shape::float_type, {{1, 4, {2}}, {3, 3}}};
+    migraphx::shape s{migraphx::shape::float_type, {{1, 2}, {3, 3}}};
     auto x = mm->add_parameter("x", s);
     mm->add_instruction(migraphx::make_op("fixed_pad", {{"output_lens", {2, 3}}}), x);
     p.compile(migraphx::make_target("ref"));

--- a/test/ref/fixed_pad.cpp
+++ b/test/ref/fixed_pad.cpp
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/instruction.hpp>
+#include <migraphx/literal.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/program.hpp>
+#include <migraphx/register_target.hpp>
+#include <migraphx/verify.hpp>
+
+#include <test.hpp>
+
+TEST_CASE(fixed_pad_test)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape s{migraphx::shape::float_type, {{1, 4, {3}}, {3, 3}}};
+    auto x = mm->add_parameter("x", s);
+    mm->add_instruction(migraphx::make_op("fixed_pad", {{"output_lens", {3, 3}}}), x);
+    p.compile(migraphx::make_target("ref"));
+    std::vector<float> data = {-3, -2, -1, 0, 1, 2};
+    migraphx::shape s2{migraphx::shape::float_type, {2, 3}};
+    migraphx::argument arg(s2, data.data());
+    auto result = p.eval({{"x", arg}}).back();
+    std::vector<float> results_vector(9);
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    std::vector<float> gold = {-3, -2, -1, 0, 1, 2, 0, 0, 0};
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+}
+
+TEST_CASE(fixed_pad_same_shape_test)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape s{migraphx::shape::float_type, {{1, 4, {2}}, {3, 3}}};
+    auto x = mm->add_parameter("x", s);
+    mm->add_instruction(migraphx::make_op("fixed_pad", {{"output_lens", {2, 3}}}), x);
+    p.compile(migraphx::make_target("ref"));
+    std::vector<float> data = {-3, -2, -1, 0, 1, 2};
+    migraphx::shape s2{migraphx::shape::float_type, {2, 3}};
+    migraphx::argument arg(s2, data.data());
+    auto result = p.eval({{"x", arg}}).back();
+    std::vector<float> results_vector(6);
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    std::vector<float> gold = {-3, -2, -1, 0, 1, 2};
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+}

--- a/test/verify/test_fixed_pad.cpp
+++ b/test/verify/test_fixed_pad.cpp
@@ -38,5 +38,4 @@ struct test_fixed_pad : verify_program<test_fixed_pad>
         mm->add_instruction(migraphx::make_op("fixed_pad", {{"output_lens", {3, 3}}}), x);
         return p;
     }
-    size_t max_batch() const { return 2; }
 };

--- a/test/verify/test_fixed_pad.cpp
+++ b/test/verify/test_fixed_pad.cpp
@@ -35,7 +35,7 @@ struct test_fixed_pad : verify_program<test_fixed_pad>
         auto* mm = p.get_main_module();
         migraphx::shape s{migraphx::shape::float_type, {1, 3}};
         auto x = mm->add_parameter("x", s);
-        mm->add_instruction(migraphx::make_op("fixed_pad", {{"output_lens", {3, 3}}}), x);
+        mm->add_instruction(migraphx::make_op("fixed_pad"), x);
         return p;
     }
 };

--- a/test/verify/test_fixed_pad.cpp
+++ b/test/verify/test_fixed_pad.cpp
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "verify_program.hpp"
+#include <migraphx/program.hpp>
+#include <migraphx/generate.hpp>
+#include <migraphx/make_op.hpp>
+
+
+struct test_fixed_pad : verify_program<test_fixed_pad>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        migraphx::shape s{migraphx::shape::float_type, {1, 3}};
+        auto x = mm->add_parameter("x", s);
+        mm->add_instruction(migraphx::make_op("fixed_pad", {{"output_lens", {3, 3}}}), x);
+        return p;
+    }
+    size_t max_batch() const { return 2; }
+};
+

--- a/test/verify/test_fixed_pad.cpp
+++ b/test/verify/test_fixed_pad.cpp
@@ -27,7 +27,6 @@
 #include <migraphx/generate.hpp>
 #include <migraphx/make_op.hpp>
 
-
 struct test_fixed_pad : verify_program<test_fixed_pad>
 {
     migraphx::program create_program() const
@@ -41,4 +40,3 @@ struct test_fixed_pad : verify_program<test_fixed_pad>
     }
     size_t max_batch() const { return 2; }
 };
-


### PR DESCRIPTION
## Motivation
Create an operator that pads to the nearest static shape. 

## Technical Details
Implemented ref and GPU version and tests. We are enforcing the fixed_pad `output_lens` must match the max dyn dim value for each dimension. This is to prevent undefined behavior at runtime if the input dimension is larger than the padding value.

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- [X] Added: New functionality.
- [ ] Changed: Changes to existing functionality.
- [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- [ ] Optimized: Component performance that has been optimized or improved.
- [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- [ ] Not Applicable: This PR is not to be included in the changelog.
