### PR TITLE
[AIMIGRAPHX-544] Parallel compilation for dynamic graphs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,6 +130,7 @@ add_library(migraphx
     rewrite_quantization.cpp
     rewrite_rnn.cpp
     rewrite_topk.cpp
+    runtime_compile.cpp
     schedule.cpp
     serialize.cpp
     shape.cpp

--- a/src/include/migraphx/runtime_compile.hpp
+++ b/src/include/migraphx/runtime_compile.hpp
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MIGRAPHX_GUARD_MIGRAPHX_RUNTIME_COMPILE_HPP
+#define MIGRAPHX_GUARD_MIGRAPHX_RUNTIME_COMPILE_HPP
+
+#include <migraphx/config.hpp>
+#include <migraphx/module_ref.hpp>
+#include <migraphx/shape.hpp>
+#include <unordered_map>
+#include <string>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+
+struct context;
+
+MIGRAPHX_EXPORT void compile_dyn_ins(context& ctx,
+                                      module_ref& mod,
+                                      const std::unordered_map<std::string, shape>& param_shapes);
+
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+
+#endif // MIGRAPHX_GUARD_MIGRAPHX_RUNTIME_COMPILE_HPP
+

--- a/src/runtime_compile.cpp
+++ b/src/runtime_compile.cpp
@@ -40,7 +40,7 @@ struct runtime_compile_op
         return pack();
     }
 
-    std::string name() const { return "gpu::runtime_compile_op"; }
+    std::string name() const { return "runtime_compile_op"; }
 
     shape compute_shape(const std::vector<shape>&, const std::vector<module_ref>&) const
     {
@@ -104,7 +104,6 @@ void compile_dyn_ins(context& ctx,
         auto ins = runtime_dyn_inss[i];
         assert(ins->get_operator().name() == "gpu::dynamic_code_object_op");
 
-        // Call the runtime_compile method through the operation interface
         ins->get_operator().runtime_compile(
             ctx, compile_input_shapes.at(ins), ins->module_inputs());
     });

--- a/src/runtime_compile.cpp
+++ b/src/runtime_compile.cpp
@@ -1,0 +1,114 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/runtime_compile.hpp>
+#include <migraphx/shape.hpp>
+#include <migraphx/module.hpp>
+#include <migraphx/instruction.hpp>
+#include <migraphx/iterator_for.hpp>
+#include <migraphx/par_for.hpp>
+#include <migraphx/register_op.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+
+struct runtime_compile_op
+{
+    template <class Self, class F>
+    static auto reflect(Self&, F)
+    {
+        return pack();
+    }
+
+    std::string name() const { return "gpu::runtime_compile_op"; }
+
+    shape compute_shape(const std::vector<shape>&, const std::vector<module_ref>&) const
+    {
+        return {};
+    }
+};
+MIGRAPHX_REGISTER_OP(runtime_compile_op);
+
+void find_dyn_ins_shapes(
+    module_ref target_mod,
+    std::unordered_map<std::string, shape> param_shapes,
+    std::unordered_map<instruction_ref, std::vector<shape>>& compile_input_shapes)
+{
+    std::unordered_map<instruction_ref, shape> ins_shapes;
+    for(auto ins : iterator_for(*target_mod))
+    {
+        if(ins->name() == "@param")
+        {
+            auto param_name = any_cast<builtin::param>(ins->get_operator()).parameter;
+            ins_shapes[ins] = param_shapes.at(param_name);
+        }
+        else if(ins->name() == "@literal")
+        {
+            ins_shapes[ins] = ins->get_shape();
+        }
+        else
+        {
+            std::vector<shape> input_shapes;
+            input_shapes.reserve(ins->inputs().size());
+            for(auto input_ins : ins->inputs())
+            {
+                input_shapes.push_back(ins_shapes.at(input_ins));
+            }
+            if(ins->name() == "gpu::dynamic_code_object_op")
+            {
+                compile_input_shapes[ins] = input_shapes;
+            }
+            ins_shapes[ins] = ins->get_operator().compute_shape(input_shapes, ins->module_inputs());
+        }
+    }
+}
+
+void compile_dyn_ins(context& ctx,
+                     module_ref& mod,
+                     const std::unordered_map<std::string, shape>& param_shapes)
+{
+    std::unordered_map<instruction_ref, std::vector<shape>> compile_input_shapes;
+    find_dyn_ins_shapes(mod, param_shapes, compile_input_shapes);
+
+    if(compile_input_shapes.empty())
+        return;
+
+    std::vector<instruction_ref> runtime_dyn_inss;
+    runtime_dyn_inss.reserve(compile_input_shapes.size());
+    std::transform(compile_input_shapes.begin(),
+                   compile_input_shapes.end(),
+                   std::back_inserter(runtime_dyn_inss),
+                   [](const auto& kv) { return kv.first; });
+
+    par_for(runtime_dyn_inss.size(), [&](std::size_t i) {
+        auto ins = runtime_dyn_inss[i];
+        assert(ins->get_operator().name() == "gpu::dynamic_code_object_op");
+
+        // Call the runtime_compile method through the operation interface
+        ins->get_operator().runtime_compile(
+            ctx, compile_input_shapes.at(ins), ins->module_inputs());
+    });
+}
+
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx

--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -176,6 +176,7 @@ add_library(migraphx_gpu
     hipblaslt.cpp
     hip_gemm_impl.cpp
     hsa_chiplet.cpp
+    insert_runtime_compile_op.cpp
     kernel.cpp
     lowering.cpp
     logsoftmax.cpp

--- a/src/targets/gpu/include/migraphx/gpu/insert_runtime_compile_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/insert_runtime_compile_op.hpp
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MIGRAPHX_GUARD_RTGLIB_GPU_INSERT_RUNTIME_COMPILE_OP_HPP
+#define MIGRAPHX_GUARD_RTGLIB_GPU_INSERT_RUNTIME_COMPILE_OP_HPP
+
+#include <migraphx/config.hpp>
+#include <string>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+
+struct module_pass_manager;
+
+namespace gpu {
+
+struct MIGRAPHX_EXPORT insert_runtime_compile_op
+{
+    std::string name() const { return "gpu::insert_runtime_compile_op"; }
+    void apply(module_pass_manager& mpm) const;
+};
+
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+
+#endif
+

--- a/src/targets/gpu/insert_runtime_compile_op.cpp
+++ b/src/targets/gpu/insert_runtime_compile_op.cpp
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/gpu/insert_runtime_compile_op.hpp>
+#include <migraphx/module.hpp>
+#include <migraphx/instruction.hpp>
+#include <migraphx/iterator_for.hpp>
+#include <migraphx/runtime_compile.hpp>
+#include <migraphx/pass_manager.hpp>
+#include <migraphx/make_op.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
+
+void insert_runtime_compile_op::apply(module_pass_manager& mpm) const
+{
+    auto& mod = mpm.get_module();
+
+    // Check if there are any dynamic_code_object_op nodes in the module
+    if(not std::any_of(iterator_for(mod).begin(), iterator_for(mod).end(), [](auto ins) {
+           return ins->name() == "gpu::dynamic_code_object_op";
+       }))
+        return;
+
+    // Insert runtime_compile_op at the very beginning of the module
+    mod.insert_instruction(mod.begin(), make_op("runtime_compile_op"));
+}
+
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -76,6 +76,7 @@
 #include <migraphx/gpu/sync_device.hpp>
 #include <migraphx/gpu/target.hpp>
 #include <migraphx/gpu/write_literals.hpp>
+#include <migraphx/gpu/insert_runtime_compile_op.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -187,6 +188,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
         preallocate_param{"scratch", gpu_allocation_model{}},
         dead_code_elimination{},
         eliminate_allocation{"hip::allocate"},
+        insert_runtime_compile_op{},
         check_context<context>{},
         normalize_ops{},
         dead_code_elimination{},

--- a/tools/include/operation.hpp
+++ b/tools/include/operation.hpp
@@ -477,6 +477,31 @@ value compile_op(const T& x,
 }
 
 template <class T>
+auto runtime_compile_op(rank<1>,
+                        const T& x,
+                        context& ctx,
+                        const std::vector<shape>& input,
+                        const std::vector<module_ref>& module_args)
+    -> decltype(x.runtime_compile(auto_any_cast(ctx), input, module_args), void())
+{
+    x.runtime_compile(auto_any_cast(ctx), input, module_args);
+}
+
+template <class T>
+void runtime_compile_op(rank<0>, const T&, context&, const std::vector<shape>&, const std::vector<module_ref>&)
+{
+}
+
+template <class T>
+void runtime_compile_op(const T& x,
+                        context& ctx,
+                        const std::vector<shape>& input,
+                        const std::vector<module_ref>& module_args)
+{
+    runtime_compile_op(rank<1>{}, x, ctx, input, module_args);
+}
+
+template <class T>
 value attributes_op(const T&)
 {
     return value::object{};
@@ -583,6 +608,12 @@ lifetime get_lifetime_op(const T&)
                 'std::function<std::vector<argument>(module_ref&, const std::unordered_map<std::string, argument>&)>',
             const   = True,
             default = 'detail::compute_op'),
+        virtual('runtime_compile',
+                ctx         = 'context&',
+                input       = 'const std::vector<shape>&',
+                module_args = 'const std::vector<module_ref>&',
+                const       = True,
+                default     = 'detail::runtime_compile_op'),
         virtual('to_value', returns = 'value', const = True, default = 'detail::to_value_op'),
         virtual('from_value', v = 'const value&', default = 'detail::from_value_op'),
         virtual('attributes', returns = 'value', const = True, default = 'detail::attributes_op'),


### PR DESCRIPTION
## Motivation
Capture all kernels that need to be compiled during runtime and compile in parallel rather than the current lazy implementation

## Technical Details
- Add interface under operation for runtime_compile similar to compute
- Add runtime_compile_op used to trigger runtime compilation
- Add function that uses par_for to call all runtime_compile 

Refactors #4616 to avoid introducing circular submodule dependencies avoid moving parameters after scheduling.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
