### PR TITLE
Move move_output_instructions_after to the module class

### DIFF
--- a/src/fuse_pointwise.cpp
+++ b/src/fuse_pointwise.cpp
@@ -257,7 +257,7 @@ find_output_pointwise(const module& m, instruction_ref ins, bool multi_out)
                          return false;
                      if(is_dead(output))
                          return false;
-                    return true;
+                     return true;
                  });
     if(outputs.size() < 2)
         return result;

--- a/src/fuse_pointwise.cpp
+++ b/src/fuse_pointwise.cpp
@@ -257,11 +257,7 @@ find_output_pointwise(const module& m, instruction_ref ins, bool multi_out)
                          return false;
                      if(is_dead(output))
                          return false;
-                     // TODO: move_output_instructions_after doesnt handle outputs from different
-                     // modules so only fuse from the same module
-                     return std::all_of(output->outputs().begin(),
-                                        output->outputs().end(),
-                                        [&](auto out) { return m.has_instruction(out); });
+                    return true;
                  });
     if(outputs.size() < 2)
         return result;

--- a/src/include/migraphx/module.hpp
+++ b/src/include/migraphx/module.hpp
@@ -128,6 +128,8 @@ struct MIGRAPHX_EXPORT module
     instruction_ref move_instruction(instruction_ref src, instruction_ref dst);
     instruction_ref move_instructions(instruction_ref src, instruction_ref dst);
 
+    void move_output_instructions_after(instruction_ref src, instruction_ref dst);
+
     std::vector<instruction_ref>
     add_instructions(const std::vector<instruction_ref>& instructions,
                      std::unordered_map<instruction_ref, instruction_ref>* map_ins = nullptr,

--- a/src/include/migraphx/module.hpp
+++ b/src/include/migraphx/module.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -441,14 +441,15 @@ void module::move_output_instructions_after(instruction_ref src, instruction_ref
     // When an output is in a submodule (cross-module reference), resolve it to
     // the instruction in this module that owns the submodule containing the output.
     // The map is lazily built on the first cross-module output encountered.
-    std::optional<std::unordered_map<const module*, instruction_ref>> mod_owner_map;
+    std::optional<std::unordered_map<const_module_ref, instruction_ref>> mod_owner_map;
     auto resolve_output = [&](instruction_ref output) -> instruction_ref {
         if(this->has_instruction(output))
             return output;
         if(not mod_owner_map)
         {
             mod_owner_map.emplace();
-            for(auto ins = std::next(src); ins != dst; ++ins)
+            auto r = range(std::next(src), dst);
+            for(auto ins:iterator_for(r))
             {
                 for(auto* mod : ins->module_inputs())
                 {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -458,10 +458,9 @@ void module::move_output_instructions_after(instruction_ref src, instruction_ref
                 }
             }
         }
-        auto it = std::find_if(
-            mod_owner_map->begin(), mod_owner_map->end(), [&](const auto& p) {
-                return p.first->has_instruction(output);
-            });
+        auto it = std::find_if(mod_owner_map->begin(), mod_owner_map->end(), [&](const auto& p) {
+            return p.first->has_instruction(output);
+        });
         if(it != mod_owner_map->end())
             return it->second;
         return this->end();

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -449,7 +449,7 @@ void module::move_output_instructions_after(instruction_ref src, instruction_ref
         {
             mod_owner_map.emplace();
             auto r = range(std::next(src), dst);
-            for(auto ins:iterator_for(r))
+            for(auto ins : iterator_for(r))
             {
                 for(auto* mod : ins->module_inputs())
                 {

--- a/test/fuse_pointwise.cpp
+++ b/test/fuse_pointwise.cpp
@@ -1228,24 +1228,35 @@ TEST_CASE(if_cross_module_multi_out_find_output)
         auto x    = mm->add_parameter("x", s1);
         auto y    = mm->add_parameter("y", s1);
         auto cond = mm->add_parameter("cond", migraphx::shape{migraphx::shape::bool_type, {1}});
-        auto add1 = add_pointwise(p2, "main:pointwise0", {x, y}, single_pointwise("add"));
+        auto fused = add_pointwise(
+            p2,
+            "main:pointwise0",
+            {x, y},
+            [=](auto* pm, const auto& inputs) -> std::vector<migraphx::instruction_ref> {
+                auto sqrt_r = pm->add_instruction(migraphx::make_op("sqrt"), inputs[0]);
+                auto add_r =
+                    pm->add_instruction(migraphx::make_op("add"), inputs[0], inputs[1]);
+                return {sqrt_r, add_r};
+            });
+        auto sqrt_out =
+            mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), fused);
+        auto add_out =
+            mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), fused);
 
         auto* then_mod = p2.create_module("If_then_1");
         {
             auto relu = add_pointwise(
-                p2, then_mod, "If_then_1:pointwise0", {add1}, single_pointwise("relu"));
+                p2, then_mod, "If_then_1:pointwise0", {add_out}, single_pointwise("relu"));
             then_mod->add_return({relu});
         }
 
         auto* else_mod = p2.create_module("If_else_1");
         {
-            else_mod->add_return({add1});
+            else_mod->add_return({add_out});
         }
 
         auto if_ins = mm->add_instruction(migraphx::make_op("if"), {cond}, {then_mod, else_mod});
-
-        auto sqrt = add_pointwise(p2, "main:pointwise1", {x}, single_pointwise("sqrt"));
-        mm->add_return({sqrt, if_ins});
+        mm->add_return({sqrt_out, if_ins});
     }
     EXPECT(p1.sort() == p2.sort());
 }

--- a/test/fuse_pointwise.cpp
+++ b/test/fuse_pointwise.cpp
@@ -1234,8 +1234,7 @@ TEST_CASE(if_cross_module_multi_out_find_output)
             {x, y},
             [=](auto* pm, const auto& inputs) -> std::vector<migraphx::instruction_ref> {
                 auto sqrt_r = pm->add_instruction(migraphx::make_op("sqrt"), inputs[0]);
-                auto add_r =
-                    pm->add_instruction(migraphx::make_op("add"), inputs[0], inputs[1]);
+                auto add_r  = pm->add_instruction(migraphx::make_op("add"), inputs[0], inputs[1]);
                 return {sqrt_r, add_r};
             });
         auto sqrt_out =

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -1957,8 +1957,7 @@ TEST_CASE(move_output_instructions_after_cross_module_mixed)
         else_mod1->add_return({sub2});
 
         // if1 is between src and dst — should be moved
-        auto if1 =
-            mm->add_instruction(migraphx::make_op("if"), {cond1}, {then_mod1, else_mod1});
+        auto if1 = mm->add_instruction(migraphx::make_op("if"), {cond1}, {then_mod1, else_mod1});
         auto dst = mm->add_instruction(migraphx::make_op("sqrt"), x);
 
         auto* then_mod2 = p1.create_module("then_mod2");
@@ -1970,8 +1969,7 @@ TEST_CASE(move_output_instructions_after_cross_module_mixed)
         else_mod2->add_return({sub4});
 
         // if2 is after dst — should NOT be moved
-        auto if2 =
-            mm->add_instruction(migraphx::make_op("if"), {cond2}, {then_mod2, else_mod2});
+        auto if2 = mm->add_instruction(migraphx::make_op("if"), {cond2}, {then_mod2, else_mod2});
         mm->add_return({if1, if2, dst});
         mm->move_output_instructions_after(src, dst);
     }
@@ -2002,10 +2000,8 @@ TEST_CASE(move_output_instructions_after_cross_module_mixed)
 
         // Expected: if1 moved after dst, if2 stays after dst
         auto dst = mm->add_instruction(migraphx::make_op("sqrt"), x);
-        auto if1 =
-            mm->add_instruction(migraphx::make_op("if"), {cond1}, {then_mod1, else_mod1});
-        auto if2 =
-            mm->add_instruction(migraphx::make_op("if"), {cond2}, {then_mod2, else_mod2});
+        auto if1 = mm->add_instruction(migraphx::make_op("if"), {cond1}, {then_mod1, else_mod1});
+        auto if2 = mm->add_instruction(migraphx::make_op("if"), {cond2}, {then_mod2, else_mod2});
         mm->add_return({if1, if2, dst});
     }
 


### PR DESCRIPTION
## Motivation
This functions needs to be used outside of the fuse_pointwise pass.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
