### PR TITLE
Only throw on the root module when dumping benchmark-mxr files

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -527,7 +527,7 @@ struct compile_manager
         par_compile(cps.size(), [&](auto i) { cps[i].update_config(exhaustive); });
     }
 
-    void compile(module& m)
+    void compile(module& m, bool is_root)
     {
         std::vector<std::function<void()>> compiles;
         for(auto& cp : cps)
@@ -558,7 +558,11 @@ struct compile_manager
             }
         }
 
-        if(dump_mxr)
+        // Only throw on the root module so that submodules (which are processed
+        // first by the pass manager and may legitimately have no precompile ops
+        // or no multi-solution candidates) don't abort compilation before the
+        // root module has had a chance to dump its benchmark MXR files.
+        if(dump_mxr and is_root)
         {
             MIGRAPHX_THROW(
                 "Benchmark MXR files dumped to " + mxr_path +
@@ -573,8 +577,10 @@ struct compile_manager
     }
 };
 
-void compile_ops::apply(module& m) const
+void compile_ops::apply(module_pass_manager& mpm) const
 {
+    bool is_root = &mpm.get_module() == mpm.get_root_module();
+    auto& m      = mpm.get_module();
     compile_manager cm;
     cm.exhaustive = exhaustive_tune;
     // Find all precompile ops
@@ -586,9 +592,9 @@ void compile_ops::apply(module& m) const
         cm.add_plan(ctx, preop, ins, &m);
     }
     cm.update_configs();
-    cm.compile(m);
+    cm.compile(m, is_root);
     // Compile already tuned configs
-    cm.compile(m);
+    cm.compile(m, is_root);
     assert(cm.cps.empty());
 }
 

--- a/src/targets/gpu/include/migraphx/gpu/compile_ops.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/compile_ops.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,7 @@
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
-struct module;
+struct module_pass_manager;
 
 namespace gpu {
 
@@ -41,7 +41,7 @@ struct MIGRAPHX_GPU_EXPORT compile_ops
     context* ctx         = nullptr;
     bool exhaustive_tune = false;
     std::string name() const { return "gpu::compile_ops"; }
-    void apply(module& m) const;
+    void apply(module_pass_manager& mpm) const;
 };
 
 } // namespace gpu


### PR DESCRIPTION
## Motivation
Only throw on the root module so that submodules (which are processed
first by the pass manager and may legitimately have no precompile ops
or no multi-solution candidates) don't abort compilation before the
root module has had a chance to dump its benchmark MXR files.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
