### PR TITLE
Revert "Lrn ref fix"

### DIFF
--- a/docs/reference/MIGraphX-dev-env-vars.rst
+++ b/docs/reference/MIGraphX-dev-env-vars.rst
@@ -220,6 +220,14 @@ Model performance tunable variables change the compilation behavior of a model. 
       | ``0``: Returns to default behavior.
 
       | Default: No tuning is done for composable kernels.
+
+  * - | ``MIGRAPHX_REWRITE_LRN``
+      | Turns on LRN-to-pooling lowering in the rewrite_pooling pass.
+      
+    - | ``1``: Turns on LRN-to-pooling lowering.
+      | ``0``: Returns to default behavior.
+
+      | Default: LRN-to-pooling lowering is turned off.
                
 Matching
 **********

--- a/src/include/migraphx/rewrite_pooling.hpp
+++ b/src/include/migraphx/rewrite_pooling.hpp
@@ -38,6 +38,7 @@ struct module;
  */
 struct MIGRAPHX_EXPORT rewrite_pooling
 {
+    bool rewrite_lrn = false;
     std::string name() const { return "rewrite_pooling"; }
     void apply(module& m) const;
 };

--- a/src/rewrite_pooling.cpp
+++ b/src/rewrite_pooling.cpp
@@ -222,12 +222,11 @@ void rewrite_pooling::apply(module& m) const
     {
         if(ins->inputs().empty())
             continue;
-        if(ins->name() == "lrn")
+        if(rewrite_lrn and ins->name() == "lrn")
         {
             lower_lrn_to_pooling(m, ins);
             continue;
         }
-
         if(ins->name() != "pooling")
             continue;
 

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -84,6 +84,7 @@ namespace gpu {
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_DISABLE_SCHEDULE_PASS)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_NHWC)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_REWRITE_DOT)
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_REWRITE_LRN)
 #ifndef _WIN32
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_CK)
 #endif
@@ -203,7 +204,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
         insert_pad{{"convolution"}},
         dead_code_elimination{},
         inline_module{},
-        rewrite_pooling{},
+        rewrite_pooling{.rewrite_lrn = enabled(MIGRAPHX_REWRITE_LRN{})},
         dead_code_elimination{},
         rewrite_gelu{options.fast_math},
         optimize_module{},

--- a/src/targets/ref/lowering.cpp
+++ b/src/targets/ref/lowering.cpp
@@ -77,19 +77,18 @@ struct ref_lrn
             int channels        = output_shape.lens()[1];
             int height          = output_shape.lens()[2];
             int width           = output_shape.lens()[3];
-            double alphaoverarea = op.alpha / double(op.size);
+            float alphaoverarea = op.alpha / float(op.size);
             int radius_lower    = (op.size - 1) / 2;
             int radius_upper    = op.size / 2 + 1;
 
             par_dfor(n_batch, height, width)([&](int b, int h, int w) {
+                float scale = 0;
                 dfor(channels)([&](int c) {
-                    double scale = 0;
                     auto start = (c - radius_lower) < 0 ? 0 : (c - radius_lower);
                     auto end   = (c + radius_upper) > channels ? channels : (c + radius_upper);
                     for(auto k = start; k < end; ++k)
                     {
-                        double x = input(b, k, h, w);
-                        scale += x * x;
+                        scale += std::pow(input(b, k, h, w), 2);
                     }
                     scale *= alphaoverarea;
                     scale += op.bias;

--- a/test/rewrite_pooling_test.cpp
+++ b/test/rewrite_pooling_test.cpp
@@ -36,6 +36,7 @@
 
 #include <migraphx/iterator.hpp>
 
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_REWRITE_LRN);
 static void opt_pooling(migraphx::module& m)
 {
     migraphx::rewrite_pooling rp;
@@ -323,8 +324,11 @@ TEST_CASE(test_lower_lrn_to_pooling)
             input1);
         m1.add_return({lrn1});
     }
-
-    opt_pooling(m1);
+    // Apply the pass directly when the flag enabled
+    migraphx::rewrite_pooling rp{.rewrite_lrn = true};
+    migraphx::dead_code_elimination dce;
+    rp.apply(m1);
+    dce.apply(m1);
 
     migraphx::module m2;
     {

--- a/test/verify/test_lrn.cpp
+++ b/test/verify/test_lrn.cpp
@@ -44,11 +44,7 @@ struct test_lrn : verify_program<test_lrn<ChannelSize, LrnSize>>
     }
 };
 
-template struct test_lrn<31, 3>;
-template struct test_lrn<31, 4>;
-template struct test_lrn<31, 5>;
-template struct test_lrn<31, 8>;
-template struct test_lrn<32, 3>;
-template struct test_lrn<32, 4>;
-template struct test_lrn<32, 5>;
 template struct test_lrn<32, 6>;
+template struct test_lrn<32, 5>;
+template struct test_lrn<31, 8>;
+template struct test_lrn<31, 5>;


### PR DESCRIPTION
Reverts ROCm/AMDMIGraphX#4359. Lrn rewrite should not be enabled by default. Only when miopen is disabled.