### PR TITLE
use latest cmake for ORT

### DIFF
--- a/tools/docker/ort.dockerfile
+++ b/tools/docker/ort.dockerfile
@@ -51,4 +51,4 @@ ADD tools/build_and_test_onnxrt.sh /onnxruntime/build_and_test_onnxrt.sh
 ADD tools/pai_test_launcher.sh /onnxruntime/tools/ci_build/github/pai/pai_test_launcher.sh
 ADD tools/pai_provider_test_launcher.sh /onnxruntime/tools/ci_build/github/pai/pai_provider_test_launcher.sh
 
-RUN pip install cmake==3.28
+RUN pip install cmake

--- a/tools/docker/ort.dockerfile
+++ b/tools/docker/ort.dockerfile
@@ -21,7 +21,6 @@ COPY test/onnx/.onnxrt-commit /.onnxrt-commit
 
 # Install half package and gdb required by the test stage
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
-    cmake \
     gdb \
     git \
     half \

--- a/tools/docker/ort.dockerfile
+++ b/tools/docker/ort.dockerfile
@@ -50,4 +50,4 @@ ADD tools/build_and_test_onnxrt.sh /onnxruntime/build_and_test_onnxrt.sh
 ADD tools/pai_test_launcher.sh /onnxruntime/tools/ci_build/github/pai/pai_test_launcher.sh
 ADD tools/pai_provider_test_launcher.sh /onnxruntime/tools/ci_build/github/pai/pai_provider_test_launcher.sh
 
-RUN pip install cmake
+RUN pip install cmake==4.3.1


### PR DESCRIPTION
## Motivation
ORT docker file is now failing because the version of cmake was removed from pypi recently

## Technical Details
Switched from using 3.28 to the default value for the OS

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
