### PR TITLE
Fix issues with dangling references in the test framework

### DIFF
--- a/src/targets/gpu/kernels/include/migraphx/kernels/test.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/test.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/kernels/include/migraphx/kernels/test.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/test.hpp
@@ -144,18 +144,20 @@ template <class T, class Operator>
 constexpr lhs_expression<T, Operator> make_lhs_expression(T&& lhs, Operator);
 
 // NOLINTNEXTLINE
-#define TEST_EXPR_BINARY_OPERATOR(op, name)                                                          \
-    template <class V>                                                                               \
-    friend constexpr auto operator op(self_t lhs2, V&& rhs2) /* NOLINT */                            \
-    {                                                                                                \
-        return make_expression(static_cast<self_t&&>(lhs2), static_cast<V&&>(rhs2), name{}); /* NOLINT */ \
+#define TEST_EXPR_BINARY_OPERATOR(op, name)                                            \
+    template <class V>                                                                 \
+    friend constexpr auto operator op(self_t lhs2, V&& rhs2) /* NOLINT */              \
+    {                                                                                  \
+        return make_expression(                                                        \
+            static_cast<self_t&&>(lhs2), static_cast<V&&>(rhs2), name{}); /* NOLINT */ \
     }
 
 // NOLINTNEXTLINE
-#define TEST_EXPR_UNARY_OPERATOR(op, name)                                                              \
-    friend constexpr auto operator op(self_t self) /* NOLINT */                                          \
-    {                                                                                                   \
-        return make_lhs_expression(static_cast<decltype(self.lhs)&&>(self.lhs), name{}); /* NOLINT */   \
+#define TEST_EXPR_UNARY_OPERATOR(op, name)                                      \
+    friend constexpr auto operator op(self_t self) /* NOLINT */                 \
+    {                                                                           \
+        return make_lhs_expression(static_cast<decltype(self.lhs)&&>(self.lhs), \
+                                   name{}); /* NOLINT */                        \
     }
 
 template <class T, class U, class Operator>

--- a/src/targets/gpu/kernels/include/migraphx/kernels/test.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/test.hpp
@@ -92,7 +92,7 @@ struct nop
 {
     static constexpr const char* as_string() { return ""; }
     template <class T>
-    static constexpr decltype(auto) call(T&& x)
+    static constexpr T call(T&& x)
     {
         return static_cast<T&&>(x);
     }
@@ -254,12 +254,6 @@ struct capture
     constexpr auto operator->*(T&& x) const
     {
         return make_lhs_expression(static_cast<T&&>(x));
-    }
-
-    template <class T, class Operator>
-    constexpr auto operator->*(const lhs_expression<T, Operator>& x) const
-    {
-        return x;
     }
 };
 

--- a/src/targets/gpu/kernels/include/migraphx/kernels/test.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/test.hpp
@@ -92,7 +92,7 @@ struct nop
 {
     static constexpr const char* as_string() { return ""; }
     template <class T>
-    static constexpr auto call(T&& x)
+    static constexpr decltype(auto) call(T&& x)
     {
         return static_cast<T&&>(x);
     }
@@ -144,20 +144,24 @@ template <class T, class Operator>
 constexpr lhs_expression<T, Operator> make_lhs_expression(T&& lhs, Operator);
 
 // NOLINTNEXTLINE
-#define TEST_EXPR_BINARY_OPERATOR(op, name)                                         \
-    template <class V>                                                              \
-    constexpr auto operator op(V&& rhs2) const                                      \
-    {                                                                               \
-        return make_expression(*this, static_cast<V&&>(rhs2), name{}); /* NOLINT */ \
+#define TEST_EXPR_BINARY_OPERATOR(op, name)                                                          \
+    template <class V>                                                                               \
+    friend constexpr auto operator op(self_t lhs2, V&& rhs2) /* NOLINT */                            \
+    {                                                                                                \
+        return make_expression(static_cast<self_t&&>(lhs2), static_cast<V&&>(rhs2), name{}); /* NOLINT */ \
     }
 
 // NOLINTNEXTLINE
-#define TEST_EXPR_UNARY_OPERATOR(op, name) \
-    constexpr auto operator op() const { return make_lhs_expression(lhs, name{}); /* NOLINT */ }
+#define TEST_EXPR_UNARY_OPERATOR(op, name)                                                              \
+    friend constexpr auto operator op(self_t self) /* NOLINT */                                          \
+    {                                                                                                   \
+        return make_lhs_expression(static_cast<decltype(self.lhs)&&>(self.lhs), name{}); /* NOLINT */   \
+    }
 
 template <class T, class U, class Operator>
 struct expression
 {
+    using self_t = expression;
     T lhs;
     U rhs;
 
@@ -204,6 +208,7 @@ constexpr lhs_expression<T, Operator> make_lhs_expression(T&& lhs, Operator)
 template <class T, class Operator>
 struct lhs_expression
 {
+    using self_t = lhs_expression;
     T lhs;
     constexpr explicit lhs_expression(T e) : lhs(static_cast<T&&>(e)) {}
 
@@ -244,9 +249,9 @@ struct lhs_expression
 struct capture
 {
     template <class T>
-    constexpr auto operator->*(const T& x) const
+    constexpr auto operator->*(T&& x) const
     {
-        return make_lhs_expression(x);
+        return make_lhs_expression(static_cast<T&&>(x));
     }
 
     template <class T, class Operator>

--- a/test/gpu/kernels/test.cpp
+++ b/test/gpu/kernels/test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/gpu/kernels/test.cpp
+++ b/test/gpu/kernels/test.cpp
@@ -97,52 +97,28 @@ TEST_CASE(expression_false_value)
 }
 
 // Test lhs arithmetic: addition
-TEST_CASE(lhs_arithmetic_add)
-{
-    EXPECT((capture{}->*3 + 2).value() == 5);
-}
+TEST_CASE(lhs_arithmetic_add) { EXPECT((capture{}->*3 + 2).value() == 5); }
 
 // Test lhs arithmetic: subtraction
-TEST_CASE(lhs_arithmetic_sub)
-{
-    EXPECT((capture{}->*5 - 3).value() == 2);
-}
+TEST_CASE(lhs_arithmetic_sub) { EXPECT((capture{}->*5 - 3).value() == 2); }
 
 // Test lhs arithmetic: multiplication
-TEST_CASE(lhs_arithmetic_mul)
-{
-    EXPECT((capture{}->*3 * 4).value() == 12);
-}
+TEST_CASE(lhs_arithmetic_mul) { EXPECT((capture{}->*3 * 4).value() == 12); }
 
 // Test lhs arithmetic: division
-TEST_CASE(lhs_arithmetic_div)
-{
-    EXPECT((capture{}->*12 / 4).value() == 3);
-}
+TEST_CASE(lhs_arithmetic_div) { EXPECT((capture{}->*12 / 4).value() == 3); }
 
 // Test lhs arithmetic: modulo
-TEST_CASE(lhs_arithmetic_mod)
-{
-    EXPECT((capture{}->*7 % 3).value() == 1);
-}
+TEST_CASE(lhs_arithmetic_mod) { EXPECT((capture{}->*7 % 3).value() == 1); }
 
 // Test lhs bitwise: and
-TEST_CASE(lhs_bitwise_and)
-{
-    EXPECT((capture{}->*0xF & 0x3).value() == 0x3);
-}
+TEST_CASE(lhs_bitwise_and) { EXPECT((capture{}->*0xF & 0x3).value() == 0x3); }
 
 // Test lhs bitwise: or
-TEST_CASE(lhs_bitwise_or)
-{
-    EXPECT((capture{}->*0x1 | 0x2).value() == 0x3);
-}
+TEST_CASE(lhs_bitwise_or) { EXPECT((capture{}->*0x1 | 0x2).value() == 0x3); }
 
 // Test lhs bitwise: xor
-TEST_CASE(lhs_bitwise_xor)
-{
-    EXPECT((capture{}->*0xF ^ 0x3).value() == 0xC);
-}
+TEST_CASE(lhs_bitwise_xor) { EXPECT((capture{}->*0xF ^ 0x3).value() == 0xC); }
 
 // Test chained comparison
 TEST_CASE(chained_comparison)
@@ -211,10 +187,7 @@ TEST_CASE(operator_greater_than_equal_call)
 }
 
 // Test nop call
-TEST_CASE(nop_call)
-{
-    EXPECT(migraphx::test::nop::call(42) == 42);
-}
+TEST_CASE(nop_call) { EXPECT(migraphx::test::nop::call(42) == 42); }
 
 // Test nop as_string is empty
 TEST_CASE(nop_as_string_empty)
@@ -233,8 +206,8 @@ TEST_CASE(check_macro_passes)
 // Test capture with variables (not just temporaries)
 TEST_CASE(capture_with_variables)
 {
-    int x = 10;
-    int y = 20;
+    int x     = 10;
+    int y     = 20;
     auto expr = capture{}->*x < y;
     EXPECT(expr.value());
 }
@@ -249,10 +222,7 @@ TEST_CASE(expression_chained)
 }
 
 // Test capture preserves value for non-trivial arithmetic
-TEST_CASE(capture_complex_arithmetic)
-{
-    EXPECT((capture{}->*100 / 10 % 3).value() == 1);
-}
+TEST_CASE(capture_complex_arithmetic) { EXPECT((capture{}->*100 / 10 % 3).value() == 1); }
 
 // Test and_op operator object
 TEST_CASE(operator_and_op_call)

--- a/test/gpu/kernels/test.cpp
+++ b/test/gpu/kernels/test.cpp
@@ -330,3 +330,10 @@ TEST_CASE(capture_move_only)
     auto expr = capture{}->*move_only{42} == move_only{42};
     EXPECT(expr.value());
 }
+
+// Test chaining lhs_expressions with and through capture
+TEST_CASE(capture_chained_and)
+{
+    EXPECT((capture{}->*1 == 1) and (capture{}->*2 == 2) and (capture{}->*3 == 3) and
+           (capture{}->*4 == 4));
+}

--- a/test/gpu/kernels/test.cpp
+++ b/test/gpu/kernels/test.cpp
@@ -1,0 +1,362 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+#include <migraphx/kernels/test.hpp>
+
+using migraphx::test::capture;
+
+// Test capture with temporaries using == operator
+TEST_CASE(capture_equal)
+{
+    auto expr = capture{}->*1 == 1;
+    EXPECT(expr.value());
+}
+
+// Test capture with temporaries using != operator
+TEST_CASE(capture_not_equal)
+{
+    auto expr = capture{}->*1 != 2;
+    EXPECT(expr.value());
+}
+
+// Test capture with temporaries using < operator
+TEST_CASE(capture_less_than)
+{
+    auto expr = capture{}->*1 < 2;
+    EXPECT(expr.value());
+}
+
+// Test capture with temporaries using > operator
+TEST_CASE(capture_greater_than)
+{
+    auto expr = capture{}->*2 > 1;
+    EXPECT(expr.value());
+}
+
+// Test capture with temporaries using <= operator
+TEST_CASE(capture_less_than_equal)
+{
+    auto expr = capture{}->*1 <= 1;
+    EXPECT(expr.value());
+}
+
+// Test capture with temporaries using >= operator
+TEST_CASE(capture_greater_than_equal)
+{
+    auto expr = capture{}->*2 >= 2;
+    EXPECT(expr.value());
+}
+
+// Test capture with and operator
+TEST_CASE(capture_and)
+{
+    auto expr = capture{}->*true and true;
+    EXPECT(expr.value());
+}
+
+// Test capture with or operator
+TEST_CASE(capture_or)
+{
+    auto expr = capture{}->*false or true;
+    EXPECT(expr.value());
+}
+
+// Test capture with not operator
+TEST_CASE(capture_not)
+{
+    auto expr = not(capture{}->*false);
+    EXPECT(expr.value());
+}
+
+// Test expression false value
+TEST_CASE(expression_false_value)
+{
+    auto expr = capture{}->*1 == 2;
+    EXPECT(not expr.value());
+}
+
+// Test lhs arithmetic: addition
+TEST_CASE(lhs_arithmetic_add)
+{
+    EXPECT((capture{}->*3 + 2).value() == 5);
+}
+
+// Test lhs arithmetic: subtraction
+TEST_CASE(lhs_arithmetic_sub)
+{
+    EXPECT((capture{}->*5 - 3).value() == 2);
+}
+
+// Test lhs arithmetic: multiplication
+TEST_CASE(lhs_arithmetic_mul)
+{
+    EXPECT((capture{}->*3 * 4).value() == 12);
+}
+
+// Test lhs arithmetic: division
+TEST_CASE(lhs_arithmetic_div)
+{
+    EXPECT((capture{}->*12 / 4).value() == 3);
+}
+
+// Test lhs arithmetic: modulo
+TEST_CASE(lhs_arithmetic_mod)
+{
+    EXPECT((capture{}->*7 % 3).value() == 1);
+}
+
+// Test lhs bitwise: and
+TEST_CASE(lhs_bitwise_and)
+{
+    EXPECT((capture{}->*0xF & 0x3).value() == 0x3);
+}
+
+// Test lhs bitwise: or
+TEST_CASE(lhs_bitwise_or)
+{
+    EXPECT((capture{}->*0x1 | 0x2).value() == 0x3);
+}
+
+// Test lhs bitwise: xor
+TEST_CASE(lhs_bitwise_xor)
+{
+    EXPECT((capture{}->*0xF ^ 0x3).value() == 0xC);
+}
+
+// Test chained comparison
+TEST_CASE(chained_comparison)
+{
+    auto expr = (capture{}->*3 + 2) == 5;
+    EXPECT(expr.value());
+}
+
+// Test chained comparison false
+TEST_CASE(chained_comparison_false)
+{
+    auto expr = (capture{}->*3 + 2) == 6;
+    EXPECT(not expr.value());
+}
+
+// Test operator objects: equal as_string
+TEST_CASE(operator_equal_as_string)
+{
+    const char* s = migraphx::test::equal::as_string();
+    EXPECT(s[0] == '=');
+    EXPECT(s[1] == '=');
+}
+
+// Test operator objects: equal call
+TEST_CASE(operator_equal_call)
+{
+    EXPECT(migraphx::test::equal::call(1, 1));
+    EXPECT(not migraphx::test::equal::call(1, 2));
+}
+
+// Test operator objects: not_equal call
+TEST_CASE(operator_not_equal_call)
+{
+    EXPECT(migraphx::test::not_equal::call(1, 2));
+    EXPECT(not migraphx::test::not_equal::call(1, 1));
+}
+
+// Test operator objects: less_than call
+TEST_CASE(operator_less_than_call)
+{
+    EXPECT(migraphx::test::less_than::call(1, 2));
+    EXPECT(not migraphx::test::less_than::call(2, 1));
+}
+
+// Test operator objects: greater_than call
+TEST_CASE(operator_greater_than_call)
+{
+    EXPECT(migraphx::test::greater_than::call(2, 1));
+    EXPECT(not migraphx::test::greater_than::call(1, 2));
+}
+
+// Test operator objects: less_than_equal call
+TEST_CASE(operator_less_than_equal_call)
+{
+    EXPECT(migraphx::test::less_than_equal::call(1, 1));
+    EXPECT(migraphx::test::less_than_equal::call(1, 2));
+    EXPECT(not migraphx::test::less_than_equal::call(2, 1));
+}
+
+// Test operator objects: greater_than_equal call
+TEST_CASE(operator_greater_than_equal_call)
+{
+    EXPECT(migraphx::test::greater_than_equal::call(1, 1));
+    EXPECT(migraphx::test::greater_than_equal::call(2, 1));
+    EXPECT(not migraphx::test::greater_than_equal::call(1, 2));
+}
+
+// Test nop call
+TEST_CASE(nop_call)
+{
+    EXPECT(migraphx::test::nop::call(42) == 42);
+}
+
+// Test nop as_string is empty
+TEST_CASE(nop_as_string_empty)
+{
+    const char* s = migraphx::test::nop::as_string();
+    EXPECT(s[0] == '\0');
+}
+
+// Test CHECK macro passes without incrementing failures
+TEST_CASE(check_macro_passes)
+{
+    // cppcheck-suppress knownConditionTrueFalse
+    CHECK(1 == 1);
+}
+
+// Test capture with variables (not just temporaries)
+TEST_CASE(capture_with_variables)
+{
+    int x = 10;
+    int y = 20;
+    auto expr = capture{}->*x < y;
+    EXPECT(expr.value());
+}
+
+// Test expression chaining with multiple operators
+TEST_CASE(expression_chained)
+{
+    auto expr = (capture{}->*2 + 3) == 5;
+    EXPECT(expr.value());
+    auto expr2 = (capture{}->*10 - 3) == 7;
+    EXPECT(expr2.value());
+}
+
+// Test capture preserves value for non-trivial arithmetic
+TEST_CASE(capture_complex_arithmetic)
+{
+    EXPECT((capture{}->*100 / 10 % 3).value() == 1);
+}
+
+// Test and_op operator object
+TEST_CASE(operator_and_op_call)
+{
+    EXPECT(migraphx::test::and_op::call(true, true));
+    EXPECT(not migraphx::test::and_op::call(true, false));
+    EXPECT(not migraphx::test::and_op::call(false, true));
+    EXPECT(not migraphx::test::and_op::call(false, false));
+}
+
+// Test or_op operator object
+TEST_CASE(operator_or_op_call)
+{
+    EXPECT(migraphx::test::or_op::call(true, true));
+    EXPECT(migraphx::test::or_op::call(true, false));
+    EXPECT(migraphx::test::or_op::call(false, true));
+    EXPECT(not migraphx::test::or_op::call(false, false));
+}
+
+// Test not_op operator object
+TEST_CASE(operator_not_op_call)
+{
+    EXPECT(migraphx::test::not_op::call(false));
+    EXPECT(not migraphx::test::not_op::call(true));
+}
+
+// Test function operator object
+TEST_CASE(function_call)
+{
+    auto f = [] { return 42; };
+    EXPECT(migraphx::test::function::call(f) == 42);
+}
+
+// Test capture with negative values
+TEST_CASE(capture_negative_values)
+{
+    auto expr = capture{}->*(-5) < 0;
+    EXPECT(expr.value());
+}
+
+// Test capture equality with zero
+TEST_CASE(capture_zero)
+{
+    auto expr = capture{}->*0 == 0;
+    EXPECT(expr.value());
+}
+
+// Test multiple expressions in sequence
+TEST_CASE(multiple_expressions)
+{
+    auto e1 = capture{}->*1 == 1;
+    auto e2 = capture{}->*2 == 2;
+    auto e3 = capture{}->*3 == 3;
+    EXPECT(e1.value());
+    EXPECT(e2.value());
+    EXPECT(e3.value());
+}
+
+// Test noncopyable type with capture
+struct noncopyable
+{
+    int value;
+    constexpr noncopyable(int v) : value(v) {}
+    noncopyable(const noncopyable&)            = delete;
+    noncopyable& operator=(const noncopyable&) = delete;
+    noncopyable(noncopyable&&)                 = default;
+    noncopyable& operator=(noncopyable&&)      = default;
+    friend constexpr bool operator==(const noncopyable& a, const noncopyable& b)
+    {
+        return a.value == b.value;
+    }
+    friend constexpr bool operator!=(const noncopyable& a, const noncopyable& b)
+    {
+        return a.value != b.value;
+    }
+};
+
+TEST_CASE(capture_noncopyable)
+{
+    auto expr = capture{}->*noncopyable{42} == noncopyable{42};
+    EXPECT(expr.value());
+}
+
+// Test move-only type with capture
+struct move_only
+{
+    int value;
+    constexpr move_only(int v) : value(v) {}
+    move_only(const move_only&)            = delete;
+    move_only& operator=(const move_only&) = delete;
+    move_only(move_only&& other)           = default;
+    move_only& operator=(move_only&&)      = default;
+    friend constexpr bool operator==(const move_only& a, const move_only& b)
+    {
+        return a.value == b.value;
+    }
+    friend constexpr bool operator!=(const move_only& a, const move_only& b)
+    {
+        return a.value != b.value;
+    }
+};
+
+TEST_CASE(capture_move_only)
+{
+    auto expr = capture{}->*move_only{42} == move_only{42};
+    EXPECT(expr.value());
+}

--- a/test/gpu/kernels/test.cpp
+++ b/test/gpu/kernels/test.cpp
@@ -112,13 +112,13 @@ TEST_CASE(lhs_arithmetic_div) { EXPECT((capture{}->*12 / 4).value() == 3); }
 TEST_CASE(lhs_arithmetic_mod) { EXPECT((capture{}->*7 % 3).value() == 1); }
 
 // Test lhs bitwise: and
-TEST_CASE(lhs_bitwise_and) { EXPECT((capture{}->*0xF & 0x3).value() == 0x3); }
+TEST_CASE(lhs_bitwise_and) { EXPECT((capture{}->*0xFu & 0x3u).value() == 0x3); }
 
 // Test lhs bitwise: or
-TEST_CASE(lhs_bitwise_or) { EXPECT((capture{}->*0x1 | 0x2).value() == 0x3); }
+TEST_CASE(lhs_bitwise_or) { EXPECT((capture{}->*0x1u | 0x2u).value() == 0x3); }
 
 // Test lhs bitwise: xor
-TEST_CASE(lhs_bitwise_xor) { EXPECT((capture{}->*0xF ^ 0x3).value() == 0xC); }
+TEST_CASE(lhs_bitwise_xor) { EXPECT((capture{}->*0xFu ^ 0x3u).value() == 0xC); }
 
 // Test chained comparison
 TEST_CASE(chained_comparison)
@@ -199,7 +199,7 @@ TEST_CASE(nop_as_string_empty)
 // Test CHECK macro passes without incrementing failures
 TEST_CASE(check_macro_passes)
 {
-    // cppcheck-suppress knownConditionTrueFalse
+    // cppcheck-suppress duplicateExpression
     CHECK(1 == 1);
 }
 

--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -55,17 +55,6 @@ struct rank<0>
 {
 };
 
-template <class T>
-struct rrr
-{
-    using type = T;
-};
-
-template <class T>
-struct rrr<T&&>
-{
-    using type = T;
-};
 
 // clang-format off
 // NOLINTNEXTLINE

--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -55,7 +55,6 @@ struct rank<0>
 {
 };
 
-
 // clang-format off
 // NOLINTNEXTLINE
 #define TEST_FOREACH_BINARY_OPERATORS(m) \

--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -117,7 +117,7 @@ struct nop
 {
     static std::string as_string() { return ""; }
     template <class T>
-    static auto call(T&& x)
+    static decltype(auto) call(T&& x)
     {
         return static_cast<T&&>(x);
     }

--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -245,7 +245,7 @@ lhs_expression<T, Operator> make_lhs_expression(T&& lhs, Operator);
         return make_expression(*this, std::forward<V>(rhs2), name{}); /* NOLINT */            \
     }                                                                                         \
     template <class V>                                                                        \
-    auto operator op(V&& rhs2)&&                                                              \
+    auto operator op(V&& rhs2) &&                                                             \
     {                                                                                         \
         return make_expression(std::move(*this), std::forward<V>(rhs2), name{}); /* NOLINT */ \
     }

--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -55,6 +55,18 @@ struct rank<0>
 {
 };
 
+template <class T>
+struct rrr
+{
+    using type = T;
+};
+
+template <class T>
+struct rrr<T&&>
+{
+    using type = T;
+};
+
 // clang-format off
 // NOLINTNEXTLINE
 #define TEST_FOREACH_BINARY_OPERATORS(m) \
@@ -230,7 +242,7 @@ lhs_expression<T, Operator> make_lhs_expression(T&& lhs, Operator);
     template <class V>                                                             \
     auto operator op(V&& rhs2) const                                               \
     {                                                                              \
-        return make_expression(*this, std::forward<V>(rhs2), name{}); /* NOLINT */ \
+        return make_expression(std::move(*this), std::forward<V>(rhs2), name{}); /* NOLINT */ \
     }
 
 // NOLINTNEXTLINE

--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -246,8 +246,11 @@ lhs_expression<T, Operator> make_lhs_expression(T&& lhs, Operator);
     }
 
 // NOLINTNEXTLINE
-#define TEST_EXPR_UNARY_OPERATOR(op, name) \
-    auto operator op() const { return make_lhs_expression(lhs, name{}); /* NOLINT */ }
+#define TEST_EXPR_UNARY_OPERATOR(op, name)                                                          \
+    friend auto operator op(self_t self) /* NOLINT */                                                \
+    {                                                                                               \
+        return make_lhs_expression(static_cast<decltype(self.lhs)&&>(self.lhs), name{}); /* NOLINT */ \
+    }
 
 template <class T, class U, class Operator>
 struct expression

--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -240,14 +240,9 @@ lhs_expression<T, Operator> make_lhs_expression(T&& lhs, Operator);
 // NOLINTNEXTLINE
 #define TEST_EXPR_BINARY_OPERATOR(op, name)                                                   \
     template <class V>                                                                        \
-    auto operator op(V&& rhs2) const&                                                         \
+    friend auto operator op(self_t lhs2, V&& rhs2) /* NOLINT */                               \
     {                                                                                         \
-        return make_expression(*this, std::forward<V>(rhs2), name{}); /* NOLINT */            \
-    }                                                                                         \
-    template <class V>                                                                        \
-    auto operator op(V&& rhs2) &&                                                             \
-    {                                                                                         \
-        return make_expression(std::move(*this), std::forward<V>(rhs2), name{}); /* NOLINT */ \
+        return make_expression(std::move(lhs2), std::forward<V>(rhs2), name{}); /* NOLINT */ \
     }
 
 // NOLINTNEXTLINE
@@ -257,6 +252,7 @@ lhs_expression<T, Operator> make_lhs_expression(T&& lhs, Operator);
 template <class T, class U, class Operator>
 struct expression
 {
+    using self_t = expression;
     T lhs;
     U rhs;
 
@@ -299,6 +295,7 @@ lhs_expression<T, Operator> make_lhs_expression(T&& lhs, Operator)
 template <class T, class Operator>
 struct lhs_expression
 {
+    using self_t = lhs_expression;
     T lhs;
     explicit lhs_expression(T e) : lhs(static_cast<T&&>(e)) {}
 

--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -238,10 +238,10 @@ template <class T, class Operator>
 lhs_expression<T, Operator> make_lhs_expression(T&& lhs, Operator);
 
 // NOLINTNEXTLINE
-#define TEST_EXPR_BINARY_OPERATOR(op, name)                                                   \
-    template <class V>                                                                        \
-    friend auto operator op(self_t lhs2, V&& rhs2) /* NOLINT */                               \
-    {                                                                                         \
+#define TEST_EXPR_BINARY_OPERATOR(op, name)                                                  \
+    template <class V>                                                                       \
+    friend auto operator op(self_t lhs2, V&& rhs2) /* NOLINT */                              \
+    {                                                                                        \
         return make_expression(std::move(lhs2), std::forward<V>(rhs2), name{}); /* NOLINT */ \
     }
 

--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -117,7 +117,7 @@ struct nop
 {
     static std::string as_string() { return ""; }
     template <class T>
-    static decltype(auto) call(T&& x)
+    static T call(T&& x)
     {
         return static_cast<T&&>(x);
     }
@@ -382,12 +382,6 @@ struct capture
     auto operator->*(T&& x) const
     {
         return make_lhs_expression(std::forward<T>(x));
-    }
-
-    template <class T, class Operator>
-    auto operator->*(const lhs_expression<T, Operator>& x) const
-    {
-        return x;
     }
 };
 

--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -240,7 +240,12 @@ lhs_expression<T, Operator> make_lhs_expression(T&& lhs, Operator);
 // NOLINTNEXTLINE
 #define TEST_EXPR_BINARY_OPERATOR(op, name)                                                   \
     template <class V>                                                                        \
-    auto operator op(V&& rhs2) const                                                          \
+    auto operator op(V&& rhs2) const&                                                         \
+    {                                                                                         \
+        return make_expression(*this, std::forward<V>(rhs2), name{}); /* NOLINT */            \
+    }                                                                                         \
+    template <class V>                                                                        \
+    auto operator op(V&& rhs2)&&                                                              \
     {                                                                                         \
         return make_expression(std::move(*this), std::forward<V>(rhs2), name{}); /* NOLINT */ \
     }
@@ -295,7 +300,7 @@ template <class T, class Operator>
 struct lhs_expression
 {
     T lhs;
-    explicit lhs_expression(T e) : lhs(std::move(e)) {}
+    explicit lhs_expression(T e) : lhs(static_cast<T&&>(e)) {}
 
     friend std::ostream& operator<<(std::ostream& s, const lhs_expression& self)
     {
@@ -373,9 +378,9 @@ auto make_function(const std::string& name, F f)
 struct capture
 {
     template <class T>
-    auto operator->*(const T& x) const
+    auto operator->*(T&& x) const
     {
-        return make_lhs_expression(x);
+        return make_lhs_expression(std::forward<T>(x));
     }
 
     template <class T, class Operator>

--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -246,10 +246,11 @@ lhs_expression<T, Operator> make_lhs_expression(T&& lhs, Operator);
     }
 
 // NOLINTNEXTLINE
-#define TEST_EXPR_UNARY_OPERATOR(op, name)                                                          \
-    friend auto operator op(self_t self) /* NOLINT */                                                \
-    {                                                                                               \
-        return make_lhs_expression(static_cast<decltype(self.lhs)&&>(self.lhs), name{}); /* NOLINT */ \
+#define TEST_EXPR_UNARY_OPERATOR(op, name)                                      \
+    friend auto operator op(self_t self) /* NOLINT */                           \
+    {                                                                           \
+        return make_lhs_expression(static_cast<decltype(self.lhs)&&>(self.lhs), \
+                                   name{}); /* NOLINT */                        \
     }
 
 template <class T, class U, class Operator>

--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -238,10 +238,10 @@ template <class T, class Operator>
 lhs_expression<T, Operator> make_lhs_expression(T&& lhs, Operator);
 
 // NOLINTNEXTLINE
-#define TEST_EXPR_BINARY_OPERATOR(op, name)                                        \
-    template <class V>                                                             \
-    auto operator op(V&& rhs2) const                                               \
-    {                                                                              \
+#define TEST_EXPR_BINARY_OPERATOR(op, name)                                                   \
+    template <class V>                                                                        \
+    auto operator op(V&& rhs2) const                                                          \
+    {                                                                                         \
         return make_expression(std::move(*this), std::forward<V>(rhs2), name{}); /* NOLINT */ \
     }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -530,7 +530,7 @@ TEST_CASE(check_macro_passes)
     test::failures() = saved;
 }
 
-TEST_CASE(check_macro_failure_increments)
+TEST_CASE_SKIP(check_macro_failure_increments, "The failure keyword in the output is treated as a failure by ctest.")
 {
     auto saved       = test::failures().load();
     test::failures() = 0;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -654,12 +654,12 @@ struct move_only
 TEST_CASE(capure_move_only)
 {
     auto expr_equal = test::capture{}->*move_only{2} == move_only{2};
-    EXPECT(expr_equal.value());
-    EXPECT(test::as_string(expr_equal) == "move_only(2) == move_only(2)");
+    CHECK(expr_equal.value());
+    CHECK(test::as_string(expr_equal) == "move_only(2) == move_only(2)");
 
     auto expr_not_equal = test::capture{}->*move_only{2} != move_only{3};
-    EXPECT(expr_not_equal.value());
-    EXPECT(test::as_string(expr_not_equal) == "move_only(2) != move_only(3)");
+    CHECK(expr_not_equal.value());
+    CHECK(test::as_string(expr_not_equal) == "move_only(2) != move_only(3)");
 }
 
 // Edge cases for glob_match

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -230,9 +230,9 @@ TEST_CASE(lhs_arithmetic_operators)
 
 TEST_CASE(lhs_bitwise_operators)
 {
-    EXPECT((test::capture{}->*0xFF & 0x0F).value() == 0x0F);
-    EXPECT((test::capture{}->*0xF0 | 0x0F).value() == 0xFF);
-    EXPECT((test::capture{}->*0xFF ^ 0x0F).value() == 0xF0);
+    EXPECT((test::capture{}->*0xFFu & 0x0Fu).value() == 0x0Fu);
+    EXPECT((test::capture{}->*0xF0u | 0x0Fu).value() == 0xFFu);
+    EXPECT((test::capture{}->*0xFFu ^ 0x0Fu).value() == 0xF0u);
 }
 
 TEST_CASE(chained_comparison)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -618,7 +618,7 @@ struct noncopyable
     }
 };
 
-TEST_CASE(capure_noncopyable)
+TEST_CASE(capture_noncopyable)
 {
     noncopyable nc;
     auto expr = test::capture{}->*nc == nc;
@@ -651,7 +651,7 @@ struct move_only
     }
 };
 
-TEST_CASE(capure_move_only)
+TEST_CASE(capture_move_only)
 {
     auto expr_equal = test::capture{}->*move_only{2} == move_only{2};
     CHECK(expr_equal.value());

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -671,8 +671,8 @@ TEST_CASE(capure_move_only)
 // Test chaining lhs_expressions with and through capture
 TEST_CASE(capture_chained_and)
 {
-    EXPECT((test::capture{}->*1 == 1) and (test::capture{}->*2 == 2) and (test::capture{}->*3 == 3) and
-           (test::capture{}->*4 == 4));
+    EXPECT((test::capture{}->*1 == 1) and (test::capture{}->*2 == 2) and
+           (test::capture{}->*3 == 3) and (test::capture{}->*4 == 4));
 }
 
 // Edge cases for glob_match

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -82,6 +82,30 @@ TEST_CASE(globbing)
     EXPECT(not glob_match("test_foo", "test.foo"));
 }
 
+// Edge cases for glob_match
+TEST_CASE(globbing_edge_cases)
+{
+    // Empty strings
+    EXPECT(glob_match("", ""));
+    EXPECT(not glob_match("a", ""));
+    EXPECT(not glob_match("", "a"));
+    EXPECT(glob_match("", "*"));
+    EXPECT(not glob_match("", "?"));
+
+    // Only wildcards
+    EXPECT(glob_match("anything", "*"));
+    EXPECT(glob_match("a", "?"));
+    EXPECT(not glob_match("ab", "?"));
+    EXPECT(glob_match("ab", "??"));
+
+    // Star at beginning/end
+    EXPECT(glob_match("hello", "*hello"));
+    EXPECT(glob_match("hello", "hello*"));
+    EXPECT(glob_match("hello", "*hello*"));
+    EXPECT(glob_match("hello_world", "hello*world"));
+    EXPECT(not glob_match("hello_world", "hello*xyz"));
+}
+
 // Tests for as_string / print_stream
 TEST_CASE(as_string_basic_types)
 {
@@ -674,30 +698,6 @@ TEST_CASE(capture_chained_and)
 {
     EXPECT((test::capture{}->*1 == 1) and (test::capture{}->*2 == 2) and
            (test::capture{}->*3 == 3) and (test::capture{}->*4 == 4));
-}
-
-// Edge cases for glob_match
-TEST_CASE(globbing_edge_cases)
-{
-    // Empty strings
-    EXPECT(glob_match("", ""));
-    EXPECT(not glob_match("a", ""));
-    EXPECT(not glob_match("", "a"));
-    EXPECT(glob_match("", "*"));
-    EXPECT(not glob_match("", "?"));
-
-    // Only wildcards
-    EXPECT(glob_match("anything", "*"));
-    EXPECT(glob_match("a", "?"));
-    EXPECT(not glob_match("ab", "?"));
-    EXPECT(glob_match("ab", "??"));
-
-    // Star at beginning/end
-    EXPECT(glob_match("hello", "*hello"));
-    EXPECT(glob_match("hello", "hello*"));
-    EXPECT(glob_match("hello", "*hello*"));
-    EXPECT(glob_match("hello_world", "hello*world"));
-    EXPECT(not glob_match("hello_world", "hello*xyz"));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,10 @@
  * THE SOFTWARE.
  */
 #include <test.hpp>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 static bool glob_match(const std::string& input, const std::string& pattern)
 {
@@ -76,6 +80,593 @@ TEST_CASE(globbing)
     EXPECT(not glob_match("test.foog", "test.foo[gpu]"));
     EXPECT(not glob_match("test.foogpu", "test.foo[gpu]"));
     EXPECT(not glob_match("test_foo", "test.foo"));
+}
+
+// Tests for as_string / print_stream
+TEST_CASE(as_string_basic_types)
+{
+    EXPECT(test::as_string(42) == "42");
+    EXPECT(test::as_string(3.14) == "3.14");
+    EXPECT(test::as_string(std::string("hello")) == "hello");
+    EXPECT(test::as_string('x') == "x");
+}
+
+TEST_CASE(as_string_bool)
+{
+    EXPECT(test::as_string(true) == "true");
+    EXPECT(test::as_string(false) == "false");
+}
+
+TEST_CASE(as_string_nullptr)
+{
+    EXPECT(test::as_string(nullptr) == "nullptr");
+}
+
+TEST_CASE(as_string_vector)
+{
+    std::vector<int> v = {1, 2, 3};
+    EXPECT(test::as_string(v) == "{ 1, 2, 3}");
+}
+
+TEST_CASE(as_string_empty_vector)
+{
+    std::vector<int> v;
+    EXPECT(test::as_string(v) == "{ }");
+}
+
+TEST_CASE(as_string_single_element_vector)
+{
+    std::vector<int> v = {42};
+    EXPECT(test::as_string(v) == "{ 42}");
+}
+
+TEST_CASE(as_string_pair)
+{
+    auto p = std::make_pair(1, std::string("two"));
+    EXPECT(test::as_string(p) == "{1, two}");
+}
+
+TEST_CASE(as_string_optional_with_value)
+{
+    std::optional<int> o = 5;
+    EXPECT(test::as_string(o) == "5");
+}
+
+TEST_CASE(as_string_optional_empty)
+{
+    std::optional<int> o;
+    EXPECT(test::as_string(o) == "nullopt");
+}
+
+TEST_CASE(as_string_pointer)
+{
+    int x      = 0;
+    int* p     = &x;
+    auto s     = test::as_string(p);
+    auto sn    = test::as_string(static_cast<int*>(nullptr));
+    // Non-null pointer should produce some output (hex address)
+    EXPECT(not s.empty());
+    // Null pointer prints as 0
+    EXPECT(not sn.empty());
+}
+
+// Tests for expression templates / capture
+// Note: The expression template system stores references, so we use local
+// variables to avoid dangling references when storing expressions.
+TEST_CASE(capture_equal)
+{
+    int a = 1;
+    int b = 1;
+    auto expr = test::capture{}->*a == b;
+    EXPECT(expr.value());
+}
+
+TEST_CASE(capture_not_equal)
+{
+    int a = 1;
+    int b = 2;
+    auto expr = test::capture{}->*a != b;
+    EXPECT(expr.value());
+}
+
+TEST_CASE(capture_less_than)
+{
+    int a = 1;
+    int b = 2;
+    auto expr = test::capture{}->*a < b;
+    EXPECT(expr.value());
+}
+
+TEST_CASE(capture_greater_than)
+{
+    int a = 3;
+    int b = 2;
+    auto expr = test::capture{}->*a > b;
+    EXPECT(expr.value());
+}
+
+TEST_CASE(capture_less_than_equal)
+{
+    int a = 2;
+    int b = 2;
+    int c = 1;
+    auto expr1 = test::capture{}->*a <= b;
+    auto expr2 = test::capture{}->*c <= b;
+    EXPECT(expr1.value());
+    EXPECT(expr2.value());
+}
+
+TEST_CASE(capture_greater_than_equal)
+{
+    int a = 2;
+    int b = 2;
+    int c = 3;
+    auto expr1 = test::capture{}->*a >= b;
+    auto expr2 = test::capture{}->*c >= b;
+    EXPECT(expr1.value());
+    EXPECT(expr2.value());
+}
+
+TEST_CASE(capture_and_op)
+{
+    bool t = true;
+    bool f = false;
+    // Use EXPECT directly since expression templates store references
+    // to temporaries that cannot outlive a single statement
+    EXPECT(t and t);
+    EXPECT(not(t and f));
+    EXPECT(not(f and t));
+    EXPECT(not(f and f));
+}
+
+TEST_CASE(capture_or_op)
+{
+    bool t = true;
+    bool f = false;
+    EXPECT(t or t);
+    EXPECT(t or f);
+    EXPECT(f or t);
+    EXPECT(not(f or f));
+}
+
+TEST_CASE(capture_not_op)
+{
+    bool f = false;
+    bool t = true;
+    // not operator on lhs_expression only stores a reference to the
+    // underlying value, so storing in a variable is safe
+    auto expr = not(test::capture{}->*f);
+    EXPECT(expr.value());
+    auto expr2 = not(test::capture{}->*t);
+    EXPECT(not expr2.value());
+}
+
+TEST_CASE(expression_to_string)
+{
+    // Use the EXPECT macro's stringification to verify expression printing.
+    // The expression template uses references so we verify via as_string on
+    // simpler constructs that don't store intermediate temporaries.
+    int a = 42;
+    auto lhs = test::capture{}->*a;
+    EXPECT(test::as_string(lhs) == "42");
+    EXPECT(test::as_string(not lhs) == "not 42");
+}
+
+TEST_CASE(lhs_arithmetic_operators)
+{
+    int a = 3;
+    int b = 10;
+    int c = 4;
+    EXPECT((test::capture{}->*a + 2).value() == 5);
+    EXPECT((test::capture{}->*b - 3).value() == 7);
+    EXPECT((test::capture{}->*c * 5).value() == 20);
+    EXPECT((test::capture{}->*b / 2).value() == 5);
+    EXPECT((test::capture{}->*b % 3).value() == 1);
+}
+
+TEST_CASE(lhs_bitwise_operators)
+{
+    int a = 0xFF;
+    int b = 0xF0;
+    EXPECT((test::capture{}->*a & 0x0F).value() == 0x0F);
+    EXPECT((test::capture{}->*b | 0x0F).value() == 0xFF);
+    EXPECT((test::capture{}->*a ^ 0x0F).value() == 0xF0);
+}
+
+TEST_CASE(chained_comparison)
+{
+    int a = 3;
+    auto expr = (test::capture{}->*a + 2) == 5;
+    EXPECT(expr.value());
+}
+
+// Tests for throws
+TEST_CASE(throws_any_exception)
+{
+    EXPECT(test::throws([] { throw std::runtime_error("err"); }));
+    EXPECT(not test::throws([] {}));
+}
+
+TEST_CASE(throws_specific_exception)
+{
+    EXPECT(test::throws<std::runtime_error>([] { throw std::runtime_error("some error"); }));
+    EXPECT(not test::throws<std::runtime_error>([] {}));
+}
+
+TEST_CASE(throws_with_message)
+{
+    EXPECT(test::throws<std::runtime_error>(
+        [] { throw std::runtime_error("specific error message"); }, "specific"));
+    EXPECT(not test::throws<std::runtime_error>(
+        [] { throw std::runtime_error("specific error message"); }, "not found"));
+}
+
+TEST_CASE(throws_wrong_exception_type)
+{
+    // Throwing logic_error when expecting runtime_error should not be caught
+    bool caught = false;
+    try
+    {
+        test::throws<std::runtime_error>([] { throw std::logic_error("wrong type"); });
+    }
+    catch(const std::logic_error&)
+    {
+        caught = true;
+    }
+    EXPECT(caught);
+}
+
+// Tests for within_abs
+TEST_CASE(within_abs_close_values)
+{
+    auto result = test::within_abs(1.0, 1.0 + 1e-7, 1e-6);
+    EXPECT(result.value());
+}
+
+TEST_CASE(within_abs_exact_values)
+{
+    auto result = test::within_abs(5.0, 5.0);
+    EXPECT(result.value());
+}
+
+TEST_CASE(within_abs_far_values)
+{
+    auto result = test::within_abs(1.0, 2.0, 0.5);
+    EXPECT(not result.value());
+}
+
+TEST_CASE(within_abs_negative)
+{
+    auto result = test::within_abs(-1.0, -1.0 + 1e-8);
+    EXPECT(result.value());
+}
+
+// Tests for generic_parse
+TEST_CASE(generic_parse_basic)
+{
+    std::vector<std::string> args = {"--flag", "value1", "value2"};
+    auto result = test::generic_parse(args, [](const std::string& s) -> std::vector<std::string> {
+        if(s == "--flag")
+            return {"--flag", "--flag"};
+        return {};
+    });
+    EXPECT(result.count("--flag") > 0);
+    EXPECT(result.at("--flag").size() == 2);
+    EXPECT(result.at("--flag")[0] == "value1");
+    EXPECT(result.at("--flag")[1] == "value2");
+}
+
+TEST_CASE(generic_parse_no_flags)
+{
+    std::vector<std::string> args = {"arg1", "arg2"};
+    auto result = test::generic_parse(args, [](const std::string&) -> std::vector<std::string> {
+        return {};
+    });
+    EXPECT(result.count("") > 0);
+    EXPECT(result.at("").size() == 2);
+    EXPECT(result.at("")[0] == "arg1");
+    EXPECT(result.at("")[1] == "arg2");
+}
+
+TEST_CASE(generic_parse_flag_no_value)
+{
+    std::vector<std::string> args = {"--verbose"};
+    auto result = test::generic_parse(args, [](const std::string& s) -> std::vector<std::string> {
+        if(s == "--verbose")
+            return {"--verbose", ""};
+        return {};
+    });
+    EXPECT(result.count("--verbose") > 0);
+}
+
+TEST_CASE(generic_parse_mixed)
+{
+    // With single-element keyword return, flag stays set and all subsequent
+    // non-keyword args accumulate under it
+    std::vector<std::string> args = {"pos1", "--opt", "val1", "val2"};
+    auto result = test::generic_parse(args, [](const std::string& s) -> std::vector<std::string> {
+        if(s == "--opt")
+            return {"--opt"};
+        return {};
+    });
+    EXPECT(result.at("").size() == 1);
+    EXPECT(result.at("")[0] == "pos1");
+    EXPECT(result.at("--opt").size() == 2);
+    EXPECT(result.at("--opt")[0] == "val1");
+    EXPECT(result.at("--opt")[1] == "val2");
+}
+
+TEST_CASE(generic_parse_flag_resets)
+{
+    // Two-element keyword return {"flag", ""} sets flag then resets to ""
+    std::vector<std::string> args = {"pos1", "--flag", "pos2"};
+    auto result = test::generic_parse(args, [](const std::string& s) -> std::vector<std::string> {
+        if(s == "--flag")
+            return {"--flag", ""};
+        return {};
+    });
+    EXPECT(result.count("--flag") > 0);
+    EXPECT(result.at("").size() == 2);
+    EXPECT(result.at("")[0] == "pos1");
+    EXPECT(result.at("")[1] == "pos2");
+}
+
+// Tests for driver::parse and create_command
+TEST_CASE(driver_parse_basic)
+{
+    test::driver d;
+    const char* argv[] = {"test_exe", "case1", "case2"};
+    auto args          = d.parse(3, argv);
+    EXPECT(args.at("__exe__").front() == "test_exe");
+    EXPECT(args.at("").size() == 2);
+    EXPECT(args.at("")[0] == "case1");
+    EXPECT(args.at("")[1] == "case2");
+}
+
+TEST_CASE(driver_parse_with_flags)
+{
+    test::driver d;
+    const char* argv[] = {"test_exe", "--quiet", "case1"};
+    auto args          = d.parse(3, argv);
+    EXPECT(args.count("--quiet") > 0);
+    EXPECT(args.at("").size() == 1);
+    EXPECT(args.at("")[0] == "case1");
+}
+
+TEST_CASE(driver_parse_help_flag)
+{
+    test::driver d;
+    const char* argv[] = {"test_exe", "-h"};
+    auto args          = d.parse(2, argv);
+    EXPECT(args.count("--help") > 0);
+}
+
+TEST_CASE(driver_parse_continue_flag)
+{
+    test::driver d;
+    const char* argv[] = {"test_exe", "-c"};
+    auto args          = d.parse(2, argv);
+    EXPECT(args.count("--continue") > 0);
+}
+
+TEST_CASE(driver_create_command)
+{
+    test::string_map args;
+    args["__exe__"] = {"./bin/test"};
+    args[""]        = {"case1"};
+    auto cmd        = test::driver::create_command(args);
+    EXPECT(cmd.find("./bin/test") != std::string::npos);
+    EXPECT(cmd.find("case1") != std::string::npos);
+}
+
+// Tests for driver::glob_tests
+TEST_CASE(driver_glob_tests_exact)
+{
+    auto results = test::driver::glob_tests("globbing");
+    EXPECT(results.size() == 1);
+    EXPECT(results.front().first == "globbing");
+}
+
+TEST_CASE(driver_glob_tests_pattern)
+{
+    auto results = test::driver::glob_tests("as_string_*");
+    EXPECT(results.size() > 1);
+}
+
+TEST_CASE(driver_glob_tests_no_match)
+{
+    auto results = test::driver::glob_tests("nonexistent_test_xyz");
+    EXPECT(results.empty());
+}
+
+// Tests for failures tracking
+TEST_CASE(failures_tracking)
+{
+    test::failures() = 0;
+    EXPECT(test::failures().load() == 0);
+    test::report_failure();
+    EXPECT(test::failures().load() == 1);
+    test::report_failure(3);
+    EXPECT(test::failures().load() == 4);
+    test::failures() = 0;
+}
+
+// Tests for skip
+TEST_CASE(skip_exception)
+{
+    EXPECT(test::throws([] { test::skip("reason"); }));
+}
+
+TEST_CASE(skip_with_reason)
+{
+    try
+    {
+        test::skip("test reason");
+    }
+    catch(const test::skip_test& s)
+    {
+        EXPECT(s.reason == "test reason");
+        return;
+    }
+    // Should not reach here
+    EXPECT(false);
+}
+
+// Tests for failure_error
+TEST_CASE(fail_throws)
+{
+    EXPECT(test::throws([] { test::fail(); }));
+}
+
+// Tests for make_predicate
+TEST_CASE(make_predicate_true)
+{
+    auto pred = test::make_predicate("always_true", [] { return true; });
+    EXPECT(pred.value());
+}
+
+TEST_CASE(make_predicate_false)
+{
+    auto pred = test::make_predicate("always_false", [] { return false; });
+    EXPECT(not pred.value());
+}
+
+TEST_CASE(make_predicate_to_string)
+{
+    auto pred = test::make_predicate("my_check", [] { return true; });
+    auto s    = test::as_string(pred);
+    EXPECT(s.find("my_check") != std::string::npos);
+}
+
+// Tests for make_function
+TEST_CASE(make_function_basic)
+{
+    auto add = test::make_function("add", [](int a, int b) { return a + b == 5; });
+    auto r   = add(2, 3);
+    EXPECT(r.value());
+}
+
+TEST_CASE(make_function_to_string)
+{
+    auto is_positive = test::make_function("is_positive", [](int a) { return a > 0; });
+    auto r           = is_positive(5);
+    auto s           = test::as_string(r);
+    EXPECT(s.find("is_positive") != std::string::npos);
+}
+
+// Tests for CHECK macro (non-fatal)
+TEST_CASE(check_macro_passes)
+{
+    auto saved   = test::failures().load();
+    test::failures() = 0;
+    CHECK(1 == 1);
+    EXPECT(test::failures().load() == 0);
+    test::failures() = saved;
+}
+
+TEST_CASE(check_macro_failure_increments)
+{
+    auto saved   = test::failures().load();
+    test::failures() = 0;
+    CHECK(1 == 2);
+    EXPECT(test::failures().load() == 1);
+    test::failures() = saved;
+}
+
+// Tests for nested containers
+TEST_CASE(as_string_nested_vector)
+{
+    std::vector<std::vector<int>> v = {{1, 2}, {3, 4}};
+    auto s                          = test::as_string(v);
+    EXPECT(s.find("1") != std::string::npos);
+    EXPECT(s.find("4") != std::string::npos);
+}
+
+TEST_CASE(as_string_vector_of_strings)
+{
+    std::vector<std::string> v = {"hello", "world"};
+    auto s                     = test::as_string(v);
+    EXPECT(s.find("hello") != std::string::npos);
+    EXPECT(s.find("world") != std::string::npos);
+}
+
+// Tests for operator objects
+TEST_CASE(operator_objects_as_string)
+{
+    EXPECT(test::equal::as_string() == "==");
+    EXPECT(test::not_equal::as_string() == "!=");
+    EXPECT(test::less_than::as_string() == "<");
+    EXPECT(test::greater_than::as_string() == ">");
+    EXPECT(test::less_than_equal::as_string() == "<=");
+    EXPECT(test::greater_than_equal::as_string() == ">=");
+    EXPECT(test::and_op::as_string() == "and");
+    EXPECT(test::or_op::as_string() == "or");
+    EXPECT(test::not_op::as_string() == "not");
+    EXPECT(test::nop::as_string().empty());
+}
+
+TEST_CASE(operator_objects_call)
+{
+    EXPECT(test::equal::call(1, 1));
+    EXPECT(not test::equal::call(1, 2));
+    EXPECT(test::not_equal::call(1, 2));
+    EXPECT(test::less_than::call(1, 2));
+    EXPECT(test::greater_than::call(2, 1));
+    EXPECT(test::less_than_equal::call(1, 1));
+    EXPECT(test::greater_than_equal::call(2, 2));
+    EXPECT(test::and_op::call(true, true));
+    EXPECT(not test::and_op::call(true, false));
+    EXPECT(test::or_op::call(false, true));
+    EXPECT(test::not_op::call(false));
+}
+
+TEST_CASE(nop_call)
+{
+    EXPECT(test::nop::call(42) == 42);
+    EXPECT(test::nop::call(std::string("test")) == "test");
+}
+
+// Tests for expression value propagation
+TEST_CASE(expression_false_value)
+{
+    int a = 1;
+    int b = 2;
+    auto expr = test::capture{}->*a == b;
+    EXPECT(not expr.value());
+}
+
+TEST_CASE(expression_chained)
+{
+    int a = 1;
+    int b = 1;
+    // Binary expressions with `and` store references to temporaries,
+    // so they must be used inline via EXPECT
+    EXPECT((a == b) and (2 == 2));
+    EXPECT(not((a != b) and (2 == 2)));
+}
+
+// Edge cases for glob_match
+TEST_CASE(globbing_edge_cases)
+{
+    // Empty strings
+    EXPECT(glob_match("", ""));
+    EXPECT(not glob_match("a", ""));
+    EXPECT(not glob_match("", "a"));
+    EXPECT(glob_match("", "*"));
+    EXPECT(not glob_match("", "?"));
+
+    // Only wildcards
+    EXPECT(glob_match("anything", "*"));
+    EXPECT(glob_match("a", "?"));
+    EXPECT(not glob_match("ab", "?"));
+    EXPECT(glob_match("ab", "??"));
+
+    // Star at beginning/end
+    EXPECT(glob_match("hello", "*hello"));
+    EXPECT(glob_match("hello", "hello*"));
+    EXPECT(glob_match("hello", "*hello*"));
+    EXPECT(glob_match("hello_world", "hello*world"));
+    EXPECT(not glob_match("hello_world", "hello*xyz"));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -97,10 +97,7 @@ TEST_CASE(as_string_bool)
     EXPECT(test::as_string(false) == "false");
 }
 
-TEST_CASE(as_string_nullptr)
-{
-    EXPECT(test::as_string(nullptr) == "nullptr");
-}
+TEST_CASE(as_string_nullptr) { EXPECT(test::as_string(nullptr) == "nullptr"); }
 
 TEST_CASE(as_string_vector)
 {
@@ -140,10 +137,10 @@ TEST_CASE(as_string_optional_empty)
 
 TEST_CASE(as_string_pointer)
 {
-    int x      = 0;
-    int* p     = &x;
-    auto s     = test::as_string(p);
-    auto sn    = test::as_string(static_cast<int*>(nullptr));
+    int x   = 0;
+    int* p  = &x;
+    auto s  = test::as_string(p);
+    auto sn = test::as_string(static_cast<int*>(nullptr));
     // Non-null pointer should produce some output (hex address)
     EXPECT(not s.empty());
     // Null pointer prints as 0
@@ -155,41 +152,41 @@ TEST_CASE(as_string_pointer)
 // variables to avoid dangling references when storing expressions.
 TEST_CASE(capture_equal)
 {
-    int a = 1;
-    int b = 1;
+    int a     = 1;
+    int b     = 1;
     auto expr = test::capture{}->*a == b;
     EXPECT(expr.value());
 }
 
 TEST_CASE(capture_not_equal)
 {
-    int a = 1;
-    int b = 2;
+    int a     = 1;
+    int b     = 2;
     auto expr = test::capture{}->*a != b;
     EXPECT(expr.value());
 }
 
 TEST_CASE(capture_less_than)
 {
-    int a = 1;
-    int b = 2;
+    int a     = 1;
+    int b     = 2;
     auto expr = test::capture{}->*a < b;
     EXPECT(expr.value());
 }
 
 TEST_CASE(capture_greater_than)
 {
-    int a = 3;
-    int b = 2;
+    int a     = 3;
+    int b     = 2;
     auto expr = test::capture{}->*a > b;
     EXPECT(expr.value());
 }
 
 TEST_CASE(capture_less_than_equal)
 {
-    int a = 2;
-    int b = 2;
-    int c = 1;
+    int a      = 2;
+    int b      = 2;
+    int c      = 1;
     auto expr1 = test::capture{}->*a <= b;
     auto expr2 = test::capture{}->*c <= b;
     EXPECT(expr1.value());
@@ -198,9 +195,9 @@ TEST_CASE(capture_less_than_equal)
 
 TEST_CASE(capture_greater_than_equal)
 {
-    int a = 2;
-    int b = 2;
-    int c = 3;
+    int a      = 2;
+    int b      = 2;
+    int c      = 3;
     auto expr1 = test::capture{}->*a >= b;
     auto expr2 = test::capture{}->*c >= b;
     EXPECT(expr1.value());
@@ -246,7 +243,7 @@ TEST_CASE(expression_to_string)
     // Use the EXPECT macro's stringification to verify expression printing.
     // The expression template uses references so we verify via as_string on
     // simpler constructs that don't store intermediate temporaries.
-    int a = 42;
+    int a    = 42;
     auto lhs = test::capture{}->*a;
     EXPECT(test::as_string(lhs) == "42");
     EXPECT(test::as_string(not lhs) == "not 42");
@@ -275,7 +272,7 @@ TEST_CASE(lhs_bitwise_operators)
 
 TEST_CASE(chained_comparison)
 {
-    int a = 3;
+    int a     = 3;
     auto expr = (test::capture{}->*a + 2) == 5;
     EXPECT(expr.value());
 }
@@ -359,9 +356,8 @@ TEST_CASE(generic_parse_basic)
 TEST_CASE(generic_parse_no_flags)
 {
     std::vector<std::string> args = {"arg1", "arg2"};
-    auto result = test::generic_parse(args, [](const std::string&) -> std::vector<std::string> {
-        return {};
-    });
+    auto result                   = test::generic_parse(
+        args, [](const std::string&) -> std::vector<std::string> { return {}; });
     EXPECT(result.count("") > 0);
     EXPECT(result.at("").size() == 2);
     EXPECT(result.at("")[0] == "arg1");
@@ -557,7 +553,7 @@ TEST_CASE(make_function_to_string)
 // Tests for CHECK macro (non-fatal)
 TEST_CASE(check_macro_passes)
 {
-    auto saved   = test::failures().load();
+    auto saved       = test::failures().load();
     test::failures() = 0;
     CHECK(1 == 1);
     EXPECT(test::failures().load() == 0);
@@ -566,7 +562,7 @@ TEST_CASE(check_macro_passes)
 
 TEST_CASE(check_macro_failure_increments)
 {
-    auto saved   = test::failures().load();
+    auto saved       = test::failures().load();
     test::failures() = 0;
     CHECK(1 == 2);
     EXPECT(test::failures().load() == 1);
@@ -629,8 +625,8 @@ TEST_CASE(nop_call)
 // Tests for expression value propagation
 TEST_CASE(expression_false_value)
 {
-    int a = 1;
-    int b = 2;
+    int a     = 1;
+    int b     = 2;
     auto expr = test::capture{}->*a == b;
     EXPECT(not expr.value());
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -602,7 +602,7 @@ TEST_CASE(expression_false_value)
 TEST_CASE(expression_chained)
 {
     // cppcheck-suppress duplicateExpression
-    auto expr = (test::capture{}->*1 == 1) and (2 == 2);
+    auto expr = (test::capture{}->*1 == 1) and (2 == 2); // NOLINT(misc-redundant-expression)
     EXPECT(expr.value());
 }
 
@@ -639,9 +639,9 @@ struct move_only
     move_only() = default;
     explicit move_only(int x) : data(x) {}
 
-    move_only(move_only&& rhs)
+    move_only(move_only&& rhs) noexcept 
+    : data(rhs.data)
     {
-        data     = rhs.data;
         rhs.data = 0; // Invalidate source
     }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -601,6 +601,7 @@ TEST_CASE(expression_false_value)
 
 TEST_CASE(expression_chained)
 {
+    // cppcheck-suppress duplicateExpression
     auto expr = (test::capture{}->*1 == 1) and (2 == 2);
     EXPECT(expr.value());
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -639,8 +639,7 @@ struct move_only
     move_only() = default;
     explicit move_only(int x) : data(x) {}
 
-    move_only(move_only&& rhs) noexcept 
-    : data(rhs.data)
+    move_only(move_only&& rhs) noexcept : data(rhs.data)
     {
         rhs.data = 0; // Invalidate source
     }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -530,7 +530,8 @@ TEST_CASE(check_macro_passes)
     test::failures() = saved;
 }
 
-TEST_CASE_SKIP(check_macro_failure_increments, "The failure keyword in the output is treated as a failure by ctest.")
+TEST_CASE_SKIP(check_macro_failure_increments,
+               "The failure keyword in the output is treated as a failure by ctest.")
 {
     auto saved       = test::failures().load();
     test::failures() = 0;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -302,6 +302,12 @@ TEST_CASE(within_abs_negative)
     EXPECT(result.value());
 }
 
+TEST_CASE(within_abs_chained_and)
+{
+    EXPECT(test::within_abs(0.0, 0.0) and test::within_abs(0.5, 0.5) and
+           test::within_abs(1.0, 1.0) and test::within_abs(1.5, 1.5));
+}
+
 // Tests for generic_parse
 TEST_CASE(generic_parse_basic)
 {
@@ -660,6 +666,13 @@ TEST_CASE(capure_move_only)
     auto expr_not_equal = test::capture{}->*move_only{2} != move_only{3};
     CHECK(expr_not_equal.value());
     CHECK(test::as_string(expr_not_equal) == "move_only(2) != move_only(3)");
+}
+
+// Test chaining lhs_expressions with and through capture
+TEST_CASE(capture_chained_and)
+{
+    EXPECT((test::capture{}->*1 == 1) and (test::capture{}->*2 == 2) and (test::capture{}->*3 == 3) and
+           (test::capture{}->*4 == 4));
 }
 
 // Edge cases for glob_match

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -601,12 +601,11 @@ TEST_CASE(expression_chained)
 
 struct noncopyable
 {
-    int data = 42;
+    int data      = 42;
     noncopyable() = default;
-    explicit noncopyable(int x) : data(x)
-    {}
+    explicit noncopyable(int x) : data(x) {}
 
-    noncopyable(const noncopyable&) = delete;
+    noncopyable(const noncopyable&)            = delete;
     noncopyable& operator=(const noncopyable&) = delete;
 
     friend bool operator==(const noncopyable& x, const noncopyable& y) { return x.data == y.data; }
@@ -629,18 +628,17 @@ TEST_CASE(capure_noncopyable)
 
 struct move_only
 {
-    int data = 42;
+    int data    = 42;
     move_only() = default;
-    explicit move_only(int x) : data(x)
-    {}
+    explicit move_only(int x) : data(x) {}
 
     move_only(move_only&& rhs)
     {
-        data       = rhs.data;
-        rhs.data   = 0; // Invalidate source
+        data     = rhs.data;
+        rhs.data = 0; // Invalidate source
     }
 
-    move_only(const move_only&) = delete;
+    move_only(const move_only&)            = delete;
     move_only& operator=(const move_only&) = delete;
 
     friend bool operator==(const move_only& x, const move_only& y) { return x.data == y.data; }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -148,132 +148,96 @@ TEST_CASE(as_string_pointer)
 }
 
 // Tests for expression templates / capture
-// Note: The expression template system stores references, so we use local
-// variables to avoid dangling references when storing expressions.
 TEST_CASE(capture_equal)
 {
-    int a     = 1;
-    int b     = 1;
-    auto expr = test::capture{}->*a == b;
+    auto expr = test::capture{}->*1 == 1;
     EXPECT(expr.value());
 }
 
 TEST_CASE(capture_not_equal)
 {
-    int a     = 1;
-    int b     = 2;
-    auto expr = test::capture{}->*a != b;
+    auto expr = test::capture{}->*1 != 2;
     EXPECT(expr.value());
 }
 
 TEST_CASE(capture_less_than)
 {
-    int a     = 1;
-    int b     = 2;
-    auto expr = test::capture{}->*a < b;
+    auto expr = test::capture{}->*1 < 2;
     EXPECT(expr.value());
 }
 
 TEST_CASE(capture_greater_than)
 {
-    int a     = 3;
-    int b     = 2;
-    auto expr = test::capture{}->*a > b;
+    auto expr = test::capture{}->*3 > 2;
     EXPECT(expr.value());
 }
 
 TEST_CASE(capture_less_than_equal)
 {
-    int a      = 2;
-    int b      = 2;
-    int c      = 1;
-    auto expr1 = test::capture{}->*a <= b;
-    auto expr2 = test::capture{}->*c <= b;
+    auto expr1 = test::capture{}->*2 <= 2;
+    auto expr2 = test::capture{}->*1 <= 2;
     EXPECT(expr1.value());
     EXPECT(expr2.value());
 }
 
 TEST_CASE(capture_greater_than_equal)
 {
-    int a      = 2;
-    int b      = 2;
-    int c      = 3;
-    auto expr1 = test::capture{}->*a >= b;
-    auto expr2 = test::capture{}->*c >= b;
+    auto expr1 = test::capture{}->*2 >= 2;
+    auto expr2 = test::capture{}->*3 >= 2;
     EXPECT(expr1.value());
     EXPECT(expr2.value());
 }
 
 TEST_CASE(capture_and_op)
 {
-    bool t = true;
-    bool f = false;
-    // Use EXPECT directly since expression templates store references
-    // to temporaries that cannot outlive a single statement
-    EXPECT(t and t);
-    EXPECT(not(t and f));
-    EXPECT(not(f and t));
-    EXPECT(not(f and f));
+    auto expr1 = test::capture{}->*true and true;
+    EXPECT(expr1.value());
+    auto expr2 = test::capture{}->*true and false;
+    EXPECT(not expr2.value());
 }
 
 TEST_CASE(capture_or_op)
 {
-    bool t = true;
-    bool f = false;
-    EXPECT(t or t);
-    EXPECT(t or f);
-    EXPECT(f or t);
-    EXPECT(not(f or f));
+    auto expr1 = test::capture{}->*false or true;
+    EXPECT(expr1.value());
+    auto expr2 = test::capture{}->*false or false;
+    EXPECT(not expr2.value());
 }
 
 TEST_CASE(capture_not_op)
 {
-    bool f = false;
-    bool t = true;
-    // not operator on lhs_expression only stores a reference to the
-    // underlying value, so storing in a variable is safe
-    auto expr = not(test::capture{}->*f);
-    EXPECT(expr.value());
-    auto expr2 = not(test::capture{}->*t);
+    auto expr1 = not(test::capture{}->*false);
+    EXPECT(expr1.value());
+    auto expr2 = not(test::capture{}->*true);
     EXPECT(not expr2.value());
 }
 
 TEST_CASE(expression_to_string)
 {
-    // Use the EXPECT macro's stringification to verify expression printing.
-    // The expression template uses references so we verify via as_string on
-    // simpler constructs that don't store intermediate temporaries.
-    int a    = 42;
-    auto lhs = test::capture{}->*a;
-    EXPECT(test::as_string(lhs) == "42");
-    EXPECT(test::as_string(not lhs) == "not 42");
+    EXPECT(test::as_string(test::capture{}->*1 == 2) == "1 == 2");
+    EXPECT(test::as_string(test::capture{}->*3 != 4) == "3 != 4");
+    EXPECT(test::as_string(test::capture{}->*42) == "42");
 }
 
 TEST_CASE(lhs_arithmetic_operators)
 {
-    int a = 3;
-    int b = 10;
-    int c = 4;
-    EXPECT((test::capture{}->*a + 2).value() == 5);
-    EXPECT((test::capture{}->*b - 3).value() == 7);
-    EXPECT((test::capture{}->*c * 5).value() == 20);
-    EXPECT((test::capture{}->*b / 2).value() == 5);
-    EXPECT((test::capture{}->*b % 3).value() == 1);
+    EXPECT((test::capture{}->*3 + 2).value() == 5);
+    EXPECT((test::capture{}->*10 - 3).value() == 7);
+    EXPECT((test::capture{}->*4 * 5).value() == 20);
+    EXPECT((test::capture{}->*10 / 2).value() == 5);
+    EXPECT((test::capture{}->*10 % 3).value() == 1);
 }
 
 TEST_CASE(lhs_bitwise_operators)
 {
-    int a = 0xFF;
-    int b = 0xF0;
-    EXPECT((test::capture{}->*a & 0x0F).value() == 0x0F);
-    EXPECT((test::capture{}->*b | 0x0F).value() == 0xFF);
-    EXPECT((test::capture{}->*a ^ 0x0F).value() == 0xF0);
+    EXPECT((test::capture{}->*0xFF & 0x0F).value() == 0x0F);
+    EXPECT((test::capture{}->*0xF0 | 0x0F).value() == 0xFF);
+    EXPECT((test::capture{}->*0xFF ^ 0x0F).value() == 0xF0);
 }
 
 TEST_CASE(chained_comparison)
 {
-    int a     = 3;
-    auto expr = (test::capture{}->*a + 2) == 5;
+    auto expr = (test::capture{}->*3 + 2) == 5;
     EXPECT(expr.value());
 }
 
@@ -625,20 +589,79 @@ TEST_CASE(nop_call)
 // Tests for expression value propagation
 TEST_CASE(expression_false_value)
 {
-    int a     = 1;
-    int b     = 2;
-    auto expr = test::capture{}->*a == b;
+    auto expr = test::capture{}->*1 == 2;
     EXPECT(not expr.value());
 }
 
 TEST_CASE(expression_chained)
 {
-    int a = 1;
-    int b = 1;
-    // Binary expressions with `and` store references to temporaries,
-    // so they must be used inline via EXPECT
-    EXPECT((a == b) and (2 == 2));
-    EXPECT(not((a != b) and (2 == 2)));
+    auto expr = (test::capture{}->*1 == 1) and (2 == 2);
+    EXPECT(expr.value());
+}
+
+struct noncopyable
+{
+    int data = 42;
+    noncopyable() = default;
+    explicit noncopyable(int x) : data(x)
+    {}
+
+    noncopyable(const noncopyable&) = delete;
+    noncopyable& operator=(const noncopyable&) = delete;
+
+    friend bool operator==(const noncopyable& x, const noncopyable& y) { return x.data == y.data; }
+    friend bool operator!=(const noncopyable& x, const noncopyable& y) { return not(x == y); }
+
+    friend std::ostream& operator<<(std::ostream& os, const noncopyable& nc)
+    {
+        os << "noncopyable(" << nc.data << ")";
+        return os;
+    }
+};
+
+TEST_CASE(capure_noncopyable)
+{
+    noncopyable nc;
+    auto expr = test::capture{}->*nc == nc;
+    EXPECT(expr.value());
+    EXPECT(test::as_string(expr) == "noncopyable(42) == noncopyable(42)");
+}
+
+struct move_only
+{
+    int data = 42;
+    move_only() = default;
+    explicit move_only(int x) : data(x)
+    {}
+
+    move_only(move_only&& rhs)
+    {
+        data       = rhs.data;
+        rhs.data   = 0; // Invalidate source
+    }
+
+    move_only(const move_only&) = delete;
+    move_only& operator=(const move_only&) = delete;
+
+    friend bool operator==(const move_only& x, const move_only& y) { return x.data == y.data; }
+    friend bool operator!=(const move_only& x, const move_only& y) { return not(x == y); }
+
+    friend std::ostream& operator<<(std::ostream& os, const move_only& nc)
+    {
+        os << "move_only(" << nc.data << ")";
+        return os;
+    }
+};
+
+TEST_CASE(capure_move_only)
+{
+    auto expr_equal = test::capture{}->*move_only{2} == move_only{2};
+    EXPECT(expr_equal.value());
+    EXPECT(test::as_string(expr_equal) == "move_only(2) == move_only(2)");
+
+    auto expr_not_equal = test::capture{}->*move_only{2} != move_only{3};
+    EXPECT(expr_not_equal.value());
+    EXPECT(test::as_string(expr_not_equal) == "move_only(2) != move_only(3)");
 }
 
 // Edge cases for glob_match


### PR DESCRIPTION
## Motivation
When using types that do not have a copy constructor, the data was not passed along correctly.

## Technical Details

These changes were made for both the main test.hpp and the kernels/test.hpp for the gpu unit tests:

- `capture::operator->*(const T& x)` always stored const references, even for rvalues
- Changed to `T&& x` with `std::forward<T>(x)` so rvalues get stored by value
- `lhs_expression` constructor used `std::move(e)` which fails for reference types - changed to `static_cast<T&&>(e)`
- `TEST_EXPR_BINARY_OPERATOR` was `const` method doing `std::move(*this)` which doesn't move const objects - added friend version passing by value

Unit tests were added for both the main test.hpp and the kernels/test.hpp.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
