### PR TITLE
Use rocBLAS GEMV for skinny GEMM (M=1 or N=1) to improve performance

### DIFF
--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -331,14 +331,21 @@ auto is_mlir_dot(mlir_mode mode)
         {
             return true;
         }
-        if(mode != mlir_mode::fast)
-            return true;
         auto a = ins->inputs().front()->get_shape();
         auto b = ins->inputs().back()->get_shape();
         auto g = std::accumulate(a.lens().begin(), a.lens().end() - 2, 1, std::multiplies<>{});
         auto m = a.lens()[a.lens().size() - 2];
         auto n = b.lens().back();
         auto k = a.lens().back();
+
+        bool is_fp32 = (ins->get_shape().type() == shape::float_type);
+        if(g == 1 and (m == 1 or n == 1) and is_fp32)
+        {
+            return false;
+        }
+
+        if(mode != mlir_mode::fast)
+            return true;
         // Skipping GEMMs with a K dimension greater than 2048 is a course-grained strategy
         // to avoid poor-performing GEMM kernels from MLIR
         // TODO: Investigate a more precise strategy


### PR DESCRIPTION
## Motivation
Current rocMLIR GEMM kernels exhibit suboptimal performance for "skinny" matrices (where M=1 or N=1) . rocBLAS sgemv is better for these specific vector-matrix cases than current rocMLIR.

## Technical Details
This change introduces a dispatch logic to bypass rocMLIR and use rocblas_sgemv when:
- a. The problem size is M=1 or N=1.
- b. The data type is FP32.
- c. No batching or complex fusion is involved.

However, this change has a bug at the moment. We want to discuss the idea in the PR.
If we decide to use rocBLAS gemv, we will need to investigate the current bug. Otherwise, we will have the rocMLIR team optimize this case as an alternative.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
