### PR TITLE
[AIMIGRAPHX-885] Fuse Expert Heads into mlir_slice_sigmoid_mul

### DIFF
--- a/src/fuse_horizontal.cpp
+++ b/src/fuse_horizontal.cpp
@@ -35,6 +35,7 @@
 #include <vector>
 #include <unordered_map>
 #include <tuple>
+#include <iostream>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -61,11 +62,11 @@ inline namespace MIGRAPHX_INLINE_NS {
 template <class Finder>
 static void apply_horizontal_finder(module& m, const Finder& finder)
 {
-    // Collect all candidate instructions and build position map
     std::vector<instruction_ref> candidates;
     copy_if(iterator_for(m), std::back_inserter(candidates), [&](auto ins) {
         return finder.is_candidate(ins);
     });
+
     std::unordered_map<instruction_ref, std::size_t> pos;
     std::size_t p = 0;
     for(auto ins : iterator_for(m))
@@ -267,24 +268,268 @@ struct gather_horizontal_fusion
 };
 
 // ---------------------------------------------------------------------------
-// Future: add more horizontal fusion finders here, e.g.
+// SwiGLU expert head horizontal fusion
 //
-// struct pointwise_horizontal_fusion
-// {
-//     std::size_t min_group_size() const { return 2; }
-//     bool is_candidate(instruction_ref ins) const { ... }
-//     std::string group_key(instruction_ref ins) const { ... }
-//     std::vector<instruction_ref>
-//         fuse(module& m, const std::vector<instruction_ref>& ops,
-//              instruction_ref insert_pt) const { ... }
-// };
+// Matches the pattern: x -> sigmoid(x) -> mul(x, sigmoid(x)) -> dot(weight) -> add(bias)
+// where weight and bias are constants.
+//
+// Candidates: add instructions at the end of a SwiGLU-dot-add chain
+// Grouping:   by (add output lens, output type, weight lens)
+// Fusion:     stack all expert inputs along new batch axis 0, apply batched
+//             sigmoid, mul, dot, add, then slice+squeeze results back
 // ---------------------------------------------------------------------------
+
+struct expert_head_horizontal_fusion
+{
+    struct pattern_info
+    {
+        instruction_ref add_ins;
+        instruction_ref dot_ins;
+        instruction_ref mul_ins;
+        instruction_ref sig_ins;
+        instruction_ref input_ins;
+        instruction_ref weight_ins;
+        instruction_ref bias_ins;
+    };
+
+    static bool try_match(instruction_ref add_ins, pattern_info& pm)
+    {
+        pm.add_ins = add_ins;
+
+        if(add_ins->name() != "add" || add_ins->inputs().size() != 2)
+            return false;
+        if(add_ins->get_shape().dynamic())
+            return false;
+
+        instruction_ref dot_ins{};
+        instruction_ref bias_ins{};
+        for(const auto& in : add_ins->inputs())
+        {
+            if(in->name() == "dot")
+                dot_ins = in;
+            else
+                bias_ins = in;
+        }
+        if(dot_ins == instruction_ref{} || bias_ins == instruction_ref{})
+            return false;
+
+        if(dot_ins->inputs().size() != 2)
+            return false;
+        if(not dot_ins->inputs().at(1)->can_eval())
+            return false;
+        if(not bias_ins->can_eval())
+            return false;
+        if(dot_ins->outputs().size() != 1)
+            return false;
+
+        auto a_ins = dot_ins->inputs().at(0);
+        if(a_ins->name() != "mul" || a_ins->inputs().size() != 2)
+            return false;
+        if(a_ins->outputs().size() != 1)
+            return false;
+
+        instruction_ref sig_ins{};
+        instruction_ref x_ins{};
+        for(const auto& in : a_ins->inputs())
+        {
+            if(in->name() == "sigmoid")
+                sig_ins = in;
+            else
+                x_ins = in;
+        }
+        if(sig_ins == instruction_ref{} || x_ins == instruction_ref{})
+            return false;
+        if(sig_ins->inputs().size() != 1 || sig_ins->inputs().at(0) != x_ins)
+            return false;
+        if(sig_ins->outputs().size() != 1)
+            return false;
+
+        pm.dot_ins    = dot_ins;
+        pm.mul_ins    = a_ins;
+        pm.sig_ins    = sig_ins;
+        pm.input_ins  = x_ins;
+        pm.weight_ins = dot_ins->inputs().at(1);
+        pm.bias_ins   = bias_ins;
+        return true;
+    }
+
+    std::size_t min_group_size() const { return 4; }
+
+    bool is_candidate(instruction_ref ins) const
+    {
+        pattern_info pm;
+        return try_match(ins, pm);
+    }
+
+    auto group_key(instruction_ref ins) const
+    {
+        pattern_info pm;
+        try_match(ins, pm);
+        auto out_lens = ins->get_shape().lens();
+        auto out_type = ins->get_shape().type();
+        auto w_lens   = pm.weight_ins->get_shape().lens();
+        return std::make_tuple(out_lens, out_type, w_lens);
+    }
+
+    std::vector<instruction_ref>
+    fuse(module& m,
+         const std::vector<instruction_ref>& adds,
+         instruction_ref insert_pt) const
+    {
+        auto n = adds.size();
+        std::cerr << "[expert_horiz] FUSING group of " << n
+                  << " expert heads, out=" << adds.front()->get_shape() << "\n";
+
+        std::vector<instruction_ref> input_parts;
+        std::vector<instruction_ref> weight_parts;
+        std::vector<instruction_ref> bias_parts;
+        input_parts.reserve(n);
+        weight_parts.reserve(n);
+        bias_parts.reserve(n);
+
+        for(const auto& add_ins : adds)
+        {
+            pattern_info pm;
+            try_match(add_ins, pm);
+
+            input_parts.push_back(m.insert_instruction(
+                insert_pt, make_op("unsqueeze", {{"axes", {0}}}), pm.input_ins));
+            weight_parts.push_back(m.insert_instruction(
+                insert_pt, make_op("unsqueeze", {{"axes", {0}}}), pm.weight_ins));
+            bias_parts.push_back(m.insert_instruction(
+                insert_pt, make_op("unsqueeze", {{"axes", {0}}}), pm.bias_ins));
+        }
+
+        auto stacked_x =
+            m.insert_instruction(insert_pt, make_op("concat", {{"axis", 0}}), input_parts);
+        auto stacked_w =
+            m.insert_instruction(insert_pt, make_op("concat", {{"axis", 0}}), weight_parts);
+        auto stacked_b =
+            m.insert_instruction(insert_pt, make_op("concat", {{"axis", 0}}), bias_parts);
+
+        auto batched_sig =
+            m.insert_instruction(insert_pt, make_op("sigmoid"), stacked_x);
+        auto batched_mul =
+            m.insert_instruction(insert_pt, make_op("mul"), stacked_x, batched_sig);
+        auto batched_dot =
+            m.insert_instruction(insert_pt, make_op("dot"), batched_mul, stacked_w);
+        auto batched_add =
+            m.insert_instruction(insert_pt, make_op("add"), batched_dot, stacked_b);
+
+        std::vector<instruction_ref> results;
+        results.reserve(n);
+        for(std::size_t i = 0; i < n; ++i)
+        {
+            auto s = m.insert_instruction(
+                insert_pt,
+                make_op("slice",
+                        {{"axes", std::vector<int64_t>{0}},
+                         {"starts", std::vector<int64_t>{static_cast<int64_t>(i)}},
+                         {"ends", std::vector<int64_t>{static_cast<int64_t>(i + 1)}}}),
+                batched_add);
+            results.push_back(
+                m.insert_instruction(insert_pt, make_op("squeeze", {{"axes", {0}}}), s));
+        }
+        return results;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Dot horizontal fusion (guarded)
+//
+// Candidates: dot ops with a constant (evaluable) second input, static shapes,
+//             and whose output does NOT feed into an add followed by activation
+//             (those patterns are better handled by MLIR fusion)
+// Grouping:   by (output lens, output type, weight lens)
+// Fusion:     unsqueeze+concat inputs along new batch axis 0, single batched
+//             dot, slice+squeeze results back per original op
+// ---------------------------------------------------------------------------
+
+struct dot_horizontal_fusion
+{
+    std::size_t min_group_size() const { return 2; }
+
+    bool is_candidate(instruction_ref ins) const
+    {
+        if(ins->name() != "dot")
+            return false;
+        if(ins->get_shape().dynamic())
+            return false;
+        if(ins->inputs().size() != 2)
+            return false;
+        if(not ins->inputs().at(1)->can_eval())
+            return false;
+
+        // Skip dots that feed into add: MLIR fuses dot+add(+sigmoid+mul)
+        // more efficiently than horizontal batching
+        for(const auto& out : ins->outputs())
+        {
+            if(out->name() == "add")
+                return false;
+        }
+        return true;
+    }
+
+    auto group_key(instruction_ref ins) const
+    {
+        auto out_lens = ins->get_shape().lens();
+        auto out_type = ins->get_shape().type();
+        auto b_lens   = ins->inputs().at(1)->get_shape().lens();
+        return std::make_tuple(out_lens, out_type, b_lens);
+    }
+
+    std::vector<instruction_ref>
+    fuse(module& m, const std::vector<instruction_ref>& dots, instruction_ref insert_pt) const
+    {
+        auto n = dots.size();
+
+        std::vector<instruction_ref> a_parts;
+        a_parts.reserve(n);
+        std::vector<instruction_ref> b_parts;
+        b_parts.reserve(n);
+
+        for(const auto& d : dots)
+        {
+            a_parts.push_back(m.insert_instruction(
+                insert_pt, make_op("unsqueeze", {{"axes", {0}}}), d->inputs().at(0)));
+            b_parts.push_back(m.insert_instruction(
+                insert_pt, make_op("unsqueeze", {{"axes", {0}}}), d->inputs().at(1)));
+        }
+
+        auto stacked_a =
+            m.insert_instruction(insert_pt, make_op("concat", {{"axis", 0}}), a_parts);
+        auto stacked_b =
+            m.insert_instruction(insert_pt, make_op("concat", {{"axis", 0}}), b_parts);
+
+        auto batched = m.insert_instruction(insert_pt, make_op("dot"), stacked_a, stacked_b);
+
+        std::vector<instruction_ref> results;
+        results.reserve(n);
+        for(std::size_t i = 0; i < n; ++i)
+        {
+            auto s = m.insert_instruction(
+                insert_pt,
+                make_op("slice",
+                        {{"axes", std::vector<int64_t>{0}},
+                         {"starts", std::vector<int64_t>{static_cast<int64_t>(i)}},
+                         {"ends", std::vector<int64_t>{static_cast<int64_t>(i + 1)}}}),
+                batched);
+            results.push_back(
+                m.insert_instruction(insert_pt, make_op("squeeze", {{"axes", {0}}}), s));
+        }
+        return results;
+    }
+};
 
 void fuse_horizontal::apply(module_pass_manager& mpm) const
 {
     auto& m = mpm.get_module();
 
-    fuse_horizontal_ops(m, gather_horizontal_fusion{});
+    fuse_horizontal_ops(
+        m,
+        gather_horizontal_fusion{},
+        expert_head_horizontal_fusion{},
+        dot_horizontal_fusion{});
 }
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/test/fuse_horizontal_test.cpp
+++ b/test/fuse_horizontal_test.cpp
@@ -513,4 +513,284 @@ TEST_CASE(gather_horiz_no_fusion_dependent)
     EXPECT(m1 == m2);
 }
 
+// ===========================================================================
+// Dot horizontal fusion tests
+// ===========================================================================
+
+// 4 dots with constant weights and same shapes → fuse into 1 batched dot
+TEST_CASE(dot_horiz_fusion_basic)
+{
+    migraphx::module m1;
+    {
+        auto input = m1.add_parameter("input", {migraphx::shape::float_type, {1, 64, 128}});
+
+        auto w0 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 0));
+        auto w1 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 1));
+        auto w2 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 2));
+        auto w3 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 3));
+
+        auto d0 = m1.add_instruction(migraphx::make_op("dot"), input, w0);
+        auto d1 = m1.add_instruction(migraphx::make_op("dot"), input, w1);
+        auto d2 = m1.add_instruction(migraphx::make_op("dot"), input, w2);
+        auto d3 = m1.add_instruction(migraphx::make_op("dot"), input, w3);
+
+        m1.add_instruction(migraphx::make_op("concat", {{"axis", 2}}),
+                           std::vector<migraphx::instruction_ref>{d0, d1, d2, d3});
+    }
+    run_pass(m1);
+
+    migraphx::module m2;
+    {
+        auto input = m2.add_parameter("input", {migraphx::shape::float_type, {1, 64, 128}});
+
+        auto w0 = m2.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 0));
+        auto w1 = m2.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 1));
+        auto w2 = m2.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 2));
+        auto w3 = m2.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 3));
+
+        // Unsqueeze each A input
+        auto a0 = m2.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {0}}}), input);
+        auto a1 = m2.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {0}}}), input);
+        auto a2 = m2.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {0}}}), input);
+        auto a3 = m2.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {0}}}), input);
+
+        // Unsqueeze each B weight
+        auto b0 = m2.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {0}}}), w0);
+        auto b1 = m2.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {0}}}), w1);
+        auto b2 = m2.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {0}}}), w2);
+        auto b3 = m2.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {0}}}), w3);
+
+        auto stacked_a = m2.add_instruction(
+            migraphx::make_op("concat", {{"axis", 0}}),
+            std::vector<migraphx::instruction_ref>{a0, a1, a2, a3});
+        auto stacked_b = m2.add_instruction(
+            migraphx::make_op("concat", {{"axis", 0}}),
+            std::vector<migraphx::instruction_ref>{b0, b1, b2, b3});
+
+        auto batched = m2.add_instruction(migraphx::make_op("dot"), stacked_a, stacked_b);
+
+        auto s0 = m2.add_instruction(
+            migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {1}}}), batched);
+        auto s1 = m2.add_instruction(
+            migraphx::make_op("slice", {{"axes", {0}}, {"starts", {1}}, {"ends", {2}}}), batched);
+        auto s2 = m2.add_instruction(
+            migraphx::make_op("slice", {{"axes", {0}}, {"starts", {2}}, {"ends", {3}}}), batched);
+        auto s3 = m2.add_instruction(
+            migraphx::make_op("slice", {{"axes", {0}}, {"starts", {3}}, {"ends", {4}}}), batched);
+
+        auto sq0 = m2.add_instruction(migraphx::make_op("squeeze", {{"axes", {0}}}), s0);
+        auto sq1 = m2.add_instruction(migraphx::make_op("squeeze", {{"axes", {0}}}), s1);
+        auto sq2 = m2.add_instruction(migraphx::make_op("squeeze", {{"axes", {0}}}), s2);
+        auto sq3 = m2.add_instruction(migraphx::make_op("squeeze", {{"axes", {0}}}), s3);
+
+        m2.add_instruction(migraphx::make_op("concat", {{"axis", 2}}),
+                           std::vector<migraphx::instruction_ref>{sq0, sq1, sq2, sq3});
+    }
+    EXPECT(m1 == m2);
+}
+
+// Dots with non-constant weights → no fusion
+TEST_CASE(dot_horiz_no_fusion_non_constant_weights)
+{
+    migraphx::module m1;
+    {
+        auto input = m1.add_parameter("input", {migraphx::shape::float_type, {1, 64, 128}});
+        auto w0    = m1.add_parameter("w0", {migraphx::shape::float_type, {1, 128, 64}});
+        auto w1    = m1.add_parameter("w1", {migraphx::shape::float_type, {1, 128, 64}});
+
+        auto d0 = m1.add_instruction(migraphx::make_op("dot"), input, w0);
+        auto d1 = m1.add_instruction(migraphx::make_op("dot"), input, w1);
+
+        m1.add_instruction(migraphx::make_op("concat", {{"axis", 2}}),
+                           std::vector<migraphx::instruction_ref>{d0, d1});
+    }
+    auto m2 = m1;
+    run_pass(m1);
+    EXPECT(m1 == m2);
+}
+
+// Dots with different output shapes → separate groups, no fusion (below threshold)
+TEST_CASE(dot_horiz_no_fusion_different_shapes)
+{
+    migraphx::module m1;
+    {
+        auto input = m1.add_parameter("input", {migraphx::shape::float_type, {1, 64, 128}});
+        auto w0    = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 0));
+        auto w1 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 32}}, 1));
+
+        auto d0 = m1.add_instruction(migraphx::make_op("dot"), input, w0);
+        auto d1 = m1.add_instruction(migraphx::make_op("dot"), input, w1);
+
+        auto r0 = m1.add_instruction(migraphx::make_op("relu"), d0);
+        auto r1 = m1.add_instruction(migraphx::make_op("relu"), d1);
+
+        m1.add_instruction(migraphx::make_op("concat", {{"axis", 2}}),
+                           std::vector<migraphx::instruction_ref>{r0, r1});
+    }
+    auto m2 = m1;
+    run_pass(m1);
+    EXPECT(m1 == m2);
+}
+
+// Dots with add consumers → NOT fused by dot_horizontal (MLIR handles them better)
+TEST_CASE(dot_horiz_no_fusion_add_consumer)
+{
+    migraphx::module m1;
+    {
+        auto input = m1.add_parameter("input", {migraphx::shape::float_type, {1, 64, 128}});
+
+        auto w0 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 0));
+        auto w1 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 1));
+        auto b0 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 64, 64}}, 10));
+        auto b1 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 64, 64}}, 11));
+
+        auto d0 = m1.add_instruction(migraphx::make_op("dot"), input, w0);
+        auto d1 = m1.add_instruction(migraphx::make_op("dot"), input, w1);
+        auto a0 = m1.add_instruction(migraphx::make_op("add"), d0, b0);
+        auto a1 = m1.add_instruction(migraphx::make_op("add"), d1, b1);
+
+        m1.add_instruction(migraphx::make_op("concat", {{"axis", 2}}),
+                           std::vector<migraphx::instruction_ref>{a0, a1});
+    }
+    auto m2 = m1;
+    run_pass(m1);
+    EXPECT(m1 == m2);
+}
+
+// ===========================================================================
+// Expert head (SwiGLU + dot + add) horizontal fusion tests
+// ===========================================================================
+
+// 4 expert heads with SwiGLU pattern → fuse into batched sigmoid+mul+dot+add
+TEST_CASE(expert_head_fusion_basic)
+{
+    migraphx::module m1;
+    {
+        auto input = m1.add_parameter("input", {migraphx::shape::float_type, {1, 64, 512}});
+
+        auto s0 = m1.add_instruction(
+            migraphx::make_op("slice", {{"axes", {2}}, {"starts", {0}}, {"ends", {128}}}), input);
+        auto s1 = m1.add_instruction(
+            migraphx::make_op("slice", {{"axes", {2}}, {"starts", {128}}, {"ends", {256}}}), input);
+        auto s2 = m1.add_instruction(
+            migraphx::make_op("slice", {{"axes", {2}}, {"starts", {256}}, {"ends", {384}}}), input);
+        auto s3 = m1.add_instruction(
+            migraphx::make_op("slice", {{"axes", {2}}, {"starts", {384}}, {"ends", {512}}}), input);
+
+        auto w0 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 128}}, 0));
+        auto w1 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 128}}, 1));
+        auto w2 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 128}}, 2));
+        auto w3 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 128}}, 3));
+
+        auto b0 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 64, 128}}, 10));
+        auto b1 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 64, 128}}, 11));
+        auto b2 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 64, 128}}, 12));
+        auto b3 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 64, 128}}, 13));
+
+        // SwiGLU: sigmoid(x) * x
+        auto sig0 = m1.add_instruction(migraphx::make_op("sigmoid"), s0);
+        auto mul0 = m1.add_instruction(migraphx::make_op("mul"), s0, sig0);
+        auto sig1 = m1.add_instruction(migraphx::make_op("sigmoid"), s1);
+        auto mul1 = m1.add_instruction(migraphx::make_op("mul"), s1, sig1);
+        auto sig2 = m1.add_instruction(migraphx::make_op("sigmoid"), s2);
+        auto mul2 = m1.add_instruction(migraphx::make_op("mul"), s2, sig2);
+        auto sig3 = m1.add_instruction(migraphx::make_op("sigmoid"), s3);
+        auto mul3 = m1.add_instruction(migraphx::make_op("mul"), s3, sig3);
+
+        auto d0 = m1.add_instruction(migraphx::make_op("dot"), mul0, w0);
+        auto d1 = m1.add_instruction(migraphx::make_op("dot"), mul1, w1);
+        auto d2 = m1.add_instruction(migraphx::make_op("dot"), mul2, w2);
+        auto d3 = m1.add_instruction(migraphx::make_op("dot"), mul3, w3);
+
+        auto a0 = m1.add_instruction(migraphx::make_op("add"), d0, b0);
+        auto a1 = m1.add_instruction(migraphx::make_op("add"), d1, b1);
+        auto a2 = m1.add_instruction(migraphx::make_op("add"), d2, b2);
+        auto a3 = m1.add_instruction(migraphx::make_op("add"), d3, b3);
+
+        m1.add_instruction(migraphx::make_op("concat", {{"axis", 2}}),
+                           std::vector<migraphx::instruction_ref>{a0, a1, a2, a3});
+    }
+    run_pass(m1);
+
+    auto dot_count = std::count_if(m1.begin(), m1.end(), [](const auto& ins) {
+        return ins.name() == "dot";
+    });
+    auto sigmoid_count = std::count_if(m1.begin(), m1.end(), [](const auto& ins) {
+        return ins.name() == "sigmoid";
+    });
+    auto add_count = std::count_if(m1.begin(), m1.end(), [](const auto& ins) {
+        return ins.name() == "add";
+    });
+    EXPECT(dot_count == 1);
+    EXPECT(sigmoid_count == 1);
+    EXPECT(add_count == 1);
+}
+
+// Non-SwiGLU dots with add should NOT trigger expert head fusion
+TEST_CASE(expert_head_no_fusion_missing_sigmoid)
+{
+    migraphx::module m1;
+    {
+        auto input = m1.add_parameter("input", {migraphx::shape::float_type, {1, 64, 128}});
+
+        auto w0 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 0));
+        auto w1 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 1));
+        auto w2 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 2));
+        auto w3 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 128, 64}}, 3));
+
+        auto b0 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 64, 64}}, 10));
+        auto b1 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 64, 64}}, 11));
+        auto b2 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 64, 64}}, 12));
+        auto b3 = m1.add_literal(
+            migraphx::generate_literal({migraphx::shape::float_type, {1, 64, 64}}, 13));
+
+        // Plain dot + add (no SwiGLU) → should not trigger expert_head fusion
+        // and dot_horizontal is blocked by add consumer
+        auto d0 = m1.add_instruction(migraphx::make_op("dot"), input, w0);
+        auto d1 = m1.add_instruction(migraphx::make_op("dot"), input, w1);
+        auto d2 = m1.add_instruction(migraphx::make_op("dot"), input, w2);
+        auto d3 = m1.add_instruction(migraphx::make_op("dot"), input, w3);
+
+        auto a0 = m1.add_instruction(migraphx::make_op("add"), d0, b0);
+        auto a1 = m1.add_instruction(migraphx::make_op("add"), d1, b1);
+        auto a2 = m1.add_instruction(migraphx::make_op("add"), d2, b2);
+        auto a3 = m1.add_instruction(migraphx::make_op("add"), d3, b3);
+
+        m1.add_instruction(migraphx::make_op("concat", {{"axis", 2}}),
+                           std::vector<migraphx::instruction_ref>{a0, a1, a2, a3});
+    }
+    auto m2 = m1;
+    run_pass(m1);
+    EXPECT(m1 == m2);
+}
+
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fuse expert heads into a single set of operations to reduce overhead when using Mixture of Experts operations

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
Fuses export heads into a set of mlir_slice_sigmoid_mul operations  using the expert_head_horizontal_fusion

AI overview of this one

`expert_head_horizontal_fusion`
Matches the SwiGLU expert head pattern:
```
x → sigmoid(x) → mul(x, sigmoid(x)) → dot(weight) → add(bias)
```
When 4+ structurally identical expert heads are found (grouped by output shape, output type, and weight shape), the pass batches them by:
1. Introducing a batch axis via `unsqueeze` + `concat` on inputs, weights, and biases
2. Executing a single fused `sigmoid → mul → dot → add`
3. Splitting results back with `slice` + `squeeze`
This directly targets the 12 identical `mlir_slice_sigmoid_mul_dot_add_unsqueeze` blocks in the recommendation model.
### New: `dot_horizontal_fusion`
General-purpose horizontal fusion for standalone `dot` operations with constant (evaluable) weights. Batches 2+ matching dots into a single batched GEMM using the same `unsqueeze → concat → dot → slice → squeeze` strategy.
**Guard:** Dots whose output feeds into `add` are excluded — MLIR already efficiently fuses `dot + add (+ sigmoid + mul)` vertically, and horizontal batching would break those optimizations.
### Updated: `fuse_horizontal::apply()`
Now runs all three finders:
```cpp
fuse_horizontal_ops(m,
    gather_horizontal_fusion{},
    expert_head_horizontal_fusion{},
    dot_horizontal_fusion{});
```
## Test plan
- [x] `dot_horiz_fusion_basic` — 4 dots with constant weights fuse into 1 batched dot
- [x] `dot_horiz_no_fusion_non_constant_weights` — Dots with parameter weights are not fused
- [x] `dot_horiz_no_fusion_different_shapes` — Dots with mismatched weight shapes stay separate
- [x] `dot_horiz_no_fusion_add_consumer` — Dots feeding into `add` are excluded (MLIR guard)
- [x] `expert_head_fusion_basic` — 4 SwiGLU expert heads fuse into 1 batched `sigmoid + mul + dot + add`
- [x] `expert_head_no_fusion_missing_sigmoid` — Plain `dot + add` without SwiGLU is not matched




## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [x] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
