### PR TITLE
Fix report.yaml to handle github app token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -253,6 +253,10 @@ jobs:
           python3 tools/format.py origin/${{ github.event_name == 'pull_request' && github.base_ref || 'develop' }}
         fi
 
+    - name: Fix file ownership
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+      run: sudo chown -R $(id -u):$(id -g) .
+
     - uses: reviewdog/action-suggester@v1
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
       with:

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           client-id: ${{ vars.GH_APP_MIGRAPHX_BOT_PR_WRITE_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_MIGRAPHX_BOT_PR_WRITE_PRIVATE_KEY }}
+          repositories: AMDMIGraphX,migraphx-reports,migraphx-benchmark-utils
 
       - name: Download artifacts
         id: dl_art


### PR DESCRIPTION
## Motivation
Get perf reports per PR working after moving to Github App

## Technical Details
Github App tokens are repository specific.  Access to each repository needed to be explicit 

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
