### PR TITLE
Fix bug in rewrite_resize with nhwc

### DIFF
--- a/src/rewrite_resize.cpp
+++ b/src/rewrite_resize.cpp
@@ -127,6 +127,8 @@ static instruction_ref rewrite_nearest_resize(module& m,
     auto nearest_op = op::resize::get_nearest_op(nearest_mode);
     auto idx_op     = op::resize::get_original_idx_op(coord_trans_mode);
 
+    // Use standard strides for index computation since reshape will make input contiguous
+    auto std_in_s = in_s.as_standard();
     shape_for_each(out_s, [&](const auto& out_idx_v, size_t out_idx) {
         std::vector<size_t> in_idx(out_idx_v.size());
         for(std::size_t ii = 0; ii < in_lens.size(); ++ii)
@@ -135,7 +137,7 @@ static instruction_ref rewrite_nearest_resize(module& m,
             in_idx[ii]   = nearest_op(in_lens[ii], idx_val);
         }
 
-        ind[out_idx] = in_s.index(in_idx);
+        ind[out_idx] = std_in_s.index(in_idx);
     });
 
     auto rsp = m.insert_instruction(

--- a/test/rewrite_resize_test.cpp
+++ b/test/rewrite_resize_test.cpp
@@ -257,6 +257,46 @@ TEST_CASE(rewrite_resize_nearest_upsample_pc)
                         {migraphx::shape::float_type, {1, 1, 2, 4}}));
 }
 
+// Test nearest mode with NHWC-style permuted strides (non-standard layout)
+TEST_CASE(rewrite_resize_nearest_nhwc)
+{
+    EXPECT(check_resize({{"scales", {1.0f, 1.0f, 2.0f, 2.0f}},
+                         {"nearest_mode", "round_prefer_floor"},
+                         {"coordinate_transformation_mode", "half_pixel"}},
+                        migraphx::shape::from_permutation(
+                            migraphx::shape::float_type, {1, 3, 4, 4}, {0, 2, 3, 1})));
+}
+
+// Test nearest mode with NHWC layout and floor rounding
+TEST_CASE(rewrite_resize_nearest_nhwc_floor)
+{
+    EXPECT(check_resize({{"scales", {1.0f, 1.0f, 2.0f, 2.0f}},
+                         {"nearest_mode", "floor"},
+                         {"coordinate_transformation_mode", "asymmetric"}},
+                        migraphx::shape::from_permutation(
+                            migraphx::shape::float_type, {1, 3, 2, 2}, {0, 2, 3, 1})));
+}
+
+// Test nearest mode downsample with non-standard strides
+TEST_CASE(rewrite_resize_nearest_nhwc_downsample)
+{
+    EXPECT(check_resize({{"scales", {1.0f, 1.0f, 0.5f, 0.5f}},
+                         {"nearest_mode", "floor"},
+                         {"coordinate_transformation_mode", "asymmetric"}},
+                        migraphx::shape::from_permutation(
+                            migraphx::shape::float_type, {1, 3, 4, 4}, {0, 2, 3, 1})));
+}
+
+// Test nearest mode with transposed layout (swap H and W)
+TEST_CASE(rewrite_resize_nearest_transposed)
+{
+    EXPECT(check_resize({{"scales", {1.0f, 1.0f, 2.0f, 2.0f}},
+                         {"nearest_mode", "round_prefer_floor"},
+                         {"coordinate_transformation_mode", "half_pixel"}},
+                        migraphx::shape::from_permutation(
+                            migraphx::shape::float_type, {1, 3, 4, 4}, {0, 1, 3, 2})));
+}
+
 // Test linear mode with NHWC-style scaling pattern (from resize_nhwc_test)
 TEST_CASE(rewrite_resize_linear_nhwc)
 {

--- a/test/verify/test_resize_nearest_nonstandard.cpp
+++ b/test/verify/test_resize_nearest_nonstandard.cpp
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "verify_program.hpp"
+#include <migraphx/program.hpp>
+#include <migraphx/generate.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/instruction.hpp>
+
+struct test_resize_nearest_nonstandard : verify_program<test_resize_nearest_nonstandard>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        // NHWC permuted strides: lens={1, 8, 4, 4}, strides={128, 1, 32, 8}
+        auto in_shape = migraphx::shape::from_permutation(
+            migraphx::shape::float_type, {1, 8, 4, 4}, {0, 2, 3, 1});
+        auto x       = mm->add_parameter("x", in_shape);
+        auto resized = mm->add_instruction(
+            migraphx::make_op(
+                "resize",
+                {{"scales", {1.0f, 1.0f, 2.0f, 2.0f}},
+                 {"nearest_mode", "round_prefer_floor"},
+                 {"coordinate_transformation_mode", "half_pixel"}}),
+            x);
+        mm->add_return({resized});
+        return p;
+    };
+};

--- a/test/verify/test_resize_nearest_nonstandard.cpp
+++ b/test/verify/test_resize_nearest_nonstandard.cpp
@@ -39,11 +39,10 @@ struct test_resize_nearest_nonstandard : verify_program<test_resize_nearest_nons
             migraphx::shape::float_type, {1, 8, 4, 4}, {0, 2, 3, 1});
         auto x       = mm->add_parameter("x", in_shape);
         auto resized = mm->add_instruction(
-            migraphx::make_op(
-                "resize",
-                {{"scales", {1.0f, 1.0f, 2.0f, 2.0f}},
-                 {"nearest_mode", "round_prefer_floor"},
-                 {"coordinate_transformation_mode", "half_pixel"}}),
+            migraphx::make_op("resize",
+                              {{"scales", {1.0f, 1.0f, 2.0f, 2.0f}},
+                               {"nearest_mode", "round_prefer_floor"},
+                               {"coordinate_transformation_mode", "half_pixel"}}),
             x);
         mm->add_return({resized});
         return p;


### PR DESCRIPTION
## Motivation
When using nearest mode, the indices were calculated wrong when rewriting to gather.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
