### PR TITLE
Prevent propagate precision across precision boundaries for all ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Full documentation for MIGraphX is available at
 ### Resolved issues
 
 * Fixed a bug with operators `pack_fp4`, `unpack_fp4`, and the `fuse_mlir` pass handling non-standard input shapes (#4560).
-* Fixed an issue in `propagate_precision` pass where precision for div operations could be incorrectly propagated across type boundaries (e.g., from integral to floating-point) (#4561).
+* Fixed an issue in `propagate_precision` pass where precision could be incorrectly propagated across type boundaries (e.g., from integral to floating-point) (#4603).
 * Fixed an issue with clip operator when using fp16 input type on opset 6 (#4518). 
 * Fixed an issue with `reshape_lazy`'s shape computation that was leading to invalid reshapes (#4594).
 
@@ -58,7 +58,7 @@ Full documentation for MIGraphX is available at
 
 ### Resolved issues
 
-* Fixed an issue in `propagate_precision` pass where precision for div operations could be incorrectly propagated across type category boundaries (e.g., from integral to floating-point types).
+* Fixed an issue in `propagate_precision` pass where precision could be incorrectly propagated across type category boundaries (e.g., from integral to floating-point types).
 * Quiet nrvo and noreturn warnings (#4429).
 * Fixed `pointwise: Wrong number of arguments` error when quantizing certain models to `int8` (#4398).
 * TopK exception bugfix (#4329).

--- a/src/propagate_precision.cpp
+++ b/src/propagate_precision.cpp
@@ -135,7 +135,7 @@ static std::unordered_set<instruction_ref> find_adjacent_inputs(instruction_ref 
         if(contains(result, ins))
             return;
         // Stop at div when crossing type category boundary (e.g., int to float)
-        if(not same_category(precision{ins->get_shape().type()}, target) and ins->name() == "div")
+        if(not same_category(precision{ins->get_shape().type()}, target))
             return;
         auto next = get_next_input(ins);
         if(not next.has_value())
@@ -161,8 +161,7 @@ static std::unordered_set<instruction_ref> find_adjacent_outputs(instruction_ref
             if(contains(result, output))
                 continue;
             // Stop at div when crossing type category boundary (e.g., int to float)
-            if(not same_category(precision{output->get_shape().type()}, target) and
-               output->name() == "div")
+            if(not same_category(precision{output->get_shape().type()}, target))
                 continue;
             auto next = get_next_input(output);
             if(not next.has_value())

--- a/test/propagate_precision.cpp
+++ b/test/propagate_precision.cpp
@@ -250,11 +250,10 @@ TEST_CASE(propagate_no_crossover_through_bool_int_chain)
         auto sig      = m1.add_instruction(migraphx::make_op("sigmoid"), x);
         auto cvt_bool = m1.add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::bool_type}}), sig);
-        auto n        = m1.add_instruction(migraphx::make_op("not"), cvt_bool);
-        auto cvt_int  = m1.add_instruction(
+        auto n       = m1.add_instruction(migraphx::make_op("not"), cvt_bool);
+        auto cvt_int = m1.add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::int64_type}}), n);
-        auto rsum =
-            m1.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {1}}}), cvt_int);
+        auto rsum = m1.add_instruction(migraphx::make_op("reduce_sum", {{"axes", {1}}}), cvt_int);
         m1.add_return({rsum});
     }
     run_pass(m1);


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Found an additional test case where a non-div operation was causing accuracy issues if converted from float to int.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
For now, the simplest way to avoid such conversion is to prevent all ops, not only divs from being converted across type boundaries. Added a unit test and verified from an end-to-end model that this change is necessary.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [X] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
