### PR TITLE
[AIMIGRAPHX-885] Add Releaxed Check for Concat fusions

### DIFF
--- a/src/fuse_concat.cpp
+++ b/src/fuse_concat.cpp
@@ -151,7 +151,7 @@ struct find_concat_pointwise : concat_counter<0>
                 inputs.push_back(input);
             }
         }
-        if(num_noops > std::max(size_t{1}, concat_ins->inputs().size() / 4))
+        if((num_noops > std::max(size_t{1}, concat_ins->inputs().size() / 4) and (concat_ins->inputs().size() < 100)))
         {
             return;
         }


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Modified fuse_concats to allow larger inputs to be fused by relaxing the overhead s which will result in a concat with many noop inputs. Since we're doing a read in most of these cases these operations should be zero copy


## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
In some cases for prediction model we concat many inputs. Our concat fusion misses these as there's a large amount of noop inputs. 

Adding the additional short circuit here allows us to still perform a concat fusion for very large concats with large 100+ inputs, this is relevant when many inputs are from slice operations when reading from gather table embeddings. 


## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
