### PR TITLE
Expose op builder to the python API using a macro class

### DIFF
--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -509,8 +509,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
                const py_macro& mac,
                std::vector<migraphx::instruction_ref>& args,
                std::vector<migraphx::module*>& mod_args) {
-                return migraphx::op::builder::add(
-                    mac.op_name, mm, args, mod_args, mac.options);
+                return migraphx::op::builder::add(mac.op_name, mm, args, mod_args, mac.options);
             },
             py::arg("macro"),
             py::arg("args"),
@@ -641,9 +640,8 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             return py_macro{name, v};
         }))
         .def("name", [](const py_macro& mac) { return mac.op_name; })
-        .def("options", [](const py_macro& mac) -> py::object {
-            return to_py_object(mac.options);
-        });
+        .def("options",
+             [](const py_macro& mac) -> py::object { return to_py_object(mac.options); });
 
     m.def(
         "argument_from_pointer",

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -504,7 +504,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             },
             py::arg("args"))
         .def(
-            "add_instructions",
+            "add_macro",
             [](migraphx::module& mm,
                const py_macro& mac,
                std::vector<migraphx::instruction_ref>& args,
@@ -515,7 +515,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             py::arg("args"),
             py::arg("mod_args") = std::vector<migraphx::module*>{})
         .def(
-            "insert_instructions",
+            "insert_macro",
             [](migraphx::module& mm,
                migraphx::instruction_ref ins,
                const py_macro& mac,

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -42,6 +42,7 @@
 #include <migraphx/json.hpp>
 #include <migraphx/make_op.hpp>
 #include <migraphx/op/common.hpp>
+#include <migraphx/op/builder/insert.hpp>
 #include <migraphx/float8.hpp>
 #include <migraphx/pass_manager.hpp>
 #include <migraphx/version.h>
@@ -348,6 +349,14 @@ migraphx::shape to_shape(const py::buffer_info& info)
     }
 }
 
+namespace {
+struct py_macro
+{
+    std::string op_name;
+    migraphx::value options;
+};
+} // namespace
+
 MIGRAPHX_PYBIND11_MODULE(migraphx, m)
 {
     py::class_<migraphx::shape> shape_cls(m, "shape");
@@ -494,6 +503,32 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
                 return mm.replace_return(args);
             },
             py::arg("args"))
+        .def(
+            "add_instructions",
+            [](migraphx::module& mm,
+               const py_macro& mac,
+               std::vector<migraphx::instruction_ref>& args,
+               std::vector<migraphx::module*>& mod_args) {
+                return migraphx::op::builder::add(
+                    mac.op_name, mm, args, mod_args, mac.options);
+            },
+            py::arg("macro"),
+            py::arg("args"),
+            py::arg("mod_args") = std::vector<migraphx::module*>{})
+        .def(
+            "insert_instructions",
+            [](migraphx::module& mm,
+               migraphx::instruction_ref ins,
+               const py_macro& mac,
+               std::vector<migraphx::instruction_ref>& args,
+               std::vector<migraphx::module*>& mod_args) {
+                return migraphx::op::builder::insert(
+                    mac.op_name, mm, ins, args, mod_args, mac.options);
+            },
+            py::arg("ins"),
+            py::arg("macro"),
+            py::arg("args"),
+            py::arg("mod_args") = std::vector<migraphx::module*>{})
         .def("__repr__", [](const migraphx::module& mm) { return migraphx::to_string(mm); })
         .def(
             "__iter__",
@@ -595,6 +630,20 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         .value("forward", migraphx::op::rnn_direction::forward)
         .value("reverse", migraphx::op::rnn_direction::reverse)
         .value("bidirectional", migraphx::op::rnn_direction::bidirectional);
+
+    py::class_<py_macro>(m, "macro")
+        .def(py::init([](const std::string& name, py::kwargs kwargs) {
+            migraphx::value v = migraphx::value::object{};
+            if(kwargs)
+            {
+                v = migraphx::to_value(kwargs);
+            }
+            return py_macro{name, v};
+        }))
+        .def("name", [](const py_macro& mac) { return mac.op_name; })
+        .def("options", [](const py_macro& mac) -> py::object {
+            return to_py_object(mac.options);
+        });
 
     m.def(
         "argument_from_pointer",

--- a/test/py/CMakeLists.txt
+++ b/test/py/CMakeLists.txt
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/test/py/CMakeLists.txt
+++ b/test/py/CMakeLists.txt
@@ -102,6 +102,7 @@ add_py_test(save_load test_save_load.py common ${VENV} WORKING_DIRECTORY ${TEST_
 add_py_test(op test_op.py common ${VENV} WORKING_DIRECTORY ${TEST_ONNX_DIR})
 add_py_test(shape test_shape.py common ${VENV} WORKING_DIRECTORY ${TEST_ONNX_DIR})
 add_py_test(module_construct test_module_construct.py common ${VENV} WORKING_DIRECTORY ${TEST_ONNX_DIR})
+add_py_test(macro test_macro.py common ${VENV} WORKING_DIRECTORY ${TEST_ONNX_DIR})
 add_py_test(literal test_literal.py common ${VENV} WORKING_DIRECTORY ${TEST_ONNX_DIR})
 add_py_test(autocast_fp8 test_autocast_fp8.py common ${VENV} WORKING_DIRECTORY ${TEST_ONNX_DIR})
 if(MIGRAPHX_ENABLE_GPU)

--- a/test/py/test_macro.py
+++ b/test/py/test_macro.py
@@ -1,0 +1,180 @@
+#####################################################################################
+# The MIT License (MIT)
+#
+# Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#####################################################################################
+import migraphx, array
+
+
+def create_buffer(t, data, shape):
+    a = array.array(t, data)
+    m = memoryview(a.tobytes())
+    return m.cast(t, shape)
+
+
+def test_macro_name_and_options():
+    mac = migraphx.macro("gemm", alpha=2.0, transB=True)
+    assert mac.name() == "gemm"
+    opts = mac.options()
+    assert opts["alpha"] == 2.0
+    assert opts["transB"] == True
+
+
+def test_macro_no_options():
+    mac = migraphx.macro("add")
+    assert mac.name() == "add"
+    assert mac.options() == {}
+
+
+def test_add_instructions_add():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    x = mm.add_literal(create_buffer('f', [1.0, 2.0, 3.0], (1, 3)))
+    y = mm.add_literal(create_buffer('f', [4.0, 5.0, 6.0], (1, 3)))
+    mac = migraphx.macro("add")
+    result = mm.add_instructions(mac, [x, y])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    assert output == [5.0, 7.0, 9.0]
+
+
+def test_add_instructions_mul():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    x = mm.add_literal(create_buffer('f', [2.0, 3.0, 4.0], (1, 3)))
+    y = mm.add_literal(create_buffer('f', [5.0, 6.0, 7.0], (1, 3)))
+    mac = migraphx.macro("mul")
+    result = mm.add_instructions(mac, [x, y])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    assert output == [10.0, 18.0, 28.0]
+
+
+def test_add_instructions_broadcast():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    x = mm.add_literal(create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3)))
+    y = mm.add_literal(create_buffer('f', [10.0, 20.0, 30.0], (3,)))
+    mac = migraphx.macro("add")
+    result = mm.add_instructions(mac, [x, y])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    assert output == [11.0, 22.0, 33.0, 14.0, 25.0, 36.0]
+
+
+def test_add_instructions_gemm():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    # 2x3 matrix
+    a = mm.add_literal(
+        create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3)))
+    # 3x2 matrix
+    b = mm.add_literal(
+        create_buffer('f', [7.0, 8.0, 9.0, 10.0, 11.0, 12.0], (3, 2)))
+    mac = migraphx.macro("gemm")
+    result = mm.add_instructions(mac, [a, b])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    # [1,2,3].[7,8;9,10;11,12] = [58,64; 139,154]
+    assert output == [58.0, 64.0, 139.0, 154.0]
+
+
+def test_add_instructions_gemm_with_options():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    # 3x2 matrix, will be transposed to 2x3
+    a = mm.add_literal(
+        create_buffer('f', [1.0, 4.0, 2.0, 5.0, 3.0, 6.0], (3, 2)))
+    # 3x2 matrix
+    b = mm.add_literal(
+        create_buffer('f', [7.0, 8.0, 9.0, 10.0, 11.0, 12.0], (3, 2)))
+    mac = migraphx.macro("gemm", transA=True)
+    result = mm.add_instructions(mac, [a, b])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    # transposed A = [1,2,3;4,5,6], B = [7,8;9,10;11,12]
+    # = [58,64; 139,154]
+    assert output == [58.0, 64.0, 139.0, 154.0]
+
+
+def test_insert_instructions():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    x = mm.add_literal(create_buffer('f', [1.0, 2.0, 3.0], (1, 3)))
+    y = mm.add_literal(create_buffer('f', [4.0, 5.0, 6.0], (1, 3)))
+    # First add a mul at the end
+    mul_mac = migraphx.macro("mul")
+    mul_result = mm.add_instructions(mul_mac, [x, y])
+    # Insert an add before the mul
+    add_mac = migraphx.macro("add")
+    add_result = mm.insert_instructions(mul_result[0], add_mac, [x, y])
+    # Return the add result
+    mm.add_return([add_result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    assert output == [5.0, 7.0, 9.0]
+
+
+def test_add_instructions_sub():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    x = mm.add_literal(create_buffer('f', [10.0, 20.0, 30.0], (1, 3)))
+    y = mm.add_literal(create_buffer('f', [1.0, 2.0, 3.0], (1, 3)))
+    mac = migraphx.macro("sub")
+    result = mm.add_instructions(mac, [x, y])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    assert output == [9.0, 18.0, 27.0]
+
+
+def test_add_instructions_with_params():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    s = migraphx.shape(lens=[2, 3], type="float")
+    x = mm.add_parameter("x", s)
+    y = mm.add_parameter("y", s)
+    mac = migraphx.macro("add")
+    result = mm.add_instructions(mac, [x, y])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    x_data = create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3))
+    y_data = create_buffer('f', [10.0, 20.0, 30.0, 40.0, 50.0, 60.0], (2, 3))
+    output = p.run({"x": x_data, "y": y_data})[-1].tolist()
+    assert output == [11.0, 22.0, 33.0, 44.0, 55.0, 66.0]
+
+
+if __name__ == "__main__":
+    test_macro_name_and_options()
+    test_macro_no_options()
+    test_add_instructions_add()
+    test_add_instructions_mul()
+    test_add_instructions_broadcast()
+    test_add_instructions_gemm()
+    test_add_instructions_gemm_with_options()
+    test_insert_instructions()
+    test_add_instructions_sub()
+    test_add_instructions_with_params()

--- a/test/py/test_macro.py
+++ b/test/py/test_macro.py
@@ -44,46 +44,46 @@ def test_macro_no_options():
     assert mac.options() == {}
 
 
-def test_add_instructions_add():
+def test_add_macro_add():
     p = migraphx.program()
     mm = p.get_main_module()
     x = mm.add_literal(create_buffer('f', [1.0, 2.0, 3.0], (1, 3)))
     y = mm.add_literal(create_buffer('f', [4.0, 5.0, 6.0], (1, 3)))
     mac = migraphx.macro("add")
-    result = mm.add_instructions(mac, [x, y])
+    result = mm.add_macro(mac, [x, y])
     mm.add_return([result[-1]])
     p.compile(migraphx.get_target("ref"))
     output = p.run({})[-1].tolist()
     assert output == [5.0, 7.0, 9.0]
 
 
-def test_add_instructions_mul():
+def test_add_macro_mul():
     p = migraphx.program()
     mm = p.get_main_module()
     x = mm.add_literal(create_buffer('f', [2.0, 3.0, 4.0], (1, 3)))
     y = mm.add_literal(create_buffer('f', [5.0, 6.0, 7.0], (1, 3)))
     mac = migraphx.macro("mul")
-    result = mm.add_instructions(mac, [x, y])
+    result = mm.add_macro(mac, [x, y])
     mm.add_return([result[-1]])
     p.compile(migraphx.get_target("ref"))
     output = p.run({})[-1].tolist()
     assert output == [10.0, 18.0, 28.0]
 
 
-def test_add_instructions_broadcast():
+def test_add_macro_broadcast():
     p = migraphx.program()
     mm = p.get_main_module()
     x = mm.add_literal(create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3)))
     y = mm.add_literal(create_buffer('f', [10.0, 20.0, 30.0], (3,)))
     mac = migraphx.macro("add")
-    result = mm.add_instructions(mac, [x, y])
+    result = mm.add_macro(mac, [x, y])
     mm.add_return([result[-1]])
     p.compile(migraphx.get_target("ref"))
     output = p.run({})[-1].tolist()
     assert output == [11.0, 22.0, 33.0, 14.0, 25.0, 36.0]
 
 
-def test_add_instructions_gemm():
+def test_add_macro_gemm():
     p = migraphx.program()
     mm = p.get_main_module()
     # 2x3 matrix
@@ -93,7 +93,7 @@ def test_add_instructions_gemm():
     b = mm.add_literal(
         create_buffer('f', [7.0, 8.0, 9.0, 10.0, 11.0, 12.0], (3, 2)))
     mac = migraphx.macro("gemm")
-    result = mm.add_instructions(mac, [a, b])
+    result = mm.add_macro(mac, [a, b])
     mm.add_return([result[-1]])
     p.compile(migraphx.get_target("ref"))
     output = p.run({})[-1].tolist()
@@ -101,7 +101,7 @@ def test_add_instructions_gemm():
     assert output == [58.0, 64.0, 139.0, 154.0]
 
 
-def test_add_instructions_gemm_with_options():
+def test_add_macro_gemm_with_options():
     p = migraphx.program()
     mm = p.get_main_module()
     # 3x2 matrix, will be transposed to 2x3
@@ -111,7 +111,7 @@ def test_add_instructions_gemm_with_options():
     b = mm.add_literal(
         create_buffer('f', [7.0, 8.0, 9.0, 10.0, 11.0, 12.0], (3, 2)))
     mac = migraphx.macro("gemm", transA=True)
-    result = mm.add_instructions(mac, [a, b])
+    result = mm.add_macro(mac, [a, b])
     mm.add_return([result[-1]])
     p.compile(migraphx.get_target("ref"))
     output = p.run({})[-1].tolist()
@@ -120,17 +120,17 @@ def test_add_instructions_gemm_with_options():
     assert output == [58.0, 64.0, 139.0, 154.0]
 
 
-def test_insert_instructions():
+def test_insert_macro():
     p = migraphx.program()
     mm = p.get_main_module()
     x = mm.add_literal(create_buffer('f', [1.0, 2.0, 3.0], (1, 3)))
     y = mm.add_literal(create_buffer('f', [4.0, 5.0, 6.0], (1, 3)))
     # First add a mul at the end
     mul_mac = migraphx.macro("mul")
-    mul_result = mm.add_instructions(mul_mac, [x, y])
+    mul_result = mm.add_macro(mul_mac, [x, y])
     # Insert an add before the mul
     add_mac = migraphx.macro("add")
-    add_result = mm.insert_instructions(mul_result[0], add_mac, [x, y])
+    add_result = mm.insert_macro(mul_result[0], add_mac, [x, y])
     # Return the add result
     mm.add_return([add_result[-1]])
     p.compile(migraphx.get_target("ref"))
@@ -138,27 +138,27 @@ def test_insert_instructions():
     assert output == [5.0, 7.0, 9.0]
 
 
-def test_add_instructions_sub():
+def test_add_macro_sub():
     p = migraphx.program()
     mm = p.get_main_module()
     x = mm.add_literal(create_buffer('f', [10.0, 20.0, 30.0], (1, 3)))
     y = mm.add_literal(create_buffer('f', [1.0, 2.0, 3.0], (1, 3)))
     mac = migraphx.macro("sub")
-    result = mm.add_instructions(mac, [x, y])
+    result = mm.add_macro(mac, [x, y])
     mm.add_return([result[-1]])
     p.compile(migraphx.get_target("ref"))
     output = p.run({})[-1].tolist()
     assert output == [9.0, 18.0, 27.0]
 
 
-def test_add_instructions_with_params():
+def test_add_macro_with_params():
     p = migraphx.program()
     mm = p.get_main_module()
     s = migraphx.shape(lens=[2, 3], type="float")
     x = mm.add_parameter("x", s)
     y = mm.add_parameter("y", s)
     mac = migraphx.macro("add")
-    result = mm.add_instructions(mac, [x, y])
+    result = mm.add_macro(mac, [x, y])
     mm.add_return([result[-1]])
     p.compile(migraphx.get_target("ref"))
     x_data = create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3))
@@ -170,11 +170,11 @@ def test_add_instructions_with_params():
 if __name__ == "__main__":
     test_macro_name_and_options()
     test_macro_no_options()
-    test_add_instructions_add()
-    test_add_instructions_mul()
-    test_add_instructions_broadcast()
-    test_add_instructions_gemm()
-    test_add_instructions_gemm_with_options()
-    test_insert_instructions()
-    test_add_instructions_sub()
-    test_add_instructions_with_params()
+    test_add_macro_add()
+    test_add_macro_mul()
+    test_add_macro_broadcast()
+    test_add_macro_gemm()
+    test_add_macro_gemm_with_options()
+    test_insert_macro()
+    test_add_macro_sub()
+    test_add_macro_with_params()

--- a/test/py/test_macro.py
+++ b/test/py/test_macro.py
@@ -21,7 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #####################################################################################
-import migraphx, array
+import migraphx, array, math
 
 
 def create_buffer(t, data, shape):
@@ -39,48 +39,9 @@ def test_macro_name_and_options():
 
 
 def test_macro_no_options():
-    mac = migraphx.macro("add")
-    assert mac.name() == "add"
+    mac = migraphx.macro("gemm")
+    assert mac.name() == "gemm"
     assert mac.options() == {}
-
-
-def test_add_macro_add():
-    p = migraphx.program()
-    mm = p.get_main_module()
-    x = mm.add_literal(create_buffer('f', [1.0, 2.0, 3.0], (1, 3)))
-    y = mm.add_literal(create_buffer('f', [4.0, 5.0, 6.0], (1, 3)))
-    mac = migraphx.macro("add")
-    result = mm.add_macro(mac, [x, y])
-    mm.add_return([result[-1]])
-    p.compile(migraphx.get_target("ref"))
-    output = p.run({})[-1].tolist()
-    assert output == [5.0, 7.0, 9.0]
-
-
-def test_add_macro_mul():
-    p = migraphx.program()
-    mm = p.get_main_module()
-    x = mm.add_literal(create_buffer('f', [2.0, 3.0, 4.0], (1, 3)))
-    y = mm.add_literal(create_buffer('f', [5.0, 6.0, 7.0], (1, 3)))
-    mac = migraphx.macro("mul")
-    result = mm.add_macro(mac, [x, y])
-    mm.add_return([result[-1]])
-    p.compile(migraphx.get_target("ref"))
-    output = p.run({})[-1].tolist()
-    assert output == [10.0, 18.0, 28.0]
-
-
-def test_add_macro_broadcast():
-    p = migraphx.program()
-    mm = p.get_main_module()
-    x = mm.add_literal(create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3)))
-    y = mm.add_literal(create_buffer('f', [10.0, 20.0, 30.0], (3,)))
-    mac = migraphx.macro("add")
-    result = mm.add_macro(mac, [x, y])
-    mm.add_return([result[-1]])
-    p.compile(migraphx.get_target("ref"))
-    output = p.run({})[-1].tolist()
-    assert output == [11.0, 22.0, 33.0, 14.0, 25.0, 36.0]
 
 
 def test_add_macro_gemm():
@@ -97,11 +58,11 @@ def test_add_macro_gemm():
     mm.add_return([result[-1]])
     p.compile(migraphx.get_target("ref"))
     output = p.run({})[-1].tolist()
-    # [1,2,3].[7,8;9,10;11,12] = [58,64; 139,154]
+    # [1,2,3;4,5,6] . [7,8;9,10;11,12] = [58,64; 139,154]
     assert output == [58.0, 64.0, 139.0, 154.0]
 
 
-def test_add_macro_gemm_with_options():
+def test_add_macro_gemm_transA():
     p = migraphx.program()
     mm = p.get_main_module()
     # 3x2 matrix, will be transposed to 2x3
@@ -120,61 +81,236 @@ def test_add_macro_gemm_with_options():
     assert output == [58.0, 64.0, 139.0, 154.0]
 
 
+def test_add_macro_gemm_with_params():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    s_a = migraphx.shape(lens=[2, 3], type="float")
+    s_b = migraphx.shape(lens=[3, 2], type="float")
+    a = mm.add_parameter("a", s_a)
+    b = mm.add_parameter("b", s_b)
+    mac = migraphx.macro("gemm")
+    result = mm.add_macro(mac, [a, b])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    a_data = create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3))
+    b_data = create_buffer('f', [7.0, 8.0, 9.0, 10.0, 11.0, 12.0], (3, 2))
+    output = p.run({"a": a_data, "b": b_data})[-1].tolist()
+    assert output == [58.0, 64.0, 139.0, 154.0]
+
+
+def test_add_macro_batchnorm():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    # Input: (1, 2, 3) - batch=1, channels=2, width=3
+    x = mm.add_literal(
+        create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (1, 2, 3)))
+    # scale, bias, mean, var each have shape (2,) for 2 channels
+    scale = mm.add_literal(create_buffer('f', [1.0, 1.0], (2,)))
+    bias = mm.add_literal(create_buffer('f', [0.0, 0.0], (2,)))
+    mean = mm.add_literal(create_buffer('f', [2.0, 5.0], (2,)))
+    var = mm.add_literal(create_buffer('f', [1.0, 1.0], (2,)))
+    mac = migraphx.macro("batchnorm")
+    result = mm.add_macro(mac, [x, scale, bias, mean, var])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    # BN: (x - mean) / sqrt(var + eps) * scale + bias
+    # Channel 0: (1-2)/sqrt(1+1e-5), (2-2)/sqrt(1+1e-5), (3-2)/sqrt(1+1e-5)
+    # Channel 1: (4-5)/sqrt(1+1e-5), (5-5)/sqrt(1+1e-5), (6-5)/sqrt(1+1e-5)
+    eps = 1e-5
+    expected = [
+        (1.0 - 2.0) / math.sqrt(1.0 + eps),
+        (2.0 - 2.0) / math.sqrt(1.0 + eps),
+        (3.0 - 2.0) / math.sqrt(1.0 + eps),
+        (4.0 - 5.0) / math.sqrt(1.0 + eps),
+        (5.0 - 5.0) / math.sqrt(1.0 + eps),
+        (6.0 - 5.0) / math.sqrt(1.0 + eps),
+    ]
+    assert len(output) == len(expected)
+    for o, e in zip(output, expected):
+        assert abs(o - e) < 1e-4
+
+
+def test_add_macro_batchnorm_with_epsilon():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    x = mm.add_literal(
+        create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (1, 2, 3)))
+    scale = mm.add_literal(create_buffer('f', [2.0, 0.5], (2,)))
+    bias = mm.add_literal(create_buffer('f', [1.0, -1.0], (2,)))
+    mean = mm.add_literal(create_buffer('f', [2.0, 5.0], (2,)))
+    var = mm.add_literal(create_buffer('f', [4.0, 4.0], (2,)))
+    mac = migraphx.macro("batchnorm", epsilon=0.01)
+    result = mm.add_macro(mac, [x, scale, bias, mean, var])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    eps = 0.01
+    expected = [
+        2.0 * (1.0 - 2.0) / math.sqrt(4.0 + eps) + 1.0,
+        2.0 * (2.0 - 2.0) / math.sqrt(4.0 + eps) + 1.0,
+        2.0 * (3.0 - 2.0) / math.sqrt(4.0 + eps) + 1.0,
+        0.5 * (4.0 - 5.0) / math.sqrt(4.0 + eps) + (-1.0),
+        0.5 * (5.0 - 5.0) / math.sqrt(4.0 + eps) + (-1.0),
+        0.5 * (6.0 - 5.0) / math.sqrt(4.0 + eps) + (-1.0),
+    ]
+    assert len(output) == len(expected)
+    for o, e in zip(output, expected):
+        assert abs(o - e) < 1e-4
+
+
+def test_add_macro_convolution():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    # Input: (1, 1, 3, 3) - batch=1, channels=1, 3x3
+    x = mm.add_literal(
+        create_buffer('f', [
+            1.0, 2.0, 3.0,
+            4.0, 5.0, 6.0,
+            7.0, 8.0, 9.0
+        ], (1, 1, 3, 3)))
+    # Weight: (1, 1, 2, 2) - out_channels=1, in_channels=1, 2x2 kernel
+    w = mm.add_literal(
+        create_buffer('f', [1.0, 0.0, 0.0, 1.0], (1, 1, 2, 2)))
+    mac = migraphx.macro("convolution")
+    result = mm.add_macro(mac, [x, w])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    # 2x2 kernel [[1,0],[0,1]] on 3x3 input, stride=1, no padding
+    # Output is 2x2:
+    # [1*1+2*0+4*0+5*1, 2*1+3*0+5*0+6*1] = [6, 8]
+    # [4*1+5*0+7*0+8*1, 5*1+6*0+8*0+9*1] = [12, 14]
+    assert output == [6.0, 8.0, 12.0, 14.0]
+
+
+def test_add_macro_convolution_with_bias():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    x = mm.add_literal(
+        create_buffer('f', [
+            1.0, 2.0, 3.0,
+            4.0, 5.0, 6.0,
+            7.0, 8.0, 9.0
+        ], (1, 1, 3, 3)))
+    w = mm.add_literal(
+        create_buffer('f', [1.0, 0.0, 0.0, 1.0], (1, 1, 2, 2)))
+    bias = mm.add_literal(create_buffer('f', [10.0], (1,)))
+    mac = migraphx.macro("convolution")
+    result = mm.add_macro(mac, [x, w, bias])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    # Same as above + bias of 10
+    assert output == [16.0, 18.0, 22.0, 24.0]
+
+
+def test_add_macro_convolution_with_padding():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    # Input: (1, 1, 3, 3)
+    x = mm.add_literal(
+        create_buffer('f', [
+            1.0, 2.0, 3.0,
+            4.0, 5.0, 6.0,
+            7.0, 8.0, 9.0
+        ], (1, 1, 3, 3)))
+    # Weight: (1, 1, 3, 3) - 3x3 kernel all ones
+    w = mm.add_literal(
+        create_buffer('f', [1.0] * 9, (1, 1, 3, 3)))
+    mac = migraphx.macro("convolution", paddings=[1, 1])
+    result = mm.add_macro(mac, [x, w])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    # 3x3 kernel of ones on 3x3 input with padding=1 => 3x3 output
+    # Each output is the sum of the overlapping region
+    assert output == [12.0, 21.0, 16.0, 27.0, 45.0, 33.0, 24.0, 39.0, 28.0]
+
+
+def test_add_macro_einsum_matmul():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    a = mm.add_literal(
+        create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3)))
+    b = mm.add_literal(
+        create_buffer('f', [7.0, 8.0, 9.0, 10.0, 11.0, 12.0], (3, 2)))
+    mac = migraphx.macro("einsum", equation="ij,jk->ik")
+    result = mm.add_macro(mac, [a, b])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    # Same as matrix multiply: [58, 64, 139, 154]
+    assert output == [58.0, 64.0, 139.0, 154.0]
+
+
+def test_add_macro_einsum_transpose():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    a = mm.add_literal(
+        create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3)))
+    mac = migraphx.macro("einsum", equation="ij->ji")
+    result = mm.add_macro(mac, [a])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    # Transpose of [[1,2,3],[4,5,6]] = [[1,4],[2,5],[3,6]]
+    assert output == [1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
+
+
+def test_add_macro_einsum_trace():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    # 3x3 identity matrix
+    a = mm.add_literal(
+        create_buffer('f', [
+            1.0, 0.0, 0.0,
+            0.0, 2.0, 0.0,
+            0.0, 0.0, 3.0
+        ], (3, 3)))
+    mac = migraphx.macro("einsum", equation="ii->")
+    result = mm.add_macro(mac, [a])
+    mm.add_return([result[-1]])
+    p.compile(migraphx.get_target("ref"))
+    output = p.run({})[-1].tolist()
+    # Trace: 1 + 2 + 3 = 6
+    assert output == [6.0]
+
+
 def test_insert_macro():
     p = migraphx.program()
     mm = p.get_main_module()
-    x = mm.add_literal(create_buffer('f', [1.0, 2.0, 3.0], (1, 3)))
-    y = mm.add_literal(create_buffer('f', [4.0, 5.0, 6.0], (1, 3)))
-    # First add a mul at the end
-    mul_mac = migraphx.macro("mul")
-    mul_result = mm.add_macro(mul_mac, [x, y])
-    # Insert an add before the mul
-    add_mac = migraphx.macro("add")
-    add_result = mm.insert_macro(mul_result[0], add_mac, [x, y])
-    # Return the add result
-    mm.add_return([add_result[-1]])
+    # 2x3 matrix
+    a = mm.add_literal(
+        create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3)))
+    # 3x2 matrix
+    b = mm.add_literal(
+        create_buffer('f', [7.0, 8.0, 9.0, 10.0, 11.0, 12.0], (3, 2)))
+    # First add a gemm at the end
+    gemm_mac = migraphx.macro("gemm")
+    gemm_result = mm.add_macro(gemm_mac, [a, b])
+    # Insert an einsum matmul before the gemm
+    einsum_mac = migraphx.macro("einsum", equation="ij,jk->ik")
+    einsum_result = mm.insert_macro(gemm_result[0], einsum_mac, [a, b])
+    # Return the einsum result
+    mm.add_return([einsum_result[-1]])
     p.compile(migraphx.get_target("ref"))
     output = p.run({})[-1].tolist()
-    assert output == [5.0, 7.0, 9.0]
-
-
-def test_add_macro_sub():
-    p = migraphx.program()
-    mm = p.get_main_module()
-    x = mm.add_literal(create_buffer('f', [10.0, 20.0, 30.0], (1, 3)))
-    y = mm.add_literal(create_buffer('f', [1.0, 2.0, 3.0], (1, 3)))
-    mac = migraphx.macro("sub")
-    result = mm.add_macro(mac, [x, y])
-    mm.add_return([result[-1]])
-    p.compile(migraphx.get_target("ref"))
-    output = p.run({})[-1].tolist()
-    assert output == [9.0, 18.0, 27.0]
-
-
-def test_add_macro_with_params():
-    p = migraphx.program()
-    mm = p.get_main_module()
-    s = migraphx.shape(lens=[2, 3], type="float")
-    x = mm.add_parameter("x", s)
-    y = mm.add_parameter("y", s)
-    mac = migraphx.macro("add")
-    result = mm.add_macro(mac, [x, y])
-    mm.add_return([result[-1]])
-    p.compile(migraphx.get_target("ref"))
-    x_data = create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3))
-    y_data = create_buffer('f', [10.0, 20.0, 30.0, 40.0, 50.0, 60.0], (2, 3))
-    output = p.run({"x": x_data, "y": y_data})[-1].tolist()
-    assert output == [11.0, 22.0, 33.0, 44.0, 55.0, 66.0]
+    assert output == [58.0, 64.0, 139.0, 154.0]
 
 
 if __name__ == "__main__":
     test_macro_name_and_options()
     test_macro_no_options()
-    test_add_macro_add()
-    test_add_macro_mul()
-    test_add_macro_broadcast()
     test_add_macro_gemm()
-    test_add_macro_gemm_with_options()
+    test_add_macro_gemm_transA()
+    test_add_macro_gemm_with_params()
+    test_add_macro_batchnorm()
+    test_add_macro_batchnorm_with_epsilon()
+    test_add_macro_convolution()
+    test_add_macro_convolution_with_bias()
+    test_add_macro_convolution_with_padding()
+    test_add_macro_einsum_matmul()
+    test_add_macro_einsum_transpose()
+    test_add_macro_einsum_trace()
     test_insert_macro()
-    test_add_macro_sub()
-    test_add_macro_with_params()

--- a/test/py/test_macro.py
+++ b/test/py/test_macro.py
@@ -21,13 +21,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #####################################################################################
-import migraphx, array, math
+import migraphx, math
 
 
-def create_buffer(t, data, shape):
-    a = array.array(t, data)
-    m = memoryview(a.tobytes())
-    return m.cast(t, shape)
+def make_arg(lens, data):
+    return migraphx.create_argument(
+        migraphx.shape(type="float_type", lens=lens), data)
 
 
 def test_macro_name_and_options():
@@ -47,12 +46,8 @@ def test_macro_no_options():
 def test_add_macro_gemm():
     p = migraphx.program()
     mm = p.get_main_module()
-    # 2x3 matrix
-    a = mm.add_literal(
-        create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3)))
-    # 3x2 matrix
-    b = mm.add_literal(
-        create_buffer('f', [7.0, 8.0, 9.0, 10.0, 11.0, 12.0], (3, 2)))
+    a = mm.add_literal(make_arg([2, 3], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
+    b = mm.add_literal(make_arg([3, 2], [7.0, 8.0, 9.0, 10.0, 11.0, 12.0]))
     mac = migraphx.macro("gemm")
     result = mm.add_macro(mac, [a, b])
     mm.add_return([result[-1]])
@@ -66,11 +61,8 @@ def test_add_macro_gemm_transA():
     p = migraphx.program()
     mm = p.get_main_module()
     # 3x2 matrix, will be transposed to 2x3
-    a = mm.add_literal(
-        create_buffer('f', [1.0, 4.0, 2.0, 5.0, 3.0, 6.0], (3, 2)))
-    # 3x2 matrix
-    b = mm.add_literal(
-        create_buffer('f', [7.0, 8.0, 9.0, 10.0, 11.0, 12.0], (3, 2)))
+    a = mm.add_literal(make_arg([3, 2], [1.0, 4.0, 2.0, 5.0, 3.0, 6.0]))
+    b = mm.add_literal(make_arg([3, 2], [7.0, 8.0, 9.0, 10.0, 11.0, 12.0]))
     mac = migraphx.macro("gemm", transA=True)
     result = mm.add_macro(mac, [a, b])
     mm.add_return([result[-1]])
@@ -84,16 +76,16 @@ def test_add_macro_gemm_transA():
 def test_add_macro_gemm_with_params():
     p = migraphx.program()
     mm = p.get_main_module()
-    s_a = migraphx.shape(lens=[2, 3], type="float")
-    s_b = migraphx.shape(lens=[3, 2], type="float")
+    s_a = migraphx.shape(lens=[2, 3], type="float_type")
+    s_b = migraphx.shape(lens=[3, 2], type="float_type")
     a = mm.add_parameter("a", s_a)
     b = mm.add_parameter("b", s_b)
     mac = migraphx.macro("gemm")
     result = mm.add_macro(mac, [a, b])
     mm.add_return([result[-1]])
     p.compile(migraphx.get_target("ref"))
-    a_data = create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3))
-    b_data = create_buffer('f', [7.0, 8.0, 9.0, 10.0, 11.0, 12.0], (3, 2))
+    a_data = make_arg([2, 3], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    b_data = make_arg([3, 2], [7.0, 8.0, 9.0, 10.0, 11.0, 12.0])
     output = p.run({"a": a_data, "b": b_data})[-1].tolist()
     assert output == [58.0, 64.0, 139.0, 154.0]
 
@@ -102,21 +94,18 @@ def test_add_macro_batchnorm():
     p = migraphx.program()
     mm = p.get_main_module()
     # Input: (1, 2, 3) - batch=1, channels=2, width=3
-    x = mm.add_literal(
-        create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (1, 2, 3)))
+    x = mm.add_literal(make_arg([1, 2, 3], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
     # scale, bias, mean, var each have shape (2,) for 2 channels
-    scale = mm.add_literal(create_buffer('f', [1.0, 1.0], (2,)))
-    bias = mm.add_literal(create_buffer('f', [0.0, 0.0], (2,)))
-    mean = mm.add_literal(create_buffer('f', [2.0, 5.0], (2,)))
-    var = mm.add_literal(create_buffer('f', [1.0, 1.0], (2,)))
+    scale = mm.add_literal(make_arg([2], [1.0, 1.0]))
+    bias = mm.add_literal(make_arg([2], [0.0, 0.0]))
+    mean = mm.add_literal(make_arg([2], [2.0, 5.0]))
+    var = mm.add_literal(make_arg([2], [1.0, 1.0]))
     mac = migraphx.macro("batchnorm")
     result = mm.add_macro(mac, [x, scale, bias, mean, var])
     mm.add_return([result[-1]])
     p.compile(migraphx.get_target("ref"))
     output = p.run({})[-1].tolist()
     # BN: (x - mean) / sqrt(var + eps) * scale + bias
-    # Channel 0: (1-2)/sqrt(1+1e-5), (2-2)/sqrt(1+1e-5), (3-2)/sqrt(1+1e-5)
-    # Channel 1: (4-5)/sqrt(1+1e-5), (5-5)/sqrt(1+1e-5), (6-5)/sqrt(1+1e-5)
     eps = 1e-5
     expected = [
         (1.0 - 2.0) / math.sqrt(1.0 + eps),
@@ -134,12 +123,11 @@ def test_add_macro_batchnorm():
 def test_add_macro_batchnorm_with_epsilon():
     p = migraphx.program()
     mm = p.get_main_module()
-    x = mm.add_literal(
-        create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (1, 2, 3)))
-    scale = mm.add_literal(create_buffer('f', [2.0, 0.5], (2,)))
-    bias = mm.add_literal(create_buffer('f', [1.0, -1.0], (2,)))
-    mean = mm.add_literal(create_buffer('f', [2.0, 5.0], (2,)))
-    var = mm.add_literal(create_buffer('f', [4.0, 4.0], (2,)))
+    x = mm.add_literal(make_arg([1, 2, 3], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
+    scale = mm.add_literal(make_arg([2], [2.0, 0.5]))
+    bias = mm.add_literal(make_arg([2], [1.0, -1.0]))
+    mean = mm.add_literal(make_arg([2], [2.0, 5.0]))
+    var = mm.add_literal(make_arg([2], [4.0, 4.0]))
     mac = migraphx.macro("batchnorm", epsilon=0.01)
     result = mm.add_macro(mac, [x, scale, bias, mean, var])
     mm.add_return([result[-1]])
@@ -163,15 +151,13 @@ def test_add_macro_convolution():
     p = migraphx.program()
     mm = p.get_main_module()
     # Input: (1, 1, 3, 3) - batch=1, channels=1, 3x3
-    x = mm.add_literal(
-        create_buffer('f', [
-            1.0, 2.0, 3.0,
-            4.0, 5.0, 6.0,
-            7.0, 8.0, 9.0
-        ], (1, 1, 3, 3)))
+    x = mm.add_literal(make_arg([1, 1, 3, 3], [
+        1.0, 2.0, 3.0,
+        4.0, 5.0, 6.0,
+        7.0, 8.0, 9.0
+    ]))
     # Weight: (1, 1, 2, 2) - out_channels=1, in_channels=1, 2x2 kernel
-    w = mm.add_literal(
-        create_buffer('f', [1.0, 0.0, 0.0, 1.0], (1, 1, 2, 2)))
+    w = mm.add_literal(make_arg([1, 1, 2, 2], [1.0, 0.0, 0.0, 1.0]))
     mac = migraphx.macro("convolution")
     result = mm.add_macro(mac, [x, w])
     mm.add_return([result[-1]])
@@ -187,15 +173,13 @@ def test_add_macro_convolution():
 def test_add_macro_convolution_with_bias():
     p = migraphx.program()
     mm = p.get_main_module()
-    x = mm.add_literal(
-        create_buffer('f', [
-            1.0, 2.0, 3.0,
-            4.0, 5.0, 6.0,
-            7.0, 8.0, 9.0
-        ], (1, 1, 3, 3)))
-    w = mm.add_literal(
-        create_buffer('f', [1.0, 0.0, 0.0, 1.0], (1, 1, 2, 2)))
-    bias = mm.add_literal(create_buffer('f', [10.0], (1,)))
+    x = mm.add_literal(make_arg([1, 1, 3, 3], [
+        1.0, 2.0, 3.0,
+        4.0, 5.0, 6.0,
+        7.0, 8.0, 9.0
+    ]))
+    w = mm.add_literal(make_arg([1, 1, 2, 2], [1.0, 0.0, 0.0, 1.0]))
+    bias = mm.add_literal(make_arg([1], [10.0]))
     mac = migraphx.macro("convolution")
     result = mm.add_macro(mac, [x, w, bias])
     mm.add_return([result[-1]])
@@ -208,33 +192,27 @@ def test_add_macro_convolution_with_bias():
 def test_add_macro_convolution_with_padding():
     p = migraphx.program()
     mm = p.get_main_module()
-    # Input: (1, 1, 3, 3)
-    x = mm.add_literal(
-        create_buffer('f', [
-            1.0, 2.0, 3.0,
-            4.0, 5.0, 6.0,
-            7.0, 8.0, 9.0
-        ], (1, 1, 3, 3)))
+    x = mm.add_literal(make_arg([1, 1, 3, 3], [
+        1.0, 2.0, 3.0,
+        4.0, 5.0, 6.0,
+        7.0, 8.0, 9.0
+    ]))
     # Weight: (1, 1, 3, 3) - 3x3 kernel all ones
-    w = mm.add_literal(
-        create_buffer('f', [1.0] * 9, (1, 1, 3, 3)))
+    w = mm.add_literal(make_arg([1, 1, 3, 3], [1.0] * 9))
     mac = migraphx.macro("convolution", paddings=[1, 1])
     result = mm.add_macro(mac, [x, w])
     mm.add_return([result[-1]])
     p.compile(migraphx.get_target("ref"))
     output = p.run({})[-1].tolist()
     # 3x3 kernel of ones on 3x3 input with padding=1 => 3x3 output
-    # Each output is the sum of the overlapping region
     assert output == [12.0, 21.0, 16.0, 27.0, 45.0, 33.0, 24.0, 39.0, 28.0]
 
 
 def test_add_macro_einsum_matmul():
     p = migraphx.program()
     mm = p.get_main_module()
-    a = mm.add_literal(
-        create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3)))
-    b = mm.add_literal(
-        create_buffer('f', [7.0, 8.0, 9.0, 10.0, 11.0, 12.0], (3, 2)))
+    a = mm.add_literal(make_arg([2, 3], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
+    b = mm.add_literal(make_arg([3, 2], [7.0, 8.0, 9.0, 10.0, 11.0, 12.0]))
     mac = migraphx.macro("einsum", equation="ij,jk->ik")
     result = mm.add_macro(mac, [a, b])
     mm.add_return([result[-1]])
@@ -247,8 +225,7 @@ def test_add_macro_einsum_matmul():
 def test_add_macro_einsum_transpose():
     p = migraphx.program()
     mm = p.get_main_module()
-    a = mm.add_literal(
-        create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3)))
+    a = mm.add_literal(make_arg([2, 3], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
     mac = migraphx.macro("einsum", equation="ij->ji")
     result = mm.add_macro(mac, [a])
     mm.add_return([result[-1]])
@@ -261,13 +238,11 @@ def test_add_macro_einsum_transpose():
 def test_add_macro_einsum_trace():
     p = migraphx.program()
     mm = p.get_main_module()
-    # 3x3 identity matrix
-    a = mm.add_literal(
-        create_buffer('f', [
-            1.0, 0.0, 0.0,
-            0.0, 2.0, 0.0,
-            0.0, 0.0, 3.0
-        ], (3, 3)))
+    a = mm.add_literal(make_arg([3, 3], [
+        1.0, 0.0, 0.0,
+        0.0, 2.0, 0.0,
+        0.0, 0.0, 3.0
+    ]))
     mac = migraphx.macro("einsum", equation="ii->")
     result = mm.add_macro(mac, [a])
     mm.add_return([result[-1]])
@@ -280,12 +255,8 @@ def test_add_macro_einsum_trace():
 def test_insert_macro():
     p = migraphx.program()
     mm = p.get_main_module()
-    # 2x3 matrix
-    a = mm.add_literal(
-        create_buffer('f', [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3)))
-    # 3x2 matrix
-    b = mm.add_literal(
-        create_buffer('f', [7.0, 8.0, 9.0, 10.0, 11.0, 12.0], (3, 2)))
+    a = mm.add_literal(make_arg([2, 3], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
+    b = mm.add_literal(make_arg([3, 2], [7.0, 8.0, 9.0, 10.0, 11.0, 12.0]))
     # First add a gemm at the end
     gemm_mac = migraphx.macro("gemm")
     gemm_result = mm.add_macro(gemm_mac, [a, b])


### PR DESCRIPTION
## Motivation
This exposes the op builder to the API, but uses slightly different API. Instead there is a `m.add_instructions` method that will take a `macro` that will then insert the ops from the op builder. I chose `macro` as it is short and descriptive of what it does.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [x] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
