### PR TITLE
Add missing `trace` check for debug output in `compile_plan`

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -444,7 +444,7 @@ struct compile_plan
                            problem_string() + "\n\n" + print_modules());
         auto skipped = std::count_if(
             results.begin(), results.end(), [](const auto& cr) { return not cr.has_value(); });
-        if(skipped > 0)
+        if(trace_level > 0 and skipped > 0)
             std::cout << "Skipped " << skipped << " configs for " << preop.name() << std::endl;
 
         return *results[i];


### PR DESCRIPTION
## Motivation
After the last few changes on the `develop` branch we've started getting the following output in our logs that we couldn't remove with any environment variable modifications:
```
Skipped 4 configs for gpu::mlir_op
```

## Technical Details
This is the only call to `std::cout` in the entire file (`src/targets/gpu/compile_ops.cpp`) that didn't check `trace` before calling `std::cout`. You may want me to tweak the trace level that is checked.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
