### PR TITLE
Update C API to give current() caller information with errors

### DIFF
--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -38,6 +38,7 @@
 #include <migraphx/register_op.hpp>
 #include <migraphx/json.hpp>
 #include <migraphx/convert_to_json.hpp>
+#include <migraphx/source_location.hpp>
 #include <array>
 #include <algorithm>
 #include <cstdarg>
@@ -54,7 +55,7 @@ extern "C" MIGRAPHX_C_EXPORT void migraphx_test_private_disable_exception_catch(
 #endif
 
 template <class F>
-migraphx_status try_(F f, bool output = true) // NOLINT
+migraphx_status try_(F f, bool output = true, source_location llc=source_location::current()) // NOLINT
 {
 #ifdef MIGRAPHX_BUILD_TESTING
     if(disable_exception_catch)
@@ -71,7 +72,7 @@ migraphx_status try_(F f, bool output = true) // NOLINT
         catch(const migraphx::exception& ex)
         {
             if(output)
-                std::cerr << "MIGraphX Error: " << ex.what() << std::endl;
+                std::cerr << "MIGraphX Error: Caller:" << llc.function_name() << " what:" << ex.what() << std::endl;
             if(ex.error > 0)
                 return migraphx_status(ex.error);
             else
@@ -80,7 +81,7 @@ migraphx_status try_(F f, bool output = true) // NOLINT
         catch(const std::exception& ex)
         {
             if(output)
-                std::cerr << "MIGraphX Error: " << ex.what() << std::endl;
+                std::cerr << "MIGraphX Error: Caller:" << llc.function_name()  << " what:" << ex.what() << std::endl;
             return migraphx_status_unknown_error;
         }
         catch(...)


### PR DESCRIPTION
useful to debug issues with MIGraphX C API

## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When debugging issues that leverage the C api there's no simple way to get error info of the caller/cause of the issue

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
leverage the use of the source_location header that gives us info when an error occurs

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [x] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
