### PR TITLE
Fix literal promotion

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -197,10 +197,15 @@ std::vector<instruction_ref> insert_common_args(module& m,
         auto common = common_shape(to_shapes(inputs));
         if(options.common_type)
         {
+            // Exclude scalar literals from the common type decision. A scalar constant
+            // (e.g. an epsilon stored as float32) should adapt to the tensor's type rather
+            // than widening it. Without this, mixing a float32 scalar with a float16 tensor
+            // would promote the entire computation to float32, causing type mismatches in
+            // downstream ops (e.g. convolution, dot) whose weights remain float16.
             std::vector<shape> tensor_shapes;
             for(const auto& input : inputs)
             {
-                if(not(input->can_eval() and input->get_shape().elements() == 1))
+                if(not input->can_eval() or input->get_shape().elements() != 1)
                     tensor_shapes.push_back(input->get_shape());
             }
             if(not tensor_shapes.empty())

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -209,7 +209,7 @@ std::vector<instruction_ref> insert_common_args(module& m,
                 if(tensor_type != common.type())
                     common = shape{tensor_type, common.lens()};
             }
-        }        
+        }
         std::transform(inputs.begin(), inputs.end(), inputs.begin(), [&](auto input) {
             if(options.common_lens and input->get_shape().lens() != common.lens())
             {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -195,6 +195,21 @@ std::vector<instruction_ref> insert_common_args(module& m,
     else
     {
         auto common = common_shape(to_shapes(inputs));
+        if(options.common_type)
+        {
+            std::vector<shape> tensor_shapes;
+            for(const auto& input : inputs)
+            {
+                if(not(input->can_eval() and input->get_shape().elements() == 1))
+                    tensor_shapes.push_back(input->get_shape());
+            }
+            if(not tensor_shapes.empty())
+            {
+                auto tensor_type = compute_common_types(tensor_shapes);
+                if(tensor_type != common.type())
+                    common = shape{tensor_type, common.lens()};
+            }
+        }        
         std::transform(inputs.begin(), inputs.end(), inputs.begin(), [&](auto input) {
             if(options.common_lens and input->get_shape().lens() != common.lens())
             {

--- a/src/onnx/parse_gru.cpp
+++ b/src/onnx/parse_gru.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/onnx/parse_gru.cpp
+++ b/src/onnx/parse_gru.cpp
@@ -166,7 +166,12 @@ struct parse_gru : op_parser<parse_gru>
         {
             gru_transpose_inputs(info, args);
         }
-
+        if(not args[5]->is_undefined() and
+           args[5]->get_shape().type() != args[1]->get_shape().type())
+        {
+            args[5] = info.add_instruction(
+                make_op("convert", {{"target_type", args[1]->get_shape().type()}}), args[5]);
+        }
         // first output for concatenation of hidden states
         auto hidden_states =
             info.add_instruction(make_op("gru",

--- a/test/common_test.cpp
+++ b/test/common_test.cpp
@@ -26,6 +26,7 @@
 #include <migraphx/module.hpp>
 #include <migraphx/make_op.hpp>
 #include <migraphx/literal.hpp>
+#include <migraphx/instruction.hpp>
 
 TEST_CASE(add_common_op_scalar_literal_preserves_tensor_type)
 {
@@ -83,3 +84,5 @@ TEST_CASE(add_common_op_float_tensor_with_float_scalar_keeps_float)
 
     EXPECT(result->get_shape().type() == migraphx::shape::float_type);
 }
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/common_test.cpp
+++ b/test/common_test.cpp
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "test.hpp"
+#include <migraphx/common.hpp>
+#include <migraphx/module.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/literal.hpp>
+
+TEST_CASE(add_common_op_scalar_literal_preserves_tensor_type)
+{
+    migraphx::module mm;
+
+    auto tensor =
+        mm.add_parameter("x", migraphx::shape{migraphx::shape::half_type, {1, 100, 128}});
+    auto scalar = mm.add_literal(
+        migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {1e-5f}});
+
+    auto result = migraphx::add_common_op(mm, migraphx::make_op("add"), {tensor, scalar});
+
+    EXPECT(result->get_shape().type() == migraphx::shape::half_type);
+}
+
+TEST_CASE(add_common_op_scalar_literal_preserves_tensor_type_reversed)
+{
+    migraphx::module mm;
+
+    auto tensor =
+        mm.add_parameter("x", migraphx::shape{migraphx::shape::half_type, {1, 100, 128}});
+    auto scalar = mm.add_literal(
+        migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {1e-5f}});
+
+    auto result = migraphx::add_common_op(mm, migraphx::make_op("add"), {scalar, tensor});
+
+    EXPECT(result->get_shape().type() == migraphx::shape::half_type);
+}
+
+TEST_CASE(add_common_op_two_tensors_promotes_to_wider_type)
+{
+    migraphx::module mm;
+
+    auto half_tensor =
+        mm.add_parameter("x", migraphx::shape{migraphx::shape::half_type, {1, 128}});
+    auto float_tensor =
+        mm.add_parameter("y", migraphx::shape{migraphx::shape::float_type, {1, 128}});
+
+    auto result =
+        migraphx::add_common_op(mm, migraphx::make_op("add"), {half_tensor, float_tensor});
+
+    EXPECT(result->get_shape().type() == migraphx::shape::float_type);
+}
+
+TEST_CASE(add_common_op_float_tensor_with_float_scalar_keeps_float)
+{
+    migraphx::module mm;
+
+    auto tensor =
+        mm.add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 100, 128}});
+    auto scalar = mm.add_literal(
+        migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {1e-5f}});
+
+    auto result = migraphx::add_common_op(mm, migraphx::make_op("add"), {tensor, scalar});
+
+    EXPECT(result->get_shape().type() == migraphx::shape::float_type);
+}

--- a/test/common_test.cpp
+++ b/test/common_test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,10 +32,9 @@ TEST_CASE(add_common_op_scalar_literal_preserves_tensor_type)
 {
     migraphx::module mm;
 
-    auto tensor =
-        mm.add_parameter("x", migraphx::shape{migraphx::shape::half_type, {1, 100, 128}});
-    auto scalar = mm.add_literal(
-        migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {1e-5f}});
+    auto tensor = mm.add_parameter("x", migraphx::shape{migraphx::shape::half_type, {1, 100, 128}});
+    auto scalar =
+        mm.add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {1e-5f}});
 
     auto result = migraphx::add_common_op(mm, migraphx::make_op("add"), {tensor, scalar});
 
@@ -46,10 +45,9 @@ TEST_CASE(add_common_op_scalar_literal_preserves_tensor_type_reversed)
 {
     migraphx::module mm;
 
-    auto tensor =
-        mm.add_parameter("x", migraphx::shape{migraphx::shape::half_type, {1, 100, 128}});
-    auto scalar = mm.add_literal(
-        migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {1e-5f}});
+    auto tensor = mm.add_parameter("x", migraphx::shape{migraphx::shape::half_type, {1, 100, 128}});
+    auto scalar =
+        mm.add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {1e-5f}});
 
     auto result = migraphx::add_common_op(mm, migraphx::make_op("add"), {scalar, tensor});
 
@@ -60,8 +58,7 @@ TEST_CASE(add_common_op_two_tensors_promotes_to_wider_type)
 {
     migraphx::module mm;
 
-    auto half_tensor =
-        mm.add_parameter("x", migraphx::shape{migraphx::shape::half_type, {1, 128}});
+    auto half_tensor = mm.add_parameter("x", migraphx::shape{migraphx::shape::half_type, {1, 128}});
     auto float_tensor =
         mm.add_parameter("y", migraphx::shape{migraphx::shape::float_type, {1, 128}});
 
@@ -77,8 +74,8 @@ TEST_CASE(add_common_op_float_tensor_with_float_scalar_keeps_float)
 
     auto tensor =
         mm.add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 100, 128}});
-    auto scalar = mm.add_literal(
-        migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {1e-5f}});
+    auto scalar =
+        mm.add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {1e-5f}});
 
     auto result = migraphx::add_common_op(mm, migraphx::make_op("add"), {tensor, scalar});
 


### PR DESCRIPTION
## Motivation
 When parsing ONNX models with half-precision (float16) weights, scalar float32 constants (e.g. epsilon in LayerNorm) were causing unintended type promotion of entire computation paths from float16 to float32. This resulted in a type mismatch error when the promoted float32 tensor reached a downstream operation (e.g. convolution or dot) whose weights remained float16. Result in this error:

same_type: convolution: Types do not match

## Technical Details
Before applying the common type, inputs that are scalar literals (single-element and evaluable) are excluded from the type decision. If the remaining tensor inputs share a type, that type takes precedence over the scalar's type, and the scalar is cast down to match.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
