### PR TITLE
Cache repeated HIP compilation and MIOpen solution lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Full documentation for MIGraphX is available at
 * Implemented JIT compilation for `logsoftmax` by decomposing it into fusible operations (`log`, `exp`, `reduce_max`, `reduce_sum`), enabling kernel fusion. (#4630).
 * Improved `find_attention` to move evaluable constant inputs inside the operator, allowing rocMLIR to detect causal masks. (#4660)
 * Added early return for `find_conv_dot_horiz_fusion` matcher based on if operator output size is less than two (#4662).
+* Cached repeated HIP compilation and MIOpen solution lookups for repeated GPU compile paths (#4668).
 * Add matcher to simplify_algebra to find and replace pow(x, 2) with mul(x, x) (#4681)
 
 ### Removed

--- a/src/targets/gpu/compile_hip.cpp
+++ b/src/targets/gpu/compile_hip.cpp
@@ -27,9 +27,13 @@
 #include <migraphx/ranges.hpp>
 #include <migraphx/env.hpp>
 #include <migraphx/fileutils.hpp>
+#include <migraphx/hash.hpp>
 #include <cassert>
 #include <iostream>
 #include <deque>
+#include <future>
+#include <mutex>
+#include <unordered_map>
 
 #ifdef MIGRAPHX_USE_HIPRTC
 #include <hip/hiprtc.h>
@@ -57,9 +61,137 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GPU_DUMP_ASM);
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GPU_DUMP_SRC);
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GPU_HIP_FLAGS);
 
+namespace {
+struct cached_src_file
+{
+    std::string path    = {};
+    std::string content = {};
+};
+
+bool operator==(const cached_src_file& x, const cached_src_file& y)
+{
+    return x.path == y.path and x.content == y.content;
+}
+
+struct hip_compile_cache_key
+{
+    std::string mode              = {};
+    std::vector<cached_src_file> srcs = {};
+    std::vector<std::string> flags    = {};
+};
+
+bool operator==(const hip_compile_cache_key& x, const hip_compile_cache_key& y)
+{
+    return x.mode == y.mode and x.srcs == y.srcs and x.flags == y.flags;
+}
+
+struct hip_compile_cache_key_hash
+{
+    std::size_t operator()(const hip_compile_cache_key& key) const
+    {
+        std::size_t seed = hash_value(key.mode);
+        for(const auto& src : key.srcs)
+        {
+            hash_combine(seed, src.path);
+            hash_combine(seed, src.content);
+        }
+        for(const auto& flag : key.flags)
+        {
+            hash_combine(seed, flag);
+        }
+        return seed;
+    }
+};
+
+using hip_compile_cache_entry = std::shared_future<std::vector<std::vector<char>>>;
+
+struct hip_compile_cache
+{
+    template <class F>
+    std::vector<std::vector<char>> get_or_compile(hip_compile_cache_key key, F compile)
+    {
+        std::shared_ptr<std::promise<std::vector<std::vector<char>>>> promise;
+        hip_compile_cache_entry future;
+        bool should_compile = false;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            auto it = cache.find(key);
+            if(it == cache.end())
+            {
+                promise        = std::make_shared<std::promise<std::vector<std::vector<char>>>>();
+                future         = promise->get_future().share();
+                it             = cache.emplace(key, future).first;
+                should_compile = true;
+            }
+            future = it->second;
+        }
+
+        if(should_compile)
+        {
+            try
+            {
+                promise->set_value(compile());
+            }
+            catch(...)
+            {
+                promise->set_exception(std::current_exception());
+                std::lock_guard<std::mutex> lock(mutex);
+                auto it = cache.find(key);
+                if(it != cache.end())
+                    cache.erase(it);
+            }
+        }
+
+        return future.get();
+    }
+
+    std::mutex mutex;
+    std::unordered_map<hip_compile_cache_key, hip_compile_cache_entry, hip_compile_cache_key_hash>
+        cache = {};
+};
+
+std::vector<std::string> make_hiprtc_options(const std::vector<std::string>& params,
+                                             const std::string& arch)
+{
+    auto options = params;
+    options.push_back("-DMIGRAPHX_USE_HIPRTC=1");
+    if(enabled(MIGRAPHX_GPU_DEBUG{}))
+        options.push_back("-DMIGRAPHX_DEBUG");
+    if(std::none_of(options.begin(), options.end(), [](const std::string& s) {
+           return starts_with(s, "--std=") or starts_with(s, "-std=");
+       }))
+        options.push_back("-std=c++17");
+    options.push_back("-fno-gpu-rdc");
+    options.push_back("-O" + string_value_of(MIGRAPHX_GPU_OPTIMIZE{}, "3"));
+    options.push_back("-Wno-cuda-compat");
+    options.push_back("--offload-arch=" + arch);
+    auto extra_flags = split_string(string_value_of(MIGRAPHX_GPU_HIP_FLAGS{}, ""), ' ');
+    options.insert(options.end(), extra_flags.begin(), extra_flags.end());
+    return options;
+}
+
+hip_compile_cache_key make_hip_compile_cache_key(const std::string& mode,
+                                                 const std::vector<src_file>& srcs,
+                                                 std::vector<std::string> flags)
+{
+    hip_compile_cache_key key;
+    key.mode = mode;
+    key.srcs.reserve(srcs.size());
+    std::transform(srcs.begin(), srcs.end(), std::back_inserter(key.srcs), [](const src_file& src) {
+        return cached_src_file{src.path.string(), std::string(src.content)};
+    });
+    key.flags = std::move(flags);
+    return key;
+}
+
+hip_compile_cache& get_hip_compile_cache()
+{
+    static hip_compile_cache result;
+    return result;
+}
+
 #ifdef MIGRAPHX_USE_HIPRTC
 
-namespace {
 std::string hiprtc_error(hiprtcResult err, const std::string& msg)
 {
     return "hiprtc: " + (hiprtcGetErrorString(err) + (": " + msg));
@@ -205,22 +337,7 @@ std::vector<std::vector<char>> compile_hip_src_with_hiprtc(std::vector<hiprtc_sr
                                                            bool quiet)
 {
     hiprtc_program prog(std::move(srcs));
-    auto options = params;
-    options.push_back("-DMIGRAPHX_USE_HIPRTC=1");
-    if(enabled(MIGRAPHX_GPU_DEBUG{}))
-        options.push_back("-DMIGRAPHX_DEBUG");
-    if(std::none_of(options.begin(), options.end(), [](const std::string& s) {
-           return starts_with(s, "--std=") or starts_with(s, "-std=");
-       }))
-        options.push_back("-std=c++17");
-    options.push_back("-fno-gpu-rdc");
-    options.push_back("-O" + string_value_of(MIGRAPHX_GPU_OPTIMIZE{}, "3"));
-    options.push_back("-Wno-cuda-compat");
-    options.push_back("--offload-arch=" + arch);
-    std::vector<std::string> extra_flags =
-        split_string(string_value_of(MIGRAPHX_GPU_HIP_FLAGS{}, ""), ' ');
-    options.insert(options.end(), extra_flags.begin(), extra_flags.end());
-
+    auto options = make_hiprtc_options(params, arch);
     prog.compile(options, quiet);
 
     return {prog.get_code_obj()};
@@ -255,21 +372,25 @@ std::vector<std::vector<char>> compile_hip_src(const std::vector<src_file>& srcs
 
     if(found)
     {
+        auto options = make_hiprtc_options(params, arch);
+        auto key     = make_hip_compile_cache_key("hiprtc", srcs, options);
         value v;
         v["srcs"]   = to_value(hsrcs);
         v["params"] = to_value(params);
         v["arch"]   = to_value(arch);
         v["quiet"]  = quiet;
 
-        tmp_dir td{};
-        auto out = td.path / "output";
+        return get_hip_compile_cache().get_or_compile(std::move(key), [&] {
+            tmp_dir td{};
+            auto out = td.path / "output";
 
-        process(driver, {quote_string(out.string())}).write([&](auto writer) {
-            to_msgpack(v, std::move(writer));
+            process(driver, {quote_string(out.string())}).write([&](auto writer) {
+                to_msgpack(v, std::move(writer));
+            });
+            if(fs::exists(out))
+                return std::vector<std::vector<char>>{read_buffer(out)};
+            MIGRAPHX_THROW("hiprtc compilation failed!");
         });
-        if(fs::exists(out))
-            return {read_buffer(out)};
-        MIGRAPHX_THROW("hiprtc compilation failed!");
     }
     return compile_hip_src_with_hiprtc(std::move(hsrcs), params, arch, quiet);
 }
@@ -364,7 +485,14 @@ std::vector<std::vector<char>> compile_hip_src(const std::vector<src_file>& srcs
         std::cout << assemble(compiler).compile(srcs).data() << std::endl;
     }
 
-    return {compiler.compile(srcs)};
+    auto key = make_hip_compile_cache_key("hip-clang", srcs, compiler.flags);
+    key.flags.push_back("compiler=" + compiler.compiler.string());
+    if(not compiler.launcher.empty())
+        key.flags.push_back("launcher=" + compiler.launcher.string());
+
+    return get_hip_compile_cache().get_or_compile(std::move(key),
+                                                  [&] { return std::vector<std::vector<char>>{
+                                                             compiler.compile(srcs)}; });
 }
 
 #endif // MIGRAPHX_USE_HIPRTC

--- a/src/targets/gpu/compile_hip.cpp
+++ b/src/targets/gpu/compile_hip.cpp
@@ -28,6 +28,7 @@
 #include <migraphx/env.hpp>
 #include <migraphx/fileutils.hpp>
 #include <migraphx/hash.hpp>
+#include <algorithm>
 #include <cassert>
 #include <iostream>
 #include <deque>
@@ -105,6 +106,11 @@ struct hip_compile_cache_key_hash
 
 using hip_compile_cache_entry = std::shared_future<std::vector<std::vector<char>>>;
 
+bool same_future(const hip_compile_cache_entry& x, const hip_compile_cache_entry& y)
+{
+    return not x.owner_before(y) and not y.owner_before(x);
+}
+
 struct hip_compile_cache
 {
     template <class F>
@@ -120,7 +126,7 @@ struct hip_compile_cache
             {
                 promise        = std::make_shared<std::promise<std::vector<std::vector<char>>>>();
                 future         = promise->get_future().share();
-                it             = cache.emplace(key, future).first;
+                it             = cache.emplace(std::move(key), future).first;
                 should_compile = true;
             }
             future = it->second;
@@ -136,7 +142,9 @@ struct hip_compile_cache
             {
                 promise->set_exception(std::current_exception());
                 std::lock_guard<std::mutex> lock(mutex);
-                auto it = cache.find(key);
+                auto it = std::find_if(cache.begin(), cache.end(), [&](const auto& item) {
+                    return same_future(item.second, future);
+                });
                 if(it != cache.end())
                     cache.erase(it);
             }

--- a/src/targets/gpu/include/migraphx/gpu/convolution.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/convolution.hpp
@@ -32,9 +32,11 @@
 #include <migraphx/op/convolution.hpp>
 #include <migraphx/op/quant_convolution.hpp>
 #include <migraphx/op/convolution_backwards.hpp>
-#include <unordered_map>
 #include <migraphx/reflect.hpp>
 #include <migraphx/gpu/context.hpp>
+#include <migraphx/value.hpp>
+#include <mutex>
+#include <unordered_map>
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
@@ -53,6 +55,64 @@ inline shape reshape_if_1d(const shape& input)
     return new_shape;
 }
 #if MIGRAPHX_USE_MIOPEN
+struct miopen_convolution_solution_cache_entry
+{
+    shape workspace_shape = {};
+#ifdef MIGRAPHX_HAS_FIND_2_API
+    value::binary solution_object = {};
+#else
+    miopenConvFwdAlgorithm_t algo{};
+    uint64_t solution_id = 0;
+#endif
+};
+
+struct miopen_convolution_solution_cache
+{
+    std::mutex mutex;
+    std::unordered_map<value, miopen_convolution_solution_cache_entry> cache = {};
+};
+
+inline miopen_convolution_solution_cache& get_miopen_convolution_solution_cache()
+{
+    static miopen_convolution_solution_cache result;
+    return result;
+}
+
+template <class Op>
+inline value make_miopen_convolution_cache_key(const Op& op,
+                                               const context& ctx,
+                                               const shape& output_shape,
+                                               const std::vector<shape>& inputs)
+{
+    value key;
+    key["op"]         = to_value(op);
+    key["output"]     = to_value(output_shape);
+    key["inputs"]     = to_value(inputs);
+    key["gfx"]        = ctx.get_current_device().get_gfx_name();
+    key["exhaustive"] = ctx.get_exhaustive_tune_flag();
+    return key;
+}
+
+inline bool load_cached_miopen_convolution_solution(
+    const value& key, miopen_convolution_solution_cache_entry& result)
+{
+    auto& cache = get_miopen_convolution_solution_cache();
+    std::lock_guard<std::mutex> lock(cache.mutex);
+    const auto it = cache.cache.find(key);
+    if(it == cache.cache.end())
+        return false;
+    result = it->second;
+    return true;
+}
+
+inline void insert_miopen_convolution_solution_cache(
+    const value& key, const miopen_convolution_solution_cache_entry& result)
+{
+    auto& cache = get_miopen_convolution_solution_cache();
+    std::lock_guard<std::mutex> lock(cache.mutex);
+    cache.cache[key] = result;
+}
+
 template <class Op>
 struct miopen_convolution
 {
@@ -163,6 +223,7 @@ struct miopen_convolution
         auto x_desc = make_tensor(reshape_if_1d(inputs[0]));
         auto w_desc = make_tensor(reshape_if_1d(inputs[1]));
         auto y_desc = make_tensor(reshape_if_1d(output_shape));
+        const auto cache_key = make_miopen_convolution_cache_key(op, ctx, output_shape, inputs);
 
         auto* miopen_stream_handle = ctx.get_stream().get_miopen();
         std::size_t workspace_size = 0;
@@ -176,6 +237,19 @@ struct miopen_convolution
             MIGRAPHX_THROW("MIOpen" + op.name() + " : Failed to get forward workspace size");
 
         workspace_shape = shape{shape::int8_type, {workspace_size}};
+
+        miopen_convolution_solution_cache_entry cache_result;
+        if(load_cached_miopen_convolution_solution(cache_key, cache_result))
+        {
+#ifdef MIGRAPHX_HAS_FIND_2_API
+            solution_ptr   = nullptr;
+            solution_object = cache_result.solution_object;
+#else
+            algo        = cache_result.algo;
+            solution_id = cache_result.solution_id;
+#endif
+            return cache_result.workspace_shape;
+        }
 
         const auto& x_shape = inputs[0];
         const auto& w_shape = inputs[1];
@@ -233,7 +307,10 @@ struct miopen_convolution
             if(status != miopenStatusSuccess)
                 MIGRAPHX_THROW("MIOpen" + op.name() + ": Saving solution failed");
             solution_object = value::binary{solution_binary.data(), solution_size};
-            return shape{shape::int8_type, {workspace_size}};
+            workspace_shape = shape{shape::int8_type, {workspace_size}};
+            insert_miopen_convolution_solution_cache(
+                cache_key, miopen_convolution_solution_cache_entry{workspace_shape, solution_object});
+            return workspace_shape;
         }
 #else
         auto x         = to_gpu(generate_argument(x_shape, seed++, random_mode::random));
@@ -285,7 +362,10 @@ struct miopen_convolution
 
         solution_id = solutions.front().solution_id;
 
-        return shape{shape::int8_type, {perf.memory}};
+        workspace_shape = shape{shape::int8_type, {perf.memory}};
+        insert_miopen_convolution_solution_cache(
+            cache_key, miopen_convolution_solution_cache_entry{workspace_shape, algo, solution_id});
+        return workspace_shape;
 #endif
     }
 

--- a/test/gpu/compile_hip_cache.cpp
+++ b/test/gpu/compile_hip_cache.cpp
@@ -1,0 +1,180 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/file_buffer.hpp>
+#include <migraphx/gpu/compile_hip.hpp>
+#include <migraphx/gpu/device_name.hpp>
+#include <migraphx/tmp_dir.hpp>
+#include <test.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string_view>
+#include <vector>
+
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+const std::string cached_write_kernel = R"__migraphx__(
+#ifndef __HIPCC_RTC__
+#include <hip/hip_runtime.h>
+#endif
+
+extern "C" {
+__global__ void write(char* data)
+{
+    int num = threadIdx.x + blockDim.x * blockIdx.x;
+    data[num] = 7;
+}
+}
+
+int main() {}
+
+)__migraphx__";
+
+std::size_t count_occurrences(std::string_view text, std::string_view needle)
+{
+    if(needle.empty())
+        return 0;
+
+    std::size_t count = 0;
+    std::size_t pos   = 0;
+    while((pos = text.find(needle, pos)) != std::string_view::npos)
+    {
+        ++count;
+        pos += needle.size();
+    }
+    return count;
+}
+
+struct scoped_env_var
+{
+    scoped_env_var(const char* env_name, const char* env_value) : name(env_name)
+    {
+        if(const char* current = std::getenv(env_name))
+        {
+            had_previous   = true;
+            previous_value = current;
+        }
+        setenv(env_name, env_value, 1);
+    }
+
+    ~scoped_env_var()
+    {
+        if(had_previous)
+            setenv(name.c_str(), previous_value.c_str(), 1);
+        else
+            unsetenv(name.c_str());
+    }
+
+    std::string name           = {};
+    std::string previous_value = {};
+    bool had_previous          = false;
+};
+
+#ifndef _WIN32
+struct scoped_output_capture
+{
+    explicit scoped_output_capture(const migraphx::fs::path& path)
+    {
+        fd = ::open(path.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0600);
+        if(fd < 0)
+            throw std::runtime_error("Failed to open capture file");
+
+        saved_stdout = ::dup(STDOUT_FILENO);
+        saved_stderr = ::dup(STDERR_FILENO);
+        if(saved_stdout < 0 or saved_stderr < 0)
+            throw std::runtime_error("Failed to duplicate stdout/stderr");
+
+        std::fflush(stdout);
+        std::fflush(stderr);
+        if(::dup2(fd, STDOUT_FILENO) < 0 or ::dup2(fd, STDERR_FILENO) < 0)
+            throw std::runtime_error("Failed to redirect stdout/stderr");
+    }
+
+    scoped_output_capture(const scoped_output_capture&) = delete;
+    scoped_output_capture& operator=(const scoped_output_capture&) = delete;
+
+    ~scoped_output_capture() { restore(); }
+
+    void restore()
+    {
+        if(restored)
+            return;
+
+        std::fflush(stdout);
+        std::fflush(stderr);
+        if(saved_stdout >= 0)
+            ::dup2(saved_stdout, STDOUT_FILENO);
+        if(saved_stderr >= 0)
+            ::dup2(saved_stderr, STDERR_FILENO);
+        if(saved_stdout >= 0)
+            ::close(saved_stdout);
+        if(saved_stderr >= 0)
+            ::close(saved_stderr);
+        if(fd >= 0)
+            ::close(fd);
+        restored = true;
+    }
+
+    int fd          = -1;
+    int saved_stdout = -1;
+    int saved_stderr = -1;
+    bool restored    = false;
+};
+#endif
+
+} // namespace
+
+TEST_CASE(compile_hip_src_reuses_cached_result)
+{
+#ifdef _WIN32
+    EXPECT(true);
+#else
+    scoped_env_var trace_env{"MIGRAPHX_TRACE_HIPRTC", "1"};
+    migraphx::tmp_dir td{"hip-compile-cache"};
+    const auto capture_path = td.path / "trace.log";
+
+    std::vector<migraphx::src_file> srcs = {{"main.cpp", cached_write_kernel}};
+    const auto arch                      = migraphx::gpu::get_device_name();
+
+    scoped_output_capture capture(capture_path);
+    const auto first_compile  = migraphx::gpu::compile_hip_src(srcs, {}, arch);
+    const auto second_compile = migraphx::gpu::compile_hip_src(srcs, {}, arch);
+    capture.restore();
+
+    EXPECT(first_compile == second_compile);
+
+#ifdef MIGRAPHX_USE_HIPRTC
+    const auto trace = migraphx::read_string(capture_path);
+    EXPECT(count_occurrences(trace, "hiprtc ") == 1);
+#endif
+#endif
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/gpu/compile_hip_cache.cpp
+++ b/test/gpu/compile_hip_cache.cpp
@@ -72,6 +72,7 @@ std::size_t count_occurrences(std::string_view text, std::string_view needle)
     return count;
 }
 
+#ifndef _WIN32
 struct scoped_env_var
 {
     scoped_env_var(const char* env_name, const char* env_value) : name(env_name)
@@ -96,6 +97,7 @@ struct scoped_env_var
     std::string previous_value = {};
     bool had_previous          = false;
 };
+#endif
 
 #ifndef _WIN32
 struct scoped_output_capture

--- a/test/gpu/compile_hip_cache.cpp
+++ b/test/gpu/compile_hip_cache.cpp
@@ -104,19 +104,27 @@ struct scoped_output_capture
 {
     explicit scoped_output_capture(const migraphx::fs::path& path)
     {
-        fd = ::open(path.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0600);
-        if(fd < 0)
-            throw std::runtime_error("Failed to open capture file");
+        try
+        {
+            fd = ::open(path.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0600);
+            if(fd < 0)
+                throw std::runtime_error("Failed to open capture file");
 
-        saved_stdout = ::dup(STDOUT_FILENO);
-        saved_stderr = ::dup(STDERR_FILENO);
-        if(saved_stdout < 0 or saved_stderr < 0)
-            throw std::runtime_error("Failed to duplicate stdout/stderr");
+            saved_stdout = ::dup(STDOUT_FILENO);
+            saved_stderr = ::dup(STDERR_FILENO);
+            if(saved_stdout < 0 or saved_stderr < 0)
+                throw std::runtime_error("Failed to duplicate stdout/stderr");
 
-        std::fflush(stdout);
-        std::fflush(stderr);
-        if(::dup2(fd, STDOUT_FILENO) < 0 or ::dup2(fd, STDERR_FILENO) < 0)
-            throw std::runtime_error("Failed to redirect stdout/stderr");
+            std::fflush(stdout);
+            std::fflush(stderr);
+            if(::dup2(fd, STDOUT_FILENO) < 0 or ::dup2(fd, STDERR_FILENO) < 0)
+                throw std::runtime_error("Failed to redirect stdout/stderr");
+        }
+        catch(...)
+        {
+            restore();
+            throw;
+        }
     }
 
     scoped_output_capture(const scoped_output_capture&) = delete;
@@ -144,7 +152,7 @@ struct scoped_output_capture
         restored = true;
     }
 
-    int fd          = -1;
+    int fd           = -1;
     int saved_stdout = -1;
     int saved_stderr = -1;
     bool restored    = false;

--- a/test/gpu/compile_miopen_cache.cpp
+++ b/test/gpu/compile_miopen_cache.cpp
@@ -1,0 +1,174 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/context.hpp>
+#include <migraphx/file_buffer.hpp>
+#include <migraphx/gpu/context.hpp>
+#include <migraphx/gpu/convolution.hpp>
+#include <migraphx/op/convolution.hpp>
+#include <migraphx/tmp_dir.hpp>
+#include <test.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string_view>
+
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+std::size_t count_occurrences(std::string_view text, std::string_view needle)
+{
+    if(needle.empty())
+        return 0;
+
+    std::size_t count = 0;
+    std::size_t pos   = 0;
+    while((pos = text.find(needle, pos)) != std::string_view::npos)
+    {
+        ++count;
+        pos += needle.size();
+    }
+    return count;
+}
+
+struct scoped_env_var
+{
+    scoped_env_var(const char* env_name, const char* env_value) : name(env_name)
+    {
+        if(const char* current = std::getenv(env_name))
+        {
+            had_previous   = true;
+            previous_value = current;
+        }
+        setenv(env_name, env_value, 1);
+    }
+
+    ~scoped_env_var()
+    {
+        if(had_previous)
+            setenv(name.c_str(), previous_value.c_str(), 1);
+        else
+            unsetenv(name.c_str());
+    }
+
+    std::string name           = {};
+    std::string previous_value = {};
+    bool had_previous          = false;
+};
+
+#ifndef _WIN32
+struct scoped_output_capture
+{
+    explicit scoped_output_capture(const migraphx::fs::path& path)
+    {
+        fd = ::open(path.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0600);
+        if(fd < 0)
+            throw std::runtime_error("Failed to open capture file");
+
+        saved_stdout = ::dup(STDOUT_FILENO);
+        saved_stderr = ::dup(STDERR_FILENO);
+        if(saved_stdout < 0 or saved_stderr < 0)
+            throw std::runtime_error("Failed to duplicate stdout/stderr");
+
+        std::fflush(stdout);
+        std::fflush(stderr);
+        if(::dup2(fd, STDOUT_FILENO) < 0 or ::dup2(fd, STDERR_FILENO) < 0)
+            throw std::runtime_error("Failed to redirect stdout/stderr");
+    }
+
+    scoped_output_capture(const scoped_output_capture&) = delete;
+    scoped_output_capture& operator=(const scoped_output_capture&) = delete;
+
+    ~scoped_output_capture() { restore(); }
+
+    void restore()
+    {
+        if(restored)
+            return;
+
+        std::fflush(stdout);
+        std::fflush(stderr);
+        if(saved_stdout >= 0)
+            ::dup2(saved_stdout, STDOUT_FILENO);
+        if(saved_stderr >= 0)
+            ::dup2(saved_stderr, STDERR_FILENO);
+        if(saved_stdout >= 0)
+            ::close(saved_stdout);
+        if(saved_stderr >= 0)
+            ::close(saved_stderr);
+        if(fd >= 0)
+            ::close(fd);
+        restored = true;
+    }
+
+    int fd           = -1;
+    int saved_stdout = -1;
+    int saved_stderr = -1;
+    bool restored    = false;
+};
+#endif
+
+} // namespace
+
+TEST_CASE(miopen_convolution_compile_reuses_cached_solution)
+{
+#if !MIGRAPHX_USE_MIOPEN || defined(_WIN32)
+    EXPECT(true);
+#else
+    scoped_env_var logging_env{"MIOPEN_ENABLE_LOGGING", "1"};
+    scoped_env_var logging_cmd_env{"MIOPEN_ENABLE_LOGGING_CMD", "1"};
+    migraphx::tmp_dir td{"miopen-compile-cache"};
+    const auto capture_path = td.path / "trace.log";
+
+    migraphx::gpu::context gpu_ctx;
+    migraphx::context ctx{gpu_ctx};
+
+    migraphx::op::convolution conv{};
+    conv.padding = {1, 1};
+
+    const migraphx::shape x{migraphx::shape::float_type, {1, 64, 16, 16}};
+    const migraphx::shape w{migraphx::shape::float_type, {64, 64, 3, 3}};
+    const migraphx::shape y = migraphx::compute_shape(conv, {x, w});
+    const std::vector<migraphx::shape> inputs = {x, w, y};
+
+    migraphx::gpu::miopen_convolution<migraphx::op::convolution> first_op{conv};
+    migraphx::gpu::miopen_convolution<migraphx::op::convolution> second_op{conv};
+
+    scoped_output_capture capture(capture_path);
+    const auto first_result  = first_op.compile(ctx, y, inputs);
+    const auto second_result = second_op.compile(ctx, y, inputs);
+    capture.restore();
+
+    EXPECT(first_result == second_result);
+
+    const auto trace = migraphx::read_string(capture_path);
+    EXPECT(count_occurrences(trace, "miopenFindSolutions") == 1);
+#endif
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/gpu/compile_miopen_cache.cpp
+++ b/test/gpu/compile_miopen_cache.cpp
@@ -56,6 +56,7 @@ std::size_t count_occurrences(std::string_view text, std::string_view needle)
     return count;
 }
 
+#ifndef _WIN32
 struct scoped_env_var
 {
     scoped_env_var(const char* env_name, const char* env_value) : name(env_name)
@@ -80,6 +81,7 @@ struct scoped_env_var
     std::string previous_value = {};
     bool had_previous          = false;
 };
+#endif
 
 #ifndef _WIN32
 struct scoped_output_capture

--- a/test/gpu/compile_miopen_cache.cpp
+++ b/test/gpu/compile_miopen_cache.cpp
@@ -88,19 +88,27 @@ struct scoped_output_capture
 {
     explicit scoped_output_capture(const migraphx::fs::path& path)
     {
-        fd = ::open(path.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0600);
-        if(fd < 0)
-            throw std::runtime_error("Failed to open capture file");
+        try
+        {
+            fd = ::open(path.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0600);
+            if(fd < 0)
+                throw std::runtime_error("Failed to open capture file");
 
-        saved_stdout = ::dup(STDOUT_FILENO);
-        saved_stderr = ::dup(STDERR_FILENO);
-        if(saved_stdout < 0 or saved_stderr < 0)
-            throw std::runtime_error("Failed to duplicate stdout/stderr");
+            saved_stdout = ::dup(STDOUT_FILENO);
+            saved_stderr = ::dup(STDERR_FILENO);
+            if(saved_stdout < 0 or saved_stderr < 0)
+                throw std::runtime_error("Failed to duplicate stdout/stderr");
 
-        std::fflush(stdout);
-        std::fflush(stderr);
-        if(::dup2(fd, STDOUT_FILENO) < 0 or ::dup2(fd, STDERR_FILENO) < 0)
-            throw std::runtime_error("Failed to redirect stdout/stderr");
+            std::fflush(stdout);
+            std::fflush(stderr);
+            if(::dup2(fd, STDOUT_FILENO) < 0 or ::dup2(fd, STDERR_FILENO) < 0)
+                throw std::runtime_error("Failed to redirect stdout/stderr");
+        }
+        catch(...)
+        {
+            restore();
+            throw;
+        }
     }
 
     scoped_output_capture(const scoped_output_capture&) = delete;


### PR DESCRIPTION
Split from #4668 to isolate the GPU compile/cache changes.

This PR includes:
- HIP compilation result caching
- MIOpen convolution solution caching
- Windows guards for the cache tests from the prior review follow-up
- changelog coverage for this slice

Validation in this slice:
- targeted test coverage for `test_gpu_compile_hip_cache` and `test_gpu_compile_miopen_cache` is included in the diff
- branch was split cleanly from `develop` and passes `git diff --check`

Local ROCm build/test execution from this environment is currently blocked because the checkout is missing required third-party headers (`half.hpp` via `CMAKE_PREFIX_PATH`), so runtime/perf validation still needs repo CI or perf infra.