### PR TITLE
Edit github action to cleanup deployments before github-pages deployment

### DIFF
--- a/.github/workflows/pr-review-status.yaml
+++ b/.github/workflows/pr-review-status.yaml
@@ -20,7 +20,8 @@ env:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      deployments: write
     steps:
       - name: Delete Deployment Environment
         uses: strumwolf/delete-deployment-environment@v3

--- a/.github/workflows/pr-review-status.yaml
+++ b/.github/workflows/pr-review-status.yaml
@@ -30,6 +30,7 @@ jobs:
           environment: github-pages
           onlyRemoveDeployments: true
   deploy:
+    needs: cleanup
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/pr-review-status.yaml
+++ b/.github/workflows/pr-review-status.yaml
@@ -24,6 +24,7 @@ jobs:
       deployments: write
     steps:
       - name: Delete Deployment Environment
+        continue-on-error: true
         uses: strumwolf/delete-deployment-environment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-review-status.yaml
+++ b/.github/workflows/pr-review-status.yaml
@@ -18,6 +18,16 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Delete Deployment Environment
+        uses: strumwolf/delete-deployment-environment@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment: github-pages
+          onlyRemoveDeployments: true
   deploy:
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
* Deployments tab was being filled up with github-pages deployments. We do not need the history for the deployments.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
* Adds a cleanup step that removes deployments before the github-pages job.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
