### PR TITLE
test/py: warn when an onnx_backend_test include pattern matches no tests

### DIFF
--- a/test/py/onnx_backend_test.py
+++ b/test/py/onnx_backend_test.py
@@ -1231,12 +1231,43 @@ def create_backend_test(testname=None, target_device=None):
         if version.parse(onnx.__version__) >= version.parse("1.18.0"):
             disabled_tests_onnx_1_18_0(backend_test)
 
+    _check_include_patterns_match(backend_test)
 
 # import all test cases at global scope to make
 # them visible to python.unittest.
     globals().update(backend_test.enable_report().test_cases)
 
     return backend_test
+
+
+def _check_include_patterns_match(backend_test):
+    """Warn for backend_test.include(...) patterns that match no tests.
+
+    Without this guard a typo (e.g. r'.*test_abss.*' instead of r'.*test_abs.*')
+    silently filters every test out of that include, the suite reports zero
+    failures, and CI passes even though that include contributed no coverage.
+    Surface unmatched patterns at test setup time so misspellings — and dead
+    entries left behind when ONNX renames or removes tests — are visible.
+    """
+    all_test_names = {
+        name
+        for items_map in backend_test._test_items.values()
+        for name in items_map
+    }
+    unmatched = sorted(
+        pat.pattern
+        for pat in backend_test._include_patterns
+        if not any(pat.search(name) for name in all_test_names)
+    )
+    if unmatched:
+        print(
+            "onnx_backend_test.py: WARNING: {} include() pattern(s) matched "
+            "no test cases (check for misspellings or stale entries):"
+            .format(len(unmatched)),
+            file=sys.stderr,
+        )
+        for pattern in unmatched:
+            print("  " + pattern, file=sys.stderr)
 
 
 def parse_args():


### PR DESCRIPTION
Closes #1115.

## What

A typo in `backend_test.include(...)` in `test/py/onnx_backend_test.py` (e.g. `test_abss` vs `test_abs`) silently filters every test out of that include — the suite reports zero failures and CI passes even though that pattern contributed no coverage. The same trap fires when ONNX renames or removes a test that an existing pattern still referred to.

This PR adds `_check_include_patterns_match()`, called once at the end of `create_backend_test()` after all `include`/`exclude`/`xfail` patterns are wired up. It walks the loaded `_test_items` and prints a stderr warning listing every `include()` pattern that matches nothing.

## Why a warning, not a hard error

A smoke run against the current tree surfaces **13 stale patterns** that match no test in the installed onnx (1.18.x) — for example `.*test_randomnormal.*`, `.*test_sequence_construct.*`, `.*test_globallppool.*`, `.*test_log2.*`. They appear to be entries that were valid against earlier ONNX versions and silently broke when those tests were renamed/removed upstream. Erroring out would break CI today; warning surfaces the dead entries so they can be cleaned up in a follow-up, and the gate can later be tightened to an error once the suite is clean.

Output for those 13 patterns looks like:

```
onnx_backend_test.py: WARNING: 13 include() pattern(s) matched no test cases (check for misspellings or stale entries):
  .*test_[mM]ultinomial.*
  .*test_globallppool.*
  ...
```

## Verification

- Smoke-tested locally against onnx 1.18.0 by importing `create_backend_test()` with a stub backend and confirming the warning fires for the existing 13 stale patterns and *does not* fire for any of the other 226 valid patterns.
- A deliberate typo (`r'.*test_zzznotreal.*'`) is correctly listed as unmatched, while a real pattern (`r'.*test_abs.*'`) is not.
- No behavior change for tests that currently run.