### PR TITLE
[AIMIGRAPHX-1050] Enable MLIR Attention by Default on MI350

### DIFF
--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -135,14 +135,17 @@ bool mlir_attention_enabled(context* ctx)
         return false;
     if(specific_op<rejected>("attention"))
         return false;
-    // Enable attention by default for mi300/350
-    const auto& supported_prefixes = {"gfx94", "gfx95"};
-    bool is_supported =
-        std::any_of(supported_prefixes.begin(), supported_prefixes.end(), [&](const auto& prefix) {
-            return starts_with(ctx->get_current_device().get_gfx_name(), prefix);
-        });
-    if(ctx != nullptr and is_supported)
-        return true;
+    if(ctx != nullptr)
+    {
+        // Enable attention by default for mi300/350
+        const auto& supported_prefixes = {"gfx94", "gfx95"};
+        const auto& device_name        = ctx->get_current_device().get_gfx_name();
+        for(const auto& prefix : supported_prefixes)
+        {
+            if(starts_with(device_name, prefix))
+                return true;
+        }
+    }
     return specific_op<requested>("attention");
 #else
     return false;

--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -138,13 +138,12 @@ bool mlir_attention_enabled(context* ctx)
     if(ctx != nullptr)
     {
         // Enable attention by default for mi300/350
-        const auto& supported_prefixes = {"gfx94", "gfx95"};
-        const auto& device_name        = ctx->get_current_device().get_gfx_name();
-        for(const auto& prefix : supported_prefixes)
-        {
-            if(starts_with(device_name, prefix))
-                return true;
-        }
+        const auto supported_prefixes = {"gfx94", "gfx95"};
+        const auto& device_name       = ctx->get_current_device().get_gfx_name();
+        if(std::any_of(supported_prefixes.begin(),
+                       supported_prefixes.end(),
+                       [&](const char* prefix) { return starts_with(device_name, prefix); }))
+            return true;
     }
     return specific_op<requested>("attention");
 #else

--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -135,8 +135,13 @@ bool mlir_attention_enabled(context* ctx)
         return false;
     if(specific_op<rejected>("attention"))
         return false;
-    // Enable attention by default for mi300
-    if(ctx != nullptr and starts_with(ctx->get_current_device().get_gfx_name(), "gfx94"))
+    // Enable attention by default for mi300/350
+    const auto& supported_prefixes = {"gfx94", "gfx95"};
+    bool is_supported =
+        std::any_of(supported_prefixes.begin(), supported_prefixes.end(), [&](const auto& prefix) {
+            return starts_with(ctx->get_current_device().get_gfx_name(), prefix);
+        });
+    if(ctx != nullptr and is_supported)
         return true;
     return specific_op<requested>("attention");
 #else


### PR DESCRIPTION
## Motivation
rocMLIR attention is currently only default for gfx94x (MI300). We can probably enable this for MI350 as well.

## Technical Details
Adds a list of gfx prefixes that will use MLIR attention by default.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
