### PR TITLE
Lowel "Skipped configs..." message to `log::info()`

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -465,7 +465,7 @@ struct compile_plan
                            problem_string() + "\n\n" + print_modules());
         auto skipped = std::count_if(
             results.begin(), results.end(), [](const auto& cr) { return not cr.has_value(); });
-        if(trace_level > 0 && skipped > 0)
+        if(trace_level > 0 and skipped > 0)
             std::cout << "Skipped " << skipped << " configs for " << preop.name() << "\n";
 
         return *results[i];

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -466,7 +466,7 @@ struct compile_plan
         auto skipped = std::count_if(
             results.begin(), results.end(), [](const auto& cr) { return not cr.has_value(); });
         if(trace_level > 0 && skipped > 0)
-            std::cout << "Skipped " << skipped << " configs for " << preop.name();
+            std::cout << "Skipped " << skipped << " configs for " << preop.name() << "\n";
 
         return *results[i];
     }

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -465,8 +465,8 @@ struct compile_plan
                            problem_string() + "\n\n" + print_modules());
         auto skipped = std::count_if(
             results.begin(), results.end(), [](const auto& cr) { return not cr.has_value(); });
-        if(skipped > 0)
-            log::info() << "Skipped " << skipped << " configs for " << preop.name();
+        if(trace_level > 0 && skipped > 0)
+            std::cout << "Skipped " << skipped << " configs for " << preop.name();
 
         return *results[i];
     }


### PR DESCRIPTION
The change has been migrated from the uai-develop branch.

The "logging" from the method is inconsistent. It entirely uses `std::cout` and is controlled by `trace_level`, except for this single instance. The logs saying "Skipped ... configs ..." appear out of nowhere and without proper context, confusing the QA team and leading to defect submissions.