### PR TITLE
[AIMIGRAPHX-801] Fix int convert bf16/fp16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Full documentation for MIGraphX is available at
 * Fixed an issue with `reshape_lazy`'s shape computation that was leading to invalid reshapes (#4594).
 * Fixed `eliminate_pad` pass bug that was removing nonzero `pad` instructions (#4600).
 * Fixed an issue with `convert` output overflowing when converting inf/-inf to integral types (#4669).
+* Fixed issue with `find_concat_op` matcher merging converted int32 inputs after bf16/fp16 quant during compilation (#4745)
 
 ### Optimized
 * Optimized fusion for local_window mode of GQA operator (#4617).

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -950,11 +950,12 @@ struct find_concat_op
     {
         auto concat_lens = ins.front()->get_shape().lens();
         concat_lens.erase(concat_lens.begin() + axis);
+        auto front_type = ins.front()->get_shape().type();
 
         return std::all_of(ins.begin(), ins.end(), [&](auto i) {
             auto lens = i->get_shape().lens();
             lens.erase(lens.begin() + axis);
-            return lens == concat_lens;
+            return lens == concat_lens and i->get_shape().type() == front_type;
         });
     }
 

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -1336,6 +1336,31 @@ TEST_CASE(concat_convert_fusion)
     EXPECT(m1 == m2);
 }
 
+TEST_CASE(concat_convert_mismatched_input_types)
+{
+    auto sx = migraphx::shape{migraphx::shape::float_type, {1, 128}};
+    auto sy = migraphx::shape{migraphx::shape::int32_type, {1, 64}};
+    migraphx::module m1;
+    {
+        auto x  = m1.add_parameter("x", sx);
+        auto y  = m1.add_parameter("y", sy);
+        auto xc = m1.add_instruction(
+            migraphx::make_op("convert",
+                              {{"target_type", migraphx::to_value(migraphx::shape::bf16_type)}}),
+            x);
+        auto yc = m1.add_instruction(
+            migraphx::make_op("convert",
+                              {{"target_type", migraphx::to_value(migraphx::shape::bf16_type)}}),
+            y);
+        auto concat =
+            m1.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), xc, yc);
+        m1.add_instruction(pass_op{}, concat);
+    }
+    auto m2 = m1;
+    run_pass(m1);
+    EXPECT(m1 == m2);
+}
+
 TEST_CASE(simplify_div_const)
 {
     migraphx::module m1;

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -1346,11 +1346,11 @@ TEST_CASE(concat_convert_mismatched_input_types)
         auto y  = m1.add_parameter("y", sy);
         auto xc = m1.add_instruction(
             migraphx::make_op("convert",
-                              {{"target_type", migraphx::to_value(migraphx::shape::bf16_type)}}),
+                              {{"target_type", migraphx::shape::bf16_type}}),
             x);
         auto yc = m1.add_instruction(
             migraphx::make_op("convert",
-                              {{"target_type", migraphx::to_value(migraphx::shape::bf16_type)}}),
+                              {{"target_type", migraphx::shape::bf16_type}}),
             y);
         auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), xc, yc);
         m1.add_instruction(pass_op{}, concat);

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -1345,13 +1345,9 @@ TEST_CASE(concat_convert_mismatched_input_types)
         auto x  = m1.add_parameter("x", sx);
         auto y  = m1.add_parameter("y", sy);
         auto xc = m1.add_instruction(
-            migraphx::make_op("convert",
-                              {{"target_type", migraphx::shape::bf16_type}}),
-            x);
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::bf16_type}}), x);
         auto yc = m1.add_instruction(
-            migraphx::make_op("convert",
-                              {{"target_type", migraphx::shape::bf16_type}}),
-            y);
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::bf16_type}}), y);
         auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), xc, yc);
         m1.add_instruction(pass_op{}, concat);
     }

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -1352,8 +1352,7 @@ TEST_CASE(concat_convert_mismatched_input_types)
             migraphx::make_op("convert",
                               {{"target_type", migraphx::to_value(migraphx::shape::bf16_type)}}),
             y);
-        auto concat =
-            m1.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), xc, yc);
+        auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), xc, yc);
         m1.add_instruction(pass_op{}, concat);
     }
     auto m2 = m1;


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fixes issue when we convert customer model that have int32 inputs. We're errornously adding converts which later fail from quantization.





## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
Issue is in the find_concat_op matcher causing the invalid inputs to be put into a concat resulting in a same_type() mismatch error. This resolves that later in the compile process


## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
