### PR TITLE
[Ex CI] Disabling Azure Pipeline

### DIFF
--- a/.azuredevops/rocm-ci.yml
+++ b/.azuredevops/rocm-ci.yml
@@ -15,37 +15,9 @@ resources:
     name: ROCm/ROCm
     ref: ${{ parameters.pipelinesRepoRef }}
 
-trigger:
-  batch: true
-  branches:
-    include:
-    - develop
-    - master
-  paths:
-    exclude:
-    - .githooks
-    - .github
-    - docs
-    - '.*.y*ml'
-    - '*.md'
-    - Jenkinsfile
-    - LICENSE
-
-pr:
-  autoCancel: true
-  branches:
-    include:
-    - develop
-    - master
-  paths:
-    exclude:
-    - .github
-    - docs
-    - '.*.y*ml'
-    - '*.md'
-    - Jenkinsfile
-    - LICENSE
-  drafts: false
+# Pipeline disabled: AMDMIGraphX depends on hipBLAS, which depends on rocsparse (disabled)
+trigger: none
+pr: none
 
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/AMDMIGraphX.yml@pipelines_repo


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
As Azure is being deprecated, some pipeline are being disabled. Disable Azure pipeline due to rocsparse dependency
AMDMIGraphX depends on hipBLAS, which depends on rocsparse. Since rocsparse pipelines are being disabled, this pipeline must also be disabled.

Related ticket on rocm-lib: https://github.com/ROCm/rocm-libraries/issues/3724
## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
Set trigger: none and pr: none to disable all pipeline runs.
## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [x] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
