### PR TITLE
Split gpu passes into seperate pipelines

### DIFF
--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -41,6 +41,7 @@
 #include <migraphx/memory_coloring.hpp>
 #include <migraphx/normalize_ops.hpp>
 #include <migraphx/optimize_module.hpp>
+#include <migraphx/output_iterator.hpp>
 #include <migraphx/preallocate_param.hpp>
 #include <migraphx/promote_literals.hpp>
 #include <migraphx/propagate_precision.hpp>
@@ -93,114 +94,176 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_CK)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_SET_GEMM_PROVIDER)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_FULL_DYNAMIC)
 
+namespace {
+struct pipeline_factory
+{
+    migraphx::context* gctx_ptr = nullptr;
+    compile_options options;
+
+    migraphx::context* get_generic_context()
+    {
+        return gctx_ptr;
+    }
+
+    context* get_context()
+    {
+        return any_cast<context>(gctx_ptr);
+    }
+
+    std::vector<pass> dynamic_shapes_pipeline()
+    {
+        return
+        {
+            enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), split_single_dyn_dim{}),
+            dead_code_elimination{},
+            simplify_dyn_ops{},
+            dead_code_elimination{},
+        };
+    }
+
+    std::vector<pass> required_pipeline()
+    {
+        return
+        {
+            normalize_ops{},
+            dead_code_elimination{},
+            eliminate_identity{},
+            dead_code_elimination{},
+            enable_pass(not gpu::gfx_has_fp8ocp_intrinsics() and gpu::gfx_has_fp8fnuz_intrinsics(), fp8_ocp_to_fnuz{}),
+            enable_pass(not gpu::gfx_has_fp8ocp_intrinsics() and gpu::gfx_has_fp8fnuz_intrinsics(), dead_code_elimination{}),
+            simplify_qdq{.use_mx_quant=gpu::gfx_has_mx_intrinsics()},
+            enable_pass(not mlir_enabled(), rewrite_quantization{}),
+            dead_code_elimination{},
+            rewrite_rnn{},
+            dead_code_elimination{},
+            eliminate_data_type_for_gpu{.disable_64bit = options.fast_math},
+            rewrite_resize{.affine_only = true},
+            dead_code_elimination{},
+            simplify_reshapes{.enable_gather_rewrite = true},
+            eliminate_identity{},
+            eliminate_pad{},
+            dead_code_elimination{},
+            insert_pad{{"convolution"}},
+            dead_code_elimination{},
+            inline_module{},
+            enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), rewrite_pooling{.rewrite_lrn = (not MIGRAPHX_USE_MIOPEN or enabled(MIGRAPHX_REWRITE_LRN{}))}),
+            dead_code_elimination{},
+        };
+    }
+
+    std::vector<pass> optimize_rewrite_pipeline()
+    {
+        return
+        {
+            rewrite_gelu{options.fast_math},
+            optimize_module{},
+            layout_convolution{.channels_last = enabled(MIGRAPHX_ENABLE_NHWC{})},
+            dead_code_elimination{},
+            enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), fuse_horizontal{}),
+            dead_code_elimination{},
+            prefuse_ops{get_context()},
+            dead_code_elimination{},
+            dead_code_elimination{},
+            rewrite_reduce{},
+            rewrite_topk{},
+            rewrite_low_precision{},
+            enable_pass(enabled(MIGRAPHX_ENABLE_REWRITE_DOT{}), rewrite_dot{}),
+            dead_code_elimination{},
+            propagate_precision{},
+            dead_code_elimination{},
+            simplify_reshapes{.enable_op_shape_transform_op=true},
+            dead_code_elimination{},
+        };
+    }
+    
+    std::vector<pass> fusion_pipeline()
+    {
+        return
+        {
+            enable_pass(mlir_enabled(), fuse_attention{.attn_enabled = mlir_attention_enabled(get_context()),
+                                                   .flash_decoding_enabled = mlir_flash_decoding_enabled()}),
+            dead_code_elimination{},
+            optimize_module{},
+            fuse_pointwise_reduce{},
+            dead_code_elimination{},
+#ifndef _WIN32
+            enable_pass(enabled(MIGRAPHX_ENABLE_CK{}), fuse_ck{}),
+#endif
+            dead_code_elimination{},
+            enable_pass(mlir_enabled(), fuse_mlir{get_context()}),
+            dead_code_elimination{},
+            fuse_concat{},
+            dead_code_elimination{},
+        };
+    }
+
+    std::vector<pass> backend_pipeline()
+    {
+        return
+        {
+            auto_contiguous{},
+            dead_code_elimination{},
+            lowering{get_context(), options.offload_copy},
+            eliminate_contiguous{"gpu::contiguous"},
+            dead_code_elimination{},
+            adjust_allocation{gpu_allocation_model{.use_hip_allocate = false}},
+            dead_code_elimination{},
+            eliminate_concat{concat_gpu_optimization{}},
+            dead_code_elimination{},
+#if MIGRAPHX_USE_MIOPEN
+            compile_miopen{get_generic_context()},
+            dead_code_elimination{},
+#endif
+            fuse_ops{get_context(), options.fast_math},
+            dead_code_elimination{},
+#if MIGRAPHX_USE_HIPBLASLT
+            compile_hipblaslt{get_generic_context()},
+            dead_code_elimination{},
+#endif
+            replace_allocate{gpu_allocation_model{}, options.offload_copy},
+            dead_code_elimination{},
+            adjust_allocation{gpu_allocation_model{}},
+            dead_code_elimination{},
+            compile_ops{get_context(), options.exhaustive_tune},
+            dead_code_elimination{},
+            promote_literals{},
+            dead_code_elimination{},
+            write_literals{get_context()},
+            schedule{gpu::schedule_model{get_context()->get_current_device().nstreams()}, not enabled(MIGRAPHX_DISABLE_SCHEDULE_PASS{})},
+            memory_coloring{"hip::allocate"},
+            sync_device{},
+            preallocate_param{"scratch", gpu_allocation_model{}},
+            dead_code_elimination{},
+            eliminate_allocation{"hip::allocate"},
+            check_context<context>{},
+            normalize_ops{},
+            dead_code_elimination{},
+            eliminate_identity{},
+        };
+    }
+};
+}
+
 std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_options& options) const
 {
     auto& ctx = any_cast<context>(gctx);
     ctx.set_exhaustive_tune_flag(options.exhaustive_tune);
     ctx.load_problem_cache();
 
-    // clang-format off
-    return
+    pipeline_factory p{&gctx, options};
+
+    std::vector<std::vector<pass>> pipelines = 
     {
-        enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), split_single_dyn_dim{}),
-        dead_code_elimination{},
-        simplify_dyn_ops{},
-        dead_code_elimination{},
-        normalize_ops{},
-        dead_code_elimination{},
-        eliminate_identity{},
-        dead_code_elimination{},
-        enable_pass(not gpu::gfx_has_fp8ocp_intrinsics() and gpu::gfx_has_fp8fnuz_intrinsics(), fp8_ocp_to_fnuz{}),
-        enable_pass(not gpu::gfx_has_fp8ocp_intrinsics() and gpu::gfx_has_fp8fnuz_intrinsics(), dead_code_elimination{}),
-        simplify_qdq{.use_mx_quant=gpu::gfx_has_mx_intrinsics()},
-        enable_pass(not mlir_enabled(), rewrite_quantization{}),
-        dead_code_elimination{},
-        rewrite_rnn{},
-        dead_code_elimination{},
-        eliminate_data_type_for_gpu{.disable_64bit = options.fast_math},
-        rewrite_resize{.affine_only = true},
-        dead_code_elimination{},
-        simplify_reshapes{.enable_gather_rewrite = true},
-        eliminate_identity{},
-        eliminate_pad{},
-        dead_code_elimination{},
-        insert_pad{{"convolution"}},
-        dead_code_elimination{},
-        inline_module{},
-        enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), rewrite_pooling{.rewrite_lrn = (not MIGRAPHX_USE_MIOPEN or enabled(MIGRAPHX_REWRITE_LRN{}))}),
-        dead_code_elimination{},
-        rewrite_gelu{options.fast_math},
-        optimize_module{},
-        layout_convolution{.channels_last = enabled(MIGRAPHX_ENABLE_NHWC{})},
-        dead_code_elimination{},
-        enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), fuse_horizontal{}),
-        dead_code_elimination{},
-        prefuse_ops{&ctx},
-        dead_code_elimination{},
-        dead_code_elimination{},
-        rewrite_reduce{},
-        rewrite_topk{},
-        rewrite_low_precision{},
-        enable_pass(enabled(MIGRAPHX_ENABLE_REWRITE_DOT{}), rewrite_dot{}),
-        dead_code_elimination{},
-        propagate_precision{},
-        dead_code_elimination{},
-        simplify_reshapes{.enable_op_shape_transform_op=true},
-        dead_code_elimination{},
-        enable_pass(mlir_enabled(), fuse_attention{.attn_enabled = mlir_attention_enabled(&ctx),
-                                                   .flash_decoding_enabled = mlir_flash_decoding_enabled()}),
-        dead_code_elimination{},
-        optimize_module{},
-        fuse_pointwise_reduce{},
-        dead_code_elimination{},
-#ifndef _WIN32
-        enable_pass(enabled(MIGRAPHX_ENABLE_CK{}), fuse_ck{}),
-#endif
-        dead_code_elimination{},
-        enable_pass(mlir_enabled(), fuse_mlir{&ctx}),
-        dead_code_elimination{},
-        fuse_concat{},
-        dead_code_elimination{},
-        auto_contiguous{},
-        dead_code_elimination{},
-        lowering{&ctx, options.offload_copy},
-        eliminate_contiguous{"gpu::contiguous"},
-        dead_code_elimination{},
-        adjust_allocation{gpu_allocation_model{.use_hip_allocate = false}},
-        dead_code_elimination{},
-        eliminate_concat{concat_gpu_optimization{}},
-        dead_code_elimination{},
-#if MIGRAPHX_USE_MIOPEN
-        compile_miopen{&gctx},
-        dead_code_elimination{},
-#endif
-        fuse_ops{&ctx, options.fast_math},
-        dead_code_elimination{},
-#if MIGRAPHX_USE_HIPBLASLT
-        compile_hipblaslt{&gctx},
-        dead_code_elimination{},
-#endif
-        replace_allocate{gpu_allocation_model{}, options.offload_copy},
-        dead_code_elimination{},
-        adjust_allocation{gpu_allocation_model{}},
-        dead_code_elimination{},
-        compile_ops{&ctx, options.exhaustive_tune},
-        dead_code_elimination{},
-        promote_literals{},
-        dead_code_elimination{},
-        write_literals{&ctx},
-        schedule{gpu::schedule_model{ctx.get_current_device().nstreams()}, not enabled(MIGRAPHX_DISABLE_SCHEDULE_PASS{})},
-        memory_coloring{"hip::allocate"},
-        sync_device{},
-        preallocate_param{"scratch", gpu_allocation_model{}},
-        dead_code_elimination{},
-        eliminate_allocation{"hip::allocate"},
-        check_context<context>{},
-        normalize_ops{},
-        dead_code_elimination{},
-        eliminate_identity{}
+        p.dynamic_shapes_pipeline(),
+        p.required_pipeline(),
+        p.optimize_rewrite_pipeline(),
+        p.fusion_pipeline(),
+        p.backend_pipeline(),
     };
-    // clang-format on
+
+    std::vector<pass> passes;
+    std::copy(pipelines.begin(), pipelines.end(), join_back_inserter(passes));
+    return passes;
 }
 
 std::string target::name() const { return "gpu"; }

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -100,11 +100,11 @@ struct pipeline_factory
     migraphx::context* gctx_ptr = nullptr;
     compile_options options;
 
-    migraphx::context* get_generic_context() { return gctx_ptr; }
+    migraphx::context* get_generic_context() const { return gctx_ptr; }
 
-    context* get_context() { return any_cast<context>(gctx_ptr); }
+    context* get_context() const { return any_cast<context>(gctx_ptr); }
 
-    std::vector<pass> dynamic_shapes_pipeline()
+    std::vector<pass> dynamic_shapes_pipeline() const
     {
         return {
             enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), split_single_dyn_dim{}),
@@ -114,7 +114,7 @@ struct pipeline_factory
         };
     }
 
-    std::vector<pass> required_pipeline()
+    std::vector<pass> required_pipeline() const
     {
         return {
             normalize_ops{},
@@ -147,7 +147,7 @@ struct pipeline_factory
         };
     }
 
-    std::vector<pass> optimize_rewrite_pipeline()
+    std::vector<pass> optimize_rewrite_pipeline() const
     {
         return {
             rewrite_gelu{options.fast_math},
@@ -171,7 +171,7 @@ struct pipeline_factory
         };
     }
 
-    std::vector<pass> fusion_pipeline()
+    std::vector<pass> fusion_pipeline() const
     {
         return {
             enable_pass(mlir_enabled(),
@@ -192,7 +192,7 @@ struct pipeline_factory
         };
     }
 
-    std::vector<pass> backend_pipeline()
+    std::vector<pass> backend_pipeline() const
     {
         return {
             auto_contiguous{},

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -100,6 +100,7 @@ struct pipeline_factory
     migraphx::context* gctx_ptr = nullptr;
     compile_options options;
 
+    // cppcheck-suppress CastIntegerToAddressAtReturn
     migraphx::context* get_generic_context() const { return gctx_ptr; }
 
     context* get_context() const { return any_cast<context>(gctx_ptr); }

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -100,20 +100,13 @@ struct pipeline_factory
     migraphx::context* gctx_ptr = nullptr;
     compile_options options;
 
-    migraphx::context* get_generic_context()
-    {
-        return gctx_ptr;
-    }
+    migraphx::context* get_generic_context() { return gctx_ptr; }
 
-    context* get_context()
-    {
-        return any_cast<context>(gctx_ptr);
-    }
+    context* get_context() { return any_cast<context>(gctx_ptr); }
 
     std::vector<pass> dynamic_shapes_pipeline()
     {
-        return
-        {
+        return {
             enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), split_single_dyn_dim{}),
             dead_code_elimination{},
             simplify_dyn_ops{},
@@ -123,15 +116,16 @@ struct pipeline_factory
 
     std::vector<pass> required_pipeline()
     {
-        return
-        {
+        return {
             normalize_ops{},
             dead_code_elimination{},
             eliminate_identity{},
             dead_code_elimination{},
-            enable_pass(not gpu::gfx_has_fp8ocp_intrinsics() and gpu::gfx_has_fp8fnuz_intrinsics(), fp8_ocp_to_fnuz{}),
-            enable_pass(not gpu::gfx_has_fp8ocp_intrinsics() and gpu::gfx_has_fp8fnuz_intrinsics(), dead_code_elimination{}),
-            simplify_qdq{.use_mx_quant=gpu::gfx_has_mx_intrinsics()},
+            enable_pass(not gpu::gfx_has_fp8ocp_intrinsics() and gpu::gfx_has_fp8fnuz_intrinsics(),
+                        fp8_ocp_to_fnuz{}),
+            enable_pass(not gpu::gfx_has_fp8ocp_intrinsics() and gpu::gfx_has_fp8fnuz_intrinsics(),
+                        dead_code_elimination{}),
+            simplify_qdq{.use_mx_quant = gpu::gfx_has_mx_intrinsics()},
             enable_pass(not mlir_enabled(), rewrite_quantization{}),
             dead_code_elimination{},
             rewrite_rnn{},
@@ -146,15 +140,16 @@ struct pipeline_factory
             insert_pad{{"convolution"}},
             dead_code_elimination{},
             inline_module{},
-            enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), rewrite_pooling{.rewrite_lrn = (not MIGRAPHX_USE_MIOPEN or enabled(MIGRAPHX_REWRITE_LRN{}))}),
+            enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}),
+                        rewrite_pooling{.rewrite_lrn = (not MIGRAPHX_USE_MIOPEN or
+                                                        enabled(MIGRAPHX_REWRITE_LRN{}))}),
             dead_code_elimination{},
         };
     }
 
     std::vector<pass> optimize_rewrite_pipeline()
     {
-        return
-        {
+        return {
             rewrite_gelu{options.fast_math},
             optimize_module{},
             layout_convolution{.channels_last = enabled(MIGRAPHX_ENABLE_NHWC{})},
@@ -171,17 +166,17 @@ struct pipeline_factory
             dead_code_elimination{},
             propagate_precision{},
             dead_code_elimination{},
-            simplify_reshapes{.enable_op_shape_transform_op=true},
+            simplify_reshapes{.enable_op_shape_transform_op = true},
             dead_code_elimination{},
         };
     }
-    
+
     std::vector<pass> fusion_pipeline()
     {
-        return
-        {
-            enable_pass(mlir_enabled(), fuse_attention{.attn_enabled = mlir_attention_enabled(get_context()),
-                                                   .flash_decoding_enabled = mlir_flash_decoding_enabled()}),
+        return {
+            enable_pass(mlir_enabled(),
+                        fuse_attention{.attn_enabled = mlir_attention_enabled(get_context()),
+                                       .flash_decoding_enabled = mlir_flash_decoding_enabled()}),
             dead_code_elimination{},
             optimize_module{},
             fuse_pointwise_reduce{},
@@ -199,8 +194,7 @@ struct pipeline_factory
 
     std::vector<pass> backend_pipeline()
     {
-        return
-        {
+        return {
             auto_contiguous{},
             dead_code_elimination{},
             lowering{get_context(), options.offload_copy},
@@ -229,7 +223,8 @@ struct pipeline_factory
             promote_literals{},
             dead_code_elimination{},
             write_literals{get_context()},
-            schedule{gpu::schedule_model{get_context()->get_current_device().nstreams()}, not enabled(MIGRAPHX_DISABLE_SCHEDULE_PASS{})},
+            schedule{gpu::schedule_model{get_context()->get_current_device().nstreams()},
+                     not enabled(MIGRAPHX_DISABLE_SCHEDULE_PASS{})},
             memory_coloring{"hip::allocate"},
             sync_device{},
             preallocate_param{"scratch", gpu_allocation_model{}},
@@ -242,7 +237,7 @@ struct pipeline_factory
         };
     }
 };
-}
+} // namespace
 
 std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_options& options) const
 {
@@ -252,8 +247,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
 
     pipeline_factory p{&gctx, options};
 
-    std::vector<std::vector<pass>> pipelines = 
-    {
+    std::vector<std::vector<pass>> pipelines = {
         p.dynamic_shapes_pipeline(),
         p.required_pipeline(),
         p.optimize_rewrite_pipeline(),

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -100,9 +100,9 @@ struct pipeline_factory
     migraphx::context* gctx_ptr = nullptr;
     compile_options options;
 
-    // cppcheck-suppress CastIntegerToAddressAtReturn
     migraphx::context* get_generic_context() const { return gctx_ptr; }
 
+    // cppcheck-suppress CastIntegerToAddressAtReturn
     context* get_context() const { return any_cast<context>(gctx_ptr); }
 
     std::vector<pass> dynamic_shapes_pipeline() const


### PR DESCRIPTION
## Motivation
This will make it easier to use to change the passes needed for different compilation modes.

## Technical Details
None of the passes are changed here. In the future we could look at moving some of the passes around to put into another pipeline that makes more sense. 

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
