### PR TITLE
Fix bug in compile_ops caused by config having a single solution

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -216,6 +216,11 @@ struct compile_plan
             if(not results.front().has_value())
                 MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
                                problem_string() + "\n\n" + print_modules());
+            if(config and config->solutions.size() == 1)
+            {
+                ctx->get_problem_cache().insert(
+                    preop.name(), config->problem, config->solutions.front());
+            }
             return *results.front();
         }
         if(not config)


### PR DESCRIPTION
## Motivation
A configuration with a single solution leads to precompile_ops with the same problem not getting replaced.

## Technical Details
In add_compiles, if a config exists but a cache entry doesn't, mark() add a new, null, cache entry. The null is intended to be replaced by an actual value later down the line after benchmarking.
But, if the config has only a single solution, there would be only a single entry in results, and in benchmark() the early return would be taken, leaving a dangling null entry in the cache. 
Any other op with the same problem takes the solution.is_null() early exit in add_compiles, and is left uncompiled.

Quite a niche bug as it's highly unlikely that a config will have a single solution, but a bug nonetheless.

It was triggered by resizing config->solutions to 1 in update_config, and using this program:
```
module: "main"
x = @param:x -> float_type, {64, 64}, {64, 1}
@1 = dot(x,x) -> float_type, {64, 64}, {64, 1}
@2 = dot(@1,x) -> float_type, {64, 64}, {64, 1}
@3 = @return(@2)
```
Compiles to:
```
module: "main"
@0 = check_context::migraphx::gpu::context -> float_type, {}, {}
@1 = hip::hip_allocate_memory[shape=int8_type, {16384}, {1},id=main:scratch] -> int8_type, {16384}, {1}
@2 = load[offset=0,end=16384](@1) -> float_type, {64, 64}, {64, 1}
x = @param:x -> float_type, {64, 64}, {64, 1}
@4 = gpu::code_object[code_object=5888,symbol_name=mlir_dot,global=1024,local=64,output_arg=2,](x,x,@2) -> float_type, {64, 64}, {64, 1}
main:#output_0 = @param:main:#output_0 -> float_type, {64, 64}, {64, 1}
@6 = gpu::precompile_op[op=gpu::mlir_op[op=dot],additional_args=1,ignore_modules=0,output_shape=nullopt](@4,x,main:#output_0), [mlir_dot1] -> float_type, {64, 64}, {64, 1}
@7 = @return(@6)
```

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
