### PR TITLE
AIMIGRAPHX-279 Fix BF16/FP16 Quantization - Concat pass to remove zero element inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 Full documentation for MIGraphX is available at
 [https://rocmdocs.amd.com/projects/AMDMIGraphX/en/latest/](https://rocmdocs.amd.com/projects/AMDMIGraphX/en/latest/).
 
+
+## MIGraphX 2.16 for ROCm 7.2.1
+
+### Added
+
+### Changed
+
+### Resolved Issues
+* Fixed BF16/FP16 Quantization failure via zero element concats (#4512).
+
+### Optimized
+
+### Removed
+
+
+
+
+
 ## MIGraphX 2.15 for ROCm 7.2.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ Full documentation for MIGraphX is available at
 [https://rocmdocs.amd.com/projects/AMDMIGraphX/en/latest/](https://rocmdocs.amd.com/projects/AMDMIGraphX/en/latest/).
 
 
-## MIGraphX 2.16 for ROCm 7.2.1
+## Develop
 
 ### Added
 
 ### Changed
 
-### Resolved Issues
+### Resolved issues
 * Fixed BF16/FP16 Quantization failure via zero element concats (#4512).
 
 ### Optimized

--- a/src/include/migraphx/op/concat.hpp
+++ b/src/include/migraphx/op/concat.hpp
@@ -91,7 +91,8 @@ struct concat
                 if(ll != axis)
                 {
                     // Skip if any input dimension is 0 since we'll optimize this out later
-                    if(std::any_of(inputs.begin(), inputs.end(), [&](auto s) { return s.lens()[ll] == 0; }))
+                    if(std::any_of(
+                           inputs.begin(), inputs.end(), [&](auto s) { return s.lens()[ll] == 0; }))
                     {
                         continue;
                     }

--- a/src/include/migraphx/op/concat.hpp
+++ b/src/include/migraphx/op/concat.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/op/concat.hpp
+++ b/src/include/migraphx/op/concat.hpp
@@ -90,6 +90,12 @@ struct concat
             {
                 if(ll != axis)
                 {
+                    // Skip if any input dimension is 0 since we'll optimize this out later
+                    if(std::any_of(inputs.begin(), inputs.end(), [&](auto s) { return s.lens()[ll] == 0; }))
+                    {
+                        continue;
+                    }
+
                     if(not std::all_of(inputs.begin(), inputs.end(), [&](auto s) {
                            return s.lens()[ll] == first_shape_lens[ll];
                        }))

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -578,9 +578,10 @@ struct find_concat_zero_element_inputs
 {
     auto matcher() const
     {
-        return match::name("concat")(match::any_of[match::inputs()](match::make_basic_pred_matcher([](const auto& ins) { return ins->get_shape().elements() != 0; })));
+        return match::name("concat")(match::any_of[match::inputs()](match::make_basic_pred_matcher(
+            [](const auto& ins) { return ins->get_shape().elements() != 0; })));
     }
- 
+
     void apply(module& m, const match::matcher_result& mr) const
     {
         auto ins    = mr.result;
@@ -595,7 +596,7 @@ struct find_concat_zero_element_inputs
             std::back_inserter(new_inputs),
             [&](const auto& in) { return in->get_shape().elements() != 0; },
             [&](const auto& in) { return in; });
-        
+
         // Replace old concat with updated concat with updated inputs
         if(new_inputs.empty())
         {
@@ -609,9 +610,9 @@ struct find_concat_zero_element_inputs
             }
             else
             {
-               auto op     = any_cast<op::concat>(ins->get_operator());
-               auto concat = m.insert_instruction(ins, op, new_inputs);
-               m.replace_instruction(ins, concat);
+                auto op     = any_cast<op::concat>(ins->get_operator());
+                auto concat = m.insert_instruction(ins, op, new_inputs);
+                m.replace_instruction(ins, concat);
             }
         }
     }

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -601,7 +601,7 @@ struct find_concat_zero_element_inputs
         {
             m.remove_instruction(ins);
         }
-        else if (new_inputs.size() < inputs.size())
+        else if(new_inputs.size() < inputs.size())
         {
             auto op     = any_cast<op::concat>(ins->get_operator());
             auto concat = m.insert_instruction(ins, op, new_inputs);

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -585,8 +585,6 @@ struct find_concat_zero_element_inputs
     {
         auto ins    = mr.result;
         auto inputs = ins->inputs();
-        auto outs   = ins->outputs();
-        auto op     = any_cast<op::concat>(ins->get_operator());
 
         std::vector<instruction_ref> new_inputs;
 
@@ -598,14 +596,14 @@ struct find_concat_zero_element_inputs
             [&](const auto& in) { return in->get_shape().elements() != 0; },
             [&](const auto& in) { return in; });
          
-
         // Replace old concat with updated concat with updated inputs
-        if(new_inputs.empty() == 0)
+        if(new_inputs.empty())
         {
             m.remove_instruction(ins);
         }
         else if (new_inputs.size() < inputs.size())
         {
+            auto op     = any_cast<op::concat>(ins->get_operator());
             auto concat = m.insert_instruction(ins, op, new_inputs);
             m.replace_instruction(ins, concat);
         }

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -578,7 +578,7 @@ struct find_concat_zero_element_inputs
 {
     auto matcher() const
     {
-        return match::name("concat");
+        return match::name("concat")(match::any_of[match::inputs()](match::make_basic_pred_matcher([](const auto& ins) { return ins->get_shape().elements() != 0; })));
     }
  
     void apply(module& m, const match::matcher_result& mr) const
@@ -595,7 +595,7 @@ struct find_concat_zero_element_inputs
             std::back_inserter(new_inputs),
             [&](const auto& in) { return in->get_shape().elements() != 0; },
             [&](const auto& in) { return in; });
-         
+        
         // Replace old concat with updated concat with updated inputs
         if(new_inputs.empty())
         {

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -600,7 +600,7 @@ struct find_concat_zero_element_inputs
          
 
         // Replace old concat with updated concat with updated inputs
-        if(new_inputs.size() == 0)
+        if(new_inputs.empty() == 0)
         {
             m.remove_instruction(ins);
         }

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -574,27 +574,6 @@ struct find_concat_multibroadcasts
     }
 };
 
-/*struct find_zero_element_literal
-{
-    auto matcher() const
-    {
-        return match::name("@literal");
-    }
-
-    void apply(module& m, const match::matcher_result& mr) const
-    {
-        auto lit = mr.result;
-        auto s   = lit->get_shape();
-
-        if(s.elements() == 0)
-        {
-            std::cout << "Found zero element literal" << std::endl;
-            lit->debug_print();
-            m.remove_instruction(lit);
-        }
-    }
-}; */
-
 struct find_concat_zero_element_inputs
 {
     auto matcher() const
@@ -623,16 +602,11 @@ struct find_concat_zero_element_inputs
         // Replace old concat with updated concat with updated inputs
         if(new_inputs.size() == 0)
         {
-            std::cout << "found instruction to remove" << std::endl;
-            ins->debug_print();
             m.remove_instruction(ins);
         }
         else if (new_inputs.size() < inputs.size())
         {
-            std::cout << "found instruction to replace" << std::endl;
-            ins->debug_print();
             auto concat = m.insert_instruction(ins, op, new_inputs);
-            concat->debug_print();
             m.replace_instruction(ins, concat);
         }
     }
@@ -1486,7 +1460,6 @@ void simplify_reshapes::apply(module& m) const
 {
     m.repeat_while_changes(depth, [&] {
         match::find_matches(m,
-                            //find_zero_element_literal{},
                             find_where_op{},
                             find_resize{},
                             find_nop_reshapes{},

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -574,7 +574,7 @@ struct find_concat_multibroadcasts
     }
 };
 
-struct find_zero_element_literal
+/*struct find_zero_element_literal
 {
     auto matcher() const
     {
@@ -593,7 +593,7 @@ struct find_zero_element_literal
             m.remove_instruction(lit);
         }
     }
-};
+}; */
 
 struct find_concat_zero_element_inputs
 {
@@ -1486,7 +1486,7 @@ void simplify_reshapes::apply(module& m) const
 {
     m.repeat_while_changes(depth, [&] {
         match::find_matches(m,
-                            find_zero_element_literal{},
+                            //find_zero_element_literal{},
                             find_where_op{},
                             find_resize{},
                             find_nop_reshapes{},
@@ -1497,9 +1497,9 @@ void simplify_reshapes::apply(module& m) const
                             find_concat_transpose{},
                             find_concat_reshape{},
                             find_concat_multibroadcasts{},
-                            find_concat_zero_element_inputs{},
                             find_nested_slice{},
                             find_nested_concat{},
+                            find_concat_zero_element_inputs{},
                             find_transpose_slice{},
                             find_slice_transpose{},
                             find_unary_shape_transforms{},

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -603,9 +603,16 @@ struct find_concat_zero_element_inputs
         }
         else if(new_inputs.size() < inputs.size())
         {
-            auto op     = any_cast<op::concat>(ins->get_operator());
-            auto concat = m.insert_instruction(ins, op, new_inputs);
-            m.replace_instruction(ins, concat);
+            if(new_inputs.size() == 1)
+            {
+                m.replace_instruction(ins, new_inputs.front());
+            }
+            else
+            {
+               auto op     = any_cast<op::concat>(ins->get_operator());
+               auto concat = m.insert_instruction(ins, op, new_inputs);
+               m.replace_instruction(ins, concat);
+            }
         }
     }
 };

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -3661,7 +3661,7 @@ TEST_CASE(conv_add_layernorm_conv)
     EXPECT(m1.sort() == m2.sort());
 }
 
-//TODO: Add test case for all zero inputs and determine how we want to hanlde this
+// TODO: Add test case for all zero inputs and determine how we want to hanlde this
 /*TEST_CASE(concat_zero_element_inputs_all_zero)
 {
     // Test case where all inputs have zero elements - concat should be removed
@@ -3686,12 +3686,12 @@ TEST_CASE(concat_zero_element_inputs_some_zero)
     // Test case where some inputs have zero elements - they should be filtered out
     migraphx::module m1;
     {
-        auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
-        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
-        auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
-        auto x  = m1.add_parameter("x", s1);
-        auto y  = m1.add_parameter("y", s2);
-        auto z  = m1.add_parameter("z", s3);
+        auto s1     = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
+        auto s2     = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
+        auto s3     = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
+        auto x      = m1.add_parameter("x", s1);
+        auto y      = m1.add_parameter("y", s2);
+        auto z      = m1.add_parameter("z", s3);
         auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), x, y, z);
         m1.add_return({concat});
     }
@@ -3704,7 +3704,7 @@ TEST_CASE(concat_zero_element_inputs_some_zero)
         auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
         auto x  = m2.add_parameter("x", s1);
         m2.add_parameter("y", s2);
-        auto z  = m2.add_parameter("z", s3);
+        auto z = m2.add_parameter("z", s3);
         // Only x and z should remain in the concat (y is filtered out)
         auto concat = m2.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), x, z);
         m2.add_return({concat});
@@ -3718,12 +3718,12 @@ TEST_CASE(concat_zero_element_inputs_first_zero)
     // Test case where the first input has zero elements
     migraphx::module m1;
     {
-        auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
-        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
-        auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
-        auto x  = m1.add_parameter("x", s1);
-        auto y  = m1.add_parameter("y", s2);
-        auto z  = m1.add_parameter("z", s3);
+        auto s1     = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
+        auto s2     = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
+        auto s3     = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
+        auto x      = m1.add_parameter("x", s1);
+        auto y      = m1.add_parameter("y", s2);
+        auto z      = m1.add_parameter("z", s3);
         auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), x, y, z);
         m1.add_return({concat});
     }
@@ -3735,8 +3735,8 @@ TEST_CASE(concat_zero_element_inputs_first_zero)
         auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
         auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
         m2.add_parameter("x", s1);
-        auto y  = m2.add_parameter("y", s2);
-        auto z  = m2.add_parameter("z", s3);
+        auto y      = m2.add_parameter("y", s2);
+        auto z      = m2.add_parameter("z", s3);
         auto concat = m2.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), y, z);
         m2.add_return({concat});
     }
@@ -3749,12 +3749,12 @@ TEST_CASE(concat_zero_element_inputs_last_zero)
     // Test case where the last input has zero elements
     migraphx::module m1;
     {
-        auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
-        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
-        auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
-        auto x  = m1.add_parameter("x", s1);
-        auto y  = m1.add_parameter("y", s2);
-        auto z  = m1.add_parameter("z", s3);
+        auto s1     = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
+        auto s2     = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
+        auto s3     = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
+        auto x      = m1.add_parameter("x", s1);
+        auto y      = m1.add_parameter("y", s2);
+        auto z      = m1.add_parameter("z", s3);
         auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), x, y, z);
         m1.add_return({concat});
     }
@@ -3780,16 +3780,15 @@ TEST_CASE(concat_zero_element_inputs_multiple_zero)
     // Test case where multiple inputs have zero elements
     migraphx::module m1;
     {
-        auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
-        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
-        auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
-        auto s4 = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
-        auto w  = m1.add_parameter("w", s1);
-        auto x  = m1.add_parameter("x", s2);
-        auto y  = m1.add_parameter("y", s3);
-        auto z  = m1.add_parameter("z", s4);
-        auto concat =
-            m1.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), w, x, y, z);
+        auto s1     = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
+        auto s2     = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
+        auto s3     = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
+        auto s4     = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
+        auto w      = m1.add_parameter("w", s1);
+        auto x      = m1.add_parameter("x", s2);
+        auto y      = m1.add_parameter("y", s3);
+        auto z      = m1.add_parameter("z", s4);
+        auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), w, x, y, z);
         m1.add_return({concat});
     }
     run_pass(m1);
@@ -3801,9 +3800,9 @@ TEST_CASE(concat_zero_element_inputs_multiple_zero)
         auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
         auto s4 = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
         m2.add_parameter("w", s1);
-        auto x  = m2.add_parameter("x", s2);
+        auto x = m2.add_parameter("x", s2);
         m2.add_parameter("y", s3);
-        auto z  = m2.add_parameter("z", s4);
+        auto z      = m2.add_parameter("z", s4);
         auto concat = m2.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), x, z);
         m2.add_return({concat});
     }
@@ -3816,12 +3815,12 @@ TEST_CASE(concat_zero_element_inputs_no_zero)
     // Test case where no inputs have zero elements - concat should remain unchanged
     migraphx::module m1;
     {
-        auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
-        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
-        auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 7, 4}};
-        auto x  = m1.add_parameter("x", s1);
-        auto y  = m1.add_parameter("y", s2);
-        auto z  = m1.add_parameter("z", s3);
+        auto s1     = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
+        auto s2     = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
+        auto s3     = migraphx::shape{migraphx::shape::float_type, {2, 7, 4}};
+        auto x      = m1.add_parameter("x", s1);
+        auto y      = m1.add_parameter("y", s2);
+        auto z      = m1.add_parameter("z", s3);
         auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), x, y, z);
         m1.add_return({concat});
     }
@@ -3837,12 +3836,12 @@ TEST_CASE(concat_zero_element_inputs_different_axis)
     // Test case with zero elements on a different axis
     migraphx::module m1;
     {
-        auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
-        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
-        auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 3, 5}};
-        auto x  = m1.add_parameter("x", s1);
-        auto y  = m1.add_parameter("y", s2);
-        auto z  = m1.add_parameter("z", s3);
+        auto s1     = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
+        auto s2     = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
+        auto s3     = migraphx::shape{migraphx::shape::float_type, {2, 3, 5}};
+        auto x      = m1.add_parameter("x", s1);
+        auto y      = m1.add_parameter("y", s2);
+        auto z      = m1.add_parameter("z", s3);
         auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 2}}), x, y, z);
         m1.add_return({concat});
     }
@@ -3855,7 +3854,7 @@ TEST_CASE(concat_zero_element_inputs_different_axis)
         auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 3, 5}};
         auto x  = m2.add_parameter("x", s1);
         m2.add_parameter("y", s2);
-        auto z  = m2.add_parameter("z", s3);
+        auto z      = m2.add_parameter("z", s3);
         auto concat = m2.add_instruction(migraphx::make_op("concat", {{"axis", 2}}), x, z);
         m2.add_return({concat});
     }
@@ -3868,12 +3867,12 @@ TEST_CASE(concat_zero_element_one_input)
     // Test case with zero elements on a different axis
     migraphx::module m1;
     {
-        auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 3, 0}};
-        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 3, 0}};
-        auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
-        auto x  = m1.add_parameter("x", s1);
-        auto y  = m1.add_parameter("y", s2);
-        auto z  = m1.add_parameter("z", s3);
+        auto s1     = migraphx::shape{migraphx::shape::float_type, {2, 3, 0}};
+        auto s2     = migraphx::shape{migraphx::shape::float_type, {2, 3, 0}};
+        auto s3     = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
+        auto x      = m1.add_parameter("x", s1);
+        auto y      = m1.add_parameter("y", s2);
+        auto z      = m1.add_parameter("z", s3);
         auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 2}}), x, y, z);
         m1.add_return({concat});
     }
@@ -3887,7 +3886,7 @@ TEST_CASE(concat_zero_element_one_input)
         m2.add_parameter("x", s1);
         m2.add_parameter("y", s2);
         auto z = m2.add_parameter("z", s3);
- 
+
         m2.add_return({z});
     }
 

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -3679,8 +3679,6 @@ TEST_CASE(concat_zero_element_inputs_all_zero)
     {
         auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 0, 3}};
         auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 0, 3}};
-        auto x  = m2.add_parameter("x", s1);
-        auto y  = m2.add_parameter("y", s2);
         // concat should be removed, but we still need a return value
         // The optimization removes the concat, leaving the graph incomplete
         // This test verifies the concat is removed

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -3661,7 +3661,8 @@ TEST_CASE(conv_add_layernorm_conv)
     EXPECT(m1.sort() == m2.sort());
 }
 
-TEST_CASE(concat_zero_element_inputs_all_zero)
+//TODO: Add test case for all zero inputs and determine how we want to hanlde this
+/*TEST_CASE(concat_zero_element_inputs_all_zero)
 {
     // Test case where all inputs have zero elements - concat should be removed
     migraphx::module m1;
@@ -3678,7 +3679,7 @@ TEST_CASE(concat_zero_element_inputs_all_zero)
     // After optimization, concat should be removed
     EXPECT(std::count_if(m1.begin(), m1.end(), [](auto ins) { return ins.name() == "concat"; }) ==
            0);
-}
+} */
 
 TEST_CASE(concat_zero_element_inputs_some_zero)
 {

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -3827,7 +3827,7 @@ TEST_CASE(concat_zero_element_inputs_different_axis)
     migraphx::module m1;
     {
         auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
-        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 3, 0}};
+        auto s2 = migraphx::shape{migraphx::shape::float_type, {0, 2, 4}};
         auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 3, 5}};
         auto x  = m1.add_parameter("x", s1);
         auto y  = m1.add_parameter("y", s2);

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -3699,8 +3699,10 @@ TEST_CASE(concat_zero_element_inputs_some_zero)
     migraphx::module m2;
     {
         auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
+        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
         auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
         auto x  = m2.add_parameter("x", s1);
+        m2.add_parameter("y", s2);
         auto z  = m2.add_parameter("z", s3);
         // Only x and z should remain in the concat (y is filtered out)
         auto concat = m2.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), x, z);
@@ -3728,8 +3730,10 @@ TEST_CASE(concat_zero_element_inputs_first_zero)
 
     migraphx::module m2;
     {
+        auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
         auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
         auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
+        m2.add_parameter("x", s1);
         auto y  = m2.add_parameter("y", s2);
         auto z  = m2.add_parameter("z", s3);
         auto concat = m2.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), y, z);
@@ -3759,8 +3763,10 @@ TEST_CASE(concat_zero_element_inputs_last_zero)
     {
         auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
         auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
+        auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
         auto x  = m2.add_parameter("x", s1);
         auto y  = m2.add_parameter("y", s2);
+        m2.add_parameter("z", s3);
         auto concat = m2.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), x, y);
         m2.add_return({concat});
     }
@@ -3789,9 +3795,13 @@ TEST_CASE(concat_zero_element_inputs_multiple_zero)
 
     migraphx::module m2;
     {
+        auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
         auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
+        auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
         auto s4 = migraphx::shape{migraphx::shape::float_type, {2, 5, 4}};
+        m2.add_parameter("w", s1);
         auto x  = m2.add_parameter("x", s2);
+        m2.add_parameter("y", s3);
         auto z  = m2.add_parameter("z", s4);
         auto concat = m2.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), x, z);
         m2.add_return({concat});
@@ -3827,7 +3837,7 @@ TEST_CASE(concat_zero_element_inputs_different_axis)
     migraphx::module m1;
     {
         auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
-        auto s2 = migraphx::shape{migraphx::shape::float_type, {0, 2, 4}};
+        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
         auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 3, 5}};
         auto x  = m1.add_parameter("x", s1);
         auto y  = m1.add_parameter("y", s2);
@@ -3840,11 +3850,44 @@ TEST_CASE(concat_zero_element_inputs_different_axis)
     migraphx::module m2;
     {
         auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
+        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 0, 4}};
         auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 3, 5}};
         auto x  = m2.add_parameter("x", s1);
+        m2.add_parameter("y", s2);
         auto z  = m2.add_parameter("z", s3);
         auto concat = m2.add_instruction(migraphx::make_op("concat", {{"axis", 2}}), x, z);
         m2.add_return({concat});
+    }
+
+    EXPECT(m1.sort() == m2.sort());
+}
+
+TEST_CASE(concat_zero_element_one_input)
+{
+    // Test case with zero elements on a different axis
+    migraphx::module m1;
+    {
+        auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 3, 0}};
+        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 3, 0}};
+        auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
+        auto x  = m1.add_parameter("x", s1);
+        auto y  = m1.add_parameter("y", s2);
+        auto z  = m1.add_parameter("z", s3);
+        auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 2}}), x, y, z);
+        m1.add_return({concat});
+    }
+    run_pass(m1);
+
+    migraphx::module m2;
+    {
+        auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 3, 0}};
+        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 3, 0}};
+        auto s3 = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
+        m2.add_parameter("x", s1);
+        m2.add_parameter("y", s2);
+        auto z = m2.add_parameter("z", s3);
+ 
+        m2.add_return({z});
     }
 
     EXPECT(m1.sort() == m2.sort());

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -3675,15 +3675,6 @@ TEST_CASE(concat_zero_element_inputs_all_zero)
     }
     run_pass(m1);
 
-    migraphx::module m2;
-    {
-        auto s1 = migraphx::shape{migraphx::shape::float_type, {2, 0, 3}};
-        auto s2 = migraphx::shape{migraphx::shape::float_type, {2, 0, 3}};
-        // concat should be removed, but we still need a return value
-        // The optimization removes the concat, leaving the graph incomplete
-        // This test verifies the concat is removed
-    }
-
     // After optimization, concat should be removed
     EXPECT(std::count_if(m1.begin(), m1.end(), [](auto ins) { return ins.name() == "concat"; }) ==
            0);


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fixes an issue seen with bf16/fp16 quantization on MI300 

Required to remove zero elements from a concat since we try to convert these at the quantization step

AI genreated tests

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
Remove any zero element inputs sent to concat operator so that we don't include them in the final output. The overall contribution when used on a given axis will be zero this making their use irrelevant to the model 

This occurred in a customer model where input literals were generating an shape with zero elements() but had non zero lengths for other dimensions. Pruning the concat allows us to leverage dead code elimination to then avoid us trying to compile converts for the zero element literals/pieces which was resulting in MIGRAPHX_NGLOBALS == 0 and failing our jit compilation.

## Changelog Category
<!-- Also add the appropriate "Changelog:<...>" PR label. -->

- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
