### PR TITLE
Enable rewrite_lrn when miopen is disabled

### DIFF
--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -204,7 +204,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
         insert_pad{{"convolution"}},
         dead_code_elimination{},
         inline_module{},
-        rewrite_pooling{.rewrite_lrn = enabled(MIGRAPHX_REWRITE_LRN{})},
+        rewrite_pooling{.rewrite_lrn = (not MIGRAPHX_USE_MIOPEN or enabled(MIGRAPHX_REWRITE_LRN{}))},
         dead_code_elimination{},
         rewrite_gelu{options.fast_math},
         optimize_module{},


### PR DESCRIPTION
## Motivation
Enable rewrite_lrn when miopen is disabled since there is not lrn support without it.

## Technical Details


## Changelog Category

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
