### PR TITLE
[7.2.1] Fix MXR writes 

### DIFF
--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -34,7 +34,7 @@ constexpr std::size_t msgpack_size_limit = std::numeric_limits<uint32_t>::max() 
 template <class Range>
 static std::size_t msgpack_chunk_size(const Range& r)
 {
-    return 1 + (r.size() - 1) / msgpack_size_limit;
+    return 1 + (std::max<size_t>(1, r.size()) - 1) / msgpack_size_limit;
 }
 
 template <class Iterator, class F>
@@ -81,6 +81,7 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
                 break;
             }
             case msgpack::type::FLOAT32:
+            /* Intentional Fall Through This is due to value encoding floats as double. */
             case msgpack::type::FLOAT64: {
                 v = o.as<double>();
                 break;

--- a/test/msgpack.cpp
+++ b/test/msgpack.cpp
@@ -220,5 +220,20 @@ TEST_CASE(test_msgpack_binary2)
     });
     EXPECT(migraphx::to_msgpack(bin) == msgpack_buffer(bin));
 }
+
+TEST_CASE(test_msgpack_binary_empty)
+{
+    migraphx::value::binary bin{};
+    EXPECT(migraphx::to_msgpack(bin) == msgpack_buffer(bin));
+}
+
+TEST_CASE(test_msgpack_binary_roundtrip_empty)
+{
+    migraphx::value bin = migraphx::value::binary{};
+    auto buffer         = migraphx::to_msgpack(bin);
+    auto mp             = migraphx::from_msgpack(buffer);
+    EXPECT(mp == bin);
+}
+
 #endif
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation
Fix underflow bug with msgpack_size_limit chunking logic.  The underflow makes it appear we had more data than necessary to pack causing EOF and other sorts of packing issues

## Technical Details
Merge PR#4480 in to the 7.2 branch

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
