### PR TITLE
onnx version change

### DIFF
--- a/examples/onnxruntime/inceptionV3/inceptionv3.py
+++ b/examples/onnxruntime/inceptionV3/inceptionv3.py
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Motivation
Fix migx models failing with RuntimeError after switching to PyTorch 2.9 docker.

## Technical Details
The issue was caused by ONNX opset version incompatibility with PyTorch 2.9. Updated opset_version in the example.

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
