### PR TITLE
Set jenkins home dynamically

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ def rocmtestnode(Map conf) {
     def docker_args = conf.get("docker_args", "")
     def docker_build_args = conf.get("docker_build_args", "")
     def pre = conf.get("pre", {})
-    def ccache = "${env.HOME}/workspace/.cache/ccache"
+    def ccache = "/ccache/.cache/ccache"
     def image = 'migraphxlib'
     env.CCACHE_COMPRESSLEVEL = 7
     env.CCACHE_DIR = ccache
@@ -71,7 +71,7 @@ def rocmtestnode(Map conf) {
                     sh "echo $DOCKERHUB_PASS | docker login --username $DOCKERHUB_USER --password-stdin"
                     pre()
                     sh "docker pull ${DOCKER_IMAGE}:${env.IMAGE_TAG}"
-                    withDockerContainer(image: "${DOCKER_IMAGE}:${env.IMAGE_TAG}", args: "--device=/dev/kfd --device=/dev/dri --group-add video --cap-add SYS_PTRACE -v=${env.HOME}/:${env.HOME} ${docker_args}") {
+                    withDockerContainer(image: "${DOCKER_IMAGE}:${env.IMAGE_TAG}", args: "--device=/dev/kfd --device=/dev/dri --group-add video --cap-add SYS_PTRACE -v=${env.WORKSPACE}/..:/ccache ${docker_args}") {
                         timeout(time: 4, unit: 'HOURS') {
                             body(cmake_build)
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ def rocmtestnode(Map conf) {
                     sh "echo $DOCKERHUB_PASS | docker login --username $DOCKERHUB_USER --password-stdin"
                     pre()
                     sh "docker pull ${DOCKER_IMAGE}:${env.IMAGE_TAG}"
-                    withDockerContainer(image: "${DOCKER_IMAGE}:${env.IMAGE_TAG}", args: "--device=/dev/kfd --device=/dev/dri --group-add video --cap-add SYS_PTRACE -v=${env.WORKSPACE}/../.cache/ccache/:/ccache:rw ${docker_args}") {
+                    withDockerContainer(image: "${DOCKER_IMAGE}:${env.IMAGE_TAG}", args: "--device=/dev/kfd --device=/dev/dri --group-add video --cap-add SYS_PTRACE -v=${env.WORKSPACE}/../.cache/ccache/:/ccache:rw,z ${docker_args}") {
                         timeout(time: 4, unit: 'HOURS') {
                             body(cmake_build)
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ def rocmtestnode(Map conf) {
     def docker_args = conf.get("docker_args", "")
     def docker_build_args = conf.get("docker_build_args", "")
     def pre = conf.get("pre", {})
-    def ccache = "/ccache/.cache/ccache"
+    def ccache = "/ccache/"
     def image = 'migraphxlib'
     env.CCACHE_COMPRESSLEVEL = 7
     env.CCACHE_DIR = ccache
@@ -71,7 +71,7 @@ def rocmtestnode(Map conf) {
                     sh "echo $DOCKERHUB_PASS | docker login --username $DOCKERHUB_USER --password-stdin"
                     pre()
                     sh "docker pull ${DOCKER_IMAGE}:${env.IMAGE_TAG}"
-                    withDockerContainer(image: "${DOCKER_IMAGE}:${env.IMAGE_TAG}", args: "--device=/dev/kfd --device=/dev/dri --group-add video --cap-add SYS_PTRACE -v=${env.WORKSPACE}/..:/ccache ${docker_args}") {
+                    withDockerContainer(image: "${DOCKER_IMAGE}:${env.IMAGE_TAG}", args: "--device=/dev/kfd --device=/dev/dri --group-add video --cap-add SYS_PTRACE -v=${env.WORKSPACE}/../.cache/ccache/:/ccache ${docker_args}") {
                         timeout(time: 4, unit: 'HOURS') {
                             body(cmake_build)
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ def rocmtestnode(Map conf) {
     def docker_args = conf.get("docker_args", "")
     def docker_build_args = conf.get("docker_build_args", "")
     def pre = conf.get("pre", {})
-    def ccache = "/ccache/"
+    def ccache = "/ccache"
     def image = 'migraphxlib'
     env.CCACHE_COMPRESSLEVEL = 7
     env.CCACHE_DIR = ccache

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ def rocmtestnode(Map conf) {
                     sh "echo $DOCKERHUB_PASS | docker login --username $DOCKERHUB_USER --password-stdin"
                     pre()
                     sh "docker pull ${DOCKER_IMAGE}:${env.IMAGE_TAG}"
-                    withDockerContainer(image: "${DOCKER_IMAGE}:${env.IMAGE_TAG}", args: "--device=/dev/kfd --device=/dev/dri --group-add video --cap-add SYS_PTRACE -v=${env.WORKSPACE}/../.cache/ccache/:/ccache,rw ${docker_args}") {
+                    withDockerContainer(image: "${DOCKER_IMAGE}:${env.IMAGE_TAG}", args: "--device=/dev/kfd --device=/dev/dri --group-add video --cap-add SYS_PTRACE -v=${env.WORKSPACE}/../.cache/ccache/:/ccache:rw ${docker_args}") {
                         timeout(time: 4, unit: 'HOURS') {
                             body(cmake_build)
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ def rocmtestnode(Map conf) {
     def docker_args = conf.get("docker_args", "")
     def docker_build_args = conf.get("docker_build_args", "")
     def pre = conf.get("pre", {})
-    def ccache = "/home/jenkins/workspace/.cache/ccache"
+    def ccache = "${env.HOME}/workspace/.cache/ccache"
     def image = 'migraphxlib'
     env.CCACHE_COMPRESSLEVEL = 7
     env.CCACHE_DIR = ccache
@@ -71,7 +71,7 @@ def rocmtestnode(Map conf) {
                     sh "echo $DOCKERHUB_PASS | docker login --username $DOCKERHUB_USER --password-stdin"
                     pre()
                     sh "docker pull ${DOCKER_IMAGE}:${env.IMAGE_TAG}"
-                    withDockerContainer(image: "${DOCKER_IMAGE}:${env.IMAGE_TAG}", args: "--device=/dev/kfd --device=/dev/dri --group-add video --cap-add SYS_PTRACE -v=/home/jenkins/:/home/jenkins ${docker_args}") {
+                    withDockerContainer(image: "${DOCKER_IMAGE}:${env.IMAGE_TAG}", args: "--device=/dev/kfd --device=/dev/dri --group-add video --cap-add SYS_PTRACE -v=${env.HOME}/:${env.HOME} ${docker_args}") {
                         timeout(time: 4, unit: 'HOURS') {
                             body(cmake_build)
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ def rocmtestnode(Map conf) {
                     sh "echo $DOCKERHUB_PASS | docker login --username $DOCKERHUB_USER --password-stdin"
                     pre()
                     sh "docker pull ${DOCKER_IMAGE}:${env.IMAGE_TAG}"
-                    withDockerContainer(image: "${DOCKER_IMAGE}:${env.IMAGE_TAG}", args: "--device=/dev/kfd --device=/dev/dri --group-add video --cap-add SYS_PTRACE -v=${env.WORKSPACE}/../.cache/ccache/:/ccache ${docker_args}") {
+                    withDockerContainer(image: "${DOCKER_IMAGE}:${env.IMAGE_TAG}", args: "--device=/dev/kfd --device=/dev/dri --group-add video --cap-add SYS_PTRACE -v=${env.WORKSPACE}/../.cache/ccache/:/ccache,rw ${docker_args}") {
                         timeout(time: 4, unit: 'HOURS') {
                             body(cmake_build)
                         }


### PR DESCRIPTION
## Motivation
CI build machines are changing the jenkins home dir to a different location.  Need to allow for locations beyond /home/jenkins

## Technical Details
switch from /home/jenkins to $HOME which is an environment variable 

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
