### PR TITLE
Use fp32 FMA in channelwise conv

### DIFF
--- a/src/targets/gpu/kernels/include/migraphx/kernels/channelwise_conv.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/channelwise_conv.hpp
@@ -53,19 +53,19 @@ channelwise_conv(TileLens, Padding, F f, Output output, Input x, Weights w, Inpu
     auto xs_pack = pack(tiler.slice(inputs)...);
 
     using type = typename Output::type;
-    array<type, decltype(w_ch.get_shape().elements()){}> wregs_arr;
+    array<float, decltype(w_ch.get_shape().elements()){}> wregs_arr;
     auto wregs = make_tensor_view(wregs_arr.begin(), make_packed_shape(w_ch.get_shape()));
     copy(w_ch.begin(), w_ch.end(), wregs.begin());
 
     __syncthreads();
 
     tiler.for_each([&](auto out_pos, auto out_multi) {
-        type acc = 0;
+        float acc = 0;
         repeat(wregs.get_shape().elements(), [&](auto ki) {
             auto k_multi = wregs.get_shape().multi(ki);
-            acc += x_ch[out_multi + k_multi] * wregs[k_multi];
+            acc += static_cast<float>(x_ch[out_multi + k_multi]) * wregs[k_multi];
         });
-        xs_pack([&](auto... xs) { out_ch[out_pos] = f(acc, xs[out_pos]...); });
+        xs_pack([&](auto... xs) { out_ch[out_pos] = f(static_cast<type>(acc), xs[out_pos]...); });
     });
 }
 

--- a/src/targets/gpu/kernels/include/migraphx/kernels/channelwise_conv.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/channelwise_conv.hpp
@@ -60,7 +60,7 @@ channelwise_conv(TileLens, Padding, F f, Output output, Input x, Weights w, Inpu
     __syncthreads();
 
     tiler.for_each([&](auto out_pos, auto out_multi) {
-        float acc = 0;
+        float acc = 0.0f;
         repeat(wregs.get_shape().elements(), [&](auto ki) {
             auto k_multi = wregs.get_shape().multi(ki);
             acc +=

--- a/src/targets/gpu/kernels/include/migraphx/kernels/channelwise_conv.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/channelwise_conv.hpp
@@ -53,7 +53,7 @@ channelwise_conv(TileLens, Padding, F f, Output output, Input x, Weights w, Inpu
     auto xs_pack = pack(tiler.slice(inputs)...);
 
     using type = typename Output::type;
-    array<float, decltype(w_ch.get_shape().elements()){}> wregs_arr;
+    array<type, decltype(w_ch.get_shape().elements()){}> wregs_arr;
     auto wregs = make_tensor_view(wregs_arr.begin(), make_packed_shape(w_ch.get_shape()));
     copy(w_ch.begin(), w_ch.end(), wregs.begin());
 
@@ -63,7 +63,8 @@ channelwise_conv(TileLens, Padding, F f, Output output, Input x, Weights w, Inpu
         float acc = 0;
         repeat(wregs.get_shape().elements(), [&](auto ki) {
             auto k_multi = wregs.get_shape().multi(ki);
-            acc += static_cast<float>(x_ch[out_multi + k_multi]) * wregs[k_multi];
+            acc +=
+                static_cast<float>(x_ch[out_multi + k_multi]) * static_cast<float>(wregs[k_multi]);
         });
         xs_pack([&](auto... xs) { out_ch[out_pos] = f(static_cast<type>(acc), xs[out_pos]...); });
     });


### PR DESCRIPTION
## Motivation
Unsure whether we want to adopt a more accurate approach here; this is just a thought.

This PR is derived from https://github.com/ROCm/AMDMIGraphX/pull/4647. 

## Technical Details
Store weights in fp32 registers and accumulate in fp32 to improve accuracy for fp16 input. Cast back to output type at the end.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [X] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
