### PR TITLE
Changes to enable benchmarking mxr files using a Python script

### DIFF
--- a/src/include/migraphx/program.hpp
+++ b/src/include/migraphx/program.hpp
@@ -114,6 +114,16 @@ struct MIGRAPHX_EXPORT program
 
     void finalize();
 
+    // Attach `t` to a program that hasn't been compiled yet (e.g. one loaded
+    // from an .mxr produced by `compile_plan::save_binaries`, which contains
+    // already-lowered GPU code objects but no targets/contexts), then
+    // finalize. Unlike `compile()`, this runs no passes -- it just sets up
+    // the target + context and calls `finalize()`. Mirrors what
+    // `time_program` (src/targets/gpu/time_op.cpp) does internally so the
+    // program becomes runnable without re-running any rewrites that would
+    // mutate already-lowered instructions.
+    void finalize(const target& t);
+
     void perf_report(std::ostream& os,
                      std::size_t n,
                      parameter_map params,

--- a/src/include/migraphx/program.hpp
+++ b/src/include/migraphx/program.hpp
@@ -114,14 +114,9 @@ struct MIGRAPHX_EXPORT program
 
     void finalize();
 
-    // Attach `t` to a program that hasn't been compiled yet (e.g. one loaded
-    // from an .mxr produced by `compile_plan::save_binaries`, which contains
-    // already-lowered GPU code objects but no targets/contexts), then
-    // finalize. Unlike `compile()`, this runs no passes -- it just sets up
-    // the target + context and calls `finalize()`. Mirrors what
-    // `time_program` (src/targets/gpu/time_op.cpp) does internally so the
-    // program becomes runnable without re-running any rewrites that would
-    // mutate already-lowered instructions.
+    // Attach `t` and finalize an already-lowered program (e.g. one loaded from
+    // an .mxr) without running compile passes that would mutate the lowered
+    // instructions.
     void finalize(const target& t);
 
     void perf_report(std::ostream& os,

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -365,6 +365,16 @@ void program::finalize()
     mm->finalize(this->impl->contexts);
 }
 
+void program::finalize(const target& t)
+{
+    if(not this->is_compiled())
+    {
+        this->impl->targets  = {t};
+        this->impl->contexts = {t.get_context()};
+    }
+    this->finalize();
+}
+
 template <class T>
 static std::string classify(T x)
 {

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -564,6 +564,16 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             py::arg("offload_copy")    = true,
             py::arg("fast_math")       = true,
             py::arg("exhaustive_tune") = false)
+        .def(
+            "finalize",
+            [](migraphx::program& p, const migraphx::target& t) { p.finalize(t); },
+            "Attach a target+context and finalize without running compile "
+            "passes. Use this on programs loaded from .mxr files that are "
+            "already lowered (e.g. dumps from "
+            "MIGRAPHX_GPU_DUMP_BENCHMARK_MXR), where calling compile() would "
+            "rerun rewrites like auto_contiguous and corrupt the saved "
+            "code_object_op input shapes.",
+            py::arg("t"))
         .def("get_main_module", [](const migraphx::program& p) { return p.get_main_module(); })
         .def(
             "create_module",
@@ -574,10 +584,19 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
                  migraphx::parameter_map pm;
                  for(auto x : params)
                  {
-                     std::string key      = x.first.cast<std::string>();
-                     py::buffer b         = x.second.cast<py::buffer>();
-                     py::buffer_info info = b.request();
-                     pm[key]              = migraphx::argument(to_shape(info), info.ptr);
+                     std::string key = x.first.cast<std::string>();
+                     // Accept a migraphx.argument directly (preserves tuple-typed shapes
+                     // which can't round-trip through the Python buffer protocol).
+                     if(py::isinstance<migraphx::argument>(x.second))
+                     {
+                         pm[key] = x.second.cast<migraphx::argument>();
+                     }
+                     else
+                     {
+                         py::buffer b         = x.second.cast<py::buffer>();
+                         py::buffer_info info = b.request();
+                         pm[key]              = migraphx::argument(to_shape(info), info.ptr);
+                     }
                  }
                  return p.eval(pm);
              })
@@ -589,10 +608,17 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
                  migraphx::parameter_map pm;
                  for(auto x : params)
                  {
-                     std::string key      = x.first.cast<std::string>();
-                     py::buffer b         = x.second.cast<py::buffer>();
-                     py::buffer_info info = b.request();
-                     pm[key]              = migraphx::argument(to_shape(info), info.ptr);
+                     std::string key = x.first.cast<std::string>();
+                     if(py::isinstance<migraphx::argument>(x.second))
+                     {
+                         pm[key] = x.second.cast<migraphx::argument>();
+                     }
+                     else
+                     {
+                         py::buffer b         = x.second.cast<py::buffer>();
+                         py::buffer_info info = b.request();
+                         pm[key]              = migraphx::argument(to_shape(info), info.ptr);
+                     }
                  }
                  migraphx::execution_environment exec_env{
                      migraphx::any_ptr(reinterpret_cast<void*>(stream), stream_name), true};

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -567,12 +567,8 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         .def(
             "finalize",
             [](migraphx::program& p, const migraphx::target& t) { p.finalize(t); },
-            "Attach a target+context and finalize without running compile "
-            "passes. Use this on programs loaded from .mxr files that are "
-            "already lowered (e.g. dumps from "
-            "MIGRAPHX_GPU_DUMP_BENCHMARK_MXR), where calling compile() would "
-            "rerun rewrites like auto_contiguous and corrupt the saved "
-            "code_object_op input shapes.",
+            "Attach a target+context and finalize an already-lowered program "
+            "(e.g. loaded from an .mxr) without running compile passes.",
             py::arg("t"))
         .def("get_main_module", [](const migraphx::program& p) { return p.get_main_module(); })
         .def(

--- a/test/eval_test.cpp
+++ b/test/eval_test.cpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  */
 
+#include <algorithm>
 #include <migraphx/program.hpp>
 #include <migraphx/iterator_for.hpp>
 #include <migraphx/instruction.hpp>
@@ -724,6 +725,42 @@ TEST_CASE(context_facade_dispatches_to_member_set_and_restore_queue)
     EXPECT(held->set_calls == 2);
     EXPECT(held->restore_calls == 1);
     EXPECT(held->last_queue.unsafe_get() == &dummy);
+}
+
+TEST_CASE(finalize_target_runnable)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    auto one = mm->add_literal(1);
+    auto two = mm->add_literal(2);
+    mm->add_instruction(sum_op{}, one, two);
+
+    EXPECT(not p.is_compiled());
+    p.finalize(id_target{});
+    EXPECT(p.is_compiled());
+
+    auto result = p.eval({}).back();
+    EXPECT(result == migraphx::literal{3});
+}
+
+TEST_CASE(finalize_target_no_passes)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    auto one = mm->add_literal(1);
+    auto two = mm->add_literal(2);
+    mm->add_instruction(sum_op{}, two, one);
+
+    p.finalize(invert_target{});
+
+    EXPECT(
+        std::any_of(mm->begin(), mm->end(), [](const auto& ins) { return ins.name() == "sum"; }));
+    EXPECT(std::none_of(
+        mm->begin(), mm->end(), [](const auto& ins) { return ins.name() == "minus"; }));
+
+    // sum(2, 1) == 3, if compile(invert_target) had run, it would have produced minus(2, 1) == 1.
+    auto result = p.eval({}).back();
+    EXPECT(result == migraphx::literal{3});
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation
This adds changes for us to be able to benchmark mxr files that 
are dumped using MIGRAPHX_GPU_DUMP_BENCHMARK_MXR.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
