### PR TITLE
docs: document debug CMake builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@ Once completed, all prerequisites are in the `depend` folder and MIGraphX is in 
 
     Otherwise, you need to set `-DCMAKE_PREFIX_PATH=$your_loc` to configure CMake.
 
+    The default build type is `Release`. To build MIGraphX in debug mode, pass
+    `-DCMAKE_BUILD_TYPE=Debug` when configuring CMake:
+
+    ```bash
+    CXX=/opt/rocm/llvm/bin/clang++ cmake .. \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DGPU_TARGETS=$(/opt/rocm/bin/rocminfo | grep -o -m1 'gfx.*')
+    ```
+
+    For optimized binaries with debug symbols, use `-DCMAKE_BUILD_TYPE=RelWithDebInfo`.
+
 5. Build MIGraphX source code:
 
     ```cpp


### PR DESCRIPTION
﻿## Motivation
README source-build instructions document the default CMake flow, but they do not show how to build MIGraphX in debug mode even though the project defaults `CMAKE_BUILD_TYPE` to `Release`. This addresses the missing debug-build guidance requested in #958.

## Technical Details
- Document `-DCMAKE_BUILD_TYPE=Debug` in the CMake build section.
- Mention `RelWithDebInfo` for optimized builds that still include debug symbols.

Why this adds value: developers can now configure debug or debug-symbol builds without reading `CMakeLists.txt` or guessing the supported CMake build types.

Validation performed:
- `git diff --check`

Documentation updated:
- `README.md`

Checks not run:
- Full MIGraphX build and docs build, because this environment does not have the ROCm build dependencies required by the project.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.

Closes #958
