### PR TITLE
Add axis attribute to unpack_fp4 and pack_fp4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 Full documentation for MIGraphX is available at
 [https://rocmdocs.amd.com/projects/AMDMIGraphX/en/latest/](https://rocmdocs.amd.com/projects/AMDMIGraphX/en/latest/).
 
+## Develop
+
+### Added
+
+
+### Changed
+
+
+### Resolved issues
+
+* Fixed a bug with operators `pack_fp4`, `unpack_fp4`, and the `fuse_mlir` pass handling non-standard input shapes (#4560).
+
+
+### Optimized
+
+
+### Removed
+
+
 ## MIGraphX 2.15 for ROCm 7.2.0
 
 ### Added

--- a/src/include/migraphx/op/pack_fp4.hpp
+++ b/src/include/migraphx/op/pack_fp4.hpp
@@ -64,7 +64,9 @@ struct pack_fp4
         auto new_lens = in_shape.lens();
         if(new_lens.at(axis) % 2 != 0)
         {
-            MIGRAPHX_THROW("PACK_FP4: Can not pack axis that has odd lengths");
+            std::stringstream msg;
+            msg << "PACK_FP4: Can not pack along axis of odd length (" << new_lens.at(axis) << ")";
+            MIGRAPHX_THROW(msg.str());
         }
         new_lens[axis] /= 2;
         return in_shape.with_lens(migraphx::shape::fp4x2_type, new_lens);

--- a/src/include/migraphx/op/pack_fp4.hpp
+++ b/src/include/migraphx/op/pack_fp4.hpp
@@ -30,6 +30,8 @@
 #include <migraphx/par_for.hpp>
 #include <migraphx/fp4_casts.hpp>
 
+#include <sstream>
+
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace op {

--- a/src/include/migraphx/op/pack_fp4.hpp
+++ b/src/include/migraphx/op/pack_fp4.hpp
@@ -63,7 +63,7 @@ struct pack_fp4
     {
         check_shapes{inputs, *this}.same_dims().has(1);
         const auto& in_shape = inputs.front();
-        auto new_lens = in_shape.lens();
+        auto new_lens        = in_shape.lens();
         if(new_lens.at(axis) % 2 != 0)
         {
             std::stringstream msg;
@@ -77,7 +77,7 @@ struct pack_fp4
     argument compute(const shape& output_shape, const std::vector<argument>& args) const
     {
         const auto& input = args.front();
-        auto in_shape = input.get_shape();
+        auto in_shape     = input.get_shape();
         argument result{output_shape};
         auto out = result.get<uint8_t>();
         input.visit([&](auto inp) {

--- a/src/include/migraphx/op/pack_fp4.hpp
+++ b/src/include/migraphx/op/pack_fp4.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/op/unpack_fp4.hpp
+++ b/src/include/migraphx/op/unpack_fp4.hpp
@@ -42,7 +42,22 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace op {
 struct unpack_fp4
 {
+    int64_t axis = -1;
+
     std::string name() const { return "unpack_fp4"; }
+
+    value attributes() const
+    {
+        value normalize   = value::object{};
+        normalize["axis"] = value::array{normalize_attribute::include_min};
+        return {{"normalize_axes", normalize}};
+    }
+
+    template <class Self, class F>
+    static auto reflect(Self& self, F f)
+    {
+        return pack(f(self.axis, "axis"));
+    }
 
     migraphx::shape normalize_compute_shape(std::vector<migraphx::shape> inputs) const
     {
@@ -53,9 +68,9 @@ struct unpack_fp4
             MIGRAPHX_THROW("UNPACK_FP4: Only fp4x2_type is supported for unpacking");
         }
         auto new_lens = in_shape.lens();
-        int fast_axis = std::min_element(in_shape.strides().cbegin(), in_shape.strides().cend()) -
+        int axis = std::min_element(in_shape.strides().cbegin(), in_shape.strides().cend()) -
                         in_shape.strides().cbegin();
-        new_lens[fast_axis] *= 2;
+        new_lens[axis] *= 2;
         return in_shape.with_lens(migraphx::shape::fp8e4m3fn_type, new_lens);
     }
 
@@ -63,8 +78,6 @@ struct unpack_fp4
     {
         const auto& input = args.front();
         auto in_shape     = input.get_shape();
-        int fast_axis = std::min_element(in_shape.strides().cbegin(), in_shape.strides().cend()) -
-                        in_shape.strides().cbegin();
 
         migraphx::shape fp8_shape = shape{migraphx::shape::fp8e4m3fn_type, output_shape.lens()};
         argument fp8_arg{fp8_shape};
@@ -72,13 +85,13 @@ struct unpack_fp4
         fp8_arg.visit([&](auto out) {
             par_for(in_shape.elements(), [&](auto i) {
                 auto data_idx = in_shape.multi(i);
-                data_idx[fast_axis] *= 2;
+                data_idx[axis] *= 2;
                 // unpacking 2 unsigned parts
                 // unpacking 4 least significant bits first
                 uint8_t fp4_val = inp[i];
                 out[data_idx]   = fp4_to_fp8(fp4_val);
 
-                data_idx[fast_axis] += 1;
+                data_idx[axis] += 1;
                 fp4_val       = fp4_val >> 4u;
                 out[data_idx] = fp4_to_fp8(fp4_val);
             });

--- a/src/include/migraphx/op/unpack_fp4.hpp
+++ b/src/include/migraphx/op/unpack_fp4.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/op/unpack_fp4.hpp
+++ b/src/include/migraphx/op/unpack_fp4.hpp
@@ -68,8 +68,6 @@ struct unpack_fp4
             MIGRAPHX_THROW("UNPACK_FP4: Only fp4x2_type is supported for unpacking");
         }
         auto new_lens = in_shape.lens();
-        int axis = std::min_element(in_shape.strides().cbegin(), in_shape.strides().cend()) -
-                        in_shape.strides().cbegin();
         new_lens[axis] *= 2;
         return in_shape.with_lens(migraphx::shape::fp8e4m3fn_type, new_lens);
     }

--- a/src/onnx/parse_mxqdq.cpp
+++ b/src/onnx/parse_mxqdq.cpp
@@ -148,9 +148,10 @@ struct parse_mxquantizedequantize : op_parser<parse_mxquantizedequantize>
             q_ins = info.add_instruction(make_op("pad", {{"pads", padding}}), q_ins);
         }
         // output is fp4x2_type
-        auto pack_ins   = info.add_instruction(make_op("pack_fp4", {{"axis", fast_axis}}), q_ins);
+        auto pack_ins = info.add_instruction(make_op("pack_fp4", {{"axis", fast_axis}}), q_ins);
         // output is fp8e4m3fn_type
-        auto unpack_ins = info.add_instruction(make_op("unpack_fp4", {{"axis", fast_axis}}), pack_ins);
+        auto unpack_ins =
+            info.add_instruction(make_op("unpack_fp4", {{"axis", fast_axis}}), pack_ins);
 
         if(odd_fast_axis)
         {

--- a/src/onnx/parse_mxqdq.cpp
+++ b/src/onnx/parse_mxqdq.cpp
@@ -147,10 +147,11 @@ struct parse_mxquantizedequantize : op_parser<parse_mxquantizedequantize>
             padding.at(fast_axis * 2 + 1) = 1;
             q_ins = info.add_instruction(make_op("pad", {{"pads", padding}}), q_ins);
         }
-        auto pack_ins   = info.add_instruction(make_op("pack_fp4"),
-                                             q_ins); // output is fp4x2_type
-        auto unpack_ins = info.add_instruction(make_op("unpack_fp4"),
-                                               pack_ins); // output is fp8e4m3fn_type
+        // output is fp4x2_type
+        auto pack_ins   = info.add_instruction(make_op("pack_fp4", {{"axis", fast_axis}}), q_ins);
+        // output is fp8e4m3fn_type
+        auto unpack_ins = info.add_instruction(make_op("unpack_fp4", {{"axis", fast_axis}}), pack_ins);
+
         if(odd_fast_axis)
         {
             // slice off padded values

--- a/src/onnx/parse_mxqdq.cpp
+++ b/src/onnx/parse_mxqdq.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/onnx/parse_quantizelinear.cpp
+++ b/src/onnx/parse_quantizelinear.cpp
@@ -115,9 +115,9 @@ struct parse_quantizelinear : op_parser<parse_quantizelinear>
                 q_ins = info.add_instruction(make_op("pad", {{"pads", padding}}), q_ins);
             }
             // output is fp4x2_type
-            auto pack_ins = info.add_instruction(make_op("pack_fp4"), q_ins);
+            auto pack_ins = info.add_instruction(make_op("pack_fp4", {{"axis", fast_axis}}), q_ins);
             // output is fp8e4m3fn_type
-            auto unpack_ins = info.add_instruction(make_op("unpack_fp4"), pack_ins);
+            auto unpack_ins = info.add_instruction(make_op("unpack_fp4", {{"axis", fast_axis}}), pack_ins);
             if(odd_fast_axis)
             {
                 // slice off padded values

--- a/src/onnx/parse_quantizelinear.cpp
+++ b/src/onnx/parse_quantizelinear.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/onnx/parse_quantizelinear.cpp
+++ b/src/onnx/parse_quantizelinear.cpp
@@ -117,7 +117,8 @@ struct parse_quantizelinear : op_parser<parse_quantizelinear>
             // output is fp4x2_type
             auto pack_ins = info.add_instruction(make_op("pack_fp4", {{"axis", fast_axis}}), q_ins);
             // output is fp8e4m3fn_type
-            auto unpack_ins = info.add_instruction(make_op("unpack_fp4", {{"axis", fast_axis}}), pack_ins);
+            auto unpack_ins =
+                info.add_instruction(make_op("unpack_fp4", {{"axis", fast_axis}}), pack_ins);
             if(odd_fast_axis)
             {
                 // slice off padded values

--- a/src/targets/gpu/jit/pack_fp4.cpp
+++ b/src/targets/gpu/jit/pack_fp4.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/jit/pack_fp4.cpp
+++ b/src/targets/gpu/jit/pack_fp4.cpp
@@ -69,15 +69,13 @@ struct pack_fp4_compiler : compiler<pack_fp4_compiler>
         options.set_launch_params(v, compute_global_for(ctx, inputs.back().elements()));
 
         const auto& in_shape = inputs.front();
-        int fast_axis = std::min_element(in_shape.strides().cbegin(), in_shape.strides().cend()) -
-                        in_shape.strides().cbegin();
 
         auto src =
             interpolate_string(pack_fp4_kernel,
                                {{"kernel", options.kernel_name},
                                 {"params", enum_params(options.inputs.size(), "void * private_p")},
                                 {"args", enum_params(options.inputs.size(), "private_p")},
-                                {"axis", std::to_string(fast_axis)}});
+                                {"axis", std::to_string(v.at("axis").to<int>())}});
         return compile_hip_code_object(ctx, src, options);
     }
 

--- a/src/targets/gpu/jit/pack_fp4.cpp
+++ b/src/targets/gpu/jit/pack_fp4.cpp
@@ -68,8 +68,6 @@ struct pack_fp4_compiler : compiler<pack_fp4_compiler>
         options.kernel_name    = "pack_fp4_kernel";
         options.set_launch_params(v, compute_global_for(ctx, inputs.back().elements()));
 
-        const auto& in_shape = inputs.front();
-
         auto src =
             interpolate_string(pack_fp4_kernel,
                                {{"kernel", options.kernel_name},

--- a/src/targets/gpu/jit/unpack_fp4.cpp
+++ b/src/targets/gpu/jit/unpack_fp4.cpp
@@ -68,8 +68,6 @@ struct unpack_fp4_compiler : compiler<unpack_fp4_compiler>
         options.kernel_name    = "unpack_fp4_kernel";
         options.set_launch_params(v, compute_global_for(ctx, inputs.front().elements()));
 
-        const auto& in_shape = inputs.front();
-
         auto src =
             interpolate_string(unpack_fp4_kernel,
                                {{"kernel", options.kernel_name},

--- a/src/targets/gpu/jit/unpack_fp4.cpp
+++ b/src/targets/gpu/jit/unpack_fp4.cpp
@@ -69,15 +69,13 @@ struct unpack_fp4_compiler : compiler<unpack_fp4_compiler>
         options.set_launch_params(v, compute_global_for(ctx, inputs.front().elements()));
 
         const auto& in_shape = inputs.front();
-        int fast_axis = std::min_element(in_shape.strides().cbegin(), in_shape.strides().cend()) -
-                        in_shape.strides().cbegin();
 
         auto src =
             interpolate_string(unpack_fp4_kernel,
                                {{"kernel", options.kernel_name},
                                 {"params", enum_params(options.inputs.size(), "void * private_p")},
                                 {"args", enum_params(options.inputs.size(), "private_p")},
-                                {"axis", std::to_string(fast_axis)}});
+                                {"axis", std::to_string(v.at("axis").to<int>())}});
         return compile_hip_code_object(ctx, src, options);
     }
 

--- a/src/targets/gpu/jit/unpack_fp4.cpp
+++ b/src/targets/gpu/jit/unpack_fp4.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/gpu/fuse_mlir.cpp
+++ b/test/gpu/fuse_mlir.cpp
@@ -1786,12 +1786,12 @@ TEST_CASE(unpack_fp4_nonstandard)
         shape shape_a = shape::from_permutation(shape::fp4x2_type, {1, 3, 8, 8}, {1, 0, 3, 2});
         auto param_a = m->add_parameter("a", shape_a);
         auto param_b = m->add_parameter("b", {shape::fp4x2_type, {1, 3, 8, 8}});
-        auto packed_a = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 0}}), param_a);
-        auto packed_b = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 0}}), param_b);
+        auto packed_a = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 3}}), param_a);
+        auto packed_b = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 3}}), param_b);
         auto scale_a  = m->add_parameter("scale_a", {shape::float_type, {1, 3, 8, 8}});
         auto scale_b  = m->add_parameter("scale_b", {shape::float_type, {1, 3, 8, 8}});
-        auto unpack_a = m->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 0}}), packed_a);
-        auto unpack_b = m->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 0}}), packed_b);
+        auto unpack_a = m->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), packed_a);
+        auto unpack_b = m->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), packed_b);
         auto dot      = m->add_instruction(
             migraphx::make_op("quant_dot"), unpack_a, unpack_b, scale_a, scale_b);
         m->add_return({dot});
@@ -1804,8 +1804,8 @@ TEST_CASE(unpack_fp4_nonstandard)
         shape shape_a = shape::from_permutation(shape::fp4x2_type, {1, 3, 8, 8}, {1, 0, 3, 2});
         auto param_a = m->add_parameter("a", shape_a);
         auto param_b = m->add_parameter("b", {shape::fp4x2_type, {1, 3, 8, 8}});
-        auto packed_a = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 0}}), param_a);
-        auto packed_b = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 0}}), param_b);
+        auto packed_a = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 3}}), param_a);
+        auto packed_b = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 3}}), param_b);
         auto scale_a  = m->add_parameter("scale_a", {migraphx::shape::float_type, {1, 3, 8, 8}});
         auto scale_b  = m->add_parameter("scale_b", {migraphx::shape::float_type, {1, 3, 8, 8}});
         auto fused    = add_mlir(
@@ -1814,8 +1814,8 @@ TEST_CASE(unpack_fp4_nonstandard)
             {packed_a, packed_b, scale_a, scale_b},
             {"x1", "x2", "x3", "x4"},
             [=](auto* pm, const auto& inputs) {
-                auto unpack_a = pm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 0}}), inputs[0]);
-                auto unpack_b = pm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 0}}), inputs[1]);
+                auto unpack_a = pm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), inputs[0]);
+                auto unpack_b = pm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), inputs[1]);
                 auto dot      = pm->add_instruction(
                     migraphx::make_op("quant_dot"), unpack_a, unpack_b, inputs[2], inputs[3]);
                 return std::make_tuple(dot->get_operator(), dot);

--- a/test/gpu/fuse_mlir.cpp
+++ b/test/gpu/fuse_mlir.cpp
@@ -1777,6 +1777,54 @@ TEST_CASE(unpack_fp4_dot_odd)
     EXPECT(p1.sort() == p2.sort());
 }
 
+TEST_CASE(unpack_fp4_nonstandard)
+{
+    using migraphx::shape;
+    migraphx::program p1;
+    {
+        auto* m       = p1.get_main_module();
+        shape shape_a = shape::from_permutation(shape::fp4x2_type, {1, 3, 8, 8}, {1, 0, 3, 2});
+        auto param_a = m->add_parameter("a", shape_a);
+        auto param_b = m->add_parameter("b", {shape::fp4x2_type, {1, 3, 8, 8}});
+        auto packed_a = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 0}}), param_a);
+        auto packed_b = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 0}}), param_b);
+        auto scale_a  = m->add_parameter("scale_a", {shape::float_type, {1, 3, 8, 8}});
+        auto scale_b  = m->add_parameter("scale_b", {shape::float_type, {1, 3, 8, 8}});
+        auto unpack_a = m->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 0}}), packed_a);
+        auto unpack_b = m->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 0}}), packed_b);
+        auto dot      = m->add_instruction(
+            migraphx::make_op("quant_dot"), unpack_a, unpack_b, scale_a, scale_b);
+        m->add_return({dot});
+    }
+    run_pass(p1);
+
+    migraphx::program p2;
+    {
+        auto* m       = p2.get_main_module();
+        shape shape_a = shape::from_permutation(shape::fp4x2_type, {1, 3, 8, 8}, {1, 0, 3, 2});
+        auto param_a = m->add_parameter("a", shape_a);
+        auto param_b = m->add_parameter("b", {shape::fp4x2_type, {1, 3, 8, 8}});
+        auto packed_a = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 0}}), param_a);
+        auto packed_b = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 0}}), param_b);
+        auto scale_a  = m->add_parameter("scale_a", {migraphx::shape::float_type, {1, 3, 8, 8}});
+        auto scale_b  = m->add_parameter("scale_b", {migraphx::shape::float_type, {1, 3, 8, 8}});
+        auto fused    = add_mlir(
+            p2,
+            "fp4:mlir_quant_dot0",
+            {packed_a, packed_b, scale_a, scale_b},
+            {"x1", "x2", "x3", "x4"},
+            [=](auto* pm, const auto& inputs) {
+                auto unpack_a = pm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 0}}), inputs[0]);
+                auto unpack_b = pm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 0}}), inputs[1]);
+                auto dot      = pm->add_instruction(
+                    migraphx::make_op("quant_dot"), unpack_a, unpack_b, inputs[2], inputs[3]);
+                return std::make_tuple(dot->get_operator(), dot);
+            });
+        m->add_return({fused});
+    }
+    EXPECT(p1.sort() == p2.sort());
+}
+
 TEST_CASE(dot_add_dot)
 {
     migraphx::shape s1{migraphx::shape::half_type, {2, 3}};
@@ -2726,6 +2774,7 @@ TEST_CASE_SKIP(dot_add_dot_both_multi_user, "Not supported in rocMLIR")
         return;
     EXPECT(p1.sort() == p2.sort());
 }
+
 
 int main(int argc, const char* argv[])
 {

--- a/test/gpu/fuse_mlir.cpp
+++ b/test/gpu/fuse_mlir.cpp
@@ -1784,15 +1784,17 @@ TEST_CASE(unpack_fp4_nonstandard)
     {
         auto* m       = p1.get_main_module();
         shape shape_a = shape::from_permutation(shape::fp4x2_type, {1, 3, 8, 8}, {1, 0, 3, 2});
-        auto param_a = m->add_parameter("a", shape_a);
-        auto param_b = m->add_parameter("b", {shape::fp4x2_type, {1, 3, 8, 8}});
+        auto param_a  = m->add_parameter("a", shape_a);
+        auto param_b  = m->add_parameter("b", {shape::fp4x2_type, {1, 3, 8, 8}});
         auto packed_a = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 3}}), param_a);
         auto packed_b = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 3}}), param_b);
         auto scale_a  = m->add_parameter("scale_a", {shape::float_type, {1, 3, 8, 8}});
         auto scale_b  = m->add_parameter("scale_b", {shape::float_type, {1, 3, 8, 8}});
-        auto unpack_a = m->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), packed_a);
-        auto unpack_b = m->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), packed_b);
-        auto dot      = m->add_instruction(
+        auto unpack_a =
+            m->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), packed_a);
+        auto unpack_b =
+            m->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), packed_b);
+        auto dot = m->add_instruction(
             migraphx::make_op("quant_dot"), unpack_a, unpack_b, scale_a, scale_b);
         m->add_return({dot});
     }
@@ -1802,8 +1804,8 @@ TEST_CASE(unpack_fp4_nonstandard)
     {
         auto* m       = p2.get_main_module();
         shape shape_a = shape::from_permutation(shape::fp4x2_type, {1, 3, 8, 8}, {1, 0, 3, 2});
-        auto param_a = m->add_parameter("a", shape_a);
-        auto param_b = m->add_parameter("b", {shape::fp4x2_type, {1, 3, 8, 8}});
+        auto param_a  = m->add_parameter("a", shape_a);
+        auto param_b  = m->add_parameter("b", {shape::fp4x2_type, {1, 3, 8, 8}});
         auto packed_a = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 3}}), param_a);
         auto packed_b = m->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 3}}), param_b);
         auto scale_a  = m->add_parameter("scale_a", {migraphx::shape::float_type, {1, 3, 8, 8}});
@@ -1814,9 +1816,11 @@ TEST_CASE(unpack_fp4_nonstandard)
             {packed_a, packed_b, scale_a, scale_b},
             {"x1", "x2", "x3", "x4"},
             [=](auto* pm, const auto& inputs) {
-                auto unpack_a = pm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), inputs[0]);
-                auto unpack_b = pm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), inputs[1]);
-                auto dot      = pm->add_instruction(
+                auto unpack_a =
+                    pm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), inputs[0]);
+                auto unpack_b =
+                    pm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), inputs[1]);
+                auto dot = pm->add_instruction(
                     migraphx::make_op("quant_dot"), unpack_a, unpack_b, inputs[2], inputs[3]);
                 return std::make_tuple(dot->get_operator(), dot);
             });

--- a/test/gpu/fuse_mlir.cpp
+++ b/test/gpu/fuse_mlir.cpp
@@ -2775,7 +2775,6 @@ TEST_CASE_SKIP(dot_add_dot_both_multi_user, "Not supported in rocMLIR")
     EXPECT(p1.sort() == p2.sort());
 }
 
-
 int main(int argc, const char* argv[])
 {
     if(migraphx::gpu::mlir_enabled())

--- a/test/onnx/parse/mxqdq_test.cpp
+++ b/test/onnx/parse/mxqdq_test.cpp
@@ -56,8 +56,8 @@ TEST_CASE(mxqdq_even_test)
         input,
         block_scales_ins);
     auto quantized_shape = q_ins->get_shape();
-    auto pack_ins        = mm->add_instruction(migraphx::make_op("pack_fp4"), q_ins);
-    auto unpack_ins      = mm->add_instruction(migraphx::make_op("unpack_fp4"), pack_ins);
+    auto pack_ins        = mm->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 3}}), q_ins);
+    auto unpack_ins      = mm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), pack_ins);
     mm->add_instruction(migraphx::make_op("dequantizelinear"), unpack_ins, block_scales_ins);
 
     auto prog = optimize_onnx("mxqdq_even_test.onnx");
@@ -103,8 +103,8 @@ TEST_CASE(mxqdq_odd_test)
     auto quantized_shape = q_ins->get_shape();
     auto pad_ins =
         mm->add_instruction(migraphx::make_op("pad", {{"pads", {0, 0, 0, 0, 0, 1}}}), q_ins);
-    auto pack_ins   = mm->add_instruction(migraphx::make_op("pack_fp4"), pad_ins);
-    auto unpack_ins = mm->add_instruction(migraphx::make_op("unpack_fp4"), pack_ins);
+    auto pack_ins   = mm->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 2}}), pad_ins);
+    auto unpack_ins = mm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 2}}), pack_ins);
     auto slice_ins  = mm->add_instruction(
         migraphx::make_op("slice", {{"axes", {2}}, {"starts", {0}}, {"ends", {5}}}), unpack_ins);
     mm->add_instruction(migraphx::make_op("dequantizelinear"), slice_ins, block_scales_ins);

--- a/test/onnx/parse/mxqdq_test.cpp
+++ b/test/onnx/parse/mxqdq_test.cpp
@@ -57,7 +57,7 @@ TEST_CASE(mxqdq_even_test)
         block_scales_ins);
     auto quantized_shape = q_ins->get_shape();
     auto pack_ins        = mm->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 3}}), q_ins);
-    auto unpack_ins      = mm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), pack_ins);
+    auto unpack_ins = mm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), pack_ins);
     mm->add_instruction(migraphx::make_op("dequantizelinear"), unpack_ins, block_scales_ins);
 
     auto prog = optimize_onnx("mxqdq_even_test.onnx");

--- a/test/onnx/parse/mxqdq_test.cpp
+++ b/test/onnx/parse/mxqdq_test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/onnx/parse/quantizelinear_mx_type_test.cpp
+++ b/test/onnx/parse/quantizelinear_mx_type_test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/onnx/parse/quantizelinear_mx_type_test.cpp
+++ b/test/onnx/parse/quantizelinear_mx_type_test.cpp
@@ -41,8 +41,8 @@ TEST_CASE(quantizelinear_mxfp4_even_test)
         migraphx::make_op("quantizelinear", {{"out_type", migraphx::shape::float_type}}),
         l0,
         l1_reshape);
-    auto pack_ins   = mm->add_instruction(migraphx::make_op("pack_fp4"), q_ins);
-    auto unpack_ins = mm->add_instruction(migraphx::make_op("unpack_fp4"), pack_ins);
+    auto pack_ins   = mm->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 3}}), q_ins);
+    auto unpack_ins = mm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), pack_ins);
     mm->add_return({unpack_ins});
 
     auto prog = read_onnx("quantizelinear_mxfp4_even_test.onnx");
@@ -67,8 +67,8 @@ TEST_CASE(quantizelinear_mxfp4_odd_test)
         l1_reshape);
     auto pad_ins =
         mm->add_instruction(migraphx::make_op("pad", {{"pads", {0, 0, 0, 0, 0, 0, 0, 1}}}), q_ins);
-    auto pack_ins   = mm->add_instruction(migraphx::make_op("pack_fp4"), pad_ins);
-    auto unpack_ins = mm->add_instruction(migraphx::make_op("unpack_fp4"), pack_ins);
+    auto pack_ins   = mm->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 3}}), pad_ins);
+    auto unpack_ins = mm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 3}}), pack_ins);
     auto slice_ins  = mm->add_instruction(
         migraphx::make_op("slice", {{"axes", {3}}, {"starts", {0}}, {"ends", {7}}}), unpack_ins);
     mm->add_return({slice_ins});

--- a/test/ref/pack_unpack_fp4.cpp
+++ b/test/ref/pack_unpack_fp4.cpp
@@ -37,7 +37,7 @@ TEST_CASE(pack_fp4)
     auto* mm = p.get_main_module();
     migraphx::shape s{migraphx::shape::float_type, {2, 2}};
     auto l0 = mm->add_literal(migraphx::literal{s, {-2.f, 3.4f, 3.5f, 0.f}});
-    mm->add_instruction(migraphx::make_op("pack_fp4"), l0);
+    mm->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 1}}), l0);
     p.compile(migraphx::make_target("ref"));
     auto result = p.eval({}).back();
     result =
@@ -57,7 +57,7 @@ TEST_CASE(unpack_fp4)
     std::vector<uint8_t> packed_data = {0x5C, 0x06};
     auto lit                         = migraphx::literal{s, packed_data.data()};
     auto l0                          = mm->add_literal(lit);
-    mm->add_instruction(migraphx::make_op("unpack_fp4"), l0);
+    mm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 1}}), l0);
     p.compile(migraphx::make_target("ref"));
     auto result = p.eval({}).back();
     std::vector<float> results_vector(4);
@@ -75,8 +75,8 @@ TEST_CASE(pack_unpack_fp4)
     auto* mm = p.get_main_module();
     migraphx::shape s{migraphx::shape::float_type, {2, 2}};
     auto l0       = mm->add_literal(migraphx::literal{s, {-2.f, 3.4f, 3.5f, 0.f}});
-    auto pack_ins = mm->add_instruction(migraphx::make_op("pack_fp4"), l0);
-    mm->add_instruction(migraphx::make_op("unpack_fp4"), pack_ins);
+    auto pack_ins = mm->add_instruction(migraphx::make_op("pack_fp4", {{"axis", 1}}), l0);
+    mm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", 1}}), pack_ins);
     p.compile(migraphx::make_target("ref"));
     auto result = p.eval({}).back();
     std::vector<float> results_vector(4);

--- a/test/ref/pack_unpack_fp4.cpp
+++ b/test/ref/pack_unpack_fp4.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/verify/test_pack_fp4.cpp
+++ b/test/verify/test_pack_fp4.cpp
@@ -42,4 +42,5 @@ struct test_pack_fp4 : verify_program<test_pack_fp4<T, Axis>>
 };
 
 template struct test_pack_fp4<migraphx::shape::float_type>;
+template struct test_pack_fp4<migraphx::shape::float_type, 0>;
 template struct test_pack_fp4<migraphx::shape::float_type, 1>;

--- a/test/verify/test_pack_fp4.cpp
+++ b/test/verify/test_pack_fp4.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,8 +27,8 @@
 #include <migraphx/generate.hpp>
 #include <migraphx/make_op.hpp>
 
-template <migraphx::shape::type_t T>
-struct test_pack_fp4 : verify_program<test_pack_fp4<T>>
+template <migraphx::shape::type_t T, int Axis = -1>
+struct test_pack_fp4 : verify_program<test_pack_fp4<T, Axis>>
 {
     migraphx::program create_program() const
     {
@@ -36,9 +36,10 @@ struct test_pack_fp4 : verify_program<test_pack_fp4<T>>
         auto* mm = p.get_main_module();
 
         auto x = mm->add_parameter("x", migraphx::shape{T, {64, 32}});
-        mm->add_instruction(migraphx::make_op("pack_fp4"), x);
+        mm->add_instruction(migraphx::make_op("pack_fp4", {{"axis", Axis}}), x);
         return p;
     }
 };
 
 template struct test_pack_fp4<migraphx::shape::float_type>;
+template struct test_pack_fp4<migraphx::shape::float_type, 1>;

--- a/test/verify/test_unpack_fp4.cpp
+++ b/test/verify/test_unpack_fp4.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +27,8 @@
 #include <migraphx/generate.hpp>
 #include <migraphx/make_op.hpp>
 
-struct test_unpack_fp4 : verify_program<test_unpack_fp4>
+template <int Axis = -1>
+struct test_unpack_fp4 : verify_program<test_unpack_fp4<Axis>>
 {
     migraphx::program create_program() const
     {
@@ -35,8 +36,11 @@ struct test_unpack_fp4 : verify_program<test_unpack_fp4>
         auto* mm = p.get_main_module();
 
         auto x = mm->add_parameter("x", migraphx::shape{migraphx::shape::fp4x2_type, {32, 16}});
-        mm->add_instruction(migraphx::make_op("unpack_fp4"), x);
+        mm->add_instruction(migraphx::make_op("unpack_fp4", {{"axis", Axis}}), x);
 
         return p;
     }
 };
+
+template struct test_unpack_fp4<>;
+template struct test_unpack_fp4<1>;

--- a/test/verify/test_unpack_fp4.cpp
+++ b/test/verify/test_unpack_fp4.cpp
@@ -43,4 +43,5 @@ struct test_unpack_fp4 : verify_program<test_unpack_fp4<Axis>>
 };
 
 template struct test_unpack_fp4<>;
+template struct test_unpack_fp4<0>;
 template struct test_unpack_fp4<1>;


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Encountered a MIGX bug of shape mismatching after the fuse_mlir pass after an unpack_fp4 with non-standard input shape. 

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
When we insert module parameters the shapes are changed to standard. We made `unpack_fp4` always unpack on the fast dimension, so if the original input was non-standard the unpack will happen on the wrong axis after the as_standard() call.

Fix here is to reintroduce the axis attribute so that the shape between pack_fp4 and unpack_fp4 stays consistent.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
