### PR TITLE
Check if workaround deduction guide is needed

### DIFF
--- a/src/targets/gpu/compile_hip.cpp
+++ b/src/targets/gpu/compile_hip.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/compile_hip.cpp
+++ b/src/targets/gpu/compile_hip.cpp
@@ -386,10 +386,7 @@ bool hip_can_compile(const std::string& src, const std::vector<std::string>& fla
     }
 }
 
-bool hip_has_flags(const std::vector<std::string>& flags)
-{
-    return hip_can_compile(" ", flags);
-}
+bool hip_has_flags(const std::vector<std::string>& flags) { return hip_can_compile(" ", flags); }
 
 std::string enum_params(std::size_t count, std::string param)
 {

--- a/src/targets/gpu/compile_hip.cpp
+++ b/src/targets/gpu/compile_hip.cpp
@@ -369,9 +369,8 @@ std::vector<std::vector<char>> compile_hip_src(const std::vector<src_file>& srcs
 
 #endif // MIGRAPHX_USE_HIPRTC
 
-bool hip_has_flags(const std::vector<std::string>& flags)
+bool hip_can_compile(const std::string& src, const std::vector<std::string>& flags)
 {
-    std::string src = " ";
     src_file input{"main.cpp", src};
     std::vector<src_file> srcs = {input};
 
@@ -385,6 +384,11 @@ bool hip_has_flags(const std::vector<std::string>& flags)
     {
         return false;
     }
+}
+
+bool hip_has_flags(const std::vector<std::string>& flags)
+{
+    return hip_can_compile(" ", flags);
 }
 
 std::string enum_params(std::size_t count, std::string param)

--- a/src/targets/gpu/compile_hip_code_object.cpp
+++ b/src/targets/gpu/compile_hip_code_object.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/compile_hip_code_object.cpp
+++ b/src/targets/gpu/compile_hip_code_object.cpp
@@ -116,6 +116,9 @@ static std::vector<std::string> get_compiler_warnings()
     if(hip_has_flags({"-Werror", "-Wnrvo"}))
         warnings.push_back("-Wno-nrvo");
 
+    if(hip_has_flags({"-Werror", "-Wlifetime-safety-intra-tu-suggestions"}))
+        warnings.push_back("-Wno-lifetime-safety-intra-tu-suggestions");
+
     return warnings;
 }
 
@@ -141,6 +144,30 @@ static bool hip_accept_non_uniform_wg()
 {
     static bool non_uniform_wg = hip_has_flags({"-fno-offload-uniform-block"});
     return non_uniform_wg;
+}
+
+static bool hip_workaround_broken_deduction_guide()
+{
+    static const char* const test = R"__migraphx__(
+template<class T>
+struct S
+{
+    T x;
+};
+
+template<class T>
+S(T) -> S<T>;
+
+__attribute__((device)) auto f()
+{
+    return S{1};
+}
+
+
+)__migraphx__";
+
+    static bool can_compile = hip_can_compile(test, {"-std=c++17"});
+    return not can_compile;
 }
 
 std::function<std::size_t(std::size_t local)>
@@ -187,6 +214,9 @@ compile_hip_raw(context& ctx, const std::string& content, hip_compile_options op
         options.emplace_param("-fno-offload-uniform-block");
     else
         assert(options.global % options.local == 0);
+    if(hip_workaround_broken_deduction_guide())
+        options.emplace_param("-DMIGRAPHX_WORKAROUND_BROKEN_DEDUCTION_GUIDE");
+
 
     options.emplace_param("-DMIGRAPHX_NGLOBAL=" + std::to_string(options.global));
     options.emplace_param("-DMIGRAPHX_NLOCAL=" + std::to_string(options.local));

--- a/src/targets/gpu/compile_hip_code_object.cpp
+++ b/src/targets/gpu/compile_hip_code_object.cpp
@@ -217,7 +217,6 @@ compile_hip_raw(context& ctx, const std::string& content, hip_compile_options op
     if(hip_workaround_broken_deduction_guide())
         options.emplace_param("-DMIGRAPHX_WORKAROUND_BROKEN_DEDUCTION_GUIDE");
 
-
     options.emplace_param("-DMIGRAPHX_NGLOBAL=" + std::to_string(options.global));
     options.emplace_param("-DMIGRAPHX_NLOCAL=" + std::to_string(options.local));
     options.emplace_param("-DMIGRAPHX_WAVEFRONTSIZE=" +

--- a/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
@@ -54,7 +54,8 @@ struct hiprtc_src_file
     }
 };
 
-MIGRAPHX_GPU_EXPORT bool hip_can_compile(const std::string& src, const std::vector<std::string>& flags);
+MIGRAPHX_GPU_EXPORT bool hip_can_compile(const std::string& src,
+                                         const std::vector<std::string>& flags);
 
 MIGRAPHX_GPU_EXPORT bool hip_has_flags(const std::vector<std::string>& flags);
 

--- a/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
@@ -54,6 +54,8 @@ struct hiprtc_src_file
     }
 };
 
+MIGRAPHX_GPU_EXPORT bool hip_can_compile(const std::string& src, const std::vector<std::string>& flags);
+
 MIGRAPHX_GPU_EXPORT bool hip_has_flags(const std::vector<std::string>& flags);
 
 MIGRAPHX_GPU_EXPORT std::vector<std::vector<char>>

--- a/src/targets/gpu/kernels/include/migraphx/kernels/types.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/types.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/kernels/include/migraphx/kernels/types.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/types.hpp
@@ -62,10 +62,17 @@ static_assert(sizeof(uint64_t) == 8, "uint64_t must be 8 bytes");
 
 #define MIGRAPHX_DEVICE_CONSTEXPR constexpr __device__ __host__ // NOLINT
 
+#ifdef MIGRAPHX_WORKAROUND_BROKEN_DEDUCTION_GUIDE
 // NOLINTNEXTLINE
 #define MIGRAPHX_AUTO_DEDUCE(name) \
     template <class... Ts>         \
     __host__ __device__ name(Ts...) -> name<Ts...>;
+#else
+// NOLINTNEXTLINE
+#define MIGRAPHX_AUTO_DEDUCE(name) \
+    template <class... Ts>         \
+    name(Ts...) -> name<Ts...>;
+#endif
 
 template <class T, index_int N>
 using vec = T __attribute__((ext_vector_type(N)));


### PR DESCRIPTION
## Motivation
The deduction guides for aggregates constructors have been broken on hip as it doesnt propagate the device target from the constructor. This has been fixed on a newer compiler and the workaround is deprecated behaviour. For now, detect when this behaviour works and adjust the workaround. The `MIGRAPHX_AUTO_DEDUCE` can be removed on a newer version of the compiler.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
