### PR TITLE
Lrn ref fix

### DIFF
--- a/src/targets/ref/lowering.cpp
+++ b/src/targets/ref/lowering.cpp
@@ -89,7 +89,7 @@ struct ref_lrn
                     for(auto k = start; k < end; ++k)
                     {
                         double x = input(b, k, h, w);
-                        scale += (x*x);
+                        scale += (x * x);
                     }
                     scale *= alphaoverarea;
                     scale += op.bias;

--- a/src/targets/ref/lowering.cpp
+++ b/src/targets/ref/lowering.cpp
@@ -77,18 +77,19 @@ struct ref_lrn
             int channels        = output_shape.lens()[1];
             int height          = output_shape.lens()[2];
             int width           = output_shape.lens()[3];
-            float alphaoverarea = op.alpha / float(op.size);
+            double alphaoverarea = op.alpha / double(op.size);
             int radius_lower    = (op.size - 1) / 2;
             int radius_upper    = op.size / 2 + 1;
 
             par_dfor(n_batch, height, width)([&](int b, int h, int w) {
-                float scale = 0;
                 dfor(channels)([&](int c) {
+                    double scale = 0;
                     auto start = (c - radius_lower) < 0 ? 0 : (c - radius_lower);
                     auto end   = (c + radius_upper) > channels ? channels : (c + radius_upper);
                     for(auto k = start; k < end; ++k)
                     {
-                        scale += std::pow(input(b, k, h, w), 2);
+                        double x = input(b, k, h, w);
+                        scale += (x*x);
                     }
                     scale *= alphaoverarea;
                     scale += op.bias;

--- a/test/verify/test_lrn.cpp
+++ b/test/verify/test_lrn.cpp
@@ -44,6 +44,10 @@ struct test_lrn : verify_program<test_lrn<ChannelSize, LrnSize>>
     }
 };
 
+template struct test_lrn<31, 3>;
+template struct test_lrn<32, 3>;
+template struct test_lrn<31, 4>;
+template struct test_lrn<32, 4>;
 template struct test_lrn<32, 6>;
 template struct test_lrn<32, 5>;
 template struct test_lrn<31, 8>;


### PR DESCRIPTION
## Motivation
LRN ref version does produce correct values when size <= 4.

## Technical Details
The scale was set to zero outside of the loop, which was incorrect.

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
