### PR TITLE
add flag for full dynamic mode

### DIFF
--- a/src/include/migraphx/matcher.hpp
+++ b/src/include/migraphx/matcher.hpp
@@ -500,6 +500,21 @@ struct find_matches
 template <class Mod, class... Ms>
 find_matches(Mod& mod, Ms&&... ms) -> find_matches<Mod, Ms...>;
 
+template <class Mod, class... Ms>
+struct find_dyn_matches
+{
+    find_dyn_matches(Mod& mod, Ms&&... ms, source_location location = source_location::current())
+    {
+        for(auto ins : iterator_for(get_module(mod)))
+        {
+            find_matches_for(location, mod, ins, true, ms...);
+        }
+    }
+};
+
+template <class Mod, class... Ms>
+find_dyn_matches(Mod& mod, Ms&&... ms) -> find_dyn_matches<Mod, Ms...>;
+
 template <class M, class F>
 struct find_generic_match
 {

--- a/src/simplify_dyn_ops.cpp
+++ b/src/simplify_dyn_ops.cpp
@@ -703,19 +703,19 @@ struct simplify_select_module_output_shape
 
 void simplify_dyn_ops::apply(module& m) const
 {
-    match::find_matches(m,
-                        find_broadcast_with_dims_static{},
-                        find_resize_static{},
-                        find_static_dimensions_of{},
-                        find_const_alloc_reshapes{},
-                        find_static_2in_broadcasts{},
-                        find_const_2in_slice{},
-                        find_const_3in_slice{},
-                        find_const_4in_slice{},
-                        find_const_alloc_fill{},
-                        find_static_broadcast_for_dot{},
-                        find_static_onehot{});
-    match::find_matches(m, simplify_select_module_output_shape{});
+    match::find_dyn_matches(m,
+                            find_broadcast_with_dims_static{},
+                            find_resize_static{},
+                            find_static_dimensions_of{},
+                            find_const_alloc_reshapes{},
+                            find_static_2in_broadcasts{},
+                            find_const_2in_slice{},
+                            find_const_3in_slice{},
+                            find_const_4in_slice{},
+                            find_const_alloc_fill{},
+                            find_static_broadcast_for_dot{},
+                            find_static_onehot{});
+    match::find_dyn_matches(m, simplify_select_module_output_shape{});
 }
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -88,6 +88,7 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_REWRITE_DOT)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_CK)
 #endif
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_SET_GEMM_PROVIDER)
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_FULL_DYNAMIC)
 
 std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_options& options) const
 {
@@ -178,7 +179,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
     // clang-format off
     return
     {
-        split_single_dyn_dim{},
+        enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), split_single_dyn_dim{}),
         dead_code_elimination{},
         simplify_dyn_ops{},
         dead_code_elimination{},
@@ -203,7 +204,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
         insert_pad{{"convolution"}},
         dead_code_elimination{},
         inline_module{},
-        rewrite_pooling{},
+        enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), rewrite_pooling{}),
         dead_code_elimination{},
         rewrite_gelu{options.fast_math},
         optimize_module{},
@@ -226,13 +227,13 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
         enable_pass(mlir_attention_enabled(&ctx), fuse_attention{}),
         dead_code_elimination{},
         optimize_module{},
-        fuse_pointwise_reduce{},
+        enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), fuse_pointwise_reduce{}),
         dead_code_elimination{},
 #ifndef _WIN32
         enable_pass(enabled(MIGRAPHX_ENABLE_CK{}), fuse_ck{}),
 #endif
         dead_code_elimination{},
-        enable_pass(mlir_enabled(), fuse_mlir{&ctx}),
+        enable_pass(mlir_enabled() and disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), fuse_mlir{&ctx}),
         dead_code_elimination{},
         fuse_concat{},
         dead_code_elimination{},


### PR DESCRIPTION
## Motivation
This PR simply adds a developer flag that can be used to enable full dynamic mode for development purposes. 

## Technical Details
Enabling this flag will disable all optimizations for now. Added a new `find_dyn_matches` call for applying optimizations for the dynamic shape case.
This is only the first step in the series of PRs to address this issue: [202](https://github.com/ROCm/AMDMIGraphX-internal/issues/202)
Follow up PRs will address required changes to enable passes such as `fuse_pointwise` when using this flag.

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
