### PR TITLE
Free parse literal data in instruction::replace()

### DIFF
--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -261,6 +261,7 @@ void instruction::replace(instruction_ref ins,
 
 void instruction::replace(operation o, const shape& r, std::vector<instruction_ref> args)
 {
+    lit        = literal{};
     normalized = false;
     op         = std::move(o);
     replace(r);
@@ -272,6 +273,7 @@ void instruction::replace(operation o,
                           std::vector<instruction_ref> args,
                           std::vector<module_ref> mdl_args)
 {
+    lit = literal{};
     op = std::move(o);
     replace(r);
     replace(std::move(args), std::move(mdl_args));

--- a/test/instruction.cpp
+++ b/test/instruction.cpp
@@ -26,6 +26,7 @@
 #include <migraphx/program.hpp>
 #include <migraphx/make_op.hpp>
 #include "test.hpp"
+#include "rob.hpp"
 
 TEST_CASE(check_undefined)
 {
@@ -605,6 +606,35 @@ TEST_CASE(find_instructions_between_complex)
     EXPECT(result.count(y) == 0);
     EXPECT(result.count(z) == 0);
     EXPECT(result.count(add2) == 0);
+}
+
+// Verify that replacing a @literal instruction clears the literal data.
+// This ensures host memory from parsed weights is freed after compilation
+// replaces @literal with gpu_literal via instruction::replace().
+MIGRAPHX_ROB(access_ins_lit, migraphx::literal, migraphx::instruction, lit)
+
+TEST_CASE(check_replace_clears_literal)
+{
+    migraphx::module m;
+    migraphx::shape s{migraphx::shape::float_type, {2, 3}};
+    std::vector<float> data = {1, 2, 3, 4, 5, 6};
+
+    auto lit = m.add_literal(migraphx::literal(s, data));
+
+    // Before replacement: literal data is present
+    EXPECT(lit->name() == "@literal");
+    EXPECT(not access_ins_lit(*lit).empty());
+
+    // Replace @literal with a non-literal op via module API
+    auto input = m.add_parameter("x", s);
+    m.replace_instruction(lit, migraphx::make_op("abs"), input);
+
+    // After replacement: no longer @literal
+    EXPECT(lit->name() == "abs");
+
+    // After replacement: literal data should be cleared
+    EXPECT(lit->name() == "abs");
+    EXPECT(access_ins_lit(*lit).empty());
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation
When loading large LLM models (7B-14B parameters), `parse_onnx_buffer` creates **_@literal instructions_** holding ~14-28 GB of weight data on the host. After compilation, `write_literals` replaces these with `gpu_literal` instructions via `instruction::replace()`, but _the original host weight buffers are never freed_, causing `bad_alloc` during model cache serialization on memory-constrained systems.

## Technical Details
Add `lit = literal{};` at the start of both `replace(operation, ...)` overloads in instruction.cpp. After replace(), the instruction is no longer @literal (it becomes gpu_literal), so the lit field is dead weight; get_literal() asserts the instruction name is "@literal". The weight data has already been copied into gpu_literal::data via get_argument() before replace_instruction() is called.

This reclaims ~14-28 GB of host memory after compilation, allowing save_compiled_model() to succeed on memory-constrained systems.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
