### PR TITLE
Use --input-dim for specifying dynamic shapes at driver runtime

### DIFF
--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -603,7 +603,7 @@ struct compiler
     auto params(const program& p)
     {
         return parameters.generate(
-            p, ct.get_target(), co.offload_copy, l.batch, l.parse_param_dims(l.param_dims));
+            p, ct.get_target(), co.offload_copy, l.batch, loader::parse_param_dims(l.param_dims));
     }
 
     auto host_params(const program& p)
@@ -742,7 +742,7 @@ struct verify : command<verify>
         std::cout << p << std::endl;
 
         auto t = c.ct.get_target();
-        auto m = c.parameters.generate(p, t, true, c.l.batch, c.l.parse_param_dims(c.l.param_dims));
+        auto m = c.parameters.generate(p, t, true, c.l.batch, loader::parse_param_dims(c.l.param_dims));
 
         if(c.to_fp16)
         {

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -64,6 +64,9 @@
 #include <iomanip>
 
 namespace {
+
+using dims_map = std::unordered_map<std::string, std::vector<std::size_t>>;
+
 std::vector<std::string>
 get_unrecognized_migraphx_envs(const char* envp[],
                                const std::map<std::string, std::string>& used_env)
@@ -213,7 +216,7 @@ struct loader
 
     static auto parse_param_dims(const std::vector<std::string>& param_dims_info)
     {
-        std::unordered_map<std::string, std::vector<std::size_t>> map_input_dims;
+        dims_map map_input_dims;
         std::string name = "";
         for(auto&& x : param_dims_info)
         {
@@ -502,16 +505,19 @@ struct program_params
         return map_load_args;
     }
 
-    auto generate(const program& p, const target& t, bool offload, unsigned batch)
+    auto generate(const program& p, const target& t, bool offload, unsigned batch, dims_map map_input_dims = {})
     {
         parameter_map m;
         auto param_shapes = p.get_parameter_shapes();
         std::unordered_map<std::string, shape> static_param_shapes;
-        std::transform(
-            param_shapes.cbegin(),
-            param_shapes.cend(),
-            std::inserter(static_param_shapes, static_param_shapes.end()),
-            [&](const auto& x) { return std::make_pair(x.first, x.second.to_static(batch)); });
+        for(auto&& param : param_shapes)
+        {
+            if(contains(map_input_dims, param.first))
+                static_param_shapes[param.first] = {param.second.type(), map_input_dims[param.first]};
+            else
+                static_param_shapes[param.first] = param.second.to_static(batch);
+        }
+        
         for(auto&& s : fill0)
             m[s] = fill_argument(static_param_shapes.at(s), 0);
         for(auto&& s : fill1)
@@ -591,7 +597,7 @@ struct compiler
 
     auto params(const program& p)
     {
-        return parameters.generate(p, ct.get_target(), co.offload_copy, l.batch);
+        return parameters.generate(p, ct.get_target(), co.offload_copy, l.batch, l.parse_param_dims(l.param_dims));
     }
 
     auto host_params(const program& p)
@@ -730,7 +736,7 @@ struct verify : command<verify>
         std::cout << p << std::endl;
 
         auto t = c.ct.get_target();
-        auto m = c.parameters.generate(p, t, true, c.l.batch);
+        auto m = c.parameters.generate(p, t, true, c.l.batch, c.l.parse_param_dims(c.l.param_dims));
 
         if(c.to_fp16)
         {

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -742,7 +742,8 @@ struct verify : command<verify>
         std::cout << p << std::endl;
 
         auto t = c.ct.get_target();
-        auto m = c.parameters.generate(p, t, true, c.l.batch, loader::parse_param_dims(c.l.param_dims));
+        auto m =
+            c.parameters.generate(p, t, true, c.l.batch, loader::parse_param_dims(c.l.param_dims));
 
         if(c.to_fp16)
         {

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -505,7 +505,11 @@ struct program_params
         return map_load_args;
     }
 
-    auto generate(const program& p, const target& t, bool offload, unsigned batch, dims_map map_input_dims = {})
+    auto generate(const program& p,
+                  const target& t,
+                  bool offload,
+                  unsigned batch,
+                  dims_map map_input_dims = {})
     {
         parameter_map m;
         auto param_shapes = p.get_parameter_shapes();
@@ -513,11 +517,12 @@ struct program_params
         for(auto&& param : param_shapes)
         {
             if(contains(map_input_dims, param.first))
-                static_param_shapes[param.first] = {param.second.type(), map_input_dims[param.first]};
+                static_param_shapes[param.first] = {param.second.type(),
+                                                    map_input_dims[param.first]};
             else
                 static_param_shapes[param.first] = param.second.to_static(batch);
         }
-        
+
         for(auto&& s : fill0)
             m[s] = fill_argument(static_param_shapes.at(s), 0);
         for(auto&& s : fill1)
@@ -597,7 +602,8 @@ struct compiler
 
     auto params(const program& p)
     {
-        return parameters.generate(p, ct.get_target(), co.offload_copy, l.batch, l.parse_param_dims(l.param_dims));
+        return parameters.generate(
+            p, ct.get_target(), co.offload_copy, l.batch, l.parse_param_dims(l.param_dims));
     }
 
     auto host_params(const program& p)


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Currently the driver uses the `--batch` flag to set any dynamic dimensions. This will not work for the case where there are multiple dynamic dimensions with different values, and it won't work for the case where different inputs need different dimension values.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
Use `--input-dim` instead. The previous functionality will technically still work, but it would be preferred for the user to specify the dimensions. `program_params.generate()` will now take in the `map_input_dims`, and the function will check if the parameter name is in the map. If it's not, it will use the existing shape and convert it to static based on the `--batch` flag.

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
