### PR TITLE
Move the data into the for loop to avoid data races

### DIFF
--- a/src/include/migraphx/op/topk.hpp
+++ b/src/include/migraphx/op/topk.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/op/topk.hpp
+++ b/src/include/migraphx/op/topk.hpp
@@ -106,8 +106,8 @@ struct topk
         visit_all(res_val, args.front())([&](auto output, auto input) {
             res_ind.visit([&](auto out_ind) {
                 using type = typename decltype(input)::value_type;
-                std::vector<std::pair<type, int64_t>> data(relements);
                 par_for(outer_shape.elements(), [&](auto i) {
+                    std::vector<std::pair<type, int64_t>> data(relements);
                     auto outer_idx = outer_shape.multi(i);
                     auto x         = input.slice_at({axis}, outer_idx);
                     auto y         = output.slice_at({axis}, outer_idx);


### PR DESCRIPTION
## Motivation
Since `par_for` can run in parallel, the `data` vector can get corrupted across multiple threads. This can make the topk ref operator produce junk data.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
