### PR TITLE
Workaround pull request tasklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,9 +7,9 @@
 ## Changelog Category
 <!-- Also add the appropriate "Changelog:<...>" PR label. -->
 
-- [ ] Added: New functionality.
-- [ ] Changed: Changes to existing functionality.
-- [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
-- [ ] Optimized: Component performance that has been optimized or improved.
-- [ ] Resolved Issues: Known issues from a previous version that have been resolved.
-- [ ] Not Applicable: This PR is not to be included in the changelog.
+- - [ ] Added: New functionality.
+- - [ ] Changed: Changes to existing functionality.
+- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
+- - [ ] Optimized: Component performance that has been optimized or improved.
+- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
+- - [ ] Not Applicable: This PR is not to be included in the changelog.


### PR DESCRIPTION
## Motivation
Disable tasklist for PR changelog categories

## Technical Details
Workaround using bulletpoints to have github ignore checkboxes for tasklist.

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
