### PR TITLE
Checking if instruction is actually a literal before calling get_literal()

### DIFF
--- a/src/simplify_qdq.cpp
+++ b/src/simplify_qdq.cpp
@@ -362,18 +362,18 @@ bool compare_literals(instruction_ref ins1, instruction_ref ins2)
 {
     if(ins1->name() == "broadcast" or ins1->name() == "multibroadcast")
         ins1 = ins1->inputs().front();
+    if(ins1->name() != "@literal")
+        return false;
     auto x = ins1->eval();
     if(x.empty())
-        return false;
-    if(ins1->name() != "@literal")
         return false;
     auto literal1 = ins1->get_literal();
     if(ins2->name() == "broadcast" or ins2->name() == "multibroadcast")
         ins2 = ins2->inputs().front();
+    if(ins2->name() != "@literal")
+        return false;
     auto y = ins2->eval();
     if(y.empty())
-        return false;
-    if(ins2->name() != "@literal")
         return false;
     auto literal2 = ins2->get_literal();
 


### PR DESCRIPTION
## Motivation
The compare_literals function was calling `instruction::get_literal()` on instructions that were not necessarily literal instructions. The function assumed that if an instruction could be evaluated (eval() returns non-empty), it was safe to call `get_literal()`, but this assumption was incorrect.

## Technical Details


## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
