### PR TITLE
CI: Automating workflow execution for internal contributors only

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -69,6 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: read
     if: >
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -67,11 +67,17 @@ env:
 jobs:
   get_config:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: >
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       github.event.action == 'closed' ||
-      contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test') ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      github.event.pull_request.author_association == 'MEMBER'
     outputs:
       rocm_version: ${{ steps.read_config.outputs.rocm_version }}
       utils_repo: ${{ steps.read_config.outputs.utils_repo }}
@@ -85,6 +91,20 @@ jobs:
       perf_workspace: ${{ steps.read_config.outputs.perf_workspace }}
       runner_label: ${{ steps.read_config.outputs.runner_label }}
     steps:
+      - name: Remove ok-to-test label on new commits from forked PRs by external contributors
+        if: >
+          github.event.action == 'synchronize' &&
+          contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
+          github.event.pull_request.head.repo.full_name != github.repository &&
+          github.event.pull_request.author_association != 'OWNER' &&
+          github.event.pull_request.author_association != 'COLLABORATOR' &&
+          github.event.pull_request.author_association != 'MEMBER'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "ok-to-test" --repo ${{ github.repository }} || true
+          echo "::error::New commits pushed, 'ok-to-test' label removed. Please review the changes and add the label back if tests should be run."
+          exit 1 
       - name: checkout
         uses: actions/checkout@v4
       - name: read_config


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The goal of this PR is to make sure untrusted fork contributors can't run performance pipeline without explicit maintainer approval, while trusted contributors (members, collaborators and same repo PRs) run it automatically.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
Same repo PRs and trusted contributors now run this workflow automatically without needing `ok-to-test` label, while untrusted fork contributors still require maintainer approval via `ok-to-test` label before anything runs. Also added new step to handle cases where maintainer approves a fork PR by adding the label, but the contributor then pushes new (potentially malicious) commit before the tests finish. Without this step those new unreviewed commits would run through the pipeline under the cover of previous approval.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
