### PR TITLE
Dont fuse pointwise when its used across submodules

### DIFF
--- a/src/fuse_pointwise.cpp
+++ b/src/fuse_pointwise.cpp
@@ -270,22 +270,23 @@ find_output_pointwise(const module& m, instruction_ref ins, bool multi_out)
 {
     std::vector<instruction_ref> result;
     if(not multi_out)
-        return result;    
+        return result;
     std::vector<instruction_ref> outputs;
     std::copy_if(ins->outputs().begin(),
                  ins->outputs().end(),
                  std::back_inserter(outputs),
                  [&](instruction_ref output) {
-                    if(output->name() != "pointwise")
-                        return false;
-                    if(not m.has_instruction(output))
-                        return false;
-                    if(is_dead(output))
-                        return false;
-                    // TODO: move_output_instructions_after doesnt handle outputs from different modules so only fuse from the same module
-                    return std::all_of(output->outputs().begin(), output->outputs().end(), [&](auto out) {
-                        return m.has_instruction(out);
-                    });                     
+                     if(output->name() != "pointwise")
+                         return false;
+                     if(not m.has_instruction(output))
+                         return false;
+                     if(is_dead(output))
+                         return false;
+                     // TODO: move_output_instructions_after doesnt handle outputs from different
+                     // modules so only fuse from the same module
+                     return std::all_of(output->outputs().begin(),
+                                        output->outputs().end(),
+                                        [&](auto out) { return m.has_instruction(out); });
                  });
     if(outputs.size() < 2)
         return result;

--- a/test/fuse_pointwise.cpp
+++ b/test/fuse_pointwise.cpp
@@ -1136,15 +1136,15 @@ TEST_CASE(if_cross_module_multi_out_find_output)
     migraphx::shape s1{migraphx::shape::float_type, {2, 3}};
     migraphx::program p1;
     {
-        auto* mm   = p1.get_main_module();
-        auto x     = mm->add_parameter("x", s1);
-        auto y     = mm->add_parameter("y", s1);
+        auto* mm  = p1.get_main_module();
+        auto x    = mm->add_parameter("x", s1);
+        auto y    = mm->add_parameter("y", s1);
         auto cond = mm->add_parameter("cond", migraphx::shape{migraphx::shape::bool_type, {1}});
-        auto add1  = mm->add_instruction(migraphx::make_op("add"), x, y);
+        auto add1 = mm->add_instruction(migraphx::make_op("add"), x, y);
 
         auto* then_mod = p1.create_module("If_then_1");
         {
-            auto relu        = then_mod->add_instruction(migraphx::make_op("relu"), add1);
+            auto relu = then_mod->add_instruction(migraphx::make_op("relu"), add1);
             then_mod->add_return({relu});
         }
 
@@ -1161,15 +1161,16 @@ TEST_CASE(if_cross_module_multi_out_find_output)
     run_pass(p1, {.enable_multi_output = true});
     migraphx::program p2;
     {
-        auto* mm = p2.get_main_module();
-        auto x     = mm->add_parameter("x", s1);
-        auto y     = mm->add_parameter("y", s1);
+        auto* mm  = p2.get_main_module();
+        auto x    = mm->add_parameter("x", s1);
+        auto y    = mm->add_parameter("y", s1);
         auto cond = mm->add_parameter("cond", migraphx::shape{migraphx::shape::bool_type, {1}});
         auto add1 = add_pointwise(p2, "main:pointwise0", {x, y}, single_pointwise("add"));
 
         auto* then_mod = p2.create_module("If_then_1");
         {
-            auto relu = add_pointwise(p2, then_mod, "If_then_1:pointwise0", {add1}, single_pointwise("relu"));
+            auto relu = add_pointwise(
+                p2, then_mod, "If_then_1:pointwise0", {add1}, single_pointwise("relu"));
             then_mod->add_return({relu});
         }
 
@@ -1191,15 +1192,15 @@ TEST_CASE(if_cross_module_multi_out_find_input)
     migraphx::shape s1{migraphx::shape::float_type, {2, 3}};
     migraphx::program p1;
     {
-        auto* mm   = p1.get_main_module();
-        auto x     = mm->add_parameter("x", s1);
-        auto y     = mm->add_parameter("y", s1);
-        auto add1  = mm->add_instruction(migraphx::make_op("add"), x, y);
+        auto* mm  = p1.get_main_module();
+        auto x    = mm->add_parameter("x", s1);
+        auto y    = mm->add_parameter("y", s1);
+        auto add1 = mm->add_instruction(migraphx::make_op("add"), x, y);
         auto cond = mm->add_parameter("cond", migraphx::shape{migraphx::shape::bool_type, {1}});
 
         auto* then_mod = p1.create_module("If_then_1");
         {
-            auto relu        = then_mod->add_instruction(migraphx::make_op("relu"), add1);
+            auto relu = then_mod->add_instruction(migraphx::make_op("relu"), add1);
             then_mod->add_return({relu});
         }
 
@@ -1216,15 +1217,16 @@ TEST_CASE(if_cross_module_multi_out_find_input)
     run_pass(p1, {.enable_multi_output = true});
     migraphx::program p2;
     {
-        auto* mm = p2.get_main_module();
-        auto x     = mm->add_parameter("x", s1);
-        auto y     = mm->add_parameter("y", s1);
+        auto* mm  = p2.get_main_module();
+        auto x    = mm->add_parameter("x", s1);
+        auto y    = mm->add_parameter("y", s1);
         auto cond = mm->add_parameter("cond", migraphx::shape{migraphx::shape::bool_type, {1}});
         auto add1 = add_pointwise(p2, "main:pointwise0", {x, y}, single_pointwise("add"));
 
         auto* then_mod = p2.create_module("If_then_1");
         {
-            auto relu = add_pointwise(p2, then_mod, "If_then_1:pointwise0", {add1}, single_pointwise("relu"));
+            auto relu = add_pointwise(
+                p2, then_mod, "If_then_1:pointwise0", {add1}, single_pointwise("relu"));
             then_mod->add_return({relu});
         }
 


### PR DESCRIPTION
## Motivation
Even though both pointwise are in the same module, fuse_pointwise will use `move_output_instructions_after` to move the outputs after the fusion when doing multi-output fusion. However, `move_output_instructions_after` doesnt support outputs in different modules which leads to a a infinite loop. An assert is added to avoid the hang on debug builds.

For now pointwise fusion will skip fusing these cases until we can update `move_output_instructions_after`.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
