### PR TITLE
refactor how dyn dim intervals are stored and accessed

### DIFF
--- a/src/include/migraphx/op/concat.hpp
+++ b/src/include/migraphx/op/concat.hpp
@@ -128,9 +128,10 @@ struct concat
             std::size_t new_max = 0;
             for(const auto& input : inputs)
             {
-                auto ddim = input.dyn_dims()[axis];
-                new_min += ddim.min();
-                new_max += ddim.max();
+                auto ddim         = input.dyn_dims()[axis];
+                auto dim_interval = ddim.get_interval();
+                new_min += dim_interval.min;
+                new_max += dim_interval.max;
             }
 
             auto new_dims  = inputs[0].dyn_dims();

--- a/src/include/migraphx/op/concat.hpp
+++ b/src/include/migraphx/op/concat.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -129,8 +129,8 @@ struct concat
             for(const auto& input : inputs)
             {
                 auto ddim = input.dyn_dims()[axis];
-                new_min += ddim.min;
-                new_max += ddim.max;
+                new_min += ddim.min();
+                new_max += ddim.max();
             }
 
             auto new_dims  = inputs[0].dyn_dims();

--- a/src/include/migraphx/op/convolution.hpp
+++ b/src/include/migraphx/op/convolution.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -164,8 +164,8 @@ struct convolution
                                    x.optimals.end(),
                                    std::inserter(optimals, optimals.begin()),
                                    [&](auto o) { return ceil_div(o, s); });
-                    output_dyn_dims.push_back(
-                        shape::dynamic_dimension{ceil_div(x.min, s), ceil_div(x.max, s), optimals});
+                    output_dyn_dims.push_back(shape::dynamic_dimension{
+                        ceil_div(x.min(), s), ceil_div(x.max(), s), optimals});
                 }
                 else
                 {

--- a/src/include/migraphx/op/convolution.hpp
+++ b/src/include/migraphx/op/convolution.hpp
@@ -160,8 +160,8 @@ struct convolution
                 {
                     auto x = x_shape.dyn_dims()[i + 2];
                     std::set<std::size_t> optimals{};
-                    std::transform(x.optimals.begin(),
-                                   x.optimals.end(),
+                    std::transform(x.get_optimals().begin(),
+                                   x.get_optimals().end(),
                                    std::inserter(optimals, optimals.begin()),
                                    [&](auto o) { return ceil_div(o, s); });
                     output_dyn_dims.push_back(shape::dynamic_dimension{

--- a/src/include/migraphx/op/convolution.hpp
+++ b/src/include/migraphx/op/convolution.hpp
@@ -158,10 +158,11 @@ struct convolution
                 auto s        = stride[i];
                 if(x_shape.dynamic())
                 {
-                    auto x = x_shape.dyn_dims()[i + 2];
+                    auto x      = x_shape.dyn_dims()[i + 2];
+                    auto x_opts = x.get_optimals();
                     std::set<std::size_t> optimals{};
-                    std::transform(x.get_optimals().begin(),
-                                   x.get_optimals().end(),
+                    std::transform(x_opts.begin(),
+                                   x_opts.end(),
                                    std::inserter(optimals, optimals.begin()),
                                    [&](auto o) { return ceil_div(o, s); });
                     auto x_interval = x.get_interval();

--- a/src/include/migraphx/op/convolution.hpp
+++ b/src/include/migraphx/op/convolution.hpp
@@ -164,8 +164,9 @@ struct convolution
                                    x.get_optimals().end(),
                                    std::inserter(optimals, optimals.begin()),
                                    [&](auto o) { return ceil_div(o, s); });
+                    auto x_interval = x.get_interval();
                     output_dyn_dims.push_back(shape::dynamic_dimension{
-                        ceil_div(x.min(), s), ceil_div(x.max(), s), optimals});
+                        ceil_div(x_interval.min, s), ceil_div(x_interval.max, s), optimals});
                 }
                 else
                 {

--- a/src/include/migraphx/op/gathernd.hpp
+++ b/src/include/migraphx/op/gathernd.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -63,7 +63,7 @@ struct gathernd
                 MIGRAPHX_THROW(
                     "GATHERND: last dimension of indices tensor must be fixed (min=max)");
             }
-            k = i_shape.dyn_dims().back().min;
+            k = i_shape.dyn_dims().back().min();
         }
         else
             k = i_shape.lens().back();

--- a/src/include/migraphx/op/gathernd.hpp
+++ b/src/include/migraphx/op/gathernd.hpp
@@ -63,7 +63,7 @@ struct gathernd
                 MIGRAPHX_THROW(
                     "GATHERND: last dimension of indices tensor must be fixed (min=max)");
             }
-            k = i_shape.dyn_dims().back().min();
+            k = i_shape.dyn_dims().back().get_interval().min;
         }
         else
             k = i_shape.lens().back();

--- a/src/include/migraphx/op/nonmaxsuppression.hpp
+++ b/src/include/migraphx/op/nonmaxsuppression.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -156,12 +156,12 @@ struct nonmaxsuppression
                 // check that it is only a dynamic number of classes
                 const auto scores_dims = inputs.at(1).dyn_dims();
                 const auto boxes_lens  = inputs.at(0).lens();
-                if(not scores_dims.at(0).is_fixed() or scores_dims.at(0).max != boxes_lens.at(0))
+                if(not scores_dims.at(0).is_fixed() or scores_dims.at(0).max() != boxes_lens.at(0))
                 {
                     MIGRAPHX_THROW("NonMaxSuppression: scores dynamic num_classes; num_batches not "
                                    "fixed or mismatched");
                 }
-                if(not scores_dims.at(2).is_fixed() or scores_dims.at(2).max != boxes_lens.at(1))
+                if(not scores_dims.at(2).is_fixed() or scores_dims.at(2).max() != boxes_lens.at(1))
                 {
                     MIGRAPHX_THROW("NonMaxSuppression: scores dynamic num_classes; "
                                    "spatial_dimension not fixed or mismatches");

--- a/src/include/migraphx/op/nonmaxsuppression.hpp
+++ b/src/include/migraphx/op/nonmaxsuppression.hpp
@@ -156,12 +156,14 @@ struct nonmaxsuppression
                 // check that it is only a dynamic number of classes
                 const auto scores_dims = inputs.at(1).dyn_dims();
                 const auto boxes_lens  = inputs.at(0).lens();
-                if(not scores_dims.at(0).is_fixed() or scores_dims.at(0).max() != boxes_lens.at(0))
+                if(not scores_dims.at(0).is_fixed() or
+                   scores_dims.at(0).get_interval().max != boxes_lens.at(0))
                 {
                     MIGRAPHX_THROW("NonMaxSuppression: scores dynamic num_classes; num_batches not "
                                    "fixed or mismatched");
                 }
-                if(not scores_dims.at(2).is_fixed() or scores_dims.at(2).max() != boxes_lens.at(1))
+                if(not scores_dims.at(2).is_fixed() or
+                   scores_dims.at(2).get_interval().max != boxes_lens.at(1))
                 {
                     MIGRAPHX_THROW("NonMaxSuppression: scores dynamic num_classes; "
                                    "spatial_dimension not fixed or mismatches");

--- a/src/include/migraphx/op/pooling.hpp
+++ b/src/include/migraphx/op/pooling.hpp
@@ -212,10 +212,11 @@ struct pooling
                     auto ceil_div = [](std::size_t x, std::size_t y) { return (x + y - 1) / y; };
                     auto s        = stride[i];
 
-                    auto x = x_shape.dyn_dims()[i + 2];
+                    auto x      = x_shape.dyn_dims()[i + 2];
+                    auto x_opts = x.get_optimals();
                     std::set<std::size_t> optimals{};
-                    std::transform(x.get_optimals().begin(),
-                                   x.get_optimals().end(),
+                    std::transform(x_opts.begin(),
+                                   x_opts.end(),
                                    std::inserter(optimals, optimals.begin()),
                                    [&](auto o) { return ceil_div(o, s); });
                     auto x_interval = x.get_interval();

--- a/src/include/migraphx/op/pooling.hpp
+++ b/src/include/migraphx/op/pooling.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -218,8 +218,8 @@ struct pooling
                                    x.optimals.end(),
                                    std::inserter(optimals, optimals.begin()),
                                    [&](auto o) { return ceil_div(o, s); });
-                    output_dyn_dims.push_back(
-                        shape::dynamic_dimension{ceil_div(x.min, s), ceil_div(x.max, s), optimals});
+                    output_dyn_dims.push_back(shape::dynamic_dimension{
+                        ceil_div(x.min(), s), ceil_div(x.max(), s), optimals});
                 }
                 return {input.type(), output_dyn_dims};
             }

--- a/src/include/migraphx/op/pooling.hpp
+++ b/src/include/migraphx/op/pooling.hpp
@@ -218,8 +218,9 @@ struct pooling
                                    x.get_optimals().end(),
                                    std::inserter(optimals, optimals.begin()),
                                    [&](auto o) { return ceil_div(o, s); });
+                    auto x_interval = x.get_interval();
                     output_dyn_dims.push_back(shape::dynamic_dimension{
-                        ceil_div(x.min(), s), ceil_div(x.max(), s), optimals});
+                        ceil_div(x_interval.min, s), ceil_div(x_interval.max, s), optimals});
                 }
                 return {input.type(), output_dyn_dims};
             }

--- a/src/include/migraphx/op/pooling.hpp
+++ b/src/include/migraphx/op/pooling.hpp
@@ -214,8 +214,8 @@ struct pooling
 
                     auto x = x_shape.dyn_dims()[i + 2];
                     std::set<std::size_t> optimals{};
-                    std::transform(x.optimals.begin(),
-                                   x.optimals.end(),
+                    std::transform(x.get_optimals().begin(),
+                                   x.get_optimals().end(),
                                    std::inserter(optimals, optimals.begin()),
                                    [&](auto o) { return ceil_div(o, s); });
                     output_dyn_dims.push_back(shape::dynamic_dimension{

--- a/src/include/migraphx/op/reduce_op.hpp
+++ b/src/include/migraphx/op/reduce_op.hpp
@@ -120,7 +120,7 @@ struct reduce_op : op_name<Derived>
         if(axes.empty())
         {
             std::transform(dims.begin(), dims.end(), dims.begin(), [](const auto& dim) {
-                return shape::dynamic_dimension{1, dim.max};
+                return shape::dynamic_dimension{1, dim.max()};
             });
         }
         else

--- a/src/include/migraphx/op/reduce_op.hpp
+++ b/src/include/migraphx/op/reduce_op.hpp
@@ -120,7 +120,7 @@ struct reduce_op : op_name<Derived>
         if(axes.empty())
         {
             std::transform(dims.begin(), dims.end(), dims.begin(), [](const auto& dim) {
-                return shape::dynamic_dimension{1, dim.max()};
+                return shape::dynamic_dimension{1, dim.get_interval().max};
             });
         }
         else

--- a/src/include/migraphx/op/reshape.hpp
+++ b/src/include/migraphx/op/reshape.hpp
@@ -104,16 +104,18 @@ struct reshape
             std::size_t max_cur_elements = 1;
             for(const auto& dd : output_dyn_dims)
             {
-                min_cur_elements = mul_sat(min_cur_elements, dd.min());
-                max_cur_elements = mul_sat(max_cur_elements, dd.max());
+                auto dd_interval = dd.get_interval();
+                min_cur_elements = mul_sat(min_cur_elements, dd_interval.min);
+                max_cur_elements = mul_sat(max_cur_elements, dd_interval.max);
             }
             // accumulate the elements in the input dimensions
             std::size_t min_input_elements = 1;
             std::size_t max_input_elements = 1;
             for(const auto& dd : input_dyn_dims)
             {
-                min_input_elements = mul_sat(min_input_elements, dd.min());
-                max_input_elements = mul_sat(max_input_elements, dd.max());
+                auto dd_interval   = dd.get_interval();
+                min_input_elements = mul_sat(min_input_elements, dd_interval.min);
+                max_input_elements = mul_sat(max_input_elements, dd_interval.max);
             }
 
             // maximum dimensions should never accumulate to zero

--- a/src/include/migraphx/op/reshape.hpp
+++ b/src/include/migraphx/op/reshape.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -104,16 +104,16 @@ struct reshape
             std::size_t max_cur_elements = 1;
             for(const auto& dd : output_dyn_dims)
             {
-                min_cur_elements = mul_sat(min_cur_elements, dd.min);
-                max_cur_elements = mul_sat(max_cur_elements, dd.max);
+                min_cur_elements = mul_sat(min_cur_elements, dd.min());
+                max_cur_elements = mul_sat(max_cur_elements, dd.max());
             }
             // accumulate the elements in the input dimensions
             std::size_t min_input_elements = 1;
             std::size_t max_input_elements = 1;
             for(const auto& dd : input_dyn_dims)
             {
-                min_input_elements = mul_sat(min_input_elements, dd.min);
-                max_input_elements = mul_sat(max_input_elements, dd.max);
+                min_input_elements = mul_sat(min_input_elements, dd.min());
+                max_input_elements = mul_sat(max_input_elements, dd.max());
             }
 
             // maximum dimensions should never accumulate to zero

--- a/src/include/migraphx/op/reshape_lazy.hpp
+++ b/src/include/migraphx/op/reshape_lazy.hpp
@@ -66,7 +66,7 @@ struct reshape_lazy
             if(dyn_dims[i].is_fixed())
             {
                 num_dims_ele *= dims[i];
-                num_dd_ele *= dyn_dims[i].min();
+                num_dd_ele *= dyn_dims[i].get_interval().min;
             }
             else
             {

--- a/src/include/migraphx/op/reshape_lazy.hpp
+++ b/src/include/migraphx/op/reshape_lazy.hpp
@@ -66,7 +66,7 @@ struct reshape_lazy
             if(dyn_dims[i].is_fixed())
             {
                 num_dims_ele *= dims[i];
-                num_dd_ele *= dyn_dims[i].min;
+                num_dd_ele *= dyn_dims[i].min();
             }
             else
             {

--- a/src/include/migraphx/op/resize.hpp
+++ b/src/include/migraphx/op/resize.hpp
@@ -416,12 +416,12 @@ struct resize
             {
                 for(std::size_t i = 0; i < scales.size(); i++)
                 {
-                    dyn_dims[i].min = static_cast<std::size_t>(input.dyn_dims()[i].min * scales[i]);
-                    if(input.dyn_dims()[i].max != max_val)
-                    {
-                        dyn_dims[i].max =
-                            static_cast<std::size_t>(input.dyn_dims()[i].max * scales[i]);
-                    }
+                    auto new_min = static_cast<std::size_t>(input.dyn_dims()[i].min() * scales[i]);
+                    auto new_max =
+                        input.dyn_dims()[i].max() != max_val
+                            ? static_cast<std::size_t>(input.dyn_dims()[i].max() * scales[i])
+                            : max_val;
+                    dyn_dims[i] = shape::dynamic_dimension{new_min, new_max};
                 }
             }
             return {input.type(), dyn_dims};

--- a/src/include/migraphx/op/resize.hpp
+++ b/src/include/migraphx/op/resize.hpp
@@ -416,12 +416,12 @@ struct resize
             {
                 for(std::size_t i = 0; i < scales.size(); i++)
                 {
-                    auto new_min = static_cast<std::size_t>(input.dyn_dims()[i].min() * scales[i]);
-                    auto new_max =
-                        input.dyn_dims()[i].max() != max_val
-                            ? static_cast<std::size_t>(input.dyn_dims()[i].max() * scales[i])
-                            : max_val;
-                    dyn_dims[i] = shape::dynamic_dimension{new_min, new_max};
+                    auto input_interval = input.dyn_dims()[i].get_interval();
+                    auto new_min        = static_cast<std::size_t>(input_interval.min * scales[i]);
+                    auto new_max        = input_interval.max != max_val
+                                              ? static_cast<std::size_t>(input_interval.max * scales[i])
+                                              : max_val;
+                    dyn_dims[i]         = shape::dynamic_dimension{new_min, new_max};
                 }
             }
             return {input.type(), dyn_dims};

--- a/src/include/migraphx/op/resize.hpp
+++ b/src/include/migraphx/op/resize.hpp
@@ -417,11 +417,12 @@ struct resize
                 for(std::size_t i = 0; i < scales.size(); i++)
                 {
                     auto input_interval = input.dyn_dims()[i].get_interval();
-                    auto new_min        = static_cast<std::size_t>(input_interval.min * scales[i]);
-                    auto new_max        = input_interval.max != max_val
-                                              ? static_cast<std::size_t>(input_interval.max * scales[i])
-                                              : max_val;
-                    dyn_dims[i]         = shape::dynamic_dimension{new_min, new_max};
+                    std::size_t new_min = input_interval.min * scales[i];
+                    std::size_t new_max =
+                        input_interval.max == max_val
+                            ? max_val
+                            : static_cast<std::size_t>(input_interval.max * scales[i]);
+                    dyn_dims[i] = shape::dynamic_dimension{new_min, new_max};
                 }
             }
             return {input.type(), dyn_dims};

--- a/src/include/migraphx/op/scatternd_op.hpp
+++ b/src/include/migraphx/op/scatternd_op.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -54,7 +54,7 @@ struct scatternd_op : op_name<Derived>
     shape compute_shape(std::vector<shape> inputs) const
     {
         check_shapes{inputs, *this, true}.has(3);
-        auto data_shape  = inputs.front();
+        auto data_shape         = inputs.front();
         const auto& index_shape = inputs.at(1);
         const auto& upd_shape   = inputs.back();
 
@@ -69,7 +69,7 @@ struct scatternd_op : op_name<Derived>
                 MIGRAPHX_THROW(
                     "GATHERND: last dimension of indices tensor must be fixed (min=max)");
             }
-            k = index_shape.dyn_dims().back().min;
+            k = index_shape.dyn_dims().back().min();
         }
         else
             k = index_shape.lens().back();

--- a/src/include/migraphx/op/scatternd_op.hpp
+++ b/src/include/migraphx/op/scatternd_op.hpp
@@ -69,7 +69,7 @@ struct scatternd_op : op_name<Derived>
                 MIGRAPHX_THROW(
                     "GATHERND: last dimension of indices tensor must be fixed (min=max)");
             }
-            k = index_shape.dyn_dims().back().min();
+            k = index_shape.dyn_dims().back().get_interval().min;
         }
         else
             k = index_shape.lens().back();

--- a/src/include/migraphx/op/slice.hpp
+++ b/src/include/migraphx/op/slice.hpp
@@ -166,7 +166,7 @@ struct slice
                     MIGRAPHX_THROW("SLICE: 2 input and attributes mismatch");
                 }
                 std::for_each(axes.cbegin(), axes.cend(), [&](const auto& axis) {
-                    dds.at(axis) = {0, dds.at(axis).max};
+                    dds.at(axis) = {0, dds.at(axis).max()};
                 });
             }
             else if(set_attributes == starts_axes)
@@ -177,7 +177,7 @@ struct slice
                     MIGRAPHX_THROW("SLICE: 2 input and attributes mismatch");
                 }
                 std::for_each(axes.cbegin(), axes.cend(), [&](const auto& axis) {
-                    dds.at(axis) = {0, dds.at(axis).max};
+                    dds.at(axis) = {0, dds.at(axis).max()};
                 });
             }
             else if(set_attributes == starts_ends)
@@ -188,7 +188,7 @@ struct slice
                     MIGRAPHX_THROW("SLICE: 2 input and attributes mismatch");
                 }
                 std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
-                    return shape::dynamic_dimension{0, dd.max};
+                    return shape::dynamic_dimension{0, dd.max()};
                 });
             }
             else
@@ -206,7 +206,7 @@ struct slice
                     MIGRAPHX_THROW("SLICE: 3 input and attributes mismatch");
                 }
                 std::for_each(axes.cbegin(), axes.cend(), [&](const auto& axis) {
-                    dds.at(axis) = {0, dds.at(axis).max};
+                    dds.at(axis) = {0, dds.at(axis).max()};
                 });
             }
             else if(set_attributes == ends_only)
@@ -217,7 +217,7 @@ struct slice
                     MIGRAPHX_THROW("SLICE: 3 input and attributes mismatch");
                 }
                 std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
-                    return shape::dynamic_dimension{0, dd.max};
+                    return shape::dynamic_dimension{0, dd.max()};
                 });
             }
             else if(set_attributes == starts_only)
@@ -229,7 +229,7 @@ struct slice
                     MIGRAPHX_THROW("SLICE: 3 input and attributes mismatch");
                 }
                 std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
-                    return shape::dynamic_dimension{0, dd.max};
+                    return shape::dynamic_dimension{0, dd.max()};
                 });
             }
             else
@@ -241,7 +241,7 @@ struct slice
         {
             // all 4 inputs (data, inputs_starts, input_ends, input_axes)
             std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
-                return shape::dynamic_dimension{0, dd.max};
+                return shape::dynamic_dimension{0, dd.max()};
             });
         }
         return shape{input_shape.type(), dds};

--- a/src/include/migraphx/op/slice.hpp
+++ b/src/include/migraphx/op/slice.hpp
@@ -166,7 +166,7 @@ struct slice
                     MIGRAPHX_THROW("SLICE: 2 input and attributes mismatch");
                 }
                 std::for_each(axes.cbegin(), axes.cend(), [&](const auto& axis) {
-                    dds.at(axis) = {0, dds.at(axis).max()};
+                    dds.at(axis) = {0, dds.at(axis).get_interval().max};
                 });
             }
             else if(set_attributes == starts_axes)
@@ -177,7 +177,7 @@ struct slice
                     MIGRAPHX_THROW("SLICE: 2 input and attributes mismatch");
                 }
                 std::for_each(axes.cbegin(), axes.cend(), [&](const auto& axis) {
-                    dds.at(axis) = {0, dds.at(axis).max()};
+                    dds.at(axis) = {0, dds.at(axis).get_interval().max};
                 });
             }
             else if(set_attributes == starts_ends)
@@ -188,7 +188,7 @@ struct slice
                     MIGRAPHX_THROW("SLICE: 2 input and attributes mismatch");
                 }
                 std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
-                    return shape::dynamic_dimension{0, dd.max()};
+                    return shape::dynamic_dimension{0, dd.get_interval().max};
                 });
             }
             else
@@ -206,7 +206,7 @@ struct slice
                     MIGRAPHX_THROW("SLICE: 3 input and attributes mismatch");
                 }
                 std::for_each(axes.cbegin(), axes.cend(), [&](const auto& axis) {
-                    dds.at(axis) = {0, dds.at(axis).max()};
+                    dds.at(axis) = {0, dds.at(axis).get_interval().max};
                 });
             }
             else if(set_attributes == ends_only)
@@ -217,7 +217,7 @@ struct slice
                     MIGRAPHX_THROW("SLICE: 3 input and attributes mismatch");
                 }
                 std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
-                    return shape::dynamic_dimension{0, dd.max()};
+                    return shape::dynamic_dimension{0, dd.get_interval().max};
                 });
             }
             else if(set_attributes == starts_only)
@@ -229,7 +229,7 @@ struct slice
                     MIGRAPHX_THROW("SLICE: 3 input and attributes mismatch");
                 }
                 std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
-                    return shape::dynamic_dimension{0, dd.max()};
+                    return shape::dynamic_dimension{0, dd.get_interval().max};
                 });
             }
             else
@@ -241,7 +241,7 @@ struct slice
         {
             // all 4 inputs (data, inputs_starts, input_ends, input_axes)
             std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
-                return shape::dynamic_dimension{0, dd.max()};
+                return shape::dynamic_dimension{0, dd.get_interval().max};
             });
         }
         return shape{input_shape.type(), dds};

--- a/src/include/migraphx/shape.hpp
+++ b/src/include/migraphx/shape.hpp
@@ -96,15 +96,41 @@ struct MIGRAPHX_EXPORT shape
 
     struct MIGRAPHX_EXPORT dynamic_dimension
     {
-        std::size_t min = 0;
-        std::size_t max = 0;
+        struct interval
+        {
+            std::size_t min;
+            std::size_t max;
+            template <class Self, class F>
+            static auto reflect(Self& self, F f)
+            {
+                return pack(f(self.min, "min"), f(self.max, "max"));
+            }
+            friend bool operator==(const interval& a, const interval& b)
+            {
+                return a.min == b.min and a.max == b.max;
+            }
+            friend bool operator!=(const interval& a, const interval& b) { return not(a == b); }
+        };
+
+        interval range = {0, 0};
         std::set<std::size_t> optimals{};
+
+        dynamic_dimension() = default;
+        dynamic_dimension(std::size_t min_v, std::size_t max_v) : range{min_v, max_v} {}
+        dynamic_dimension(std::size_t min_v, std::size_t max_v, std::set<std::size_t> opt)
+            : range{min_v, max_v}, optimals(std::move(opt))
+        {
+        }
 
         template <class Self, class F>
         static auto reflect(Self& self, F f)
         {
-            return pack(f(self.min, "min"), f(self.max, "max"), f(self.optimals, "optimals"));
+            return pack(f(self.range, "range"), f(self.optimals, "optimals"));
         }
+
+        std::size_t min() const { return range.min; }
+        std::size_t max() const { return range.max; }
+        interval get_interval() const { return range; }
 
         bool is_fixed() const;
         bool has_optimal() const;
@@ -115,8 +141,8 @@ struct MIGRAPHX_EXPORT shape
          */
         std::optional<dynamic_dimension> intersection(const dynamic_dimension& other) const
         {
-            auto left  = std::max(this->min, other.min);
-            auto right = std::min(this->max, other.max);
+            auto left  = std::max(this->min(), other.min());
+            auto right = std::min(this->max(), other.max());
             if(left <= right)
             {
                 return dynamic_dimension{left, right};

--- a/src/include/migraphx/shape.hpp
+++ b/src/include/migraphx/shape.hpp
@@ -98,8 +98,8 @@ struct MIGRAPHX_EXPORT shape
     {
         struct interval
         {
-            std::size_t min;
-            std::size_t max;
+            std::size_t min = 0;
+            std::size_t max = 0;
             template <class Self, class F>
             static auto reflect(Self& self, F f)
             {

--- a/src/include/migraphx/shape.hpp
+++ b/src/include/migraphx/shape.hpp
@@ -131,6 +131,7 @@ struct MIGRAPHX_EXPORT shape
         std::size_t min() const { return range.min; }
         std::size_t max() const { return range.max; }
         interval get_interval() const { return range; }
+        const std::set<std::size_t>& get_optimals() const { return optimals; }
 
         bool is_fixed() const;
         bool has_optimal() const;

--- a/src/include/migraphx/shape.hpp
+++ b/src/include/migraphx/shape.hpp
@@ -129,7 +129,7 @@ struct MIGRAPHX_EXPORT shape
         }
 
         interval get_interval() const { return range; }
-        const std::set<std::size_t>& get_optimals() const { return optimals; }
+        std::set<std::size_t> get_optimals() const { return optimals; }
 
         bool is_fixed() const;
         bool has_optimal() const;

--- a/src/include/migraphx/shape.hpp
+++ b/src/include/migraphx/shape.hpp
@@ -128,8 +128,6 @@ struct MIGRAPHX_EXPORT shape
             return pack(f(self.range, "range"), f(self.optimals, "optimals"));
         }
 
-        std::size_t min() const { return range.min; }
-        std::size_t max() const { return range.max; }
         interval get_interval() const { return range; }
         const std::set<std::size_t>& get_optimals() const { return optimals; }
 
@@ -142,8 +140,10 @@ struct MIGRAPHX_EXPORT shape
          */
         std::optional<dynamic_dimension> intersection(const dynamic_dimension& other) const
         {
-            auto left  = std::max(this->min(), other.min());
-            auto right = std::min(this->max(), other.max());
+            auto this_interval  = this->get_interval();
+            auto other_interval = other.get_interval();
+            auto left           = std::max(this_interval.min, other_interval.min);
+            auto right          = std::min(this_interval.max, other_interval.max);
             if(left <= right)
             {
                 return dynamic_dimension{left, right};

--- a/src/normalize_attributes.cpp
+++ b/src/normalize_attributes.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -74,7 +74,7 @@ static auto tune_attribute(const std::vector<int64_t>& vec,
                 return vec;
             }
             std::transform(axes.begin(), axes.end(), max_vals.begin(), [&](auto i) {
-                return input_shape.dyn_dims().at(i).max;
+                return input_shape.dyn_dims().at(i).max();
             });
         }
         else

--- a/src/normalize_attributes.cpp
+++ b/src/normalize_attributes.cpp
@@ -74,7 +74,7 @@ static auto tune_attribute(const std::vector<int64_t>& vec,
                 return vec;
             }
             std::transform(axes.begin(), axes.end(), max_vals.begin(), [&](auto i) {
-                return input_shape.dyn_dims().at(i).max();
+                return input_shape.dyn_dims().at(i).get_interval().max;
             });
         }
         else

--- a/src/onnx/onnx_parser.cpp
+++ b/src/onnx/onnx_parser.cpp
@@ -54,7 +54,7 @@ static shape shape_from_dyn_dims(shape::type_t shape_type,
         std::transform(dyn_dims.cbegin(),
                        dyn_dims.cend(),
                        std::back_inserter(dims),
-                       [](const auto& d) { return d.max; });
+                       [](const auto& d) { return d.max(); });
         return {shape_type, dims};
     }
     return {shape_type, dyn_dims};

--- a/src/onnx/onnx_parser.cpp
+++ b/src/onnx/onnx_parser.cpp
@@ -54,7 +54,7 @@ static shape shape_from_dyn_dims(shape::type_t shape_type,
         std::transform(dyn_dims.cbegin(),
                        dyn_dims.cend(),
                        std::back_inserter(dims),
-                       [](const auto& d) { return d.max(); });
+                       [](const auto& d) { return d.get_interval().max; });
         return {shape_type, dims};
     }
     return {shape_type, dyn_dims};

--- a/src/onnx/parse_depthtospace.cpp
+++ b/src/onnx/parse_depthtospace.cpp
@@ -74,7 +74,7 @@ struct parse_depthtospace : op_parser<parse_depthtospace>
             {
                 MIGRAPHX_THROW("DepthToSpace: dynamic channels are not supported");
             }
-            int64_t c = dyn_dims1[1].max();
+            int64_t c = dyn_dims1[1].get_interval().max;
             auto h =
                 info.add_instruction(make_op("dimensions_of", {{"start", 2}, {"end", 3}}), args[0]);
             auto w =
@@ -82,9 +82,10 @@ struct parse_depthtospace : op_parser<parse_depthtospace>
 
             auto c_div = info.add_literal({c / divisor});
 
-            dyn_dims2[1] = {dyn_dims2[1].min() / divisor, dyn_dims2[1].max() / divisor};
-            dyn_dims2[2] = dyn_dims2[2] * blocksize_unsigned;
-            dyn_dims2[3] = dyn_dims2[3] * blocksize_unsigned;
+            auto chan_interval = dyn_dims2[1].get_interval();
+            dyn_dims2[1]       = {chan_interval.min / divisor, chan_interval.max / divisor};
+            dyn_dims2[2]       = dyn_dims2[2] * blocksize_unsigned;
+            dyn_dims2[3]       = dyn_dims2[3] * blocksize_unsigned;
             // push back h and w to expand the vector to 6d
             dyn_dims1.push_back(dyn_dims1[2]);
             dyn_dims1.push_back(dyn_dims1[3]);
@@ -96,10 +97,11 @@ struct parse_depthtospace : op_parser<parse_depthtospace>
             if(mode == "DCR")
             {
                 // expanded vector = n, blocksize, blocksize, c // (blocksize**2), h, w
-                dyn_dims1[3] = {dyn_dims1[1].min() / divisor, dyn_dims1[1].max() / divisor, {}};
-                dyn_dims1[1] = {blocksize_unsigned, blocksize_unsigned, {}};
-                perm         = {0, 3, 4, 1, 5, 2};
-                new_shape1   = info.add_instruction(
+                auto dcr_chan = dyn_dims1[1].get_interval();
+                dyn_dims1[3]  = {dcr_chan.min / divisor, dcr_chan.max / divisor, {}};
+                dyn_dims1[1]  = {blocksize_unsigned, blocksize_unsigned, {}};
+                perm          = {0, 3, 4, 1, 5, 2};
+                new_shape1    = info.add_instruction(
                     make_op("concat"), n, blocksize_literal, blocksize_literal, c_div, h, w);
                 new_shape_alloc1 = info.add_instruction(
                     make_op("allocate",
@@ -121,10 +123,11 @@ struct parse_depthtospace : op_parser<parse_depthtospace>
             else if(mode == "CRD")
             {
                 // expanded vector = b, c // (blocksize ** 2), blocksize, blocksize, h, w
-                dyn_dims1[1] = {dyn_dims1[1].min() / divisor, dyn_dims1[1].max() / divisor, {}};
-                dyn_dims1[3] = {blocksize_unsigned, blocksize_unsigned, {}};
-                perm         = {0, 1, 4, 2, 5, 3};
-                new_shape1   = info.add_instruction(
+                auto crd_chan = dyn_dims1[1].get_interval();
+                dyn_dims1[1]  = {crd_chan.min / divisor, crd_chan.max / divisor, {}};
+                dyn_dims1[3]  = {blocksize_unsigned, blocksize_unsigned, {}};
+                perm          = {0, 1, 4, 2, 5, 3};
+                new_shape1    = info.add_instruction(
                     make_op("concat"), n, c_div, blocksize_literal, blocksize_literal, h, w);
                 new_shape_alloc1 = info.add_instruction(
                     make_op("allocate",

--- a/src/onnx/parse_depthtospace.cpp
+++ b/src/onnx/parse_depthtospace.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -74,7 +74,7 @@ struct parse_depthtospace : op_parser<parse_depthtospace>
             {
                 MIGRAPHX_THROW("DepthToSpace: dynamic channels are not supported");
             }
-            int64_t c = dyn_dims1[1].max;
+            int64_t c = dyn_dims1[1].max();
             auto h =
                 info.add_instruction(make_op("dimensions_of", {{"start", 2}, {"end", 3}}), args[0]);
             auto w =
@@ -82,7 +82,7 @@ struct parse_depthtospace : op_parser<parse_depthtospace>
 
             auto c_div = info.add_literal({c / divisor});
 
-            dyn_dims2[1] = {dyn_dims2[1].min / divisor, dyn_dims2[1].max / divisor};
+            dyn_dims2[1] = {dyn_dims2[1].min() / divisor, dyn_dims2[1].max() / divisor};
             dyn_dims2[2] = dyn_dims2[2] * blocksize_unsigned;
             dyn_dims2[3] = dyn_dims2[3] * blocksize_unsigned;
             // push back h and w to expand the vector to 6d
@@ -96,7 +96,7 @@ struct parse_depthtospace : op_parser<parse_depthtospace>
             if(mode == "DCR")
             {
                 // expanded vector = n, blocksize, blocksize, c // (blocksize**2), h, w
-                dyn_dims1[3] = {dyn_dims1[1].min / divisor, dyn_dims1[1].max / divisor, {}};
+                dyn_dims1[3] = {dyn_dims1[1].min() / divisor, dyn_dims1[1].max() / divisor, {}};
                 dyn_dims1[1] = {blocksize_unsigned, blocksize_unsigned, {}};
                 perm         = {0, 3, 4, 1, 5, 2};
                 new_shape1   = info.add_instruction(
@@ -121,7 +121,7 @@ struct parse_depthtospace : op_parser<parse_depthtospace>
             else if(mode == "CRD")
             {
                 // expanded vector = b, c // (blocksize ** 2), blocksize, blocksize, h, w
-                dyn_dims1[1] = {dyn_dims1[1].min / divisor, dyn_dims1[1].max / divisor, {}};
+                dyn_dims1[1] = {dyn_dims1[1].min() / divisor, dyn_dims1[1].max() / divisor, {}};
                 dyn_dims1[3] = {blocksize_unsigned, blocksize_unsigned, {}};
                 perm         = {0, 1, 4, 2, 5, 3};
                 new_shape1   = info.add_instruction(

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -397,8 +397,10 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         .def(py::init<>())
         .def(py::init<std::size_t, std::size_t>())
         .def(py::init<std::size_t, std::size_t, std::set<std::size_t>>())
-        .def_readwrite("min", &migraphx::shape::dynamic_dimension::min)
-        .def_readwrite("max", &migraphx::shape::dynamic_dimension::max)
+        .def_property_readonly("min",
+                               [](const migraphx::shape::dynamic_dimension& d) { return d.min(); })
+        .def_property_readonly("max",
+                               [](const migraphx::shape::dynamic_dimension& d) { return d.max(); })
         .def_readwrite("optimals", &migraphx::shape::dynamic_dimension::optimals)
         .def("is_fixed", &migraphx::shape::dynamic_dimension::is_fixed);
 

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -401,7 +401,9 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
                                [](const migraphx::shape::dynamic_dimension& d) { return d.min(); })
         .def_property_readonly("max",
                                [](const migraphx::shape::dynamic_dimension& d) { return d.max(); })
-        .def_readwrite("optimals", &migraphx::shape::dynamic_dimension::optimals)
+        .def_property_readonly(
+            "optimals",
+            [](const migraphx::shape::dynamic_dimension& d) { return d.get_optimals(); })
         .def("is_fixed", &migraphx::shape::dynamic_dimension::is_fixed);
 
     py::class_<migraphx::argument>(m, "argument", py::buffer_protocol())

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -397,10 +397,10 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         .def(py::init<>())
         .def(py::init<std::size_t, std::size_t>())
         .def(py::init<std::size_t, std::size_t, std::set<std::size_t>>())
-        .def_property_readonly("min",
-                               [](const migraphx::shape::dynamic_dimension& d) { return d.min(); })
-        .def_property_readonly("max",
-                               [](const migraphx::shape::dynamic_dimension& d) { return d.max(); })
+        .def_property_readonly(
+            "min", [](const migraphx::shape::dynamic_dimension& d) { return d.get_interval().min; })
+        .def_property_readonly(
+            "max", [](const migraphx::shape::dynamic_dimension& d) { return d.get_interval().max; })
         .def_property_readonly(
             "optimals",
             [](const migraphx::shape::dynamic_dimension& d) { return d.get_optimals(); })

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -714,7 +714,7 @@ bool shape::dynamic_dimension::is_fixed() const
     return i.min == i.max;
 }
 
-bool shape::dynamic_dimension::has_optimal() const { return not optimals.empty(); }
+bool shape::dynamic_dimension::has_optimal() const { return not this->get_optimals().empty(); }
 
 shape::dynamic_dimension& shape::dynamic_dimension::operator+=(const std::size_t& x)
 {

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -212,7 +212,7 @@ struct shape_impl
         std::transform(m_dyn_dims.cbegin(),
                        m_dyn_dims.cend(),
                        ret.begin(),
-                       [](const shape::dynamic_dimension& x) { return x.optimals; });
+                       [](const shape::dynamic_dimension& x) { return x.get_optimals(); });
         return ret;
     }
 
@@ -756,7 +756,7 @@ shape::dynamic_dimension& shape::dynamic_dimension::operator*=(const std::size_t
 bool operator==(const shape::dynamic_dimension& x, const shape::dynamic_dimension& y)
 {
     return (x.min() == y.min() and x.max() == y.max() and
-            ((x.is_fixed() and y.is_fixed()) or (x.optimals == y.optimals)));
+            ((x.is_fixed() and y.is_fixed()) or (x.get_optimals() == y.get_optimals())));
 }
 
 bool operator!=(const shape::dynamic_dimension& x, const shape::dynamic_dimension& y)
@@ -765,7 +765,7 @@ bool operator!=(const shape::dynamic_dimension& x, const shape::dynamic_dimensio
 }
 std::ostream& operator<<(std::ostream& os, const shape::dynamic_dimension& x)
 {
-    os << "[ " << x.min() << ", " << x.max() << ", {" << migraphx::to_string_range(x.optimals)
+    os << "[ " << x.min() << ", " << x.max() << ", {" << migraphx::to_string_range(x.get_optimals())
        << "} ]";
     return os;
 }

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -192,7 +192,7 @@ struct shape_impl
         std::transform(m_dyn_dims.cbegin(),
                        m_dyn_dims.cend(),
                        ret.begin(),
-                       [](const shape::dynamic_dimension& x) { return x.min(); });
+                       [](const shape::dynamic_dimension& x) { return x.get_interval().min; });
         return ret;
     }
 
@@ -202,7 +202,7 @@ struct shape_impl
         std::transform(m_dyn_dims.cbegin(),
                        m_dyn_dims.cend(),
                        ret.begin(),
-                       [](const shape::dynamic_dimension& x) { return x.max(); });
+                       [](const shape::dynamic_dimension& x) { return x.get_interval().max; });
         return ret;
     }
 
@@ -321,7 +321,10 @@ bool shape::is_compatible_lens(const shape& actual, const shape& expected)
         return std::equal(actual.lens().begin(),
                           actual.lens().end(),
                           expected.dyn_dims().begin(),
-                          [&](auto a, const auto& e) { return a >= e.min() and a <= e.max(); });
+                          [&](auto a, const auto& e) {
+                              auto expected_interval = e.get_interval();
+                              return a >= expected_interval.min and a <= expected_interval.max;
+                          });
     }
     return actual.lens() == expected.lens();
 }
@@ -705,7 +708,11 @@ std::vector<std::size_t> shape::max_lens() const
 
 std::vector<std::set<std::size_t>> shape::opt_lens() const { return impl->opt_lens(); }
 
-bool shape::dynamic_dimension::is_fixed() const { return this->min() == this->max(); }
+bool shape::dynamic_dimension::is_fixed() const
+{
+    auto i = this->get_interval();
+    return i.min == i.max;
+}
 
 bool shape::dynamic_dimension::has_optimal() const { return not optimals.empty(); }
 
@@ -755,7 +762,7 @@ shape::dynamic_dimension& shape::dynamic_dimension::operator*=(const std::size_t
 
 bool operator==(const shape::dynamic_dimension& x, const shape::dynamic_dimension& y)
 {
-    return (x.min() == y.min() and x.max() == y.max() and
+    return (x.get_interval() == y.get_interval() and
             ((x.is_fixed() and y.is_fixed()) or (x.get_optimals() == y.get_optimals())));
 }
 
@@ -765,14 +772,16 @@ bool operator!=(const shape::dynamic_dimension& x, const shape::dynamic_dimensio
 }
 std::ostream& operator<<(std::ostream& os, const shape::dynamic_dimension& x)
 {
-    os << "[ " << x.min() << ", " << x.max() << ", {" << migraphx::to_string_range(x.get_optimals())
-       << "} ]";
+    auto x_interval = x.get_interval();
+    os << "[ " << x_interval.min << ", " << x_interval.max << ", {"
+       << migraphx::to_string_range(x.get_optimals()) << "} ]";
     return os;
 }
 
 bool operator==(const shape::dynamic_dimension& x, const std::size_t& y)
 {
-    return x.min() == y and x.max() == y;
+    auto x_interval = x.get_interval();
+    return x_interval.min == y and x_interval.max == y;
 }
 bool operator==(const std::size_t& x, const shape::dynamic_dimension& y) { return y == x; }
 bool operator!=(const shape::dynamic_dimension& x, const std::size_t& y) { return not(x == y); }

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -192,7 +192,7 @@ struct shape_impl
         std::transform(m_dyn_dims.cbegin(),
                        m_dyn_dims.cend(),
                        ret.begin(),
-                       [](const shape::dynamic_dimension& x) { return x.min; });
+                       [](const shape::dynamic_dimension& x) { return x.min(); });
         return ret;
     }
 
@@ -202,7 +202,7 @@ struct shape_impl
         std::transform(m_dyn_dims.cbegin(),
                        m_dyn_dims.cend(),
                        ret.begin(),
-                       [](const shape::dynamic_dimension& x) { return x.max; });
+                       [](const shape::dynamic_dimension& x) { return x.max(); });
         return ret;
     }
 
@@ -321,7 +321,7 @@ bool shape::is_compatible_lens(const shape& actual, const shape& expected)
         return std::equal(actual.lens().begin(),
                           actual.lens().end(),
                           expected.dyn_dims().begin(),
-                          [&](auto a, const auto& e) { return a >= e.min and a <= e.max; });
+                          [&](auto a, const auto& e) { return a >= e.min() and a <= e.max(); });
     }
     return actual.lens() == expected.lens();
 }
@@ -705,14 +705,14 @@ std::vector<std::size_t> shape::max_lens() const
 
 std::vector<std::set<std::size_t>> shape::opt_lens() const { return impl->opt_lens(); }
 
-bool shape::dynamic_dimension::is_fixed() const { return this->min == this->max; }
+bool shape::dynamic_dimension::is_fixed() const { return this->min() == this->max(); }
 
 bool shape::dynamic_dimension::has_optimal() const { return not optimals.empty(); }
 
 shape::dynamic_dimension& shape::dynamic_dimension::operator+=(const std::size_t& x)
 {
-    this->min += x;
-    this->max += x;
+    this->range.min += x;
+    this->range.max += x;
     std::set<std::size_t> new_optimals;
     std::transform(this->optimals.begin(),
                    this->optimals.end(),
@@ -724,10 +724,10 @@ shape::dynamic_dimension& shape::dynamic_dimension::operator+=(const std::size_t
 
 shape::dynamic_dimension& shape::dynamic_dimension::operator-=(const std::size_t& x)
 {
-    assert(this->min >= x);
-    assert(this->max >= x);
-    this->min -= x;
-    this->max -= x;
+    assert(this->range.min >= x);
+    assert(this->range.max >= x);
+    this->range.min -= x;
+    this->range.max -= x;
     std::set<std::size_t> new_optimals;
     std::transform(this->optimals.begin(),
                    this->optimals.end(),
@@ -742,8 +742,8 @@ shape::dynamic_dimension& shape::dynamic_dimension::operator-=(const std::size_t
 
 shape::dynamic_dimension& shape::dynamic_dimension::operator*=(const std::size_t& x)
 {
-    this->min *= x;
-    this->max *= x;
+    this->range.min *= x;
+    this->range.max *= x;
     std::set<std::size_t> new_optimals;
     std::transform(this->optimals.begin(),
                    this->optimals.end(),
@@ -755,8 +755,7 @@ shape::dynamic_dimension& shape::dynamic_dimension::operator*=(const std::size_t
 
 bool operator==(const shape::dynamic_dimension& x, const shape::dynamic_dimension& y)
 {
-    // don't check optimals if both are fixed
-    return (x.min == y.min and x.max == y.max and
+    return (x.min() == y.min() and x.max() == y.max() and
             ((x.is_fixed() and y.is_fixed()) or (x.optimals == y.optimals)));
 }
 
@@ -766,13 +765,14 @@ bool operator!=(const shape::dynamic_dimension& x, const shape::dynamic_dimensio
 }
 std::ostream& operator<<(std::ostream& os, const shape::dynamic_dimension& x)
 {
-    os << "[ " << x.min << ", " << x.max << ", {" << migraphx::to_string_range(x.optimals) << "} ]";
+    os << "[ " << x.min() << ", " << x.max() << ", {" << migraphx::to_string_range(x.optimals)
+       << "} ]";
     return os;
 }
 
 bool operator==(const shape::dynamic_dimension& x, const std::size_t& y)
 {
-    return x.min == y and x.max == y;
+    return x.min() == y and x.max() == y;
 }
 bool operator==(const std::size_t& x, const shape::dynamic_dimension& y) { return y == x; }
 bool operator!=(const shape::dynamic_dimension& x, const std::size_t& y) { return not(x == y); }

--- a/src/split_single_dyn_dim.cpp
+++ b/src/split_single_dyn_dim.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -117,9 +117,9 @@ static bool any_sm_next(const_module_ref mm, const std::vector<dynamic_dimension
  */
 void split_single_dyn_dim::apply(module_pass_manager& mpm) const
 {
-    module_ref mm                               = &mpm.get_module();
-    auto param_names                            = mm->get_parameter_names();
-    auto param_shapes                           = mm->get_parameter_shapes();
+    module_ref mm     = &mpm.get_module();
+    auto param_names  = mm->get_parameter_names();
+    auto param_shapes = mm->get_parameter_shapes();
     optional<std::vector<dynamic_dimensions_check>> dd_check_vec =
         has_one_unique_dyn_dim(param_shapes);
     if(dd_check_vec.has_value() and not any_sm_next(mm, dd_check_vec.value()))
@@ -128,7 +128,7 @@ void split_single_dyn_dim::apply(module_pass_manager& mpm) const
         auto dyn_dim = dd_check_vec->at(0).dd;
         // create submodules for each dimension size
         std::vector<module_ref> submodules;
-        for(size_t dim_size : migraphx::range(dyn_dim.min, dyn_dim.max + 1))
+        for(size_t dim_size : migraphx::range(dyn_dim.min(), dyn_dim.max() + 1))
         {
             auto* submod = mpm.create_module("dim_" + std::to_string(dim_size));
             // instruction map for new static shaped submodule parameters
@@ -157,7 +157,7 @@ void split_single_dyn_dim::apply(module_pass_manager& mpm) const
         migraphx::shape out_attr = migraphx::shape{output_shapes};
         auto sm_ins              = mm->add_instruction(
             migraphx::make_op("select_module",
-                              {{"output_dyn_shapes", migraphx::to_value(out_attr)}}),
+                                           {{"output_dyn_shapes", migraphx::to_value(out_attr)}}),
             sm_inputs,
             submodules);
         std::vector<instruction_ref> outputs(output_shapes.size());

--- a/src/split_single_dyn_dim.cpp
+++ b/src/split_single_dyn_dim.cpp
@@ -128,7 +128,8 @@ void split_single_dyn_dim::apply(module_pass_manager& mpm) const
         auto dyn_dim = dd_check_vec->at(0).dd;
         // create submodules for each dimension size
         std::vector<module_ref> submodules;
-        for(size_t dim_size : migraphx::range(dyn_dim.min(), dyn_dim.max() + 1))
+        auto dim_interval = dyn_dim.get_interval();
+        for(size_t dim_size : migraphx::range(dim_interval.min, dim_interval.max + 1))
         {
             auto* submod = mpm.create_module("dim_" + std::to_string(dim_size));
             // instruction map for new static shaped submodule parameters


### PR DESCRIPTION
## Motivation
For symbolic shapes work effort, it would be more efficient to compute intervals and optimals in a lazy way rather than eagerly. The goal here is to modify all call sites to min, max and optimals to use accessor methods instead for existing features.

## Technical Details
See https://github.com/ROCm/AMDMIGraphX/pull/4760#discussion_r3076210285

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
