### PR TITLE
Streamline find_matches function

### DIFF
--- a/src/include/migraphx/matcher.hpp
+++ b/src/include/migraphx/matcher.hpp
@@ -495,7 +495,7 @@ auto make_match_runner(Finder& f)
 }
 
 template <class Mod, class RunnerPack>
-void find_matches_for(Mod& mod, instruction_ref ins, RunnerPack rp)
+void find_matches_for(Mod& mod, instruction_ref ins, const RunnerPack& rp)
 {
     rp([&](auto&&... rs) {
         bool matched = false;


### PR DESCRIPTION
## Motivation
Refactor `find_matches` to help improve performance by moving many things outside of the loop.

## Technical Details
The `find_matches` function would do many things inside of the loop even when tracing is not enabled:

- Checking if the trace filter matches
- Run time on the apply function
- Call to `matcher()` to construct the matcher, which is usually a no-op but in some cases we are constructing maps, etc, so we can benefit from constructing it once

This also separates the checking with and without tracing enabled, so the tracing wont interfere with optimizations the compiler might do. 

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [x] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
