### PR TITLE
[7.1.1] check if instruction is actually a literal (#4388)

### DIFF
--- a/src/simplify_qdq.cpp
+++ b/src/simplify_qdq.cpp
@@ -365,16 +365,14 @@ bool compare_literals(instruction_ref ins1, instruction_ref ins2)
     auto x = ins1->eval();
     if(x.empty())
         return false;
-    auto literal1 = ins1->get_literal();
     if(ins2->name() == "broadcast" or ins2->name() == "multibroadcast")
         ins2 = ins2->inputs().front();
     auto y = ins2->eval();
     if(y.empty())
         return false;
-    auto literal2 = ins2->get_literal();
 
     bool diff_shapes_equal_vals = false;
-    visit_all(ins1->get_literal(), ins2->get_literal())([&](const auto l1, const auto l2) {
+    visit_all(x, y)([&](const auto l1, const auto l2) {
         diff_shapes_equal_vals =
             std::all_of(l1.begin() + 1,
                         l1.end(),


### PR DESCRIPTION
## Motivation
The compare_literals function was calling instruction::get_literal() on instructions that were not necessarily literal instructions. The function assumed that if an instruction could be evaluated (eval() returns non-empty), it was safe to call get_literal(), but this assumption was incorrect.

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
