### PR TITLE
handle git log with large descriptions

### DIFF
--- a/tools/build_and_test_onnxrt.sh
+++ b/tools/build_and_test_onnxrt.sh
@@ -36,7 +36,7 @@ pip3 install -r requirements-dev.txt
 export PATH="/opt/cmake/bin:$PATH"
 export CXXFLAGS="-D__HIP_PLATFORM_AMD__=1 -w"
 echo "ONNX Runtime log..."
-git --no-pager log -1
+git log -1 --oneline
 ./build.sh --config Release  --cmake_extra_defines CMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ --update --build --build_wheel --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --skip_tests --rocm_home /opt/rocm --use_migraphx --migraphx_home /opt/rocm --rocm_version=`cat /opt/rocm/.info/version-dev` --allow_running_as_root --enable_pybind
 
 cd build/Linux/Release


### PR DESCRIPTION
## Motivation
When running build_and_test_onnxrt.sh locally a page hang can occur during the "git log -1" command if the description  is longer then the terminal size.  It forces the user to hit the space bar.  

## Technical Details
Add the --oneline option to avoid the user interaction.  

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
