### PR TITLE
Bump onnx to 1.18.0

### DIFF
--- a/test/py/onnx_backend_test.py
+++ b/test/py/onnx_backend_test.py
@@ -629,6 +629,25 @@ def disabled_tests_onnx_1_17_0(backend_test):
     backend_test.exclude(r'test_resize_upsample_sizes_nearest_not_smaller_cpu')
 
 
+def disabled_tests_onnx_1_18_0(backend_test):
+    # src/onnx/onnx_parser.cpp:841: get_type: Prototensor data type 23 not supported
+    backend_test.exclude(r'test_cast_FLOAT16_to_FLOAT4E2M1_cpu')
+    backend_test.exclude(r'test_cast_FLOAT4E2M1_to_FLOAT16_cpu')
+    backend_test.exclude(r'test_cast_FLOAT4E2M1_to_FLOAT_cpu')
+    backend_test.exclude(r'test_cast_FLOAT_to_FLOAT4E2M1_cpu')
+    backend_test.exclude(r'test_dequantizelinear_float4e2m1_cpu')
+    backend_test.exclude(r'test_quantizelinear_float4e2m1_cpu')
+    # src/onnx/checks.cpp:35: check_arg_empty: PARSE_TopK: k input must be constant
+    backend_test.exclude(r'test_top_k_same_values_2d_cpu')
+    backend_test.exclude(r'test_top_k_same_values_cpu')
+    backend_test.exclude(r'test_top_k_same_values_largest_cpu')
+    backend_test.exclude(r'test_top_k_uint64_cpu')
+    #src/shape.cpp:367: lens: SHAPE: lens() called on a dynamic shape
+    backend_test.exclude(r'test_unique_length_1_cpu')
+    # 
+    backend_test.exclude(r'test_averagepool_2d_ceil_last_window_starts_on_pad_cpu')
+
+
 def disabled_tests_int4(backend_test):
     # quantizelinear
     backend_test.exclude(r'test_quantizelinear_int4')
@@ -1208,6 +1227,9 @@ def create_backend_test(testname=None, target_device=None):
 
         if version.parse(onnx.__version__) >= version.parse("1.17.0"):
             disabled_tests_onnx_1_17_0(backend_test)
+
+        if version.parse(onnx.__version__) >= version.parse("1.18.0"):
+            disabled_tests_onnx_1_18_0(backend_test)
 
 
 # import all test cases at global scope to make

--- a/test/py/requirements-onnx.txt
+++ b/test/py/requirements-onnx.txt
@@ -21,7 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #####################################################################################
-onnx==1.17.0;python_version>="3.11"
+onnx==1.18.0;python_version>="3.11"
 onnx==1.14.1;python_version<"3.11"
 protobuf==4.25.8
 numpy==1.26.4;python_version>="3.11"


### PR DESCRIPTION
## Motivation
Python 3.13 requires ONNX 1.18.0

## Technical Details
Updated test infra to support ONNX 1.18.0

## Changelog Category

- - [ ] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
