### PR TITLE
Fix compilation with MIOpen off after PR #4539

### DIFF
--- a/src/targets/gpu/eliminate_data_type_for_gpu.cpp
+++ b/src/targets/gpu/eliminate_data_type_for_gpu.cpp
@@ -29,7 +29,7 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
-static void insert_miopen_pooling(std::set<std::string>& u)
+static void insert_miopen_pooling([[maybe_unused]] std::set<std::string>& u)
 {
 #if MIGRAPHX_USE_MIOPEN
     u.insert("pooling");


### PR DESCRIPTION
## Motivation
After merging PR 4539, MIGraphX stopped compiling with the error "unused function parameter" when MIGRAPHX_USE_MIOPEN is OFF.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
