### PR TITLE
Add versioninfo to migraphx binaries WINDOWS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ option(BUILD_DEV "Build for development purpose only" OFF)
 rocm_setup_version(VERSION 2.16.0)
 math(EXPR MIGRAPHX_SO_MAJOR_VERSION "(${PROJECT_VERSION_MAJOR} * 1000 * 1000) + (${PROJECT_VERSION_MINOR} * 1000) + ${PROJECT_VERSION_PATCH}")
 set(MIGRAPHX_SO_VERSION ${MIGRAPHX_SO_MAJOR_VERSION}.0)
+include(AddVersionResource)
 
 option( BUILD_SHARED_LIBS "Build as a shared library" ON )
 

--- a/cmake/AddVersionResource.cmake
+++ b/cmake/AddVersionResource.cmake
@@ -1,0 +1,119 @@
+#####################################################################################
+# The MIT License (MIT)
+#
+# Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#####################################################################################
+
+#[=======================================================================[
+Add Windows version resource to a target (DLL or EXE)
+
+Usage:
+  add_version_resource(
+    TARGET target_name
+    DESCRIPTION "Brief description of the component"
+    [FILENAME output_filename]  # Optional, defaults to target output name
+  )
+
+Example:
+  add_version_resource(
+    TARGET migraphx
+    DESCRIPTION "MIGraphX Core Library"
+  )
+
+This function generates a .rc file with version information and adds it
+to the target's sources on Windows. On non-Windows platforms, it does nothing.
+#]=======================================================================]
+
+function(add_version_resource)
+    # Only process on Windows
+    if(NOT WIN32)
+        return()
+    endif()
+
+    # Parse arguments
+    set(options "")
+    set(oneValueArgs TARGET DESCRIPTION FILENAME)
+    set(multiValueArgs "")
+    cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Validate required arguments
+    if(NOT ARG_TARGET)
+        message(FATAL_ERROR "add_version_resource: TARGET argument is required")
+    endif()
+
+    if(NOT ARG_DESCRIPTION)
+        message(FATAL_ERROR "add_version_resource: DESCRIPTION argument is required for ${ARG_TARGET}")
+    endif()
+
+    # Get target properties
+    get_target_property(TARGET_TYPE ${ARG_TARGET} TYPE)
+
+    # Set component-specific variables
+    set(COMPONENT_NAME ${ARG_TARGET})
+    set(COMPONENT_DESCRIPTION "${ARG_DESCRIPTION}")
+
+    # Determine output filename
+    if(ARG_FILENAME)
+        set(COMPONENT_FILENAME "${ARG_FILENAME}")
+    else()
+        # Get the actual output name of the target
+        get_target_property(OUTPUT_NAME ${ARG_TARGET} OUTPUT_NAME)
+        if(OUTPUT_NAME)
+            set(COMPONENT_FILENAME "${OUTPUT_NAME}")
+        else()
+            set(COMPONENT_FILENAME "${ARG_TARGET}")
+        endif()
+
+        # Add appropriate extension
+        if(TARGET_TYPE STREQUAL "SHARED_LIBRARY")
+            set(COMPONENT_FILENAME "${COMPONENT_FILENAME}.dll")
+        elseif(TARGET_TYPE STREQUAL "EXECUTABLE")
+            set(COMPONENT_FILENAME "${COMPONENT_FILENAME}.exe")
+        endif()
+    endif()
+
+    # Set DLL_BUILD flag for resource compiler
+    if(TARGET_TYPE STREQUAL "SHARED_LIBRARY")
+        set(DLL_BUILD_FLAG "-DDLL_BUILD")
+    else()
+        set(DLL_BUILD_FLAG "")
+    endif()
+
+    # Configure the version resource file
+    set(RC_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${ARG_TARGET}_version.rc")
+    configure_file(
+        "${PROJECT_SOURCE_DIR}/src/migraphx_version.rc.in"
+        "${RC_OUTPUT}"
+        @ONLY
+    )
+
+    # Add the resource file to the target
+    target_sources(${ARG_TARGET} PRIVATE ${RC_OUTPUT})
+
+    # Set resource compiler flags if needed
+    if(DLL_BUILD_FLAG)
+        set_source_files_properties(${RC_OUTPUT} PROPERTIES
+            COMPILE_FLAGS ${DLL_BUILD_FLAG}
+        )
+    endif()
+
+    message(STATUS "Added version resource to ${ARG_TARGET}: ${COMPONENT_DESCRIPTION}")
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,12 +164,18 @@ rocm_install_targets(
     ${CMAKE_CURRENT_BINARY_DIR}/include
 )
 
+
 rocm_set_soversion(migraphx ${MIGRAPHX_SO_VERSION})
 function(register_migraphx_ops)
     foreach(OP ${ARGN})
         register_op(migraphx HEADER migraphx/op/${OP}.hpp OPERATORS op::${OP})
     endforeach()
 endfunction()
+
+add_version_resource(
+    TARGET migraphx
+    DESCRIPTION "MIGraphX Core Library - AMD Graph Optimization Engine"
+)
 register_migraphx_ops(
     abs
     acosh

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -33,7 +33,8 @@ migraphx_generate_export_header(migraphx_c DIRECTORY migraphx/api)
 rocm_set_soversion(migraphx_c 3.0)
 add_version_resource(
     TARGET migraphx_c
-    DESCRIPTION "MIGraphX C API - Stable C Interface")   
+    DESCRIPTION "MIGraphX C API - Stable C Interface"
+)   
 
 if(BUILD_TESTING)
     target_compile_definitions(migraphx_c PRIVATE MIGRAPHX_BUILD_TESTING)

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -30,7 +30,10 @@ migraphx_generate_export_header(migraphx_c DIRECTORY migraphx/api)
 
 # migraphx_c is stable API interface library. SO version of this should be 
 # bumped when binary compatibility is broken. 
-rocm_set_soversion(migraphx_c 3.0)   
+rocm_set_soversion(migraphx_c 3.0)
+add_version_resource(
+    TARGET migraphx_c
+    DESCRIPTION "MIGraphX C API - Stable C Interface")   
 
 if(BUILD_TESTING)
     target_compile_definitions(migraphx_c PRIVATE MIGRAPHX_BUILD_TESTING)

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -51,6 +51,11 @@ target_compile_definitions(driver PUBLIC MIGRAPHX_ORT_SHA1="${String_output}")
 
 target_link_libraries(driver migraphx_all_targets migraphx_onnx migraphx_tf)
 
+add_version_resource(
+    TARGET driver
+    DESCRIPTION "MIGraphX Driver - Command-line Interface and Testing Tool"
+)
+
 if(MIGRAPHX_ENABLE_PYTHON)
     target_link_libraries(driver migraphx_py)
     target_compile_definitions(driver PRIVATE MIGRAPHX_ENABLE_PYTHON)

--- a/src/migraphx_version.rc.in
+++ b/src/migraphx_version.rc.in
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <winver.h>
+
+#define VER_FILEVERSION             @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,0
+#define VER_FILEVERSION_STR         "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@.0\0"
+
+#define VER_PRODUCTVERSION          @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,0
+#define VER_PRODUCTVERSION_STR      "@PROJECT_VERSION@\0"
+
+#define VER_COMPANYNAME_STR         "Advanced Micro Devices, Inc.\0"
+#define VER_LEGALCOPYRIGHT_STR      "Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.\0"
+#define VER_PRODUCTNAME_STR         "AMD MIGraphX\0"
+
+#ifndef VER_FILEDESCRIPTION_STR
+#define VER_FILEDESCRIPTION_STR     "@COMPONENT_DESCRIPTION@\0"
+#endif
+
+#ifndef VER_INTERNALNAME_STR
+#define VER_INTERNALNAME_STR        "@COMPONENT_NAME@\0"
+#endif
+
+#ifndef VER_ORIGINALFILENAME_STR
+#define VER_ORIGINALFILENAME_STR    "@COMPONENT_FILENAME@\0"
+#endif
+
+#ifdef _DEBUG
+#define VER_DEBUG                   VS_FF_DEBUG
+#else
+#define VER_DEBUG                   0
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     VER_FILEVERSION
+PRODUCTVERSION  VER_PRODUCTVERSION
+FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+FILEFLAGS       VER_DEBUG
+FILEOS          VOS_NT_WINDOWS32
+#ifdef DLL_BUILD
+FILETYPE        VFT_DLL
+#else
+FILETYPE        VFT_APP
+#endif
+FILESUBTYPE     VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"  // US English, Unicode
+        BEGIN
+            VALUE "CompanyName",      VER_COMPANYNAME_STR
+            VALUE "FileDescription",  VER_FILEDESCRIPTION_STR
+            VALUE "FileVersion",      VER_FILEVERSION_STR
+            VALUE "InternalName",     VER_INTERNALNAME_STR
+            VALUE "LegalCopyright",   VER_LEGALCOPYRIGHT_STR
+            VALUE "OriginalFilename", VER_ORIGINALFILENAME_STR
+            VALUE "ProductName",      VER_PRODUCTNAME_STR
+            VALUE "ProductVersion",   VER_PRODUCTVERSION_STR
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200  // US English, Unicode
+    END
+END

--- a/src/migraphx_version.rc.in
+++ b/src/migraphx_version.rc.in
@@ -32,7 +32,7 @@
 
 #define VER_COMPANYNAME_STR         "Advanced Micro Devices, Inc.\0"
 #define VER_LEGALCOPYRIGHT_STR      "Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.\0"
-#define VER_PRODUCTNAME_STR         "AMD MIGraphX\0"
+#define VER_PRODUCTNAME_STR         "AMD MIGraphX @COMPONENT_FILENAME@\0"
 
 #ifndef VER_FILEDESCRIPTION_STR
 #define VER_FILEDESCRIPTION_STR     "@COMPONENT_DESCRIPTION@\0"

--- a/src/onnx/CMakeLists.txt
+++ b/src/onnx/CMakeLists.txt
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/src/onnx/CMakeLists.txt
+++ b/src/onnx/CMakeLists.txt
@@ -50,6 +50,10 @@ target_include_directories(migraphx_onnx PRIVATE include)
 set_target_properties(migraphx_onnx PROPERTIES EXPORT_NAME onnx)
 migraphx_generate_export_header(migraphx_onnx)
 rocm_set_soversion(migraphx_onnx ${MIGRAPHX_SO_VERSION})
+add_version_resource(
+    TARGET migraphx_onnx
+    DESCRIPTION "MIGraphX ONNX Parser - ONNX Model Support"
+)
 rocm_clang_tidy_check(migraphx_onnx)
 target_link_libraries(migraphx_onnx PRIVATE onnx-proto)
 if(NOT WIN32)

--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -103,7 +103,8 @@ set_target_properties(migraphx_device PROPERTIES EXPORT_NAME device)
 rocm_set_soversion(migraphx_device ${MIGRAPHX_SO_VERSION})
 add_version_resource(
     TARGET migraphx_device
-    DESCRIPTION "MIGraphX Device Library - GPU Device Operations")
+    DESCRIPTION "MIGraphX Device Library - GPU Device Operations"
+)
 rocm_clang_tidy_check(migraphx_device)
 target_link_libraries(migraphx_device PUBLIC migraphx)
 target_link_libraries(migraphx_device PRIVATE compile_for_gpu)

--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -101,6 +101,9 @@ endif()
 
 set_target_properties(migraphx_device PROPERTIES EXPORT_NAME device)
 rocm_set_soversion(migraphx_device ${MIGRAPHX_SO_VERSION})
+add_version_resource(
+    TARGET migraphx_device
+    DESCRIPTION "MIGraphX Device Library - GPU Device Operations")
 rocm_clang_tidy_check(migraphx_device)
 target_link_libraries(migraphx_device PUBLIC migraphx)
 target_link_libraries(migraphx_device PRIVATE compile_for_gpu)
@@ -260,6 +263,10 @@ if (MIGRAPHX_USE_MIOPEN)
         INCLUDES migraphx/gpu/context.hpp)
 endif()
 rocm_set_soversion(migraphx_gpu ${MIGRAPHX_SO_VERSION})
+add_version_resource(
+    TARGET migraphx_gpu
+    DESCRIPTION "MIGraphX GPU Target - AMD GPU Acceleration"
+)
 rocm_clang_tidy_check(migraphx_gpu)
 
 set(MIGRAPHX_ENABLE_MLIR ON CACHE BOOL "")

--- a/src/targets/gpu/hiprtc/CMakeLists.txt
+++ b/src/targets/gpu/hiprtc/CMakeLists.txt
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/hiprtc/CMakeLists.txt
+++ b/src/targets/gpu/hiprtc/CMakeLists.txt
@@ -34,6 +34,9 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_SIMULATE_ID MATCHES "
     target_link_options(migraphx-hiprtc-driver PRIVATE -Xlinker /stack:${STACK_SIZE})
 endif()
 target_link_libraries(migraphx-hiprtc-driver PRIVATE migraphx_gpu)
+add_version_resource(
+    TARGET migraphx-hiprtc-driver
+    DESCRIPTION "MIGraphX HIP RTC Driver - Runtime Compilation Driver")
 add_dependencies(migraphx_all_targets migraphx-hiprtc-driver)
 rocm_install_targets(
     TARGETS migraphx-hiprtc-driver

--- a/src/targets/gpu/hiprtc/CMakeLists.txt
+++ b/src/targets/gpu/hiprtc/CMakeLists.txt
@@ -36,7 +36,8 @@ endif()
 target_link_libraries(migraphx-hiprtc-driver PRIVATE migraphx_gpu)
 add_version_resource(
     TARGET migraphx-hiprtc-driver
-    DESCRIPTION "MIGraphX HIP RTC Driver - Runtime Compilation Driver")
+    DESCRIPTION "MIGraphX HIP RTC Driver - Runtime Compilation Driver"
+)
 add_dependencies(migraphx_all_targets migraphx-hiprtc-driver)
 rocm_install_targets(
     TARGETS migraphx-hiprtc-driver


### PR DESCRIPTION
## Motivation
Adding versioninfo for migraphx binaries on Windows

## Technical Details
Creating AddVersionResource.cmake and migraphx_version.rc.in files in order to add version info for migraphx dlls/exe. It affects this: migraphx-hiprtc-driver.exe, migraphx.dll, migraphx_c.dll, migraphx_device.dll, migraphx_gpu.dll, migraphx_onnx.dll, migraphx-driver.exe. On image bellow you can see before and after. 
<img width="593" height="523" alt="image" src="https://github.com/user-attachments/assets/9e31fdda-4a29-44aa-8803-a80335d279be" /> 

<img width="519" height="290" alt="image" src="https://github.com/user-attachments/assets/c9bb3971-b13f-4f78-915d-08f341e2235e" />

 
## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [X] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
