### PR TITLE
Bump Release number to 15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ include(ROCMSetupVersion)
 
 option(BUILD_DEV "Build for development purpose only" OFF)
 
-rocm_setup_version(VERSION 2.14.0)
+rocm_setup_version(VERSION 2.15.0)
 math(EXPR MIGRAPHX_SO_MAJOR_VERSION "(${PROJECT_VERSION_MAJOR} * 1000 * 1000) + (${PROJECT_VERSION_MINOR} * 1000) + ${PROJECT_VERSION_PATCH}")
 set(MIGRAPHX_SO_VERSION ${MIGRAPHX_SO_MAJOR_VERSION}.0)
 


### PR DESCRIPTION
## Motivation
Keeping the MIGX and ROCm versions in lock step

## Technical Details
ROCm 7.1 maps to MIGX 2.14.0
ROCm 7.x maps to MIGX 2.15.0 

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
