### PR TITLE
Fix issue in compile_ops caused by configs with only 1 solution

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -306,7 +306,7 @@ struct compile_plan
                 if(solutions.empty())
                     MIGRAPHX_THROW("No solutions provided for " + preop.name() + " with " +
                                    problem_string() + "\n\n" + print_modules());
-                if(enabled(MIGRAPHX_SKIP_BENCHMARKING{}))
+                if(enabled(MIGRAPHX_SKIP_BENCHMARKING{}) or solutions.size() == 1)
                 {
                     ctx->get_problem_cache().insert(preop.name(), problem, solutions.front());
                     results.resize(1);


### PR DESCRIPTION
## Motivation
If a program contains several identical instances of an operator (same compilation problem), 
if the compilation config happens to have only one solution, only the first instance would be compiled while the rest would be left as a gpu::precompile_op.

If limited to only one solution
```
module: "main"
x = @param:x -> float_type, {64, 64}, {64, 1}
@1 = dot(x,x) -> float_type, {64, 64}, {64, 1}
@2 = dot(@1,x) -> float_type, {64, 64}, {64, 1}
@3 = @return(@2)
```
would compile to
```
module: "main"
@0 = check_context::migraphx::gpu::context -> float_type, {}, {}
@1 = hip::hip_allocate_memory[shape=int8_type, {16384}, {1},id=main:scratch] -> int8_type, {16384}, {1}
@2 = load[offset=0,end=16384](@1) -> float_type, {64, 64}, {64, 1}
x = @param:x -> float_type, {64, 64}, {64, 1}
@4 = gpu::code_object[code_object=5888,symbol_name=mlir_dot,global=1024,local=64,output_arg=2,](x,x,@2) -> float_type, {64, 64}, {64, 1}
main:#output_0 = @param:main:#output_0 -> float_type, {64, 64}, {64, 1}
@6 = gpu::precompile_op[op=gpu::mlir_op[op=dot],additional_args=1,ignore_modules=0,output_shape=nullopt](@4,x,main:#output_0), [mlir_dot1] -> float_type, {64, 64}, {64, 1}
@7 = @return(@6)
```

## Technical Details
When encountering the first instance of the operator:

- `add_compiles` would `mark()` a solution in the problem cache.
- `benchmark` would enter the `results.size() == 1` branch and return the result, without inserting a solution into the problem cache, leaving a dangling entry.

When encountering any subsequent instance of the operator:

- `add_compiles` finds an entry in the problem cache
- `solution.is_null()` exits early, no compilation is inserted thus leaving the operator instance as is

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
