### PR TITLE
Fixing invalid characters inside path name on Windows

### DIFF
--- a/src/pass_manager.cpp
+++ b/src/pass_manager.cpp
@@ -36,8 +36,8 @@
 #include <sstream>
 #include <algorithm>
 #include <utility>
-#include <string>        
-#include <string_view>   
+#include <string>
+#include <string_view>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {


### PR DESCRIPTION
## Motivation
Ensure error dump files are correctly saved on Windows

## Technical Details
Windows does not support special characters inside file/path name

## Changelog Category
- - [ ] Changed: Changes to existing functionality. 
Replacing invalid characters with underscores _;
For example it was:
gpu::compile_ops82319806465000.mxr
now it is gpu__compile_ops82319806465000.mxr

