### PR TITLE
Fix `Clip` parsing type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,9 +54,6 @@ _toc.yml
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).
 #==============================================================================#
-# Nested build directory
-/build*
-
 # Downloaded models
 test/onnx/models
 
@@ -79,7 +76,6 @@ docs/html
 # JetBrains config directories (ignoring symlinks)
 .idea/
 cmake-build*/
-build*/
 
 # Recommended location to install rbuild dependencies from README.md
 depend*/

--- a/src/include/migraphx/common.hpp
+++ b/src/include/migraphx/common.hpp
@@ -123,6 +123,16 @@ MIGRAPHX_EXPORT std::vector<instruction_ref> insert_common_args(module& m,
                                                                 std::vector<instruction_ref> inputs,
                                                                 common_options options = {});
 
+
+/**
+ * Broadcast and convert arguments in the `inputs` list to the given `to_shape`.
+ */
+MIGRAPHX_EXPORT std::vector<instruction_ref> broadcast_convert_to_shape(module&m,
+                                                        instruction_ref ins,
+                                                        std::vector<instruction_ref> inputs,
+                                                        shape to_shape,
+                                                        common_options options = {});
+
 MIGRAPHX_EXPORT
 std::vector<instruction_ref>
 add_common_args(module& m, std::vector<instruction_ref> inputs, common_options options = {});

--- a/src/op/builder/clip.cpp
+++ b/src/op/builder/clip.cpp
@@ -41,12 +41,22 @@ struct clip : op_builder<clip>
         bool max_used = args.size() == 3 and not args[2]->is_undefined();
         bool min_used = args.size() >= 2 and not args[1]->is_undefined();
 
+        shape input_shape = args.at(0)->get_shape();
         if(min_used and max_used)
-            return {insert_common_op(m, ins, make_op("clip"), args)};
+        {
+            auto bc_args = broadcast_convert_to_shape(m, ins, args, input_shape);
+            return {m.insert_instruction(ins, make_op("clip"), bc_args)};
+        }
         if(max_used)
-            return {insert_common_op(m, ins, "min", args[0], args[2])};
+        {
+            auto bc_args = broadcast_convert_to_shape(m, ins, {args[0], args[2]}, input_shape);
+            return {m.insert_instruction(ins, make_op("min"), bc_args)};
+        }
         if(min_used)
-            return {insert_common_op(m, ins, "max", args[0], args[1])};
+        {
+            auto bc_args = broadcast_convert_to_shape(m, ins, {args[0], args[1]}, input_shape);
+            return {m.insert_instruction(ins, make_op("max"), bc_args)};
+        }
         return {m.insert_instruction(ins, make_op("identity"), args[0])};
     }
 };


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Hitting a parsing error for FP16 parsing of a DeeplabV3 model. From a bug in how ONNX `Clip` is parsed.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
* The model uses the V6 version of `Clip` https://onnx.ai/onnx/operators/onnx__Clip.html#clip-6
* Our parser parses the `min` and `max` attribute values as floats. The `insert_common_op` will then promote the output type to `float` from `half`. That results in a type issue.
* Fixing by changing the parse to broadcast and convert to the input shape always.
  * Don't have to worry about the broadcast shape between the inputs because `max` and `min` must always be scalars.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
