### PR TITLE
[AIMIGRAPHX-273] Fix Jenkins Parallel Stage Displaying Incorrect Time Elapsed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,9 +115,9 @@ def setuponnxtest() {
     env.HSA_ENABLE_SDMA = 0
     
     sh 'printenv'
+    checkout scm
     sh 'rm -rf ./build/*.deb'
     unstash 'migraphx-package'
-    checkout scm
     
     def video_id = sh(returnStdout: true, script: 'getent group video | cut -d: -f3').trim()
     def render_id = sh(returnStdout: true, script: 'getent group render | cut -d: -f3').trim()
@@ -191,6 +191,7 @@ pipeline {
                     gitStatusWrapper(credentialsId: "${env.migraphx_ci_creds}", gitHubContext: "Jenkins - Build image", account: 'ROCmSoftwarePlatform', repo: 'AMDMIGraphX', description: 'Building image', failureDescription: 'Failed to build image', successDescription: 'Image build succeeded') {
                         withCredentials([usernamePassword(credentialsId: 'docker_test_cred', passwordVariable: 'DOCKERHUB_PASS', usernameVariable: 'DOCKERHUB_USER')]) {
                             sh "echo $DOCKERHUB_PASS | docker login --username $DOCKERHUB_USER --password-stdin"
+                            checkout scm
                             def builtImage
 
                             try {


### PR DESCRIPTION
## Motivation
The parallel stage view on BlueOcean is not showing the correct total time after the whole parallel step is complete.

## Technical Details
Disabled problematic Autostatus Plugin from Jenkins. Using gitStatusWrapper to publish wanted checks instead. Also refactored to mostly Declarative Syntax in order to be able to restart from stage and simplify workflow.

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
