### PR TITLE
Disable fp32 geg

### DIFF
--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -815,7 +815,8 @@ struct find_mlir_fused_geg_ops
         auto elemwise_inputs  = elemwise_ins->inputs();
 
         // skip fp32 for now until mlir supports it better
-        if(second_gemm_ins->get_shape().type() == shape::float_type and first_gemm_ins->get_shape().type() == shape::float_type)
+        if(second_gemm_ins->get_shape().type() == shape::float_type and
+           first_gemm_ins->get_shape().type() == shape::float_type)
             return;
 
         // only one input to elemwise should depend on first_gemm

--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -814,6 +814,10 @@ struct find_mlir_fused_geg_ops
         auto* elemwise_module = elemwise_ins->module_inputs().front();
         auto elemwise_inputs  = elemwise_ins->inputs();
 
+        // skip fp32 for now until mlir supports it better
+        if(second_gemm_ins->get_shape().type() == shape::float_type and first_gemm_ins->get_shape().type() == shape::float_type)
+            return;
+
         // only one input to elemwise should depend on first_gemm
         if(std::any_of(elemwise_inputs.begin(), elemwise_inputs.end(), [&](const auto& i) {
                return i != first_gemm_ins and reaches(first_gemm_ins, i);

--- a/test/verify/CMakeLists.txt
+++ b/test/verify/CMakeLists.txt
@@ -42,7 +42,3 @@ foreach(SECTION general reduce rnn conv gemm)
         )
     endif()
 endforeach()
-
-# TODO: remove this when MIGraphX disables attn-like offloading to rocMLIR
-# f32 not supported on navi3x
-set_tests_properties(test_verify_rnn PROPERTIES ENVIRONMENT "MIGRAPHX_ENABLE_MLIR_GEG_FUSION=0")


### PR DESCRIPTION
## Motivation
MLIR doesnt support fp32 GEG fusion on navi.

## Technical Details
Disable GEG fusion for fp32. 

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
