### PR TITLE
Only use counter in mlir dump when its necessary

### DIFF
--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1106,8 +1106,9 @@ std::string dump_mlir(module m, const std::vector<shape>& inputs)
 
 static void abbreviate_symbol_names(std::string& n)
 {
-    static const std::map<std::string, std::string> abbrs = {
+    static const std::vector<std::pair<std::string, std::string>> abbrs = {
         {"reduce_max_reshape_sub_exp_reshape_reduce_sum_reshape_div", "softmax"},
+        {"reduce_max_sub_exp_reduce_sum_div", "softmax"},
         {"reshape", "rsp"},
         {"transpose", "trp"},
         {"slice", "slc"}};
@@ -1132,17 +1133,18 @@ static std::string compute_dump_name(const module& m, const std::string& ext)
 
     // On most commonly used file systems, the max file name size is 255 characters
     const int max_file_length = 255;
-    auto cnt                  = "_" + std::to_string(dump_counter()++);
     std::string fname         = sym_names + shape_str;
     replace_string_inplace(fname, ", ", "_");
     replace_string_inplace(fname, ":", "s");
-
-    if(fname.length() + cnt.length() + ext.length() > max_file_length)
+    
+    if(fname.length() + ext.length() > max_file_length)
     {
+        auto cnt                  = "_" + std::to_string(dump_counter()++);
         auto cutoff = max_file_length - ext.length() - cnt.length();
         fname.resize(cutoff);
+        fname += cnt;
     }
-    fname += cnt + ext;
+    fname += ext;
 
     return fname;
 }

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1136,10 +1136,10 @@ static std::string compute_dump_name(const module& m, const std::string& ext)
     std::string fname         = sym_names + shape_str;
     replace_string_inplace(fname, ", ", "_");
     replace_string_inplace(fname, ":", "s");
-    
+
     if(fname.length() + ext.length() > max_file_length)
     {
-        auto cnt                  = "_" + std::to_string(dump_counter()++);
+        auto cnt    = "_" + std::to_string(dump_counter()++);
         auto cutoff = max_file_length - ext.length() - cnt.length();
         fname.resize(cutoff);
         fname += cnt;


### PR DESCRIPTION
## Motivation
Always adding the counter adds to many duplicate mxr files that it makes it hard to manage.

## Technical Details
Only add the counter when the abbreviations dont work.

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
