### PR TITLE
compilation error on unused function

### DIFF
--- a/src/targets/gpu/device_name.cpp
+++ b/src/targets/gpu/device_name.cpp
@@ -135,7 +135,6 @@ bool gfx_default_rocblas(const context& ctx)
 {
     return gfx_default_rocblas_impl(get_gfx_name(ctx.get_current_device().get_device_name()));
 }
-#endif
 
 static bool hipblaslt_supported_impl(const std::string& gfx_name)
 {
@@ -143,6 +142,7 @@ static bool hipblaslt_supported_impl(const std::string& gfx_name)
             (starts_with(gfx_name, "gfx95") and gfx_name >= "gfx950") or
             starts_with(gfx_name, "gfx110") or starts_with(gfx_name, "gfx120"));
 }
+#endif
 
 bool hipblaslt_supported()
 {


### PR DESCRIPTION
Fix for the compilation error on the unused function on Windows when hipBLASLt is Off
```batch
C:/.../MIGraphX/src/targets/gpu/device_name.cpp:140:13: error: unused function 'hipblaslt_supported_impl' [-Werror,-Wunused-function]
  140 | static bool hipblaslt_supported_impl(const std::string& gfx_name)
```
