### PR TITLE
fix (nonmaxsuppression): fix output when use_dyn_output is false (make it onnx compliant) - #4679

### DIFF
--- a/src/include/migraphx/op/nonmaxsuppression.hpp
+++ b/src/include/migraphx/op/nonmaxsuppression.hpp
@@ -184,7 +184,8 @@ struct nonmaxsuppression
                     "NonMaxSuppression: dynamic input shape with use_dyn_output set to false");
             }
             fixed_shape_error_check();
-            // actual selected boxes. Previously returned fixed max_num_boxes which caused zero padding bug. https://github.com/ROCm/AMDMIGraphX/issues/4679
+            // actual selected boxes. Previously returned fixed max_num_boxes which caused zero
+            // padding bug. https://github.com/ROCm/AMDMIGraphX/issues/4679
             std::vector<shape::dynamic_dimension> out_lens = {};
             out_lens.push_back({0, max_num_boxes});
             out_lens.push_back({3, 3});
@@ -403,7 +404,8 @@ struct nonmaxsuppression
         });
         // Previously only done when use_dyn_output==True
         // Now done always - correct for both static and dynamic inputs
-        // This makes output ONNX spec compliant https://onnx.ai/onnx/operators/onnx__NonMaxSuppression.html
+        // This makes output ONNX spec compliant
+        // https://onnx.ai/onnx/operators/onnx__NonMaxSuppression.html
         return result.reshape({output_shape.type(), {num_selected, 3}});
     }
 };

--- a/src/include/migraphx/op/nonmaxsuppression.hpp
+++ b/src/include/migraphx/op/nonmaxsuppression.hpp
@@ -184,7 +184,8 @@ struct nonmaxsuppression
                     "NonMaxSuppression: dynamic input shape with use_dyn_output set to false");
             }
             fixed_shape_error_check();
-            // actual selected boxes. Previously returned fixed max_num_boxes which caused zero padding bug. https://github.com/ROCm/AMDMIGraphX/issues/4679
+            // actual selected boxes. Previously returned fixed max_num_boxes which caused zero
+            // padding bug. https://github.com/ROCm/AMDMIGraphX/issues/4679
             std::vector<shape::dynamic_dimension> out_lens = {};
             out_lens.push_back({0, max_num_boxes});
             out_lens.push_back({3, 3});
@@ -404,7 +405,8 @@ struct nonmaxsuppression
         });
         // Previously only done when use_dyn_output==True
         // Now done always - correct for both static and dynamic inputs
-        // This makes output ONNX spec compliant https://onnx.ai/onnx/operators/onnx__NonMaxSuppression.html
+        // This makes output ONNX spec compliant
+        // https://onnx.ai/onnx/operators/onnx__NonMaxSuppression.html
         return result.reshape({output_shape.type(), {num_selected, 3}});
     }
 };

--- a/src/include/migraphx/op/nonmaxsuppression.hpp
+++ b/src/include/migraphx/op/nonmaxsuppression.hpp
@@ -184,8 +184,7 @@ struct nonmaxsuppression
                     "NonMaxSuppression: dynamic input shape with use_dyn_output set to false");
             }
             fixed_shape_error_check();
-            // actual selected boxes. Previously returned fixed max_num_boxes which caused zero
-            // padding bug. https://github.com/ROCm/AMDMIGraphX/issues/4679
+            // actual selected boxes. Previously returned fixed max_num_boxes which caused zero padding bug. https://github.com/ROCm/AMDMIGraphX/issues/4679
             std::vector<shape::dynamic_dimension> out_lens = {};
             out_lens.push_back({0, max_num_boxes});
             out_lens.push_back({3, 3});
@@ -325,7 +324,8 @@ struct nonmaxsuppression
                             double iou_threshold,
                             double score_threshold) const
     {
-        // Output is trimmed in compute(), so zero-initialization is unnecessary here.
+        // We trim the output in compute() so zeros are irrelevant
+        // std::fill(output.begin(), output.end(), 0);
         const auto& lens       = scores.get_shape().lens();
         const auto num_batches = lens[0];
         const auto num_classes = lens[1];
@@ -404,8 +404,7 @@ struct nonmaxsuppression
         });
         // Previously only done when use_dyn_output==True
         // Now done always - correct for both static and dynamic inputs
-        // This makes output ONNX spec compliant
-        // https://onnx.ai/onnx/operators/onnx__NonMaxSuppression.html
+        // This makes output ONNX spec compliant https://onnx.ai/onnx/operators/onnx__NonMaxSuppression.html
         return result.reshape({output_shape.type(), {num_selected, 3}});
     }
 };

--- a/src/include/migraphx/op/nonmaxsuppression.hpp
+++ b/src/include/migraphx/op/nonmaxsuppression.hpp
@@ -324,8 +324,7 @@ struct nonmaxsuppression
                             double iou_threshold,
                             double score_threshold) const
     {
-        // We trim the output in compute() so zeros are irrelevant
-        // std::fill(output.begin(), output.end(), 0);
+        // Output is trimmed in compute(), so zero-initialization is unnecessary here.
         const auto& lens       = scores.get_shape().lens();
         const auto num_batches = lens[0];
         const auto num_classes = lens[1];

--- a/src/include/migraphx/op/nonmaxsuppression.hpp
+++ b/src/include/migraphx/op/nonmaxsuppression.hpp
@@ -184,7 +184,10 @@ struct nonmaxsuppression
                     "NonMaxSuppression: dynamic input shape with use_dyn_output set to false");
             }
             fixed_shape_error_check();
-            std::vector<std::size_t> out_lens = {max_num_boxes, 3};
+            // actual selected boxes. Previously returned fixed max_num_boxes which caused zero padding bug. https://github.com/ROCm/AMDMIGraphX/issues/4679
+            std::vector<shape::dynamic_dimension> out_lens = {};
+            out_lens.push_back({0, max_num_boxes});
+            out_lens.push_back({3, 3});
             return {shape::int64_type, out_lens};
         }
     }
@@ -321,7 +324,8 @@ struct nonmaxsuppression
                             double iou_threshold,
                             double score_threshold) const
     {
-        std::fill(output.begin(), output.end(), 0);
+        // We trim the output in compute() so zeros are irrelevant
+        // std::fill(output.begin(), output.end(), 0);
         const auto& lens       = scores.get_shape().lens();
         const auto num_batches = lens[0];
         const auto num_classes = lens[1];
@@ -398,14 +402,10 @@ struct nonmaxsuppression
                                            score_threshold);
             });
         });
-        if(use_dyn_output)
-        {
-            return result.reshape({output_shape.type(), {num_selected, 3}});
-        }
-        else
-        {
-            return result;
-        }
+        // Previously only done when use_dyn_output==True
+        // Now done always - correct for both static and dynamic inputs
+        // This makes output ONNX spec compliant https://onnx.ai/onnx/operators/onnx__NonMaxSuppression.html
+        return result.reshape({output_shape.type(), {num_selected, 3}});
     }
 };
 

--- a/src/include/migraphx/op/nonmaxsuppression.hpp
+++ b/src/include/migraphx/op/nonmaxsuppression.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -380,16 +380,16 @@ struct nonmaxsuppression
         // make buffer of maximum size
         shape max_output_shape = {output_shape.type(), output_shape.max_lens()};
         argument result{max_output_shape};
+        std::size_t num_selected = 0;
 
         std::size_t max_output_boxes_per_class =
             (args.size() > 2) ? (args.at(2).at<std::size_t>()) : 0;
         if(max_output_boxes_per_class == 0)
         {
-            return result;
+            return result.reshape({output_shape.type(), {num_selected, 3}});
         }
         double iou_threshold     = (args.size() > 3) ? (args.at(3).at<double>()) : 0.0f;
         double score_threshold   = (args.size() > 4) ? (args.at(4).at<double>()) : 0.0f;
-        std::size_t num_selected = 0;
 
         result.visit([&](auto output) {
             get_all<double>(args[0], args[1])([&](auto boxes, auto scores) {

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -639,7 +639,8 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
            bool skip_unknown_operators,
            bool print_program_on_error,
            int64_t max_loop_iterations,
-           int64_t limit_max_iterations) {
+           int64_t limit_max_iterations,
+           bool use_dyn_output) {//https://github.com/ROCm/AMDMIGraphX/issues/4679
             migraphx::onnx_options options;
             options.default_dim_value      = default_dim_value;
             options.default_dyn_dim_value  = default_dyn_dim_value;
@@ -650,6 +651,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             options.print_program_on_error = print_program_on_error;
             options.max_loop_iterations    = max_loop_iterations;
             options.limit_max_iterations   = limit_max_iterations;
+            options.use_dyn_output         = use_dyn_output; //https://github.com/ROCm/AMDMIGraphX/issues/4679
             return migraphx::parse_onnx(filename, options);
         },
         "Parse onnx file",
@@ -664,7 +666,8 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         py::arg("skip_unknown_operators") = false,
         py::arg("print_program_on_error") = false,
         py::arg("max_loop_iterations")    = 10,
-        py::arg("limit_max_iterations")   = std::numeric_limits<uint16_t>::max());
+        py::arg("limit_max_iterations")   = std::numeric_limits<uint16_t>::max(),
+        py::arg("use_dyn_output") = false); //https://github.com/ROCm/AMDMIGraphX/issues/4679
 
     m.def(
         "parse_onnx_buffer",

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -640,7 +640,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
            bool print_program_on_error,
            int64_t max_loop_iterations,
            int64_t limit_max_iterations,
-           bool use_dyn_output) { 
+           bool use_dyn_output) {
             migraphx::onnx_options options;
             options.default_dim_value      = default_dim_value;
             options.default_dyn_dim_value  = default_dyn_dim_value;
@@ -651,7 +651,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             options.print_program_on_error = print_program_on_error;
             options.max_loop_iterations    = max_loop_iterations;
             options.limit_max_iterations   = limit_max_iterations;
-            options.use_dyn_output         = use_dyn_output; 
+            options.use_dyn_output         = use_dyn_output;
             return migraphx::parse_onnx(filename, options);
         },
         "Parse onnx file",
@@ -667,7 +667,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         py::arg("print_program_on_error") = false,
         py::arg("max_loop_iterations")    = 10,
         py::arg("limit_max_iterations")   = std::numeric_limits<uint16_t>::max(),
-        py::arg("use_dyn_output") = false); 
+        py::arg("use_dyn_output")         = false);
     m.def(
         "parse_onnx_buffer",
         [](const std::string& onnx_buffer,

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -678,7 +678,8 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
                map_dyn_input_dims,
            bool skip_unknown_operators,
            bool print_program_on_error,
-           const std::string& external_data_path) {
+           const std::string& external_data_path,
+           bool use_dyn_output) {
             migraphx::onnx_options options;
             options.default_dim_value      = default_dim_value;
             options.default_dyn_dim_value  = default_dyn_dim_value;
@@ -687,6 +688,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             options.skip_unknown_operators = skip_unknown_operators;
             options.print_program_on_error = print_program_on_error;
             options.external_data_path     = external_data_path;
+            options.use_dyn_output         = use_dyn_output;
             return migraphx::parse_onnx_buffer(onnx_buffer, options);
         },
         "Parse onnx file",
@@ -698,7 +700,8 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             std::unordered_map<std::string, std::vector<migraphx::shape::dynamic_dimension>>(),
         py::arg("skip_unknown_operators") = false,
         py::arg("print_program_on_error") = false,
-        py::arg("external_data_path")     = "");
+        py::arg("external_data_path")     = "",
+        py::arg("use_dyn_output")         = false);
 
     m.def(
         "load",

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -640,7 +640,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
            bool print_program_on_error,
            int64_t max_loop_iterations,
            int64_t limit_max_iterations,
-           bool use_dyn_output) {//https://github.com/ROCm/AMDMIGraphX/issues/4679
+           bool use_dyn_output) { 
             migraphx::onnx_options options;
             options.default_dim_value      = default_dim_value;
             options.default_dyn_dim_value  = default_dyn_dim_value;
@@ -651,7 +651,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             options.print_program_on_error = print_program_on_error;
             options.max_loop_iterations    = max_loop_iterations;
             options.limit_max_iterations   = limit_max_iterations;
-            options.use_dyn_output         = use_dyn_output; //https://github.com/ROCm/AMDMIGraphX/issues/4679
+            options.use_dyn_output         = use_dyn_output; 
             return migraphx::parse_onnx(filename, options);
         },
         "Parse onnx file",
@@ -667,8 +667,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         py::arg("print_program_on_error") = false,
         py::arg("max_loop_iterations")    = 10,
         py::arg("limit_max_iterations")   = std::numeric_limits<uint16_t>::max(),
-        py::arg("use_dyn_output") = false); //https://github.com/ROCm/AMDMIGraphX/issues/4679
-
+        py::arg("use_dyn_output") = false); 
     m.def(
         "parse_onnx_buffer",
         [](const std::string& onnx_buffer,

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -2296,7 +2296,7 @@ TEST_CASE(nms_shape)
     migraphx::shape max_out_s{migraphx::shape::int64_type, {1}};
     migraphx::shape iou_thres_s{migraphx::shape::float_type, {1}};
     migraphx::shape score_thres_s{migraphx::shape::float_type, {1}};
-    migraphx::shape output_s{migraphx::shape::int64_type, {6, 3}};
+    migraphx::shape output_s{migraphx::shape::int64_type, {{0, 6}, {3, 3}}};
     expect_shape(output_s,
                  migraphx::make_op("nonmaxsuppression",
                                    {{"center_point_box", true}, {"use_dyn_output", false}}),

--- a/test/ref/nonmaxsuppression.cpp
+++ b/test/ref/nonmaxsuppression.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/ref/nonmaxsuppression.cpp
+++ b/test/ref/nonmaxsuppression.cpp
@@ -387,14 +387,9 @@ TEST_CASE(nms_static_input_dyn_out_false_test)
     auto* mm = p.get_main_module();
 
     migraphx::shape boxes_s{migraphx::shape::float_type, {1, 6, 4}};
-    std::vector<float> boxes_vec = {
-        0.0, 0.0,   1.0, 1.0,   
-        0.0, 0.1,   1.0, 1.1,  
-        0.0, -0.1,  1.0, 0.9,   
-        0.0, 10.0,  1.0, 11.0,  
-        0.0, 10.1,  1.0, 11.1,  
-        0.0, 100.0, 1.0, 101.0  
-    };
+    std::vector<float> boxes_vec = {0.0, 0.0,  1.0, 1.0,  0.0, 0.1,   1.0, 1.1,
+                                    0.0, -0.1, 1.0, 0.9,  0.0, 10.0,  1.0, 11.0,
+                                    0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0};
 
     migraphx::shape scores_s{migraphx::shape::float_type, {1, 1, 6}};
     std::vector<float> scores_vec = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
@@ -405,14 +400,13 @@ TEST_CASE(nms_static_input_dyn_out_false_test)
     auto iou_threshold   = mm->add_literal(0.5f);
     auto score_threshold = mm->add_literal(0.0f);
 
-    auto r = mm->add_instruction(
-        migraphx::make_op("nonmaxsuppression",
-                          {{"use_dyn_output", false}}),
-        boxes_l,
-        scores_l,
-        max_out_l,
-        iou_threshold,
-        score_threshold);
+    auto r =
+        mm->add_instruction(migraphx::make_op("nonmaxsuppression", {{"use_dyn_output", false}}),
+                            boxes_l,
+                            scores_l,
+                            max_out_l,
+                            iou_threshold,
+                            score_threshold);
     mm->add_return({r});
 
     p.compile(migraphx::make_target("ref"));
@@ -428,8 +422,7 @@ TEST_CASE(nms_static_input_dyn_out_false_test)
     EXPECT(migraphx::verify::verify_rms_range(result, gold));
 }
 
-
-// Static inputs + use_dyn_output=True 
+// Static inputs + use_dyn_output=True
 // Used to crash with PARSE_EXPAND error https://github.com/ROCm/AMDMIGraphX/issues/4679
 // Now works correctly with static input shapes
 TEST_CASE(nms_static_input_dyn_out_true_test)
@@ -438,14 +431,9 @@ TEST_CASE(nms_static_input_dyn_out_true_test)
     auto* mm = p.get_main_module();
 
     migraphx::shape boxes_s{migraphx::shape::float_type, {1, 6, 4}};
-    std::vector<float> boxes_vec = {
-        0.0, 0.0,   1.0, 1.0,   
-        0.0, 0.1,   1.0, 1.1,   
-        0.0, -0.1,  1.0, 0.9,   
-        0.0, 10.0,  1.0, 11.0,  
-        0.0, 10.1,  1.0, 11.1,  
-        0.0, 100.0, 1.0, 101.0  
-    };
+    std::vector<float> boxes_vec = {0.0, 0.0,  1.0, 1.0,  0.0, 0.1,   1.0, 1.1,
+                                    0.0, -0.1, 1.0, 0.9,  0.0, 10.0,  1.0, 11.0,
+                                    0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0};
 
     migraphx::shape scores_s{migraphx::shape::float_type, {1, 1, 6}};
     std::vector<float> scores_vec = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
@@ -456,14 +444,12 @@ TEST_CASE(nms_static_input_dyn_out_true_test)
     auto iou_threshold   = mm->add_literal(0.5f);
     auto score_threshold = mm->add_literal(0.0f);
 
-    auto r = mm->add_instruction(
-        migraphx::make_op("nonmaxsuppression",
-                          {{"use_dyn_output", true}}),
-        boxes_l,
-        scores_l,
-        max_out_l,
-        iou_threshold,
-        score_threshold);
+    auto r = mm->add_instruction(migraphx::make_op("nonmaxsuppression", {{"use_dyn_output", true}}),
+                                 boxes_l,
+                                 scores_l,
+                                 max_out_l,
+                                 iou_threshold,
+                                 score_threshold);
     mm->add_return({r});
 
     p.compile(migraphx::make_target("ref"));
@@ -479,7 +465,6 @@ TEST_CASE(nms_static_input_dyn_out_true_test)
     EXPECT(migraphx::verify::verify_rms_range(result, gold));
 }
 
-
 TEST_CASE(nms_dyn_out_false_and_true_same_result_test)
 {
     auto run_nms = [](bool use_dyn_output) {
@@ -487,14 +472,9 @@ TEST_CASE(nms_dyn_out_false_and_true_same_result_test)
         auto* mm = p.get_main_module();
 
         migraphx::shape boxes_s{migraphx::shape::float_type, {1, 6, 4}};
-        std::vector<float> boxes_vec = {
-            0.0, 0.0,   1.0, 1.0,
-            0.0, 0.1,   1.0, 1.1,
-            0.0, -0.1,  1.0, 0.9,
-            0.0, 10.0,  1.0, 11.0,
-            0.0, 10.1,  1.0, 11.1,
-            0.0, 100.0, 1.0, 101.0
-        };
+        std::vector<float> boxes_vec = {0.0, 0.0,  1.0, 1.0,  0.0, 0.1,   1.0, 1.1,
+                                        0.0, -0.1, 1.0, 0.9,  0.0, 10.0,  1.0, 11.0,
+                                        0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0};
 
         migraphx::shape scores_s{migraphx::shape::float_type, {1, 1, 6}};
         std::vector<float> scores_vec = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
@@ -506,8 +486,7 @@ TEST_CASE(nms_dyn_out_false_and_true_same_result_test)
         auto score_threshold = mm->add_literal(0.0f);
 
         auto r = mm->add_instruction(
-            migraphx::make_op("nonmaxsuppression",
-                              {{"use_dyn_output", use_dyn_output}}),
+            migraphx::make_op("nonmaxsuppression", {{"use_dyn_output", use_dyn_output}}),
             boxes_l,
             scores_l,
             max_out_l,
@@ -532,7 +511,6 @@ TEST_CASE(nms_dyn_out_false_and_true_same_result_test)
     EXPECT(result_false == result_true);
 }
 
-
 // Dynamic inputs + use_dyn_output=False must throw
 // This is CORRECT behavior — not a bug
 // Ensures we didn't accidentally break this check
@@ -554,13 +532,11 @@ TEST_CASE(nms_dynamic_input_dyn_out_false_throws_test)
     // Dynamic inputs + use_dyn_output=False MUST throw
     // This is intentional — dynamic inputs require True
     EXPECT(test::throws([&] {
-        mm->add_instruction(
-            migraphx::make_op("nonmaxsuppression",
-                              {{"use_dyn_output", false}}),
-            boxes_p,
-            scores_p,
-            max_out_l,
-            iou_threshold,
-            score_threshold);
+        mm->add_instruction(migraphx::make_op("nonmaxsuppression", {{"use_dyn_output", false}}),
+                            boxes_p,
+                            scores_p,
+                            max_out_l,
+                            iou_threshold,
+                            score_threshold);
     }));
 }

--- a/test/ref/nonmaxsuppression.cpp
+++ b/test/ref/nonmaxsuppression.cpp
@@ -526,8 +526,8 @@ TEST_CASE(nms_dyn_out_false_and_true_same_result_test)
     auto result_true  = run_nms(true);
 
     // Both flags must produce identical output after fix
-    // Before fix: False gave (6,3), True gave (3,3) — different!
-    // After fix:  Both give (3,3) — identical! ✅
+    // Before fix: False gave (6,3), True gave (3,3) - different.
+    // After fix:  Both give (3,3) - identical.
     EXPECT(result_false.size() == result_true.size());
     EXPECT(result_false == result_true);
 }

--- a/test/ref/nonmaxsuppression.cpp
+++ b/test/ref/nonmaxsuppression.cpp
@@ -265,7 +265,7 @@ TEST_CASE(nms_not_center_test)
     auto output = p.eval({}).back();
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
-    std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5}; // Only 3 boxes selected, no padding
     EXPECT(migraphx::verify::verify_rms_range(result, gold));
 }
 
@@ -299,7 +299,7 @@ TEST_CASE(nms_test)
     auto output = p.eval({}).back();
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
-    std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5};
     EXPECT(migraphx::verify::verify_rms_range(result, gold));
 }
 
@@ -337,7 +337,7 @@ TEST_CASE(nms_transpose1_test)
     auto output = p.eval({}).back();
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
-    std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5};
     EXPECT(migraphx::verify::verify_rms_range(result, gold));
 }
 
@@ -375,6 +375,192 @@ TEST_CASE(nms_transpose2_test)
     auto output = p.eval({}).back();
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
-    std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5};
     EXPECT(migraphx::verify::verify_rms_range(result, gold));
+}
+
+// Static inputs + use_dyn_output=False
+// Was the MAIN BUG — used to pad with fake [0,0,0] zeros
+TEST_CASE(nms_static_input_dyn_out_false_test)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+
+    migraphx::shape boxes_s{migraphx::shape::float_type, {1, 6, 4}};
+    std::vector<float> boxes_vec = {
+        0.0, 0.0,   1.0, 1.0,   
+        0.0, 0.1,   1.0, 1.1,  
+        0.0, -0.1,  1.0, 0.9,   
+        0.0, 10.0,  1.0, 11.0,  
+        0.0, 10.1,  1.0, 11.1,  
+        0.0, 100.0, 1.0, 101.0  
+    };
+
+    migraphx::shape scores_s{migraphx::shape::float_type, {1, 1, 6}};
+    std::vector<float> scores_vec = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
+
+    auto boxes_l         = mm->add_literal(migraphx::literal(boxes_s, boxes_vec));
+    auto scores_l        = mm->add_literal(migraphx::literal(scores_s, scores_vec));
+    auto max_out_l       = mm->add_literal(int64_t{3});
+    auto iou_threshold   = mm->add_literal(0.5f);
+    auto score_threshold = mm->add_literal(0.0f);
+
+    auto r = mm->add_instruction(
+        migraphx::make_op("nonmaxsuppression",
+                          {{"use_dyn_output", false}}),
+        boxes_l,
+        scores_l,
+        max_out_l,
+        iou_threshold,
+        score_threshold);
+    mm->add_return({r});
+
+    p.compile(migraphx::make_target("ref"));
+    auto output = p.eval({}).back();
+    std::vector<int64_t> result;
+    output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
+
+    // Only 3 selected boxes — NO fake [0,0,0] padding
+    // Before fix: output was (6,3) with 3 fake zero rows
+    // After fix:  output is  (3,3) with only real boxes
+    std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5};
+    EXPECT(result.size() == gold.size()); // must be 9 not 18
+    EXPECT(migraphx::verify::verify_rms_range(result, gold));
+}
+
+
+// Static inputs + use_dyn_output=True 
+// Used to crash with PARSE_EXPAND error https://github.com/ROCm/AMDMIGraphX/issues/4679
+// Now works correctly with static input shapes
+TEST_CASE(nms_static_input_dyn_out_true_test)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+
+    migraphx::shape boxes_s{migraphx::shape::float_type, {1, 6, 4}};
+    std::vector<float> boxes_vec = {
+        0.0, 0.0,   1.0, 1.0,   
+        0.0, 0.1,   1.0, 1.1,   
+        0.0, -0.1,  1.0, 0.9,   
+        0.0, 10.0,  1.0, 11.0,  
+        0.0, 10.1,  1.0, 11.1,  
+        0.0, 100.0, 1.0, 101.0  
+    };
+
+    migraphx::shape scores_s{migraphx::shape::float_type, {1, 1, 6}};
+    std::vector<float> scores_vec = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
+
+    auto boxes_l         = mm->add_literal(migraphx::literal(boxes_s, boxes_vec));
+    auto scores_l        = mm->add_literal(migraphx::literal(scores_s, scores_vec));
+    auto max_out_l       = mm->add_literal(int64_t{3});
+    auto iou_threshold   = mm->add_literal(0.5f);
+    auto score_threshold = mm->add_literal(0.0f);
+
+    auto r = mm->add_instruction(
+        migraphx::make_op("nonmaxsuppression",
+                          {{"use_dyn_output", true}}),
+        boxes_l,
+        scores_l,
+        max_out_l,
+        iou_threshold,
+        score_threshold);
+    mm->add_return({r});
+
+    p.compile(migraphx::make_target("ref"));
+    auto output = p.eval({}).back();
+    std::vector<int64_t> result;
+    output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
+
+    // Same correct output as use_dyn_output=False
+    // Before fix: crashed with PARSE_EXPAND error
+    // After fix:  works correctly with static inputs
+    std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5};
+    EXPECT(result.size() == gold.size());
+    EXPECT(migraphx::verify::verify_rms_range(result, gold));
+}
+
+
+TEST_CASE(nms_dyn_out_false_and_true_same_result_test)
+{
+    auto run_nms = [](bool use_dyn_output) {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+
+        migraphx::shape boxes_s{migraphx::shape::float_type, {1, 6, 4}};
+        std::vector<float> boxes_vec = {
+            0.0, 0.0,   1.0, 1.0,
+            0.0, 0.1,   1.0, 1.1,
+            0.0, -0.1,  1.0, 0.9,
+            0.0, 10.0,  1.0, 11.0,
+            0.0, 10.1,  1.0, 11.1,
+            0.0, 100.0, 1.0, 101.0
+        };
+
+        migraphx::shape scores_s{migraphx::shape::float_type, {1, 1, 6}};
+        std::vector<float> scores_vec = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
+
+        auto boxes_l         = mm->add_literal(migraphx::literal(boxes_s, boxes_vec));
+        auto scores_l        = mm->add_literal(migraphx::literal(scores_s, scores_vec));
+        auto max_out_l       = mm->add_literal(int64_t{3});
+        auto iou_threshold   = mm->add_literal(0.5f);
+        auto score_threshold = mm->add_literal(0.0f);
+
+        auto r = mm->add_instruction(
+            migraphx::make_op("nonmaxsuppression",
+                              {{"use_dyn_output", use_dyn_output}}),
+            boxes_l,
+            scores_l,
+            max_out_l,
+            iou_threshold,
+            score_threshold);
+        mm->add_return({r});
+
+        p.compile(migraphx::make_target("ref"));
+        auto output = p.eval({}).back();
+        std::vector<int64_t> result;
+        output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
+        return result;
+    };
+
+    auto result_false = run_nms(false);
+    auto result_true  = run_nms(true);
+
+    // Both flags must produce identical output after fix
+    // Before fix: False gave (6,3), True gave (3,3) — different!
+    // After fix:  Both give (3,3) — identical! ✅
+    EXPECT(result_false.size() == result_true.size());
+    EXPECT(result_false == result_true);
+}
+
+
+// Dynamic inputs + use_dyn_output=False must throw
+// This is CORRECT behavior — not a bug
+// Ensures we didn't accidentally break this check
+TEST_CASE(nms_dynamic_input_dyn_out_false_throws_test)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+
+    // Dynamic input shapes
+    migraphx::shape boxes_s{migraphx::shape::float_type, {{1, 3}, {6, 6}, {4, 4}}};
+    migraphx::shape scores_s{migraphx::shape::float_type, {{1, 3}, {1, 1}, {6, 6}}};
+
+    auto boxes_p         = mm->add_parameter("boxes", boxes_s);
+    auto scores_p        = mm->add_parameter("scores", scores_s);
+    auto max_out_l       = mm->add_literal(int64_t{3});
+    auto iou_threshold   = mm->add_literal(0.5f);
+    auto score_threshold = mm->add_literal(0.0f);
+
+    // Dynamic inputs + use_dyn_output=False MUST throw
+    // This is intentional — dynamic inputs require True
+    EXPECT(test::throws([&] {
+        mm->add_instruction(
+            migraphx::make_op("nonmaxsuppression",
+                              {{"use_dyn_output", false}}),
+            boxes_p,
+            scores_p,
+            max_out_l,
+            iou_threshold,
+            score_threshold);
+    }));
 }

--- a/test/ref/nonmaxsuppression.cpp
+++ b/test/ref/nonmaxsuppression.cpp
@@ -387,9 +387,14 @@ TEST_CASE(nms_static_input_dyn_out_false_test)
     auto* mm = p.get_main_module();
 
     migraphx::shape boxes_s{migraphx::shape::float_type, {1, 6, 4}};
-    std::vector<float> boxes_vec = {0.0, 0.0,  1.0, 1.0,  0.0, 0.1,   1.0, 1.1,
-                                    0.0, -0.1, 1.0, 0.9,  0.0, 10.0,  1.0, 11.0,
-                                    0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0};
+    std::vector<float> boxes_vec = {
+        0.0, 0.0,   1.0, 1.0,   
+        0.0, 0.1,   1.0, 1.1,  
+        0.0, -0.1,  1.0, 0.9,   
+        0.0, 10.0,  1.0, 11.0,  
+        0.0, 10.1,  1.0, 11.1,  
+        0.0, 100.0, 1.0, 101.0  
+    };
 
     migraphx::shape scores_s{migraphx::shape::float_type, {1, 1, 6}};
     std::vector<float> scores_vec = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
@@ -400,13 +405,14 @@ TEST_CASE(nms_static_input_dyn_out_false_test)
     auto iou_threshold   = mm->add_literal(0.5f);
     auto score_threshold = mm->add_literal(0.0f);
 
-    auto r =
-        mm->add_instruction(migraphx::make_op("nonmaxsuppression", {{"use_dyn_output", false}}),
-                            boxes_l,
-                            scores_l,
-                            max_out_l,
-                            iou_threshold,
-                            score_threshold);
+    auto r = mm->add_instruction(
+        migraphx::make_op("nonmaxsuppression",
+                          {{"use_dyn_output", false}}),
+        boxes_l,
+        scores_l,
+        max_out_l,
+        iou_threshold,
+        score_threshold);
     mm->add_return({r});
 
     p.compile(migraphx::make_target("ref"));
@@ -422,7 +428,8 @@ TEST_CASE(nms_static_input_dyn_out_false_test)
     EXPECT(migraphx::verify::verify_rms_range(result, gold));
 }
 
-// Static inputs + use_dyn_output=True
+
+// Static inputs + use_dyn_output=True 
 // Used to crash with PARSE_EXPAND error https://github.com/ROCm/AMDMIGraphX/issues/4679
 // Now works correctly with static input shapes
 TEST_CASE(nms_static_input_dyn_out_true_test)
@@ -431,9 +438,14 @@ TEST_CASE(nms_static_input_dyn_out_true_test)
     auto* mm = p.get_main_module();
 
     migraphx::shape boxes_s{migraphx::shape::float_type, {1, 6, 4}};
-    std::vector<float> boxes_vec = {0.0, 0.0,  1.0, 1.0,  0.0, 0.1,   1.0, 1.1,
-                                    0.0, -0.1, 1.0, 0.9,  0.0, 10.0,  1.0, 11.0,
-                                    0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0};
+    std::vector<float> boxes_vec = {
+        0.0, 0.0,   1.0, 1.0,   
+        0.0, 0.1,   1.0, 1.1,   
+        0.0, -0.1,  1.0, 0.9,   
+        0.0, 10.0,  1.0, 11.0,  
+        0.0, 10.1,  1.0, 11.1,  
+        0.0, 100.0, 1.0, 101.0  
+    };
 
     migraphx::shape scores_s{migraphx::shape::float_type, {1, 1, 6}};
     std::vector<float> scores_vec = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
@@ -444,12 +456,14 @@ TEST_CASE(nms_static_input_dyn_out_true_test)
     auto iou_threshold   = mm->add_literal(0.5f);
     auto score_threshold = mm->add_literal(0.0f);
 
-    auto r = mm->add_instruction(migraphx::make_op("nonmaxsuppression", {{"use_dyn_output", true}}),
-                                 boxes_l,
-                                 scores_l,
-                                 max_out_l,
-                                 iou_threshold,
-                                 score_threshold);
+    auto r = mm->add_instruction(
+        migraphx::make_op("nonmaxsuppression",
+                          {{"use_dyn_output", true}}),
+        boxes_l,
+        scores_l,
+        max_out_l,
+        iou_threshold,
+        score_threshold);
     mm->add_return({r});
 
     p.compile(migraphx::make_target("ref"));
@@ -465,6 +479,7 @@ TEST_CASE(nms_static_input_dyn_out_true_test)
     EXPECT(migraphx::verify::verify_rms_range(result, gold));
 }
 
+
 TEST_CASE(nms_dyn_out_false_and_true_same_result_test)
 {
     auto run_nms = [](bool use_dyn_output) {
@@ -472,9 +487,14 @@ TEST_CASE(nms_dyn_out_false_and_true_same_result_test)
         auto* mm = p.get_main_module();
 
         migraphx::shape boxes_s{migraphx::shape::float_type, {1, 6, 4}};
-        std::vector<float> boxes_vec = {0.0, 0.0,  1.0, 1.0,  0.0, 0.1,   1.0, 1.1,
-                                        0.0, -0.1, 1.0, 0.9,  0.0, 10.0,  1.0, 11.0,
-                                        0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0};
+        std::vector<float> boxes_vec = {
+            0.0, 0.0,   1.0, 1.0,
+            0.0, 0.1,   1.0, 1.1,
+            0.0, -0.1,  1.0, 0.9,
+            0.0, 10.0,  1.0, 11.0,
+            0.0, 10.1,  1.0, 11.1,
+            0.0, 100.0, 1.0, 101.0
+        };
 
         migraphx::shape scores_s{migraphx::shape::float_type, {1, 1, 6}};
         std::vector<float> scores_vec = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
@@ -486,7 +506,8 @@ TEST_CASE(nms_dyn_out_false_and_true_same_result_test)
         auto score_threshold = mm->add_literal(0.0f);
 
         auto r = mm->add_instruction(
-            migraphx::make_op("nonmaxsuppression", {{"use_dyn_output", use_dyn_output}}),
+            migraphx::make_op("nonmaxsuppression",
+                              {{"use_dyn_output", use_dyn_output}}),
             boxes_l,
             scores_l,
             max_out_l,
@@ -505,11 +526,12 @@ TEST_CASE(nms_dyn_out_false_and_true_same_result_test)
     auto result_true  = run_nms(true);
 
     // Both flags must produce identical output after fix
-    // Before fix: False gave (6,3), True gave (3,3) - different.
-    // After fix:  Both give (3,3) - identical.
+    // Before fix: False gave (6,3), True gave (3,3) — different!
+    // After fix:  Both give (3,3) — identical!
     EXPECT(result_false.size() == result_true.size());
     EXPECT(result_false == result_true);
 }
+
 
 // Dynamic inputs + use_dyn_output=False must throw
 // This is CORRECT behavior — not a bug
@@ -532,11 +554,13 @@ TEST_CASE(nms_dynamic_input_dyn_out_false_throws_test)
     // Dynamic inputs + use_dyn_output=False MUST throw
     // This is intentional — dynamic inputs require True
     EXPECT(test::throws([&] {
-        mm->add_instruction(migraphx::make_op("nonmaxsuppression", {{"use_dyn_output", false}}),
-                            boxes_p,
-                            scores_p,
-                            max_out_l,
-                            iou_threshold,
-                            score_threshold);
+        mm->add_instruction(
+            migraphx::make_op("nonmaxsuppression",
+                              {{"use_dyn_output", false}}),
+            boxes_p,
+            scores_p,
+            max_out_l,
+            iou_threshold,
+            score_threshold);
     }));
 }


### PR DESCRIPTION
## Motivation

Fixes #4679

The `nonmaxsuppression` operator was producing incorrect outputs when `use_dyn_output=False`. The output was padded with `[0, 0, 0]` zero triplets instead of being trimmed to only the actually selected boxes.

In reality, `[0, 0, 0]` is a valid box index (batch 0, class 0, box 0), making it appear as if box 0 was selected multiple times. This silently corrupted downstream operations like Top-K filtering, breaking ONNX spec compliance.

Additionally:
- `use_dyn_output` was never exposed in Python bindings, meaning all Python users were always hitting the code path with no way to opt out
- `use_dyn_output=True` failed with static input shapes with error: `parse: PARSE_EXPAND: dynamic input tensor with fixed dims input not supported`

**_I tested the changes on a small test script_**

**Before fix:**
```
Building NMS ONNX model...
ONNX model saved!

Loading model with MIGraphX...
 Model compiled!

Running inference...

MIGraphX NMS Output:
[[0 0 3]
 [0 0 0]
 [0 0 5]
 [0 0 0]
 [0 0 0]
 [0 0 0]]
Output shape: (6, 3)

RESULT ANALYSIS:
   Number of output boxes: 6
   Expected (ONNX spec):   3 boxes

BUG CONFIRMED!
   Output is padded with [0,0,0] zeros
   0 appears multiple times!

Expected output per ONNX spec:
[[0, 0, 3],   <- batch 0, class 0, box 3 (score 0.95)
 [0, 0, 0],   <- batch 0, class 0, box 0 (score 0.90)
 [0, 0, 5]]   <- batch 0, class 0, box 5 (score 0.30)
```

**After fix:**
```
Building NMS ONNX model... 
ONNX model saved!

Loading model with MIGraphX... 
Model compiled!

Running inference...
MIGraphX NMS Output:
[[0 0 3] 
[0 0 0] 
[0 0 5]] 
Output shape: (3, 3)

RESULT ANALYSIS: 
 Number of output boxes: 3
 Expected (ONNX spec): 3 boxes

Output is CORRECT! Only selected boxes returned — ONNX spec compliant!

Expected output per ONNX spec: 
[[0, 0, 3], <- batch 0, class 0, box 3 (score 0.95)
 [0, 0, 0], <- batch 0, class 0, box 0 (score 0.90)
 [0, 0, 5]] <- batch 0, class 0, box 5 (score 0.30)
```

## Technical Details

### Root Cause
In `compute()`, the output was only trimmed to `num_selected` boxes when `use_dyn_output=True`. The `False` path returned the full pre-allocated buffer zero-filled to `max_num_boxes` rows.

### Changes

#### `src/include/migraphx/op/nonmaxsuppression.hpp`
- Removed `std::fill` zero padding in `compute_nms()` - no longer needed since output is always trimmed
- Changed `compute()` to always trim output to `num_selected` boxes regardless of `use_dyn_output` flag value — both `True` and `False` now produce correct ONNX spec compliant output
- Fixed `compute_shape()` else branch to return dynamic output shape for static inputs so `use_dyn_output=True` works correctly with static input shapes without PARSE_EXPAND error

#### `src/py/migraphx_py.cpp`
- Added `use_dyn_output` parameter to `parse_onnx()` Python binding
  so Python users can now explicitly control this option
  (defaults to `false` for backward compatibility)

#### `test/ref/nonmaxsuppression.cpp` (**Test suite passes**)
- Fixed gold values in 4 existing tests to match ONNX spec — 
  removed 0 padding from expected outputs:
  - `nms_test`
  - `nms_not_center_test`  
  - `nms_transpose1_test`
  - `nms_transpose2_test`
- Added 4 new tests covering all combinations reported in issue: test coverage for reported scenarios | Added 4 targeted tests
  - `nms_static_input_dyn_out_false_test` — main bug fix validation
  - `nms_static_input_dyn_out_true_test` — static shapes + True works
  - `nms_dyn_out_false_and_true_same_result_test` — both flags produce identical correct output
  - `nms_dynamic_input_dyn_out_false_throws_test` — dynamic inputs with `use_dyn_output=False` correctly throws error

### Files Changed
| File | Change |
|------|--------|
| `src/include/migraphx/op/nonmaxsuppression.hpp` | Main bug fix |
| `src/py/migraphx_py.cpp` | Expose `use_dyn_output` in Python |
| `test/ref/nonmaxsuppression.cpp` | Fix gold values + new tests |

## Changelog Category

- [x] Resolved Issues: Known issues from a previous version that 
      have been resolved.