### PR TITLE
src/CMakeLists.txt: support msgpack 6.x as msgpack-cxx

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -358,13 +358,19 @@ target_link_libraries(migraphx PRIVATE nlohmann_json::nlohmann_json)
 find_package(SQLite3 REQUIRED)
 target_link_libraries(migraphx PRIVATE SQLite::SQLite3)
 
-find_package(msgpackc-cxx QUIET)
-if(NOT msgpackc-cxx_FOUND)
-    find_package(msgpack REQUIRED)
+# See: https://github.com/msgpack/msgpack-c/wiki/Q%26A#how-to-support-both-msgpack-c-c-version-5x-and-6x-
+# Prefer 6.x (msgpack-cxx)
+find_package(msgpack-cxx)
+if(msgpack-cxx_FOUND)
+    message(STATUS "Found msgpack-cxx (>=6.x)")
+else()
+    find_package(msgpackc-cxx REQUIRED NAMES msgpackc-cxx msgpack)
+    message(STATUS "Found msgpackc-cxx (<=5.x)")
+    add_library(msgpack-cxx ALIAS msgpackc-cxx)
 endif()
-target_link_libraries(migraphx PRIVATE msgpackc-cxx)
+target_link_libraries(migraphx PRIVATE msgpack-cxx)
 # Make this available to the tests
-target_link_libraries(migraphx INTERFACE $<BUILD_INTERFACE:msgpackc-cxx>)
+target_link_libraries(migraphx INTERFACE $<BUILD_INTERFACE:msgpack-cxx>)
 
 add_library(migraphx_all_targets INTERFACE)
 


### PR DESCRIPTION
## Motivation
msgpack renamed their CMake configs and targets in 6.x. Add the new name to support msgpack 6+, allow falling back to the old name.

Similar to changes made in rocm-libraries for the same reason: https://github.com/ROCm/rocm-libraries/commit/f86b000fb88bb144fc568d91aeb9b70ea3059125

## Technical Details
See: https://github.com/msgpack/msgpack-c/wiki/Q%26A#how-to-support-both-msgpack-c-c-version-5x-and-6x-

## Changelog Category
dependencies
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
