### PR TITLE
Add initial integration of amdmlss mha

### DIFF
--- a/src/onnx/CMakeLists.txt
+++ b/src/onnx/CMakeLists.txt
@@ -57,21 +57,6 @@ if(NOT WIN32)
 endif()
 target_link_libraries(migraphx_onnx PUBLIC migraphx)
 
-find_library(AMD_MLSS_LIB amdmlss)
-
-message(STATUS "amdmlss is at ${AMD_MLSS_LIB}")
-target_link_libraries(migraphx_onnx PRIVATE ${AMD_MLSS_LIB})
-
-find_path(AMDMLSS_INCLUDE_DIR NAMES amdmlss/amdmlss_api.h PATH_SUFFIXES include)
-
-if(NOT AMDMLSS_INCLUDE_DIR) 
-    message(FATAL_ERROR "Could not find MyLib headers. Set CMAKE_PREFIX_PATH or MyLib_ROOT, or provide MYLIB_INCLUDE_DIR.") 
-else()
-    message(STATUS "amdmlss_api.h is at ${AMDMLSS_INCLUDE_DIR}")
-    target_include_directories(migraphx_onnx SYSTEM PUBLIC ${AMDMLSS_INCLUDE_DIR})
-endif()
-
-
 rocm_install_targets(
   PRIVATE
   TARGETS migraphx_onnx

--- a/src/onnx/CMakeLists.txt
+++ b/src/onnx/CMakeLists.txt
@@ -57,6 +57,21 @@ if(NOT WIN32)
 endif()
 target_link_libraries(migraphx_onnx PUBLIC migraphx)
 
+find_library(AMD_MLSS_LIB amdmlss)
+
+message(STATUS "amdmlss is at ${AMD_MLSS_LIB}")
+target_link_libraries(migraphx_onnx PRIVATE ${AMD_MLSS_LIB})
+
+find_path(AMDMLSS_INCLUDE_DIR NAMES amdmlss/amdmlss_api.h PATH_SUFFIXES include)
+
+if(NOT AMDMLSS_INCLUDE_DIR) 
+    message(FATAL_ERROR "Could not find MyLib headers. Set CMAKE_PREFIX_PATH or MyLib_ROOT, or provide MYLIB_INCLUDE_DIR.") 
+else()
+    message(STATUS "amdmlss_api.h is at ${AMDMLSS_INCLUDE_DIR}")
+    target_include_directories(migraphx_onnx SYSTEM PUBLIC ${AMDMLSS_INCLUDE_DIR})
+endif()
+
+
 rocm_install_targets(
   PRIVATE
   TARGETS migraphx_onnx

--- a/src/onnx/parse_multi_head_attention.cpp
+++ b/src/onnx/parse_multi_head_attention.cpp
@@ -27,11 +27,25 @@
 #include <migraphx/make_op.hpp>
 #include <migraphx/ranges.hpp>
 #include <string>
+#include <amdmlss/amdmlss_api.h>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace onnx {
 
+void checkStatus(MLSSstatus status, int line)
+{
+    if (status != MLSS_SUCCESS)
+    {
+        MLSSstring err = mlssGetErrorString(status);
+
+        printf("Failed at line: %d, :%s\n", line, err);
+        free(err);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK_STATUS(status) checkStatus((status), __LINE__)
 enum class qkv_fomat_t
 {
     q_k_v       = 0,
@@ -210,9 +224,59 @@ struct parse_multi_head_attention : op_parser<parse_multi_head_attention>
             MIGRAPHX_THROW("MultiHeadAttention: num_heads attribute is required");
 
         int64_t num_heads = parser.parse_value(info.attributes.at("num_heads")).at<int>();
+        uint32_t verboseLevel = 4;
+
+        CHECK_STATUS(mlssSetVerboseLevel(verboseLevel));
+
+        MLSScontext context = 0;
+        MLSSstring asic = MLSS_GFX1100;
+        MLSSstring opName = MLSS_MHA;
+
+        CHECK_STATUS(mlssCreateContext(&context, asic, opName));
+
+        //CHECK_STATUS(mlssPrintParameters(context, opName));
 
         multi_head_attention_parameters params;
         check_inputs(args, num_heads, params);
+
+        MLSSuint32 batch_size = params.batch_size;
+        MLSSuint32 head_num = num_heads;
+        MLSSuint32 q_sequence_length = params.q_sequence_length;
+        MLSSuint32 kv_sequence_length = params.kv_sequence_length;
+        MLSSuint32 head_dim = params.head_size;
+        MLSSuint32 packing = 0;
+        float scale = 1 / std::sqrt(params.head_size);
+        MLSSenum data_type = MLSS_FLOAT16;
+        MLSSuint32 kvDim = 0;
+
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_BATCH, &batch_size));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_QSEQ, &q_sequence_length));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_KVSEQ, &kv_sequence_length));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_KDIM, &kvDim));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_VDIM, &kvDim));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_SIZEHEADS, &head_dim));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_PACKING, &packing));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_HEADCOUNT, &head_num));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_SCALE, &scale));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_DATATYPE, &data_type));
+        
+        MLSSstatus* pStatuses = NULL;
+        MLSSsize nStatuses = 0;
+
+        if (mlssGetCaps(context, &pStatuses, &nStatuses) != MLSS_SUCCESS)
+        {
+            std::cout << "Failed to get caps\n" << std::endl;
+        }
+        else
+        {
+            std::cout << "Got caps\n" << std::endl;
+            MLSSbinary* binaries = NULL;
+            MLSSsize n = 0;
+            CHECK_STATUS(mlssGetBinaries(context, &binaries, &n));
+            CHECK_STATUS(mlssPrintBinaries(binaries, n));
+            auto result = info.add_instruction(make_op("mlss_mha"), args);
+            return result;
+        }
 
         auto query = args[0];
         instruction_ref key;
@@ -265,7 +329,7 @@ struct parse_multi_head_attention : op_parser<parse_multi_head_attention>
             value = info.add_instruction(make_op("transpose", {{"permutation", perm}}), value);
         }
 
-        float scale = 1 / std::sqrt(params.head_size);
+        
         if(contains(info.attributes, "scale"))
             scale = parser.parse_value(info.attributes.at("scale")).at<float>();
 

--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -406,19 +406,9 @@ endif()
 add_subdirectory(driver)
 add_subdirectory(hiprtc)
 
-find_path(AMDMLSS_INCLUDE_DIR NAMES amdmlss/amdmlss_api.h PATH_SUFFIXES include)
+find_package(amdmlss REQUIRED)
+target_link_libraries(migraphx_gpu PUBLIC amdmlss::c_api)
 
-if(NOT AMDMLSS_INCLUDE_DIR) 
-    message(FATAL_ERROR "Could not find MyLib headers. Set CMAKE_PREFIX_PATH or MyLib_ROOT, or provide MYLIB_INCLUDE_DIR.") 
-else()
-    message(STATUS "amdmlss_api.h is at ${AMDMLSS_INCLUDE_DIR}")
-    target_include_directories(migraphx_gpu SYSTEM PUBLIC ${AMDMLSS_INCLUDE_DIR})
-endif()
-
-find_library(AMD_MLSS_LIB amdmlss)
-
-message(STATUS "amdmlss is at ${AMD_MLSS_LIB}")
-target_link_libraries(migraphx_gpu PRIVATE ${AMD_MLSS_LIB})
 
 rocm_install_targets(
     PRIVATE

--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -189,6 +189,7 @@ add_library(migraphx_gpu
     time_op.cpp
     topk.cpp
     write_literals.cpp
+    fuse_mlss.cpp
     ${JIT_GPU_SRCS}
     ${MIOPEN_SRCS}
 )
@@ -404,6 +405,20 @@ endif()
 
 add_subdirectory(driver)
 add_subdirectory(hiprtc)
+
+find_path(AMDMLSS_INCLUDE_DIR NAMES amdmlss/amdmlss_api.h PATH_SUFFIXES include)
+
+if(NOT AMDMLSS_INCLUDE_DIR) 
+    message(FATAL_ERROR "Could not find MyLib headers. Set CMAKE_PREFIX_PATH or MyLib_ROOT, or provide MYLIB_INCLUDE_DIR.") 
+else()
+    message(STATUS "amdmlss_api.h is at ${AMDMLSS_INCLUDE_DIR}")
+    target_include_directories(migraphx_gpu SYSTEM PUBLIC ${AMDMLSS_INCLUDE_DIR})
+endif()
+
+find_library(AMD_MLSS_LIB amdmlss)
+
+message(STATUS "amdmlss is at ${AMD_MLSS_LIB}")
+target_link_libraries(migraphx_gpu PRIVATE ${AMD_MLSS_LIB})
 
 rocm_install_targets(
     PRIVATE

--- a/src/targets/gpu/fuse_mlss.cpp
+++ b/src/targets/gpu/fuse_mlss.cpp
@@ -1,0 +1,89 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <unordered_set>
+#include <migraphx/module.hpp>
+#include <migraphx/iterator_for.hpp>
+// #include <migraphx/ranges.hpp>
+// #include <migraphx/auto_any_cast.hpp>
+// #include <migraphx/value.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/instruction.hpp>
+#include <migraphx/instruction_ref.hpp>
+#include <migraphx/register_op.hpp>
+#include <migraphx/gpu/fuse_mlss.hpp>
+
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
+
+struct mlss_mha
+{
+    std::string name() const { return "mlss_mha"; }
+
+    shape compute_shape(std::vector<shape> inputs, const std::vector<module_ref>& mods) const
+    {
+        return inputs[0];
+    }
+};
+MIGRAPHX_REGISTER_OP(mlss_mha);
+
+
+void fuse_mlss::apply(module& m) const
+{
+    for(auto ins : iterator_for(m))
+    {
+        
+        auto inputs = ins->inputs();
+        auto outputs = ins->outputs();
+        if(inputs.empty())
+            continue;
+        auto name = ins->name();        
+
+        if (name == "mlss_mha")
+        {
+            std::cout << "fuse_mlss ins name: " << name << std::endl;
+            auto names    = m.get_parameter_names();
+            for(std::size_t i = 0; i < inputs.size(); i++)
+            {
+                auto input_name = inputs[i]->name();
+                auto input_shape = inputs[i]->get_shape();
+            }
+
+            instruction_ref output = m.insert_instruction(ins, make_op("allocate", {{"shape", to_value(ins->get_shape())}}));
+            
+            std::vector<instruction_ref> refs = ins->inputs();
+            refs.push_back(output);
+
+            m.replace_instruction(
+                ins,
+                make_op("gpu::precompile_op", {{"op", to_value(ins->get_operator())}}),
+                refs);            
+        }        
+    }
+}
+
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx

--- a/src/targets/gpu/include/migraphx/gpu/fuse_mlss.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/fuse_mlss.hpp
@@ -36,6 +36,7 @@ namespace gpu {
 
 struct MIGRAPHX_GPU_EXPORT fuse_mlss
 {
+    context* ctx = nullptr;
     std::string name() const { return "fuse_mlss"; }
     void apply(module& m) const;
 };

--- a/src/targets/gpu/include/migraphx/gpu/fuse_mlss.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/fuse_mlss.hpp
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MIGRAPHX_GUARD_RTGLIB_FUSE_MLSS_HPP
+#define MIGRAPHX_GUARD_RTGLIB_FUSE_MLSS_HPP
+
+#include <migraphx/config.hpp>
+#include <migraphx/gpu/context.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+
+struct module;
+
+namespace gpu {
+
+struct MIGRAPHX_GPU_EXPORT fuse_mlss
+{
+    std::string name() const { return "fuse_mlss"; }
+    void apply(module& m) const;
+};
+
+} // namespace gpu
+
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+#endif // MIGRAPHX_GUARD_GPU_FUSE_CK_HPP

--- a/src/targets/gpu/jit/mlss.cpp
+++ b/src/targets/gpu/jit/mlss.cpp
@@ -1,0 +1,156 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/gpu/compiler.hpp>
+#include <migraphx/gpu/context.hpp>
+#include <migraphx/gpu/compile_hip_code_object.hpp>
+// #include <migraphx/gpu/compile_hip.hpp>
+#include <migraphx/gpu/compile_gen.hpp>
+#include <amdmlss/amdmlss_api.h>
+#include <migraphx/gpu/code_object_op.hpp>
+
+#include <cctype>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
+
+using namespace migraphx::gpu::gen; // NOLINT
+
+void checkStatus(MLSSstatus status, int line)
+{
+    if (status != MLSS_SUCCESS)
+    {
+        MLSSstring err = mlssGetErrorString(status);
+
+        printf("Failed at line: %d, :%s\n", line, err);
+        free(err);
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CHECK_STATUS(status) checkStatus((status), __LINE__)
+
+struct mlss_compiler : compiler<mlss_compiler>
+{
+    std::vector<std::string> names() const { return {"mlss_mha"}; }
+
+    operation compile_op(context& ctx, const std::vector<shape>& inputs, const value& v) const
+    {
+
+        const auto& device = ctx.get_current_device();
+        std::string target_arch = device.get_device_name();
+        std::size_t num_cu = device.get_cu_count();
+
+        auto query_dim  = inputs[0].ndim();
+        auto query_lens = inputs[0].lens();
+
+        auto head_size_v = query_lens[4];
+
+        MLSScontext context = 0;
+
+        for (char &ch : target_arch) {
+            ch = std::toupper(ch);
+        }
+        target_arch = "MLSS_" + target_arch;
+
+        MLSSstring asic = target_arch.data();
+        MLSSstring opName = MLSS_MHA;
+
+        
+
+
+        MLSSuint32 batch_size = query_lens[0];
+        MLSSuint32 head_num = 8;
+        MLSSuint32 q_sequence_length = query_lens[1];
+        MLSSuint32 kv_sequence_length = query_lens[1];;
+        MLSSuint32 head_dim = query_lens[4];
+        MLSSuint32 packing = 0;
+        float scale = 1 / std::sqrt(head_dim);
+        MLSSenum data_type = MLSS_FLOAT16;
+        MLSSuint32 kvDim = 0;
+
+        CHECK_STATUS(mlssCreateContext(&context, asic, opName));
+
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_BATCH, &batch_size));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_QSEQ, &q_sequence_length));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_KVSEQ, &kv_sequence_length));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_KDIM, &kvDim));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_VDIM, &kvDim));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_SIZEHEADS, &head_dim));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_PACKING, &packing));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_HEADCOUNT, &head_num));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_SCALE, &scale));
+        CHECK_STATUS(mlssSetParameterByEnum(&context, opName, MLSS_ATTR_MHA_DATATYPE, &data_type));
+        
+        MLSSstatus* pStatuses = NULL;
+        MLSSsize nStatuses = 0;
+
+        if (mlssGetCaps(context, &pStatuses, &nStatuses) != MLSS_SUCCESS)
+        {
+            std::cout << "Failed to get caps\n" << std::endl;
+        }
+        else
+        {
+            std::cout << "Got caps\n" << std::endl;
+        }
+        
+        MLSSbinary* binaries = NULL;
+        MLSSsize n = 0;
+        CHECK_STATUS(mlssGetBinaries(context, &binaries, &n));
+        CHECK_STATUS(mlssPrintBinaries(binaries, n));
+
+        const auto& binary = binaries[0];
+
+        std::string kernel_name = (binary.m_pKernelName ? binary.m_pKernelName : "N/A");
+        size_t bin_size = binary.m_binarySize;
+
+        value::binary value_binary((char*)binary.m_binaries, bin_size);
+
+        auto nelements  = inputs.back().elements();
+        auto block_size = compute_block_size(ctx, nelements, 256);
+        hip_compile_options options;
+        options.set_launch_params(
+            v, compute_global_for(ctx, nelements * block_size, 256), block_size);
+        options.output      = inputs.back();
+        options.inputs      = inputs;
+        options.kernel_name = kernel_name;
+
+        return code_object_op{value_binary,
+                          kernel_name,
+                          options.global,
+                          options.local,
+                          options.inputs,
+                          options.output,
+                          options.output_arg};
+    }
+
+    compiler_replace compile(context& ctx, instruction_ref ins, const operation& op) const
+    {
+        return compile_op(ctx, to_shapes(ins->inputs()), op.to_value());
+    }
+};
+
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -225,13 +225,13 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
         enable_pass(mlir_attention_enabled(&ctx), fuse_attention{}),
         dead_code_elimination{},
         optimize_module{},
+        fuse_mlss{&ctx},
         fuse_pointwise_reduce{},
         dead_code_elimination{},
 #ifndef _WIN32
         enable_pass(enabled(MIGRAPHX_ENABLE_CK{}), fuse_ck{}),
 #endif
         dead_code_elimination{},
-        fuse_mlss{},
         enable_pass(mlir_enabled(), fuse_mlir{&ctx}),
         dead_code_elimination{},
         fuse_concat{},

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -76,6 +76,7 @@
 #include <migraphx/gpu/sync_device.hpp>
 #include <migraphx/gpu/target.hpp>
 #include <migraphx/gpu/write_literals.hpp>
+#include <migraphx/gpu/fuse_mlss.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -230,6 +231,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
         enable_pass(enabled(MIGRAPHX_ENABLE_CK{}), fuse_ck{}),
 #endif
         dead_code_elimination{},
+        fuse_mlss{},
         enable_pass(mlir_enabled(), fuse_mlir{&ctx}),
         dead_code_elimination{},
         fuse_concat{},


### PR DESCRIPTION
## Motivation
To be able to use amdmlss library selected kernels

## Technical Details
Adds mlss_mha operator, fuse_mlss pass, and mlss jit compiler files as initial proposal of instruction replacement to support mlss_mha kernels from amdmlss. Bypassing the current MHA operator decomposition into separate instructions that uses mlir kernels.

A first step at integrating amdmlss kernels into MIGraphX


