### PR TITLE
Quiet nrvo and noreturn warnings

### DIFF
--- a/cmake/EnableCompilerWarnings.cmake
+++ b/cmake/EnableCompilerWarnings.cmake
@@ -95,8 +95,10 @@ else()
                 -Wno-float-conversion
                 -Wno-gnu-anonymous-struct
                 -Wno-gnu-zero-variadic-macro-arguments
+                -Wno-missing-noreturn
                 -Wno-missing-prototypes
                 -Wno-nested-anon-types
+                -Wno-nrvo
                 -Wno-option-ignored
                 -Wno-padded
                 -Wno-shorten-64-to-32


### PR DESCRIPTION
## Motivation
Newer LLVM compiler warnings added `nrvo` and missing `missing-noreturn`.  Due to our code design both changes required significant rewrites.  As a side note the warnings exploded our logs, generating 149MB of entries per build.  

## Technical Details
Suppressed both warnings

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
