### PR TITLE
[#4884] Fold Reduce_*(axes) op when all reduced axes have length 1

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -1710,12 +1710,12 @@ struct find_conv_dot_horiz_fusion
             // TODO: Check if axes match
             auto concat =
                 m.insert_instruction(input, make_op("concat", {{"axis", concat_axis}}), args);
-            auto fused     = m.insert_instruction(std::next(input), op, input, concat);
+            auto fused = m.insert_instruction(std::next(input), op, input, concat);
             std::vector<module::instruction_replacement> replacers;
             int64_t offset = 0;
             for(auto arg : range(start, last))
             {
-                int64_t len = arg->get_shape().lens()[axis];
+                int64_t len   = arg->get_shape().lens()[axis];
                 auto slice_op = make_op(
                     "slice", {{"axes", {axis}}, {"starts", {offset}}, {"ends", {offset + len}}});
                 replacers.push_back(module::instruction_replacement{arg, slice_op, {fused}, {}});
@@ -2372,6 +2372,48 @@ struct find_pow2
     }
 };
 
+// Fold reduce_*[axes] over axes of length 1 into the input (no-op).
+struct find_reduce_no_op
+{
+    auto matcher() const
+    {
+        return match::name("reduce_max",
+                           "reduce_min",
+                           "reduce_sum",
+                           "reduce_prod",
+                           "reduce_mean",
+                           "reduce_any",
+                           "reduce_all");
+    }
+
+    void apply(module& m, const match::matcher_result& r) const
+    {
+        auto ins = r.result;
+        // Variable-axes form (data + axes) has dynamic output; skip.
+        if(ins->inputs().size() != 1)
+            return;
+
+        const auto& in = ins->inputs().front();
+        const auto& sh = in->get_shape();
+        if(sh.dynamic())
+            return;
+
+        auto axes = ins->get_operator().to_value()["axes"].to_vector<std::int64_t>();
+        if(axes.empty())
+            return;
+
+        const auto& lens         = sh.lens();
+        const auto rank          = static_cast<std::int64_t>(lens.size());
+        const bool all_singleton = std::all_of(axes.begin(), axes.end(), [&](std::int64_t a) {
+            if(a < 0)
+                a += rank;
+            return a >= 0 and a < rank and lens[a] == 1;
+        });
+        if(all_singleton)
+            m.replace_instruction(ins, in);
+    }
+};
+
 void simplify_algebra::apply(module& m) const
 {
     // Run simplifications multiple times
@@ -2407,7 +2449,8 @@ void simplify_algebra::apply(module& m) const
                             find_splits{},
                             find_split_reshape{},
                             find_split_transpose{},
-                            find_pow2{});
+                            find_pow2{},
+                            find_reduce_no_op{});
 
         dead_code_elimination{}.apply(m);
     });

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -5348,4 +5348,100 @@ TEST_CASE(debug_symbols_simplify_div_const)
     EXPECT(m1.sort() == m2.sort());
 }
 
+// find_reduce_no_op: folds reduce_*[axes] when every reduced axis has length 1.
+static void check_reduce_folds(const std::string& op_name,
+                               const std::vector<std::size_t>& lens,
+                               const std::vector<std::int64_t>& axes)
+{
+    migraphx::shape s{migraphx::shape::float_type, lens};
+    migraphx::module m1;
+    {
+        auto x = m1.add_parameter("x", s);
+        auto r = m1.add_instruction(migraphx::make_op(op_name, {{"axes", axes}}), x);
+        m1.add_instruction(pass_op{}, r);
+    }
+    run_pass(m1);
+
+    migraphx::module m2;
+    {
+        auto x = m2.add_parameter("x", s);
+        m2.add_instruction(pass_op{}, x);
+    }
+    EXPECT(m1 == m2);
+}
+
+static void check_reduce_kept(const std::string& op_name,
+                              const std::vector<std::size_t>& lens,
+                              const std::vector<std::int64_t>& axes)
+{
+    migraphx::shape s{migraphx::shape::float_type, lens};
+    migraphx::module m1;
+    {
+        auto x = m1.add_parameter("x", s);
+        auto r = m1.add_instruction(migraphx::make_op(op_name, {{"axes", axes}}), x);
+        m1.add_instruction(pass_op{}, r);
+    }
+    auto before = m1;
+    run_pass(m1);
+    EXPECT(m1 == before);
+}
+
+TEST_CASE(simplify_reduce_no_op_singleton_axis)
+{
+    check_reduce_folds("reduce_max", {1, 21, 1}, {2});
+}
+
+TEST_CASE(simplify_reduce_no_op_negative_axis)
+{
+    check_reduce_folds("reduce_sum", {1, 21, 1}, {-1});
+}
+
+TEST_CASE(simplify_reduce_no_op_multi_axes)
+{
+    check_reduce_folds("reduce_mean", {1, 1, 21, 1}, {0, 1, 3});
+}
+
+// yolo*-pose regression: without the fold, GPU lowering JIT-fails on this shape.
+TEST_CASE(simplify_reduce_no_op_yolo_pose_shape)
+{
+    check_reduce_folds("reduce_max", {1, 8400, 1}, {-1});
+}
+
+TEST_CASE(simplify_reduce_keeps_real_reduce) { check_reduce_kept("reduce_max", {1, 21, 5}, {2}); }
+
+TEST_CASE(simplify_reduce_keeps_partial_singleton)
+{
+    check_reduce_kept("reduce_sum", {1, 21, 1}, {1, 2});
+}
+
+TEST_CASE(simplify_reduce_skips_dynamic_input)
+{
+    migraphx::shape s{migraphx::shape::float_type, {{1, 1}, {21, 21}, {1, 8}}};
+    migraphx::module m1;
+    {
+        auto x = m1.add_parameter("x", s);
+        auto r = m1.add_instruction(migraphx::make_op("reduce_max", {{"axes", {2}}}), x);
+        m1.add_instruction(pass_op{}, r);
+    }
+    auto before = m1;
+    run_pass(m1);
+    EXPECT(m1 == before);
+}
+
+TEST_CASE(simplify_reduce_skips_variable_axes)
+{
+    migraphx::shape data_s{migraphx::shape::float_type, {1, 21, 1}};
+    migraphx::shape axes_s{migraphx::shape::int64_type, {1}};
+    migraphx::module m1;
+    {
+        auto x    = m1.add_parameter("x", data_s);
+        auto axes = m1.add_parameter("axes", axes_s);
+        auto r    = m1.add_instruction(migraphx::make_op("reduce_max", {{"axes", {}}}), x, axes);
+        m1.add_instruction(pass_op{}, r);
+    }
+    auto before = m1;
+    run_pass(m1);
+    EXPECT(m1 == before);
+}
+
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation

`migraphx-driver compile --gpu` crashes on graphs where a `Reduce*` reduces over axes of length 1: it reaches GPU lowering as a  `fused_reduce<{N, 1}>` with no valid HIP kernel. Hits any **YOLO26-pose** export from Ultralytics; the post-processing emits `Slice → ReduceMax(axes=[-1])` over `[1, 8400, 1]`.

### Repro (real model)

```bash
pip install ultralytics onnx
python -c "from ultralytics import YOLO; YOLO('yolo26s-pose.pt').export(format='onnx', imgsz=640, simplify=False, device='cpu')"

migraphx-driver compile --onnx yolo26s-pose.onnx --gpu
# -> crashes in HIP codegen of fused_reduce<{8400, 1}>
```

See issue https://github.com/ROCm/AMDMIGraphX/issues/4884 for more details

## Fix

New `find_reduce_no_op` matcher in `simplify_algebra` for `reduce_max / min / sum / prod / mean / any / all`. Replaces the op with its input when every entry of `axes` resolves to a unit dim on a static shape. Skips dynamic shapes and the 2-input (runtime-axes) form.

`simplify_reshapes::find_nop_reshapes` already lists reduce ops but compares full shapes including strides. After `Slice` the input has non-canonical strides while the reduce output is canonical, so it skips the reduce. We can't relax that check (other ops in the same matcher rely on strides). `find_reduce_no_op` does a reduce-only, lens-only check.

## Tests

`test/simplify_algebra_test.cpp`:

- folds: `_singleton_axis`, `_negative_axis`, `_multi_axes`, `_yolo_pose_shape` (`{1, 8400, 1}`)
- kept: `_keeps_real_reduce`, `_keeps_partial_singleton`
- skipped: `_skips_dynamic_input`, `_skips_variable_axes`

End-to-end `compile --gpu` on `yolo26s-pose.onnx` and the minimal repro now completes.

## Changelog Category

- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
