### PR TITLE
Quieten the verbose console output in tests explicitly invoked for compiler warnings and errors

### DIFF
--- a/test/gpu/jit.cpp
+++ b/test/gpu/jit.cpp
@@ -232,16 +232,20 @@ TEST_CASE(compile_target)
 TEST_CASE(compile_errors)
 {
     EXPECT(test::throws([&] {
-        migraphx::gpu::compile_hip_src(
-            {make_src_file("main.cpp", incorrect_program)}, {}, migraphx::gpu::get_device_name());
+        migraphx::gpu::compile_hip_src({make_src_file("main.cpp", incorrect_program)},
+                                       {},
+                                       migraphx::gpu::get_device_name(),
+                                       true);
     }));
 }
 
 TEST_CASE(compile_warnings)
 {
     auto compile = [](const std::vector<std::string>& params) {
-        return migraphx::gpu::compile_hip_src(
-            {make_src_file("main.cpp", unused_param)}, params, migraphx::gpu::get_device_name());
+        return migraphx::gpu::compile_hip_src({make_src_file("main.cpp", unused_param)},
+                                              params,
+                                              migraphx::gpu::get_device_name(),
+                                              true);
     };
 
     EXPECT(not compile({}).empty());


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

A successful test output is still confusing: e.g. this following snippet is un-necessarily verbose, giving an impression of a compilation failure, while there is none actually. 

Additionally, then: another test that failed unexpectedly, which was the real failure in CI, was harder to fish out due to this preceding verbosity. So this PR quietens it.

```
[   RUN    ] compile_warnings
/tmp/comgr-294062-0-f7cfc7/input/main.cpp:4:43: warning: unused parameter 'x' [-Wunused-parameter]
    4 | __attribute__((global)) void kernel(void* x, void* y)
      |                                           ^
/tmp/comgr-294062-0-f7cfc7/input/main.cpp:4:52: warning: unused parameter 'y' [-Wunused-parameter]
    4 | __attribute__((global)) void kernel(void* x, void* y)
      |                                                    ^
2 warnings generated when compiling for gfx942.

/tmp/comgr-315183-0-992008/input/main.cpp:4:43: error: unused parameter 'x' [-Werror,-Wunused-parameter]
    4 | __attribute__((global)) void kernel(void* x, void* y)
      |                                           ^
/tmp/comgr-315183-0-992008/input/main.cpp:4:52: error: unused parameter 'y' [-Werror,-Wunused-parameter]
    4 | __attribute__((global)) void kernel(void* x, void* y)
      |                                                    ^
2 errors generated when compiling for gfx942.

/code/AMDMIGraphX/src/targets/gpu/compile_hip.cpp:177: compile: hiprtc: HIPRTC_ERROR_COMPILATION: Compilation failed.
/tmp/comgr-315185-0-4c0ee5/input/main.cpp:4:43: error: unused parameter 'x' [-Werror,-Wunused-parameter]
    4 | __attribute__((global)) void kernel(void* x, void* y)
      |                                           ^
/tmp/comgr-315185-0-4c0ee5/input/main.cpp:4:52: error: unused parameter 'y' [-Werror,-Wunused-parameter]
    4 | __attribute__((global)) void kernel(void* x, void* y)
      |                                                    ^
2 errors generated when compiling for gfx942.

/code/AMDMIGraphX/src/targets/gpu/compile_hip.cpp:177: compile: hiprtc: HIPRTC_ERROR_COMPILATION: Compilation failed.
```



## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ x] Not Applicable: This PR is not to be included in the changelog.
