### PR TITLE
Fix bug in eliminate_datatype, attempt to convert to int32 instead

### DIFF
--- a/docs/reference/MIGraphX-dev-env-vars.rst
+++ b/docs/reference/MIGraphX-dev-env-vars.rst
@@ -432,6 +432,14 @@ Debug settings for passes.
 
       | Default: Multi-output pointwise fusion is enabled.
 
+  * - | ``MIGRAPHX_DISABLE_ELIMINATE_INT64``
+      | When set, int64 types are preserved instead of being converted to int32.
+
+    - | ``1``: int64 types are preserved natively.
+      | ``0``: Returns to default behavior.
+
+      | Default: int64 is converted to int32.
+
   * - | ``MIGRAPHX_TRACE_PASSES``
       | Turns on printing of the compile passes and the program after the passes.
 

--- a/src/eliminate_data_type.cpp
+++ b/src/eliminate_data_type.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -111,6 +111,16 @@ void eliminate_data_type::apply(module& m) const
                                                            "select_module"};
     if(unsupported_types.empty())
         return;
+
+    // Warn when converting int64 to int32 as this may cause overflow for large indices
+    if(contains(unsupported_types, shape::type_t::int64_type) and
+       target_type == shape::type_t::int32_type)
+    {
+        std::cerr << "Warning: Converting int64 to int32. Values exceeding int32 range "
+                     "(>2147483647) may overflow and cause incorrect indexing. "
+                     "Set MIGRAPHX_DISABLE_ELIMINATE_INT64=1 to preserve int64 precision."
+                  << std::endl;
+    }
 
     for(auto ins : iterator_for(m))
     {

--- a/test/eliminate_data_type_test.cpp
+++ b/test/eliminate_data_type_test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,6 +35,15 @@ static void run_pass(migraphx::module& m, std::set<migraphx::shape::type_t> type
     migraphx::run_passes(
         m,
         {migraphx::eliminate_data_type{std::move(types), migraphx::shape::float_type},
+         migraphx::eliminate_identity{},
+         migraphx::dead_code_elimination{}});
+}
+
+static void run_pass_to_int32(migraphx::module& m, std::set<migraphx::shape::type_t> types)
+{
+    migraphx::run_passes(
+        m,
+        {migraphx::eliminate_data_type{std::move(types), migraphx::shape::int32_type},
          migraphx::eliminate_identity{},
          migraphx::dead_code_elimination{}});
 }
@@ -87,6 +96,71 @@ TEST_CASE(quant)
         auto add = mm2.add_instruction(migraphx::make_op("dot"), floatx, floaty);
         mm2.add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), add);
+    }
+    EXPECT(mm1 == mm2);
+}
+
+// Test int64 to int32 conversion for mod operation
+// This ensures integer semantics are preserved (not converted to float)
+TEST_CASE(int64_to_int32_mod)
+{
+    migraphx::shape s{migraphx::shape::int64_type, {1, 96}};
+    migraphx::module mm1;
+    {
+        auto x = mm1.add_parameter("x", s);
+        auto y = mm1.add_parameter("y", s);
+        mm1.add_instruction(migraphx::make_op("mod"), x, y);
+    }
+    run_pass_to_int32(mm1, {migraphx::shape::int64_type});
+
+    migraphx::module mm2;
+    {
+        auto x     = mm2.add_parameter("x", s);
+        auto y     = mm2.add_parameter("y", s);
+        auto int32x = mm2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), x);
+        auto int32y = mm2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), y);
+        auto mod_result = mm2.add_instruction(migraphx::make_op("mod"), int32x, int32y);
+        mm2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::int64_type}}), mod_result);
+    }
+    EXPECT(mm1 == mm2);
+}
+
+// Test int64 to int32 conversion for mul then mod (common pattern in gather index computation)
+TEST_CASE(int64_to_int32_mul_mod)
+{
+    migraphx::shape s{migraphx::shape::int64_type, {1, 96}};
+    migraphx::module mm1;
+    {
+        auto x = mm1.add_parameter("x", s);
+        auto y = mm1.add_parameter("y", s);
+        auto z = mm1.add_parameter("z", s);
+        auto mul = mm1.add_instruction(migraphx::make_op("mul"), x, y);
+        mm1.add_instruction(migraphx::make_op("mod"), mul, z);
+    }
+    run_pass_to_int32(mm1, {migraphx::shape::int64_type});
+
+    migraphx::module mm2;
+    {
+        auto x      = mm2.add_parameter("x", s);
+        auto y      = mm2.add_parameter("y", s);
+        auto z      = mm2.add_parameter("z", s);
+        auto int32x = mm2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), x);
+        auto int32y = mm2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), y);
+        auto int32z = mm2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), z);
+        auto mul = mm2.add_instruction(migraphx::make_op("mul"), int32x, int32y);
+        auto mul_back = mm2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::int64_type}}), mul);
+        auto mul_to_int32 = mm2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), mul_back);
+        auto mod_result = mm2.add_instruction(migraphx::make_op("mod"), mul_to_int32, int32z);
+        mm2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::int64_type}}), mod_result);
     }
     EXPECT(mm1 == mm2);
 }

--- a/test/eliminate_data_type_test.cpp
+++ b/test/eliminate_data_type_test.cpp
@@ -152,13 +152,13 @@ TEST_CASE(int64_to_int32_mul_mod)
             migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), x);
         auto int32y = mm2.add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), y);
-        auto int32z = mm2.add_instruction(
-            migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), z);
         auto mul      = mm2.add_instruction(migraphx::make_op("mul"), int32x, int32y);
         auto mul_back = mm2.add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::int64_type}}), mul);
         auto mul_to_int32 = mm2.add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), mul_back);
+        auto int32z = mm2.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), z);
         auto mod_result = mm2.add_instruction(migraphx::make_op("mod"), mul_to_int32, int32z);
         mm2.add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::int64_type}}),

--- a/test/eliminate_data_type_test.cpp
+++ b/test/eliminate_data_type_test.cpp
@@ -115,15 +115,16 @@ TEST_CASE(int64_to_int32_mod)
 
     migraphx::module mm2;
     {
-        auto x     = mm2.add_parameter("x", s);
-        auto y     = mm2.add_parameter("y", s);
+        auto x      = mm2.add_parameter("x", s);
+        auto y      = mm2.add_parameter("y", s);
         auto int32x = mm2.add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), x);
         auto int32y = mm2.add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), y);
         auto mod_result = mm2.add_instruction(migraphx::make_op("mod"), int32x, int32y);
         mm2.add_instruction(
-            migraphx::make_op("convert", {{"target_type", migraphx::shape::int64_type}}), mod_result);
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::int64_type}}),
+            mod_result);
     }
     EXPECT(mm1 == mm2);
 }
@@ -134,9 +135,9 @@ TEST_CASE(int64_to_int32_mul_mod)
     migraphx::shape s{migraphx::shape::int64_type, {1, 96}};
     migraphx::module mm1;
     {
-        auto x = mm1.add_parameter("x", s);
-        auto y = mm1.add_parameter("y", s);
-        auto z = mm1.add_parameter("z", s);
+        auto x   = mm1.add_parameter("x", s);
+        auto y   = mm1.add_parameter("y", s);
+        auto z   = mm1.add_parameter("z", s);
         auto mul = mm1.add_instruction(migraphx::make_op("mul"), x, y);
         mm1.add_instruction(migraphx::make_op("mod"), mul, z);
     }
@@ -153,14 +154,15 @@ TEST_CASE(int64_to_int32_mul_mod)
             migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), y);
         auto int32z = mm2.add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), z);
-        auto mul = mm2.add_instruction(migraphx::make_op("mul"), int32x, int32y);
+        auto mul      = mm2.add_instruction(migraphx::make_op("mul"), int32x, int32y);
         auto mul_back = mm2.add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::int64_type}}), mul);
         auto mul_to_int32 = mm2.add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::int32_type}}), mul_back);
         auto mod_result = mm2.add_instruction(migraphx::make_op("mod"), mul_to_int32, int32z);
         mm2.add_instruction(
-            migraphx::make_op("convert", {{"target_type", migraphx::shape::int64_type}}), mod_result);
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::int64_type}}),
+            mod_result);
     }
     EXPECT(mm1 == mm2);
 }


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Currently, MIGraphX is incorrectly converting int64 to float. Example sequence:
`float_input → convert[int64] → mul(int64) → mod(int64) → gather`

What MIGraphX does in eliminate_data_type:
```
float_input 
  → convert[int64]           # original model convert
  → convert[float]           # ADDED by eliminate_data_type  
  → mul (now in float)       # operation done in float!
  → convert[int64]           # ADDED to preserve output type
  → convert[float]           # ADDED for next op
  → mod (now in float)       # operation done in float!
  → convert[int64]           # ADDED to preserve output type
  → gather
```

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
Try to convert int64 to int32 instead. This should work with rocMLIR fusions since int64 is not in the list of supported types under fuse_mlir.cpp. Add a warning to indicate to the user this conversion is happening. If it's causing correctness problems, it can be disabled with environment variable `MIGRAPHX_DISABLE_ELIMINATE_INT64`.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [x] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
