### PR TITLE
find_nop_reshapes: Remove extra assignments/inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Full documentation for MIGraphX is available at
 
 ### Optimized
 * Optimized fusion for local_window mode of GQA operator (#4617).
-* Remove extra assignments and inserts of op names in find_nop_reshapes(#4696).
+* Removed extra assignments and inserts of op names in find_nop_reshapes(#4696).
 
 * Added a new pass to replace convolution with constant broadcast input with a reduced GEMM which improves model compilation time (#4621).
 * Implemented JIT compilation for `logsoftmax` by decomposing it into fusible operations (`log`, `exp`, `reduce_max`, `reduce_sum`), enabling kernel fusion. (#4630).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Full documentation for MIGraphX is available at
 
 ### Optimized
 * Optimized fusion for local_window mode of GQA operator (#4617).
+* Remove extra assignments and inserts of op names in find_nop_reshapes(#4696).
 
 * Added a new pass to replace convolution with constant broadcast input with a reduced GEMM which improves model compilation time (#4621).
 * Implemented JIT compilation for `logsoftmax` by decomposing it into fusible operations (`log`, `exp`, `reduce_max`, `reduce_sum`), enabling kernel fusion. (#4630).

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -144,7 +144,7 @@ instruction_ref insert_auto_reshape(module& m,
     return insert_auto_reshape(m, ins, std::vector<T>(dims), input);
 }
 
-const auto& reshaper_names()
+static const auto& reshaper_names()
 {
     // clang-format off
     static const std::unordered_set<std::string> names = {
@@ -153,8 +153,21 @@ const auto& reshaper_names()
         "contiguous",
         "squeeze",
         "unsqueeze"
+        "as_shape",
+        "broadcast",
+        "concat",
+        "convert",
+        "multibroadcast",
+        "pad",
+        "slice",
+        "step",
+        "transpose",
+        "reduce_mean",
+        "reduce_max",
+        "reduce_min",
+        "reduce_sum",
+        "reduce_prod",
     };
-    // clang-format on
     return names;
 }
 
@@ -605,22 +618,7 @@ struct find_nop_reshapes
 {
     auto matcher() const
     {
-        auto reshapes = reshaper_names();
-        reshapes.insert("as_shape");
-        reshapes.insert("broadcast");
-        reshapes.insert("concat");
-        reshapes.insert("convert");
-        reshapes.insert("multibroadcast");
-        reshapes.insert("pad");
-        reshapes.insert("slice");
-        reshapes.insert("step");
-        reshapes.insert("transpose");
-        reshapes.insert("reduce_mean");
-        reshapes.insert("reduce_max");
-        reshapes.insert("reduce_min");
-        reshapes.insert("reduce_sum");
-        reshapes.insert("reduce_prod");
-        return match::name(reshapes)(match::same_shape(match::arg(0)));
+       return match::name(reshaper_names())(match::same_shape(match::arg(0)));
     }
 
     void apply(module& m, const match::matcher_result& mr) const

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -144,33 +144,6 @@ instruction_ref insert_auto_reshape(module& m,
     return insert_auto_reshape(m, ins, std::vector<T>(dims), input);
 }
 
-static const auto& reshaper_names()
-{
-    // clang-format off
-    static const std::unordered_set<std::string> names = {
-        "flatten",
-        "reshape",
-        "contiguous",
-        "squeeze",
-        "unsqueeze",
-        "as_shape",
-        "broadcast",
-        "concat",
-        "convert",
-        "multibroadcast",
-        "pad",
-        "slice",
-        "step",
-        "transpose",
-        "reduce_mean",
-        "reduce_max",
-        "reduce_min",
-        "reduce_sum",
-        "reduce_prod",
-    };
-    return names;
-}
-
 instruction_ref
 insert_ops(module& m, instruction_ref ins, const std::vector<operation>& ops, instruction_ref input)
 {
@@ -618,7 +591,30 @@ struct find_nop_reshapes
 {
     auto matcher() const
     {
-       return match::name(reshaper_names())(match::same_shape(match::arg(0)));
+        // clang-format off
+        static const std::unordered_set<std::string> names = {
+            "flatten",
+            "reshape",
+            "contiguous",
+            "squeeze",
+            "unsqueeze",
+            "as_shape",
+            "broadcast",
+            "concat",
+            "convert",
+            "multibroadcast",
+            "pad",
+            "slice",
+            "step",
+            "transpose",
+            "reduce_mean",
+            "reduce_max",
+            "reduce_min",
+            "reduce_sum",
+            "reduce_prod",
+        };
+
+       return match::name(names)(match::same_shape(match::arg(0)));
     }
 
     void apply(module& m, const match::matcher_result& mr) const

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -152,7 +152,7 @@ static const auto& reshaper_names()
         "reshape",
         "contiguous",
         "squeeze",
-        "unsqueeze"
+        "unsqueeze",
         "as_shape",
         "broadcast",
         "concat",


### PR DESCRIPTION
Make the list a static const auto and  remove the inserts that always happen during the matcher after copying the const to a local matcher and then performing the match on find_nop_reshapes()

Cleaning this up should stop the overhead of added copy, inserts and destroying of local variables.

## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Bug hunting for another issue and after performing an analysis on simplify_reshapes() found that this was doing a bunch of create/destroy. Seems like this is worth a simple cleanup and avoids a bunch of copies, allocations and create/destroy.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
Since reshape_names() is used once in simplfy_reshapes.cpp, just make it a static const and remove the extra insert assignments that happen on every matcher before we even perform a match. Instead simplify the list so its a simple const lookup from the unordered set and remove the extra inserts/copy. 

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [x] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
