### PR TITLE
Check if rocBLAS is enabled when including headers in gemm_impl.cpp

### DIFF
--- a/src/targets/gpu/gemm_impl.cpp
+++ b/src/targets/gpu/gemm_impl.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,10 +22,12 @@
  * THE SOFTWARE.
  */
 
-#include <rocblas/internal/rocblas-types.h>
-#include <rocblas/rocblas.h>
-#include <migraphx/gpu/rocblas.hpp>
 #include <migraphx/gpu/gemm_impl.hpp>
+#if MIGRAPHX_USE_ROCBLAS
+#include <rocblas/rocblas.h>
+#include <rocblas/internal/rocblas-types.h>
+#include <migraphx/gpu/rocblas.hpp>
+#endif
 #include <migraphx/reduce_dims.hpp>
 #include <migraphx/generate.hpp>
 #include <migraphx/time.hpp>


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
if rocBLAS is disabled in CMake, MIGraphX will fail to compile on Linux because of src/targets/gpu/gemm_impl.cpp looking for headers which aren't available.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
wrapped the rocBLAS headers in the same `#if MIGRAPHX_USE_ROCBLAS` macro.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [X] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
