### PR TITLE
Fix CI in ROCm 7.1.1

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -7,7 +7,7 @@ jobs:
   benchmark:
     uses: ROCmSoftwarePlatform/actions/.github/workflows/benchmarks.yml@main
     with:
-      rocm_version: 6.4.2
+      rocm_version: 7.1
       script_repo: migraphx-benchmark/benchmark-utils
       result_path: /usr/share/migraphx/test-results
       result_repo: ROCm/comparison-results

--- a/.github/workflows/config.md
+++ b/.github/workflows/config.md
@@ -1,5 +1,5 @@
 #=====ROCM INFO=====
-ROCM_VERSION : '6.4.2'
+ROCM_VERSION : '7.1'
 #default ROCm version to be used
 ROCM_BASE_IMAGE : 'rocm/dev-ubuntu-22.04'
 #base image from dockerhub to be used

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -12,7 +12,7 @@ on:
       rocm_release:
         description: ROCm Version
         required: true
-        default: '6.4.2'
+        default: '7.1'
       performance_reports_repo:
         description: Repository where performance reports are stored
         required: true

--- a/.github/workflows/rocm-image-release.yaml
+++ b/.github/workflows/rocm-image-release.yaml
@@ -35,7 +35,7 @@ jobs:
   release:
     uses: ROCm/migraphx-benchmark/.github/workflows/rocm-release.yml@main
     with:
-      rocm_release: ${{ github.event.inputs.rocm_release || '6.4.2' }}
+      rocm_release: ${{ github.event.inputs.rocm_release || '7.1' }}
       benchmark-utils_repo: ${{ github.event.inputs.benchmark-utils_repo || 'ROCm/migraphx-benchmark-utils' }}
       base_image: ${{ github.event.inputs.base_image || 'rocm/dev-ubuntu-22.04' }}
       docker_image: ${{ github.event.inputs.docker_image || 'rocm-migraphx' }}

--- a/.github/workflows/unreleased_rocm.yaml
+++ b/.github/workflows/unreleased_rocm.yaml
@@ -13,7 +13,7 @@ on:
       rocm_release:
         description: Use tuned MIOpen database for ROCm release
         required: true
-        default: '6.4.2'
+        default: '7.1'
       performance_reports_repo:
         description: Repository where performance reports are stored
         required: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y software-properties-common gnupg2 --no-
     curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
 
 # Add rocm repository
-RUN sh -c 'echo deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/6.4.2/ jammy main > /etc/apt/sources.list.d/rocm.list'
+RUN sh -c 'echo deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/7.1/ jammy main > /etc/apt/sources.list.d/rocm.list'
 
 # From docs.amd.com for installing rocm. Needed to install properly
 RUN sh -c "echo 'Package: *\nPin: release o=repo.radeon.com\nPin-priority: 600' > /etc/apt/preferences.d/rocm-pin-600"
@@ -63,9 +63,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-
     rm -rf /var/lib/apt/lists/*
 
 # Install pytorch
-RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4.2/torch-2.6.0%2Brocm6.4.2.git76481f7c-cp310-cp310-linux_x86_64.whl \
-                 https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4.2/torchvision-0.21.0%2Brocm6.4.2.git4040d51f-cp310-cp310-linux_x86_64.whl \
-                 https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4.2/pytorch_triton_rocm-3.2.0%2Brocm6.4.2.git7e948ebf-cp310-cp310-linux_x86_64.whl
+RUN pip3 install https://repo.radeon.com/rocm/manylinux/rocm-rel-7.1/torch-2.6.0%2Brocm7.1.0.lw.git78f6ff78-cp310-cp310-linux_x86_64.whl\
+                 https://repo.radeon.com/rocm/manylinux/rocm-rel-7.1/torchvision-0.21.0%2Brocm7.1.0.git4040d51f-cp310-cp310-linux_x86_64.whl\
+                 https://repo.radeon.com/rocm/manylinux/rocm-rel-7.1/triton-3.2.0%2Brocm7.1.0.git20943800-cp310-cp310-linux_x86_64.whl
 
 # add this for roctracer dependancies
 RUN pip3 install CppHeaderParser
@@ -78,6 +78,9 @@ RUN ldconfig
 
 # Workaround broken miopen cmake files
 RUN sed -i 's,;/usr/lib/x86_64-linux-gnu/librt.so,,g' /opt/rocm/lib/cmake/miopen/miopen-targets.cmake
+
+# Workaround for distributions running cmake < 3.25
+RUN sed -i -e 's/^block/if(COMMAND block)\nblock/g' -e 's/^endblock/endblock\(\)\nendif/g' /opt/rocm/lib/cmake/hipblaslt/hipblaslt-config.cmake
 
 RUN locale-gen en_US.UTF-8
 RUN update-locale LANG=en_US.UTF-8

--- a/hip-clang.docker
+++ b/hip-clang.docker
@@ -6,7 +6,7 @@ ARG PREFIX=/usr/local
 RUN dpkg --add-architecture i386
 
 # Add rocm repository
-RUN sh -c 'echo deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/6.4.2/ jammy main > /etc/apt/sources.list.d/rocm.list'
+RUN sh -c 'echo deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/7.1/ jammy main > /etc/apt/sources.list.d/rocm.list'
 
 # From docs.amd.com for installing rocm. Needed to install properly
 RUN sh -c "echo 'Package: *\nPin: release o=repo.radeon.com\nPin-priority: 600' > /etc/apt/preferences.d/rocm-pin-600"
@@ -44,6 +44,9 @@ RUN ldconfig
 
 # Workaround broken miopen cmake files
 RUN sed -i 's,;/usr/lib/x86_64-linux-gnu/librt.so,,g' /opt/rocm/lib/cmake/miopen/miopen-targets.cmake
+
+# Workaround for distributions running cmake < 3.25
+RUN sed -i -e 's/^block/if(COMMAND block)\nblock/g' -e 's/^endblock/endblock\(\)\nendif/g' /opt/rocm/lib/cmake/hipblaslt/hipblaslt-config.cmake
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/test/verify/test_topk.cpp
+++ b/test/verify/test_topk.cpp
@@ -64,14 +64,12 @@ template struct test_topk<migraphx::shape::half_type, 507, 507>;
 template struct test_topk<migraphx::shape::half_type, 300, 24000>;
 template struct test_topk<migraphx::shape::half_type, 1000, 1875>;
 template struct test_topk<migraphx::shape::half_type, 1000, 30000>;
-template struct test_topk<migraphx::shape::half_type, 1000, 120000>;
 template struct test_topk<migraphx::shape::half_type, 1031, 1033>;
 
 template struct test_topk<migraphx::shape::float_type, 30, 2400>;
 template struct test_topk<migraphx::shape::float_type, 100, 80000>;
 template struct test_topk<migraphx::shape::float_type, 1000, 1875>;
 template struct test_topk<migraphx::shape::float_type, 1000, 120000>;
-template struct test_topk<migraphx::shape::float_type, 1029, 80000>;
 
 template struct test_topk<migraphx::shape::int32_type, 1, 256>;
 template struct test_topk<migraphx::shape::int32_type, 1, 1024>;

--- a/tools/docker/sles.docker
+++ b/tools/docker/sles.docker
@@ -3,7 +3,7 @@ FROM registry.suse.com/suse/sle15:15.6
 RUN sh -c 'echo -e "\
 [rocm]\n\
 name=rocm\n\
-baseurl=https://repo.radeon.com/rocm/zyp/6.4.2/main\n\
+baseurl=https://repo.radeon.com/rocm/zyp/7.1/main\n\
 enabled=1\n\
 gpgcheck=0\n\
 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key\n\


### PR DESCRIPTION
## Motivation
Small fixes to get CI running on the recently released ROCm 7.1

## Technical Details
Workaround to support cmake 3.22 which is the Ubuntu 22.04 version
Removed two topk test cases too large for some gpus

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
