### PR TITLE
[AIMIGRAPHX-814] Fix convert overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Full documentation for MIGraphX is available at
 * Fixed an issue with clip operator when using fp16 input type on opset 6 (#4518). 
 * Fixed an issue with `reshape_lazy`'s shape computation that was leading to invalid reshapes (#4594).
 * Fixed `eliminate_pad` pass bug that was removing nonzero `pad` instructions (#4600).
+* Fixed an issue with `convert` output overflowing when converting inf/-inf to integral types (#4669).
 
 ### Optimized
 * Optimized fusion for local_window mode of GQA operator (#4617).

--- a/src/include/migraphx/op/convert.hpp
+++ b/src/include/migraphx/op/convert.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/op/convert.hpp
+++ b/src/include/migraphx/op/convert.hpp
@@ -70,17 +70,17 @@ struct convert : unary<convert>
                 shape::as<output_type> as{};
                 par_transform(
                     input.begin(), input.end(), output.begin(), [as](auto x) -> output_type {
-                    auto dx = static_cast<double>(x);
-                    if(std::isnan(dx))
-                        return as.nan();
-                    if(not as.is_integral() and std::isinf(dx))
-                        return as(x);
-                    if(dx >= static_cast<double>(as.max()))
-                        return as.max();
-                    if(dx <= static_cast<double>(as.min()))
-                        return as.min();
-                    return as(dx);
-                });
+                        auto dx = static_cast<double>(x);
+                        if(std::isnan(dx))
+                            return as.nan();
+                        if(not as.is_integral() and std::isinf(dx))
+                            return as(x);
+                        if(dx >= static_cast<double>(as.max()))
+                            return as.max();
+                        if(dx <= static_cast<double>(as.min()))
+                            return as.min();
+                        return as(dx);
+                    });
             });
         });
         return result;

--- a/src/include/migraphx/op/convert.hpp
+++ b/src/include/migraphx/op/convert.hpp
@@ -68,19 +68,18 @@ struct convert : unary<convert>
             args[0].visit([&](auto input) {
                 using T = typename decltype(output)::value_type;
                 shape::as<T> as{};
-                par_transform(
-                    input.begin(), input.end(), output.begin(), [as](auto x) -> T {
-                        auto dx = static_cast<double>(x);
-                        if(std::isnan(dx))
-                            return as.nan();
-                        if(not as.is_integral() and std::isinf(dx))
-                            return as(x);
-                        if(dx >= static_cast<double>(as.max()))
-                            return as.max();
-                        if(dx <= static_cast<double>(as.min()))
-                            return as.min();
-                        return as(dx);
-                    });
+                par_transform(input.begin(), input.end(), output.begin(), [as](auto x) -> T {
+                    auto dx = static_cast<double>(x);
+                    if(std::isnan(dx))
+                        return as.nan();
+                    if(not as.is_integral() and std::isinf(dx))
+                        return as(x);
+                    if(dx >= static_cast<double>(as.max()))
+                        return as.max();
+                    if(dx <= static_cast<double>(as.min()))
+                        return as.min();
+                    return as(dx);
+                });
             });
         });
         return result;

--- a/src/include/migraphx/op/convert.hpp
+++ b/src/include/migraphx/op/convert.hpp
@@ -61,33 +61,29 @@ struct convert : unary<convert>
         return "${function:convert}<" + shape::cpp_type(target_type) + ">(${0})";
     }
 
-    auto apply() const
+    argument compute(const dyn_output& dyn_out, std::vector<argument> args) const
     {
-        auto type = target_type;
-        return [type](auto x) {
-            auto y = x;
-            shape::visit(type, [&](auto as) {
-                // clamping value between target_type's max and min doesn't work for NaNs,
-                if(std::isnan(static_cast<double>(x)))
-                {
-                    y = as.nan();
-                }
-                else if(shape::is_integral(type) and std::is_floating_point_v<decltype(x)>)
-                {
-                    // for the floating point to integer conversion, clamp first and then convert to
-                    // avoid undefined behaviour
-                    y = as(std::min(std::max(static_cast<double>(x), static_cast<double>(as.min())),
-                                    static_cast<double>(as.max())));
-                }
-                else
-                {
-                    // clamp overflowing/underflowing values to min()/max() instead of +/-infinity
-                    // during downcasting
-                    y = std::min(std::max(as(x), as.min()), as.max());
-                }
+        argument result{dyn_out.computed_shape};
+        result.visit([&](auto output) {
+            args[0].visit([&](auto input) {
+                using T = typename decltype(output)::value_type;
+                shape::as<T> as{};
+                par_transform(
+                    input.begin(), input.end(), output.begin(), [as](auto x) -> T {
+                        auto dx = static_cast<double>(x);
+                        if(std::isnan(dx))
+                            return as.nan();
+                        if(not as.is_integral() and std::isinf(dx))
+                            return as(x);
+                        if(dx >= static_cast<double>(as.max()))
+                            return as.max();
+                        if(dx <= static_cast<double>(as.min()))
+                            return as.min();
+                        return as(dx);
+                    });
             });
-            return y;
-        };
+        });
+        return result;
     }
 
     convert(shape::type_t t) : target_type{t} {}

--- a/src/include/migraphx/op/convert.hpp
+++ b/src/include/migraphx/op/convert.hpp
@@ -67,19 +67,18 @@ struct convert : unary<convert>
         result.visit([&](auto output) {
             args[0].visit([&](auto input) {
                 using output_type = typename decltype(output)::value_type;
-                shape::as<output_type> as{};
                 par_transform(
-                    input.begin(), input.end(), output.begin(), [as](auto x) -> output_type {
-                        auto dx = static_cast<double>(x);
+                    input.begin(), input.end(), output.begin(), [](auto x) -> output_type {
+                        double dx = x;
                         if(std::isnan(dx))
-                            return as.nan();
-                        if(not as.is_integral() and std::isinf(dx))
-                            return as(x);
-                        if(dx >= static_cast<double>(as.max()))
-                            return as.max();
-                        if(dx <= static_cast<double>(as.min()))
-                            return as.min();
-                        return as(dx);
+                            return std::numeric_limits<output_type>::quiet_NaN();
+                        if(not std::is_integral<output_type>{} and std::isinf(dx))
+                            return output_type(x);
+                        if(dx >= std::numeric_limits<output_type>::max())
+                            return std::numeric_limits<output_type>::max();
+                        if(dx <= std::numeric_limits<output_type>::lowest())
+                            return std::numeric_limits<output_type>::lowest();
+                        return output_type(dx);
                     });
             });
         });

--- a/src/include/migraphx/op/convert.hpp
+++ b/src/include/migraphx/op/convert.hpp
@@ -66,9 +66,10 @@ struct convert : unary<convert>
         argument result{dyn_out.computed_shape};
         result.visit([&](auto output) {
             args[0].visit([&](auto input) {
-                using T = typename decltype(output)::value_type;
-                shape::as<T> as{};
-                par_transform(input.begin(), input.end(), output.begin(), [as](auto x) -> T {
+                using output_type = typename decltype(output)::value_type;
+                shape::as<output_type> as{};
+                par_transform(
+                    input.begin(), input.end(), output.begin(), [as](auto x) -> output_type {
                     auto dx = static_cast<double>(x);
                     if(std::isnan(dx))
                         return as.nan();

--- a/test/convert_inf.cpp
+++ b/test/convert_inf.cpp
@@ -103,7 +103,7 @@ TEST_CASE(float_inf_to_int32)
 TEST_CASE(float_ninf_to_int32)
 {
     EXPECT(eval_convert(-std::numeric_limits<float>::infinity(), migraphx::shape::int32_type)
-               .at<int32_t>() == std::numeric_limits<int32_t>::min());
+               .at<int32_t>() == std::numeric_limits<int32_t>::lowest());
 }
 
 TEST_CASE(float_inf_to_int64)
@@ -115,7 +115,7 @@ TEST_CASE(float_inf_to_int64)
 TEST_CASE(float_ninf_to_int64)
 {
     EXPECT(eval_convert(-std::numeric_limits<float>::infinity(), migraphx::shape::int64_type)
-               .at<int64_t>() == std::numeric_limits<int64_t>::min());
+               .at<int64_t>() == std::numeric_limits<int64_t>::lowest());
 }
 
 TEST_CASE(double_inf_to_int64)
@@ -127,7 +127,7 @@ TEST_CASE(double_inf_to_int64)
 TEST_CASE(double_ninf_to_int64)
 {
     EXPECT(eval_convert(-std::numeric_limits<double>::infinity(), migraphx::shape::int64_type)
-               .at<int64_t>() == std::numeric_limits<int64_t>::min());
+               .at<int64_t>() == std::numeric_limits<int64_t>::lowest());
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/convert_inf.cpp
+++ b/test/convert_inf.cpp
@@ -1,0 +1,134 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/module.hpp>
+#include <migraphx/instruction.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/half.hpp>
+#include <migraphx/bf16.hpp>
+#include <cmath>
+#include <limits>
+#include "test.hpp"
+
+static migraphx::argument eval_convert(float x, migraphx::shape::type_t target)
+{
+    migraphx::module m;
+    auto lit = m.add_literal(x);
+    auto cvt = m.add_instruction(
+        migraphx::make_op("convert", {{"target_type", target}}), lit);
+    return cvt->eval();
+}
+
+template <class T>
+static bool is_pos_inf(T x)
+{
+    return std::isinf(x) and x > 0;
+}
+
+template <class T>
+static bool is_neg_inf(T x)
+{
+    return std::isinf(x) and x < 0;
+}
+
+// float -> float should preserve infinity
+TEST_CASE(float_inf_to_half)
+{
+    EXPECT(is_pos_inf(eval_convert(std::numeric_limits<float>::infinity(),
+                                   migraphx::shape::half_type).at<migraphx::half>()));
+}
+
+TEST_CASE(float_ninf_to_half)
+{
+    EXPECT(is_neg_inf(eval_convert(-std::numeric_limits<float>::infinity(),
+                                   migraphx::shape::half_type).at<migraphx::half>()));
+}
+
+TEST_CASE(float_inf_to_bf16)
+{
+    EXPECT(is_pos_inf(eval_convert(std::numeric_limits<float>::infinity(),
+                                   migraphx::shape::bf16_type).at<migraphx::bf16>()));
+}
+
+TEST_CASE(float_ninf_to_bf16)
+{
+    EXPECT(is_neg_inf(eval_convert(-std::numeric_limits<float>::infinity(),
+                                   migraphx::shape::bf16_type).at<migraphx::bf16>()));
+}
+
+TEST_CASE(double_inf_to_float)
+{
+    EXPECT(is_pos_inf(eval_convert(std::numeric_limits<double>::infinity(),
+                                   migraphx::shape::float_type).at<float>()));
+}
+
+TEST_CASE(double_ninf_to_float)
+{
+    EXPECT(is_neg_inf(eval_convert(-std::numeric_limits<double>::infinity(),
+                                   migraphx::shape::float_type).at<float>()));
+}
+
+// float -> int should clamp to min/max
+TEST_CASE(float_inf_to_int32)
+{
+    EXPECT(eval_convert(std::numeric_limits<float>::infinity(),
+                        migraphx::shape::int32_type).at<int32_t>() ==
+           std::numeric_limits<int32_t>::max());
+}
+
+TEST_CASE(float_ninf_to_int32)
+{
+    EXPECT(eval_convert(-std::numeric_limits<float>::infinity(),
+                        migraphx::shape::int32_type).at<int32_t>() ==
+           std::numeric_limits<int32_t>::min());
+}
+
+TEST_CASE(float_inf_to_int64)
+{
+    EXPECT(eval_convert(std::numeric_limits<float>::infinity(),
+                        migraphx::shape::int64_type).at<int64_t>() ==
+           std::numeric_limits<int64_t>::max());
+}
+
+TEST_CASE(float_ninf_to_int64)
+{
+    EXPECT(eval_convert(-std::numeric_limits<float>::infinity(),
+                        migraphx::shape::int64_type).at<int64_t>() ==
+           std::numeric_limits<int64_t>::min());
+}
+
+TEST_CASE(double_inf_to_int64)
+{
+    EXPECT(eval_convert(std::numeric_limits<double>::infinity(),
+                        migraphx::shape::int64_type).at<int64_t>() ==
+           std::numeric_limits<int64_t>::max());
+}
+
+TEST_CASE(double_ninf_to_int64)
+{
+    EXPECT(eval_convert(-std::numeric_limits<double>::infinity(),
+                        migraphx::shape::int64_type).at<int64_t>() ==
+           std::numeric_limits<int64_t>::min());
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/convert_inf.cpp
+++ b/test/convert_inf.cpp
@@ -34,8 +34,7 @@ static migraphx::argument eval_convert(float x, migraphx::shape::type_t target)
 {
     migraphx::module m;
     auto lit = m.add_literal(x);
-    auto cvt = m.add_instruction(
-        migraphx::make_op("convert", {{"target_type", target}}), lit);
+    auto cvt = m.add_instruction(migraphx::make_op("convert", {{"target_type", target}}), lit);
     return cvt->eval();
 }
 
@@ -54,81 +53,81 @@ static bool is_neg_inf(T x)
 // float -> float should preserve infinity
 TEST_CASE(float_inf_to_half)
 {
-    EXPECT(is_pos_inf(eval_convert(std::numeric_limits<float>::infinity(),
-                                   migraphx::shape::half_type).at<migraphx::half>()));
+    EXPECT(
+        is_pos_inf(eval_convert(std::numeric_limits<float>::infinity(), migraphx::shape::half_type)
+                       .at<migraphx::half>()));
 }
 
 TEST_CASE(float_ninf_to_half)
 {
-    EXPECT(is_neg_inf(eval_convert(-std::numeric_limits<float>::infinity(),
-                                   migraphx::shape::half_type).at<migraphx::half>()));
+    EXPECT(
+        is_neg_inf(eval_convert(-std::numeric_limits<float>::infinity(), migraphx::shape::half_type)
+                       .at<migraphx::half>()));
 }
 
 TEST_CASE(float_inf_to_bf16)
 {
-    EXPECT(is_pos_inf(eval_convert(std::numeric_limits<float>::infinity(),
-                                   migraphx::shape::bf16_type).at<migraphx::bf16>()));
+    EXPECT(
+        is_pos_inf(eval_convert(std::numeric_limits<float>::infinity(), migraphx::shape::bf16_type)
+                       .at<migraphx::bf16>()));
 }
 
 TEST_CASE(float_ninf_to_bf16)
 {
-    EXPECT(is_neg_inf(eval_convert(-std::numeric_limits<float>::infinity(),
-                                   migraphx::shape::bf16_type).at<migraphx::bf16>()));
+    EXPECT(
+        is_neg_inf(eval_convert(-std::numeric_limits<float>::infinity(), migraphx::shape::bf16_type)
+                       .at<migraphx::bf16>()));
 }
 
 TEST_CASE(double_inf_to_float)
 {
-    EXPECT(is_pos_inf(eval_convert(std::numeric_limits<double>::infinity(),
-                                   migraphx::shape::float_type).at<float>()));
+    EXPECT(is_pos_inf(
+        eval_convert(std::numeric_limits<double>::infinity(), migraphx::shape::float_type)
+            .at<float>()));
 }
 
 TEST_CASE(double_ninf_to_float)
 {
-    EXPECT(is_neg_inf(eval_convert(-std::numeric_limits<double>::infinity(),
-                                   migraphx::shape::float_type).at<float>()));
+    EXPECT(is_neg_inf(
+        eval_convert(-std::numeric_limits<double>::infinity(), migraphx::shape::float_type)
+            .at<float>()));
 }
 
 // float -> int should clamp to min/max
 TEST_CASE(float_inf_to_int32)
 {
-    EXPECT(eval_convert(std::numeric_limits<float>::infinity(),
-                        migraphx::shape::int32_type).at<int32_t>() ==
-           std::numeric_limits<int32_t>::max());
+    EXPECT(eval_convert(std::numeric_limits<float>::infinity(), migraphx::shape::int32_type)
+               .at<int32_t>() == std::numeric_limits<int32_t>::max());
 }
 
 TEST_CASE(float_ninf_to_int32)
 {
-    EXPECT(eval_convert(-std::numeric_limits<float>::infinity(),
-                        migraphx::shape::int32_type).at<int32_t>() ==
-           std::numeric_limits<int32_t>::min());
+    EXPECT(eval_convert(-std::numeric_limits<float>::infinity(), migraphx::shape::int32_type)
+               .at<int32_t>() == std::numeric_limits<int32_t>::min());
 }
 
 TEST_CASE(float_inf_to_int64)
 {
-    EXPECT(eval_convert(std::numeric_limits<float>::infinity(),
-                        migraphx::shape::int64_type).at<int64_t>() ==
-           std::numeric_limits<int64_t>::max());
+    EXPECT(eval_convert(std::numeric_limits<float>::infinity(), migraphx::shape::int64_type)
+               .at<int64_t>() == std::numeric_limits<int64_t>::max());
 }
 
 TEST_CASE(float_ninf_to_int64)
 {
-    EXPECT(eval_convert(-std::numeric_limits<float>::infinity(),
-                        migraphx::shape::int64_type).at<int64_t>() ==
-           std::numeric_limits<int64_t>::min());
+    EXPECT(eval_convert(-std::numeric_limits<float>::infinity(), migraphx::shape::int64_type)
+               .at<int64_t>() == std::numeric_limits<int64_t>::min());
 }
 
 TEST_CASE(double_inf_to_int64)
 {
-    EXPECT(eval_convert(std::numeric_limits<double>::infinity(),
-                        migraphx::shape::int64_type).at<int64_t>() ==
-           std::numeric_limits<int64_t>::max());
+    EXPECT(eval_convert(std::numeric_limits<double>::infinity(), migraphx::shape::int64_type)
+               .at<int64_t>() == std::numeric_limits<int64_t>::max());
 }
 
 TEST_CASE(double_ninf_to_int64)
 {
-    EXPECT(eval_convert(-std::numeric_limits<double>::infinity(),
-                        migraphx::shape::int64_type).at<int64_t>() ==
-           std::numeric_limits<int64_t>::min());
+    EXPECT(eval_convert(-std::numeric_limits<double>::infinity(), migraphx::shape::int64_type)
+               .at<int64_t>() == std::numeric_limits<int64_t>::min());
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation
Converting float inf to int32/int64 will overflow and cause the result to be INT_MIN.

## Technical Details
Overwrite `compute()` instead of using `apply()` so we can get the type during runtime. This bypasses the need for declaring a type and causing values to overflow.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
