### PR TITLE
Reduce dynamic-shape compile cost and select_module dispatch overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Full documentation for MIGraphX is available at
 * Added GPU kernel for ONNX `NonMaxSuppression` operation and redesigned the `nonmaxsuppression` operation to better represent the data-dependent output shape in the MIGraphX IR (#4893).
 * Added mixed length gather fusion in same_table_gather_horizontal_fusion to bundle gather kernels that share the same data (#5044).
 
+* `split_single_dyn_dim` gains a `bucket_by_optimals` field: when true and `dynamic_dimension::optimals` is non-empty, emit one submodule per (min, optimals..., max) instead of one per integer in `[min, max]` (O(|optimals|) vs O(max-min) compile cost / engine size). `select_module::compute()` always falls back to the smallest compatible bucket on a non-exact runtime shape (ref pads on host, GPU callers pre-pad). GPU/Ref targets read `MIGRAPHX_DYN_DIM_BUCKET_BY_OPTIMALS` once and forward it to the pass field; see `docs/reference/MIGraphX-dev-env-vars.rst`.
+* `select_module::compute()` adds a per-instance dispatch cache that skips the submodule scan and parameter-name / shape allocations on repeated calls with the same input-shape signature.
 
 ### Changed
 

--- a/docs/reference/MIGraphX-dev-env-vars.rst
+++ b/docs/reference/MIGraphX-dev-env-vars.rst
@@ -93,6 +93,23 @@ Model performance tunable variables change the compilation behavior of a model. 
 
       | Default: Layernorm fusion is not used.
 
+  * - | ``MIGRAPHX_DYN_DIM_BUCKET_BY_OPTIMALS``
+      | * Switches ``split_single_dyn_dim`` to bucket mode: emit
+      |   one submodule per ``dynamic_dimension::optimals`` value
+      |   (plus the ``min`` / ``max`` endpoints), instead of one
+      |   per integer in ``[min, max]``.  O(|optimals|) compile
+      |   cost.
+      | * Read once per compile in the GPU/Ref target and forwarded
+      |   as the ``split_single_dyn_dim::bucket_by_optimals``
+      |   pass field; tests use the field directly.
+      | * ``select_module::compute()`` always falls back to the
+      |   smallest compatible bucket when no exact submodule
+      |   matches the runtime shape, independent of this env var.
+      |   Ref pads on host; GPU callers pre-pad.
+
+    - | ``1``: bucket mode.
+      | ``0`` or unset: legacy enumerate mode (default).
+
   * - | ``MIGRAPHX_ENABLE_MIOPEN_POOLING``
       | When set, MIOpen pooling is used instead of MIGraphX pooling.
       

--- a/src/include/migraphx/op/select_module.hpp
+++ b/src/include/migraphx/op/select_module.hpp
@@ -24,16 +24,110 @@
 #ifndef MIGRAPHX_GUARD_OPERATORS_SELECT_MODULE_HPP
 #define MIGRAPHX_GUARD_OPERATORS_SELECT_MODULE_HPP
 
+#include <migraphx/argument.hpp>
 #include <migraphx/check_shapes.hpp>
+#include <migraphx/env.hpp>
 #include <migraphx/module.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace op {
 
+// Dispatch-cache key: hash of (type, lens) for each arg shape.
+// Strides excluded so strided views still hit.
+inline std::size_t hash_arg_shapes(const std::vector<argument>& args)
+{
+    // NOLINTBEGIN(hicpp-signed-bitwise)
+    std::uint64_t h               = 0xcbf29ce484222325ULL;
+    constexpr std::uint64_t prime = 0x100000001b3ULL;
+    for(const auto& a : args)
+    {
+        const auto& s = a.get_shape();
+        h ^= static_cast<std::uint64_t>(static_cast<unsigned int>(s.type()));
+        h *= prime;
+        for(auto l : s.lens())
+        {
+            h ^= static_cast<std::uint64_t>(l) + 0x9e3779b97f4a7c15ULL + (h << 6U) + (h >> 2U);
+        }
+    }
+    return static_cast<std::size_t>(h);
+    // NOLINTEND(hicpp-signed-bitwise)
+}
+
+// Smallest-bucket fallback for runtime dispatch.
+//   compatible: same type+rank, lens >= input lens (componentwise).
+//   winner:     compatible submodule with smallest total element count.
+// Returns end() if no compatible submodule exists.
+inline std::vector<module_ref>::const_iterator find_smallest_compatible_submodule(
+    const std::vector<module_ref>& submodule_list,
+    const std::vector<argument>& args,
+    const std::function<std::vector<std::string>(module_ref)>& get_input_parameter_names_fn)
+{
+    auto best              = submodule_list.cend();
+    std::size_t best_score = 0;
+    for(auto it = submodule_list.cbegin(); it != submodule_list.cend(); ++it)
+    {
+        auto in_param_names = get_input_parameter_names_fn(*it);
+        if(in_param_names.size() > args.size())
+            continue;
+        auto param_shapes = (*it)->get_parameter_shapes();
+        bool compatible   = true;
+        std::size_t score = 1;
+        for(std::size_t i = 0; i < in_param_names.size(); ++i)
+        {
+            const auto& a  = args[i];
+            const auto& ps = param_shapes.at(in_param_names[i]);
+            if(ps.type() != a.get_shape().type() or ps.lens().size() != a.get_shape().lens().size())
+            {
+                compatible = false;
+                break;
+            }
+            for(std::size_t d = 0; d < ps.lens().size(); ++d)
+            {
+                if(ps.lens()[d] < a.get_shape().lens()[d])
+                {
+                    compatible = false;
+                    break;
+                }
+                score *= ps.lens()[d];
+            }
+            if(not compatible)
+                break;
+        }
+        if(compatible and (best == submodule_list.cend() or score < best_score))
+        {
+            best       = it;
+            best_score = score;
+        }
+    }
+    return best;
+}
+
 struct select_module
 {
     shape output_dyn_shapes;
+
+    // Per-instance dispatch cache (compute() hot-path fast lane).
+    // On a hit we skip the find_if scan and the name/shape lookup
+    // allocations.  `mutable` because compute() is const; not
+    // thread-safe -- the runtime does not call compute() on the same
+    // op instance concurrently.
+    struct dispatch_cache_t
+    {
+        bool valid               = false;
+        std::size_t shape_hash   = 0;
+        std::size_t module_index = static_cast<std::size_t>(-1);
+        std::vector<std::string> in_names;
+        std::vector<std::string> out_names;
+        std::vector<shape> in_param_shapes; // ordered, indexed by i
+        std::unordered_map<std::string, shape> out_param_shapes;
+        bool needs_input_pad = false; // bucket-dispatch input shape != bucket shape
+    };
+    mutable dispatch_cache_t dispatch_cache;
 
     template <class Self, class F>
     static auto reflect(Self& self, F f)
@@ -80,9 +174,16 @@ struct select_module
                      const std::function<std::vector<argument>(
                          module_ref&, const std::unordered_map<std::string, argument>&)>& run) const
     {
-        // Find submodule with input parameter shapes exactly the same as the input instruction
-        // arguments. Assuming instruction arguments are in the same order as the instruction
-        // parameters.
+        // Fast path: cached dispatch for the same input-shape signature.
+        const auto h = hash_arg_shapes(args);
+        if(dispatch_cache.valid and dispatch_cache.shape_hash == h and
+           dispatch_cache.module_index < submodule_list.size())
+        {
+            return compute_with_cache(args, submodule_list, run);
+        }
+
+        // Slow path: full dispatch then populate cache.
+        // 1) Exact-shape match.
         auto module_iter =
             std::find_if(submodule_list.cbegin(), submodule_list.cend(), [&](module_ref mr) {
                 auto in_param_names = get_input_parameter_names(mr);
@@ -96,44 +197,103 @@ struct select_module
                                   });
             });
 
+        // 2) Smallest-bucket fallback. Whether buckets exist is a
+        //    compile-time decision (split_single_dyn_dim{.bucket_by_optimals}).
+        //    Ref pads on the host; GPU callers pre-pad.
+        bool bucket_dispatch = false;
+        if(module_iter == submodule_list.end())
+        {
+            module_iter =
+                find_smallest_compatible_submodule(submodule_list, args, [this](module_ref mr) {
+                    return this->get_input_parameter_names(mr);
+                });
+            bucket_dispatch = (module_iter != submodule_list.end());
+        }
+
         if(module_iter == submodule_list.end())
         {
             MIGRAPHX_THROW("SELECT_MODULE: no compatible submodules found for given input shapes");
         }
 
-        auto* module_to_run = *module_iter;
+        auto* module_to_run   = *module_iter;
+        auto in_param_names   = get_input_parameter_names(module_to_run);
+        auto out_param_names  = get_output_parameter_names(module_to_run);
+        auto param_shapes_map = module_to_run->get_parameter_shapes();
+
+        // Populate cache (success path only).
+        dispatch_cache.shape_hash = h;
+        dispatch_cache.module_index =
+            static_cast<std::size_t>(std::distance(submodule_list.cbegin(), module_iter));
+        dispatch_cache.in_names  = in_param_names;
+        dispatch_cache.out_names = out_param_names;
+        dispatch_cache.in_param_shapes.clear();
+        dispatch_cache.in_param_shapes.reserve(in_param_names.size());
+        for(const auto& name : in_param_names)
+            dispatch_cache.in_param_shapes.push_back(param_shapes_map.at(name));
+        dispatch_cache.out_param_shapes = std::move(param_shapes_map);
+        dispatch_cache.needs_input_pad  = bucket_dispatch;
+        dispatch_cache.valid            = true;
+
+        return compute_with_cache(args, submodule_list, run);
+    }
+
+    // Shared body used by both the cache-hit and post-populate paths.
+    argument compute_with_cache(
+        const std::vector<argument>& args,
+        const std::vector<module_ref>& submodule_list,
+        const std::function<std::vector<argument>(
+            module_ref&, const std::unordered_map<std::string, argument>&)>& run) const
+    {
+        auto* module_to_run = submodule_list[dispatch_cache.module_index];
         std::unordered_map<std::string, argument> p_map;
+        p_map.reserve(dispatch_cache.in_names.size() + dispatch_cache.out_names.size());
 
-        // add input parameters to parameter_map
-        auto in_param_names = get_input_parameter_names(module_to_run);
-        assert(in_param_names.size() <= args.size());
-        std::transform(in_param_names.begin(),
-                       in_param_names.end(),
-                       args.begin(),
-                       std::inserter(p_map, p_map.end()),
-                       [&](auto&& name, auto&& a) { return std::make_pair(name, a); });
+        // Inputs: pad on host when dispatching to a larger bucket.
+        if(dispatch_cache.needs_input_pad)
+        {
+            for(std::size_t i = 0; i < dispatch_cache.in_names.size(); ++i)
+            {
+                const auto& name = dispatch_cache.in_names[i];
+                const auto& a    = args[i];
+                const auto& ps   = dispatch_cache.in_param_shapes[i];
+                if(a.get_shape() == ps)
+                {
+                    p_map.emplace(name, a);
+                }
+                else
+                {
+                    argument padded{ps};
+                    std::memset(padded.data(), 0, ps.bytes());
+                    std::memcpy(padded.data(), a.data(), a.get_shape().bytes());
+                    p_map.emplace(name, std::move(padded));
+                }
+            }
+        }
+        else
+        {
+            for(std::size_t i = 0; i < dispatch_cache.in_names.size(); ++i)
+                p_map.emplace(dispatch_cache.in_names[i], args[i]);
+        }
 
-        // One tuple output parameter in main module to multiple output parameters in submodule
-        auto out_param_names    = get_output_parameter_names(module_to_run);
-        auto param_shapes       = module_to_run->get_parameter_shapes();
+        // Outputs: reshape the pre-allocated tuple buffer to submodule shapes.
         auto output_sub_objects = args.back().get_sub_objects();
-        assert(out_param_names.size() == output_sub_objects.size());
-        std::transform(out_param_names.begin(),
-                       out_param_names.end(),
-                       output_sub_objects.begin(),
-                       std::inserter(p_map, p_map.end()),
-                       [&](auto&& name, auto&& a) {
-                           auto ps = param_shapes.at(name);
-                           if(a.get_shape() != ps)
-                           {
-                               assert(ps.bytes() <= a.get_shape().bytes());
-                               return std::make_pair(name, a.reshape(ps));
-                           }
-                           else
-                           {
-                               return std::make_pair(name, a);
-                           }
-                       });
+        assert(dispatch_cache.out_names.size() == output_sub_objects.size());
+        for(std::size_t i = 0; i < dispatch_cache.out_names.size(); ++i)
+        {
+            const auto& name = dispatch_cache.out_names[i];
+            const auto& a    = output_sub_objects[i];
+            const auto& ps   = dispatch_cache.out_param_shapes.at(name);
+            if(a.get_shape() != ps)
+            {
+                assert(ps.bytes() <= a.get_shape().bytes());
+                p_map.emplace(name, a.reshape(ps));
+            }
+            else
+            {
+                p_map.emplace(name, a);
+            }
+        }
+
         auto results = run(module_to_run, p_map);
         return argument{results};
     }

--- a/src/include/migraphx/split_single_dyn_dim.hpp
+++ b/src/include/migraphx/split_single_dyn_dim.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,7 @@
 #include <migraphx/pass_manager.hpp>
 #include <migraphx/instruction_ref.hpp>
 #include <migraphx/config.hpp>
+#include <migraphx/functional.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -38,6 +39,18 @@ inline namespace MIGRAPHX_INLINE_NS {
  */
 struct MIGRAPHX_EXPORT split_single_dyn_dim
 {
+    /// If true, emit one submodule per `dynamic_dimension::optimals`
+    /// value plus the min/max endpoints, instead of one per integer in
+    /// [min, max].  O(|optimals|) compile cost; runtime falls back to
+    /// smallest compatible bucket.  Off by default (backward compat).
+    bool bucket_by_optimals = false;
+
+    template <class Self, class F>
+    static auto reflect(Self& self, F f)
+    {
+        return migraphx::pack(f(self.bucket_by_optimals, "bucket_by_optimals"));
+    }
+
     std::string name() const { return "split_single_dyn_dim"; }
     void apply(module_pass_manager&) const;
 };

--- a/src/split_single_dyn_dim.cpp
+++ b/src/split_single_dyn_dim.cpp
@@ -23,12 +23,14 @@
  */
 
 #include <migraphx/split_single_dyn_dim.hpp>
+#include <migraphx/env.hpp>
 #include <migraphx/module.hpp>
 #include <migraphx/pass_manager.hpp>
 #include <migraphx/functional.hpp>
 #include <migraphx/make_op.hpp>
 #include <migraphx/ranges.hpp>
 #include <migraphx/matcher.hpp>
+#include <set>
 #include <utility>
 
 namespace migraphx {
@@ -129,7 +131,35 @@ void split_single_dyn_dim::apply(module_pass_manager& mpm) const
         // create submodules for each dimension size
         std::vector<module_ref> submodules;
         auto dim_interval = dyn_dim.get_interval();
-        for(size_t dim_size : migraphx::range(dim_interval.min, dim_interval.max + 1))
+
+        // Pick the dim sizes to specialise for:
+        //   * default      -> every integer in [min, max]      (legacy)
+        //   * bucket mode  -> min, max, and user-supplied optimals
+        // Bucket mode requires both `bucket_by_optimals=true` and a
+        // non-empty `optimals` set; otherwise we fall back to legacy.
+        // See select_module.hpp for the runtime side.
+        std::set<std::size_t> dim_sizes;
+        auto dim_optimals      = dyn_dim.get_optimals();
+        const bool use_buckets = this->bucket_by_optimals and not dim_optimals.empty();
+        if(use_buckets)
+        {
+            // Always include endpoints so every in-range input has a bucket.
+            dim_sizes.insert(dim_interval.min);
+            dim_sizes.insert(dim_interval.max);
+            // Drop optimals outside [min, max] (would be unreachable).
+            for(std::size_t opt : dim_optimals)
+            {
+                if(opt >= dim_interval.min and opt <= dim_interval.max)
+                    dim_sizes.insert(opt);
+            }
+        }
+        else
+        {
+            for(std::size_t n : migraphx::range(dim_interval.min, dim_interval.max + 1))
+                dim_sizes.insert(n);
+        }
+
+        for(std::size_t dim_size : dim_sizes)
         {
             auto* submod = mpm.create_module("dim_" + std::to_string(dim_size));
             // instruction map for new static shaped submodule parameters

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -98,6 +98,7 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_CK)
 #endif
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_SET_GEMM_PROVIDER)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_FULL_DYNAMIC)
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_DYN_DIM_BUCKET_BY_OPTIMALS)
 
 namespace {
 // Backend options recognized by the GPU target, supplied via
@@ -127,7 +128,9 @@ struct pipeline_factory
     std::vector<pass> dynamic_shapes_pipeline() const
     {
         return {
-            enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), split_single_dyn_dim{}),
+            enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}),
+                        split_single_dyn_dim{.bucket_by_optimals =
+                                                 enabled(MIGRAPHX_DYN_DIM_BUCKET_BY_OPTIMALS{})}),
             dead_code_elimination{},
             simplify_dyn_ops{},
             dead_code_elimination{},

--- a/src/targets/ref/target.cpp
+++ b/src/targets/ref/target.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/ref/select_module.cpp
+++ b/test/ref/select_module.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,13 +29,15 @@
 #include <migraphx/verify.hpp>
 
 #include <test.hpp>
+#include <algorithm>
+#include <cmath>
 
 TEST_CASE(select_module_add_test)
 {
     migraphx::program p;
     auto* mm = p.get_main_module();
     migraphx::shape lit_s{migraphx::shape{migraphx::shape::float_type, {1}}};
-    auto literal_ins = mm->add_literal(migraphx::literal{lit_s, {6}});
+    auto literal_ins = mm->add_literal(migraphx::literal{lit_s, {6.0f}});
 
     // create batch submodules
     auto create_submodule = [&](std::size_t batch_size, const std::string& module_name) {
@@ -73,7 +75,7 @@ TEST_CASE(select_module_add_test)
     auto result    = p.eval(params).back();
     std::vector<float> results_vector;
     result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
-    std::vector<float> gold{2, 14, 5, 10, 5, 14, 14, 2};
+    std::vector<float> gold{2.0f, 14.0f, 5.0f, 10.0f, 5.0f, 14.0f, 14.0f, 2.0f};
     EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
 }
 
@@ -210,4 +212,183 @@ TEST_CASE(select_module_not_found_error)
     migraphx::shape input_fixed_shape{migraphx::shape::float_type, {5, 2, 2}};
     params["data"] = migraphx::argument(input_fixed_shape, input_data.data());
     EXPECT(test::throws([&] { std::ignore = p.eval(params).back(); }));
+}
+
+// Build a program: one static submodule (data+6) per `bucket_sizes`,
+// dispatched via select_module over the dynamic input shape.
+static migraphx::program make_select_module_add_program(
+    const std::vector<std::size_t>& bucket_sizes, std::size_t dyn_min, std::size_t dyn_max)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape lit_s{migraphx::shape{migraphx::shape::float_type, {1}}};
+    auto literal_ins = mm->add_literal(migraphx::literal{lit_s, {6.0f}});
+
+    auto create_submodule = [&](std::size_t batch_size, const std::string& module_name) {
+        auto* submod = p.create_module(module_name);
+        migraphx::shape sm_shape{migraphx::shape::float_type, {batch_size, 4}};
+        auto sm_input = submod->add_parameter("data", sm_shape);
+        auto broadcast_lit =
+            submod->add_instruction(migraphx::make_op("multibroadcast"), literal_ins, sm_input);
+        auto add_ins = submod->add_instruction(migraphx::make_op("add"), sm_input, broadcast_lit);
+        submod->add_return({add_ins});
+        return submod;
+    };
+
+    std::vector<migraphx::module_ref> submods;
+    submods.reserve(bucket_sizes.size());
+    std::transform(bucket_sizes.begin(),
+                   bucket_sizes.end(),
+                   std::back_inserter(submods),
+                   [&](auto n) { return create_submodule(n, "bucket_" + std::to_string(n)); });
+
+    migraphx::shape s{migraphx::shape::float_type, {{dyn_min, dyn_max}, {4, 4}}};
+    auto input                              = mm->add_parameter("data", s);
+    std::vector<migraphx::shape> sub_shapes = {};
+    sub_shapes.push_back(
+        migraphx::shape{migraphx::shape::float_type, {{dyn_min, dyn_max}, {4, 4}}});
+    migraphx::shape out_attr = migraphx::shape{sub_shapes};
+    auto sm_ins              = mm->add_instruction(
+        migraphx::make_op("select_module", {{"output_dyn_shapes", migraphx::to_value(out_attr)}}),
+        {input},
+        submods);
+    auto ret = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), sm_ins);
+    mm->add_return({ret});
+    return p;
+}
+
+// Exact match wins over bucket fallback.
+TEST_CASE(select_module_bucket_dispatch_exact_match)
+{
+    // N=10 matches bucket_10 exactly.
+    auto p = make_select_module_add_program({1, 10, 50, 100}, 1, 100);
+    p.compile(migraphx::make_target("ref"));
+
+    std::vector<float> input_data(10 * 4, 2.0f); // every element = 2
+    migraphx::parameter_map params;
+    migraphx::shape input_fixed_shape{migraphx::shape::float_type, {10, 4}};
+    params["data"] = migraphx::argument(input_fixed_shape, input_data.data());
+    auto result    = p.eval(params).back();
+
+    std::vector<float> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(results_vector.size() == std::size_t{10 * 4});
+    // Output should be input + 6 = 8 everywhere.
+    EXPECT(std::all_of(
+        // NOLINTNEXTLINE(clang-diagnostic-float-equal)
+        results_vector.begin(),
+        results_vector.end(),
+        [](float v) { return std::fabs(v - 8.0f) < 1e-6f; }));
+}
+
+// N=20 -> rounds up to bucket_50. First 20*4 outputs = 2+6=8 (real input);
+// tail 20*4..50*4 = 0+6=6 (zero-padded).
+TEST_CASE(select_module_bucket_dispatch_round_up_with_pad)
+{
+    auto p = make_select_module_add_program({1, 10, 50, 100}, 1, 100);
+    p.compile(migraphx::make_target("ref"));
+
+    std::vector<float> input_data(20 * 4, 2.0f);
+    migraphx::parameter_map params;
+    migraphx::shape input_fixed_shape{migraphx::shape::float_type, {20, 4}};
+    params["data"] = migraphx::argument(input_fixed_shape, input_data.data());
+    auto result    = p.eval(params).back();
+
+    std::vector<float> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    // Submodule produces a bucket-sized output (50 * 4) because we are
+    // dispatching to dim_50.
+    EXPECT(results_vector.size() == std::size_t{50 * 4});
+    // First 20*4 positions correspond to real input (2 + 6 = 8).
+    for(std::size_t i = 0; i < 20 * 4; ++i)
+        EXPECT(std::fabs(results_vector[i] - 8.0f) < 1e-6f);
+    // Remaining positions are zero-padded input (0 + 6 = 6).
+    for(std::size_t i = 20 * 4; i < 50 * 4; ++i)
+        EXPECT(std::fabs(results_vector[i] - 6.0f) < 1e-6f);
+}
+
+// N=200 exceeds every bucket -> must throw.
+TEST_CASE(select_module_bucket_dispatch_too_big_throws)
+{
+    auto p = make_select_module_add_program({1, 10, 50, 100}, 1, 1000);
+    p.compile(migraphx::make_target("ref"));
+
+    std::vector<float> input_data(200 * 4, 2.0f);
+    migraphx::parameter_map params;
+    migraphx::shape input_fixed_shape{migraphx::shape::float_type, {200, 4}};
+    params["data"] = migraphx::argument(input_fixed_shape, input_data.data());
+    EXPECT(test::throws([&] { std::ignore = p.eval(params).back(); }));
+}
+
+// Cache hot-loop: 100 calls at the same shape must return identical results.
+TEST_CASE(select_module_bucket_dispatch_cache_hot_loop)
+{
+    auto p = make_select_module_add_program({1, 10, 50, 100}, 1, 100);
+    p.compile(migraphx::make_target("ref"));
+
+    std::vector<float> input_data(10 * 4, 2.0f); // exact-match bucket=10
+    migraphx::parameter_map params;
+    migraphx::shape input_fixed_shape{migraphx::shape::float_type, {10, 4}};
+    params["data"] = migraphx::argument(input_fixed_shape, input_data.data());
+
+    std::vector<float> first_result;
+    for(int i = 0; i < 100; ++i)
+    {
+        auto r = p.eval(params).back();
+        std::vector<float> v;
+        r.visit([&](auto out) { v.assign(out.begin(), out.end()); });
+        if(i == 0)
+            first_result = v;
+        else
+            EXPECT(v.size() == first_result.size());
+        EXPECT(std::equal(v.begin(), v.end(), first_result.begin(), [](float a, float b) {
+            return std::fabs(a - b) < 1e-6f;
+        }));
+    }
+    // Same model run 100 times must produce identical output throughout.
+    EXPECT(first_result.size() == std::size_t{10 * 4});
+    EXPECT(
+        // NOLINTNEXTLINE(clang-diagnostic-float-equal)
+        std::all_of(first_result.begin(), first_result.end(), [](float x) {
+            return std::fabs(x - 8.0f) < 1e-6f;
+        }));
+}
+
+// Alternating shapes: the cache must invalidate, not serve stale data.
+TEST_CASE(select_module_bucket_dispatch_cache_alternating_shapes)
+{
+    auto p = make_select_module_add_program({1, 10, 50, 100}, 1, 100);
+    p.compile(migraphx::make_target("ref"));
+
+    std::vector<float> data_a(10 * 4, 2.0f); // bucket=10
+    std::vector<float> data_b(50 * 4, 3.0f); // bucket=50
+
+    migraphx::shape shape_a{migraphx::shape::float_type, {10, 4}};
+    migraphx::shape shape_b{migraphx::shape::float_type, {50, 4}};
+
+    for(int i = 0; i < 50; ++i)
+    {
+        migraphx::parameter_map p_a;
+
+        migraphx::parameter_map p_b;
+        p_a["data"] = migraphx::argument(shape_a, data_a.data());
+        p_b["data"] = migraphx::argument(shape_b, data_b.data());
+
+        auto r_a = p.eval(p_a).back();
+        auto r_b = p.eval(p_b).back();
+        std::vector<float> v_a;
+
+        std::vector<float> v_b;
+        r_a.visit([&](auto out) { v_a.assign(out.begin(), out.end()); });
+        r_b.visit([&](auto out) { v_b.assign(out.begin(), out.end()); });
+
+        EXPECT(v_a.size() == std::size_t{10 * 4});
+        // NOLINTNEXTLINE(clang-diagnostic-float-equal)
+        EXPECT(std::all_of(
+            v_a.begin(), v_a.end(), [](float x) { return std::fabs(x - 8.0f) < 1e-6f; }));
+        EXPECT(v_b.size() == std::size_t{50 * 4});
+        // NOLINTNEXTLINE(clang-diagnostic-float-equal)
+        EXPECT(std::all_of(
+            v_b.begin(), v_b.end(), [](float x) { return std::fabs(x - 9.0f) < 1e-6f; }));
+    }
 }

--- a/test/split_single_dyn_dim_test.cpp
+++ b/test/split_single_dyn_dim_test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,11 +31,20 @@
 #include <migraphx/instruction.hpp>
 #include <migraphx/instruction_ref.hpp>
 #include <migraphx/builtin.hpp>
+#include <set>
 #include <test.hpp>
+#include <algorithm>
 
 static void run_pass(migraphx::program& p)
 {
     migraphx::run_passes(p, {migraphx::split_single_dyn_dim{}, migraphx::dead_code_elimination{}});
+}
+
+static void run_pass_bucket(migraphx::program& p)
+{
+    migraphx::run_passes(p,
+                         {migraphx::split_single_dyn_dim{.bucket_by_optimals = true},
+                          migraphx::dead_code_elimination{}});
 }
 
 TEST_CASE(dynamic_batch)
@@ -52,7 +61,7 @@ TEST_CASE(dynamic_batch)
             migraphx::shape sm_shape{migraphx::shape::float_type, {batch_size, 4}};
             auto sm_input = submod->add_parameter("data", sm_shape);
             migraphx::shape lit_s{migraphx::shape{migraphx::shape::float_type, {1}}};
-            auto literal_ins   = submod->add_literal(migraphx::literal{lit_s, {6}});
+            auto literal_ins = submod->add_literal(migraphx::literal{lit_s, {6.0f}});
             auto broadcast_lit =
                 submod->add_instruction(migraphx::make_op("multibroadcast"), literal_ins, sm_input);
             auto add_ins =
@@ -72,7 +81,7 @@ TEST_CASE(dynamic_batch)
         migraphx::shape out_attr = migraphx::shape{sub_shapes};
         auto sm_ins              = mm0->add_instruction(
             migraphx::make_op("select_module",
-                              {{"output_dyn_shapes", migraphx::to_value(out_attr)}}),
+                                           {{"output_dyn_shapes", migraphx::to_value(out_attr)}}),
             {input0},
             {dim1, dim2, dim3, dim4});
         auto ret =
@@ -86,7 +95,7 @@ TEST_CASE(dynamic_batch)
         migraphx::shape s{migraphx::shape::float_type, {{1, 4}, {4, 4}}};
         auto input1 = mm1->add_parameter("data", s);
         migraphx::shape lit_s{migraphx::shape{migraphx::shape::float_type, {1}}};
-        auto literal_ins = mm1->add_literal(migraphx::literal{lit_s, {6}});
+        auto literal_ins = mm1->add_literal(migraphx::literal{lit_s, {6.0f}});
         auto broadcast_lit =
             mm1->add_instruction(migraphx::make_op("multibroadcast"), literal_ins, input1);
         auto add_ins = mm1->add_instruction(migraphx::make_op("add"), input1, broadcast_lit);
@@ -111,7 +120,7 @@ TEST_CASE(dynamic_batch_multiple_input)
             auto sm_input1 = submod->add_parameter("data1", sm_shape);
             auto sm_input2 = submod->add_parameter("data2", sm_shape);
             migraphx::shape lit_s{migraphx::shape{migraphx::shape::float_type, {1}}};
-            auto literal_ins   = submod->add_literal(migraphx::literal{lit_s, {6}});
+            auto literal_ins   = submod->add_literal(migraphx::literal{lit_s, {6.0f}});
             auto broadcast_lit = submod->add_instruction(
                 migraphx::make_op("multibroadcast"), literal_ins, sm_input0);
             auto add_ins0 =
@@ -151,7 +160,7 @@ TEST_CASE(dynamic_batch_multiple_input)
         auto input1 = mm1->add_parameter("data1", s);
         auto input2 = mm1->add_parameter("data2", s);
         migraphx::shape lit_s{migraphx::shape{migraphx::shape::float_type, {1}}};
-        auto literal_ins = mm1->add_literal(migraphx::literal{lit_s, {6}});
+        auto literal_ins = mm1->add_literal(migraphx::literal{lit_s, {6.0f}});
         auto broadcast_lit =
             mm1->add_instruction(migraphx::make_op("multibroadcast"), literal_ins, input0);
         auto add_ins0 = mm1->add_instruction(migraphx::make_op("add"), input0, broadcast_lit);
@@ -176,7 +185,7 @@ TEST_CASE(multiple_outputs)
             migraphx::shape sm_shape{migraphx::shape::float_type, {batch_size, 4}};
             auto sm_input = submod->add_parameter("data", sm_shape);
             migraphx::shape lit_s{migraphx::shape{migraphx::shape::float_type, {1}}};
-            auto literal_ins   = submod->add_literal(migraphx::literal{lit_s, {6}});
+            auto literal_ins = submod->add_literal(migraphx::literal{lit_s, {6.0f}});
             auto broadcast_lit =
                 submod->add_instruction(migraphx::make_op("multibroadcast"), literal_ins, sm_input);
             auto add0_ins =
@@ -199,7 +208,7 @@ TEST_CASE(multiple_outputs)
         migraphx::shape out_attr = migraphx::shape{sub_shapes};
         auto sm_ins              = mm0->add_instruction(
             migraphx::make_op("select_module",
-                              {{"output_dyn_shapes", migraphx::to_value(out_attr)}}),
+                                           {{"output_dyn_shapes", migraphx::to_value(out_attr)}}),
             {input0},
             {dim1, dim2, dim3, dim4});
         auto ret0 =
@@ -215,7 +224,7 @@ TEST_CASE(multiple_outputs)
         migraphx::shape s{migraphx::shape::float_type, {{1, 4}, {4, 4}}};
         auto input1 = mm1->add_parameter("data", s);
         migraphx::shape lit_s{migraphx::shape{migraphx::shape::float_type, {1}}};
-        auto literal_ins = mm1->add_literal(migraphx::literal{lit_s, {6}});
+        auto literal_ins = mm1->add_literal(migraphx::literal{lit_s, {6.0f}});
         auto broadcast_lit =
             mm1->add_instruction(migraphx::make_op("multibroadcast"), literal_ins, input1);
         auto add0_ins = mm1->add_instruction(migraphx::make_op("add"), input1, broadcast_lit);
@@ -236,7 +245,7 @@ TEST_CASE(empty_param_shapes)
         migraphx::shape s{migraphx::shape::float_type, {1, 4}};
         auto input0 = mm0->add_literal(migraphx::literal{s, {0, 1, 2, 3}});
         migraphx::shape lit_s{migraphx::shape{migraphx::shape::float_type, {1}}};
-        auto literal_ins = mm0->add_literal(migraphx::literal{lit_s, {6}});
+        auto literal_ins = mm0->add_literal(migraphx::literal{lit_s, {6.0f}});
         auto broadcast_lit =
             mm0->add_instruction(migraphx::make_op("multibroadcast"), literal_ins, input0);
         auto add0_ins = mm0->add_instruction(migraphx::make_op("add"), input0, broadcast_lit);
@@ -256,7 +265,7 @@ TEST_CASE(multiple_non_fixed_dd_in_a_param)
         migraphx::shape s{migraphx::shape::float_type, {{1, 4}, {4, 20}}};
         auto input0 = mm0->add_parameter("data", s);
         migraphx::shape lit_s{migraphx::shape{migraphx::shape::float_type, {1}}};
-        auto literal_ins = mm0->add_literal(migraphx::literal{lit_s, {6}});
+        auto literal_ins = mm0->add_literal(migraphx::literal{lit_s, {6.0f}});
         auto broadcast_lit =
             mm0->add_instruction(migraphx::make_op("multibroadcast"), literal_ins, input0);
         auto add0_ins = mm0->add_instruction(migraphx::make_op("add"), input0, broadcast_lit);
@@ -300,7 +309,7 @@ TEST_CASE(ordered_inputs_to_select_module)
     auto input1 = mm->add_parameter("Apricot", s);
     auto input2 = mm->add_parameter("pineapple", s);
     migraphx::shape lit_s{migraphx::shape{migraphx::shape::float_type, {1}}};
-    auto literal_ins = mm->add_literal(migraphx::literal{lit_s, {6}});
+    auto literal_ins = mm->add_literal(migraphx::literal{lit_s, {6.0f}});
     auto broadcast_lit =
         mm->add_instruction(migraphx::make_op("multibroadcast"), literal_ins, input0);
     auto add_ins0 = mm->add_instruction(migraphx::make_op("add"), input0, broadcast_lit);
@@ -321,6 +330,110 @@ TEST_CASE(ordered_inputs_to_select_module)
         }
     }
     EXPECT(std::is_sorted(sm_param_names.begin(), sm_param_names.end()));
+}
+
+// Golden post-pass program: one (data+6) submodule per bucket size,
+// dispatched via select_module.
+static migraphx::program build_bucket_add_golden(const std::vector<std::size_t>& bucket_sizes,
+                                                 std::size_t min,
+                                                 std::size_t max)
+{
+    migraphx::program p;
+    auto* mm              = p.get_main_module();
+    auto create_submodule = [&](std::size_t batch_size, const std::string& module_name) {
+        auto* submod = p.create_module(module_name);
+        migraphx::shape sm_shape{migraphx::shape::float_type, {batch_size, 4}};
+        auto sm_input = submod->add_parameter("data", sm_shape);
+        migraphx::shape lit_s{migraphx::shape{migraphx::shape::float_type, {1}}};
+        auto literal_ins = submod->add_literal(migraphx::literal{lit_s, {6.0f}});
+        auto broadcast_lit =
+            submod->add_instruction(migraphx::make_op("multibroadcast"), literal_ins, sm_input);
+        auto add_ins = submod->add_instruction(migraphx::make_op("add"), sm_input, broadcast_lit);
+        submod->add_return({add_ins});
+        return submod;
+    };
+    std::vector<migraphx::module_ref> submods;
+    submods.reserve(bucket_sizes.size());
+    std::transform(bucket_sizes.begin(),
+                   bucket_sizes.end(),
+                   std::back_inserter(submods),
+                   [&](auto n) { return create_submodule(n, "dim_" + std::to_string(n)); });
+
+    migraphx::shape s{
+        migraphx::shape::float_type,
+        {migraphx::shape::dynamic_dimension{min, max}, migraphx::shape::dynamic_dimension{4, 4}}};
+    auto input0                             = mm->add_parameter("data", s);
+    std::vector<migraphx::shape> sub_shapes = {};
+    sub_shapes.push_back(migraphx::shape{
+        migraphx::shape::float_type,
+        {migraphx::shape::dynamic_dimension{min, max}, migraphx::shape::dynamic_dimension{4, 4}}});
+    migraphx::shape out_attr = migraphx::shape{sub_shapes};
+    auto sm_ins              = mm->add_instruction(
+        migraphx::make_op("select_module", {{"output_dyn_shapes", migraphx::to_value(out_attr)}}),
+        {input0},
+        submods);
+    auto ret = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), sm_ins);
+    mm->add_return({ret});
+    return p;
+}
+
+// Pre-pass dynamic program with the given dyn_dim.
+static migraphx::program build_bucket_add_input(const migraphx::shape::dynamic_dimension& dd)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape s{migraphx::shape::float_type, {dd, migraphx::shape::dynamic_dimension{4, 4}}};
+    auto input = mm->add_parameter("data", s);
+    migraphx::shape lit_s{migraphx::shape{migraphx::shape::float_type, {1}}};
+    auto literal_ins = mm->add_literal(migraphx::literal{lit_s, {6.0f}});
+    auto broadcast_lit =
+        mm->add_instruction(migraphx::make_op("multibroadcast"), literal_ins, input);
+    auto add_ins = mm->add_instruction(migraphx::make_op("add"), input, broadcast_lit);
+    mm->add_return({add_ins});
+    return p;
+}
+
+// bucket_by_optimals=true + optimals -> 1 submodule per (min, optimals..., max).
+TEST_CASE(dynamic_batch_bucket_only_optimals)
+{
+    auto p_expected = build_bucket_add_golden({1, 10, 50, 90, 100}, 1, 100);
+    migraphx::shape::dynamic_dimension dd{1, 100, std::set<std::size_t>{10, 50, 90}};
+    auto p_actual = build_bucket_add_input(dd);
+    run_pass_bucket(p_actual);
+    EXPECT(p_expected == p_actual);
+}
+
+// bucket_by_optimals=true but no optimals -> still enumerate.
+TEST_CASE(dynamic_batch_bucket_env_on_no_optimals_keeps_enumeration)
+{
+    auto p_expected = build_bucket_add_golden({1, 2, 3, 4}, 1, 4);
+    migraphx::shape::dynamic_dimension dd{1, 4};
+    auto p_actual = build_bucket_add_input(dd);
+    run_pass_bucket(p_actual);
+    EXPECT(p_expected == p_actual);
+}
+
+// Default (bucket_by_optimals=false) preserves the legacy enumeration.
+TEST_CASE(dynamic_batch_bucket_env_off_keeps_enumeration)
+{
+    auto p_expected = build_bucket_add_golden({1, 2, 3, 4}, 1, 4);
+    migraphx::shape::dynamic_dimension dd{1, 4, std::set<std::size_t>{2, 3}};
+    auto p_actual = build_bucket_add_input(dd);
+    run_pass(p_actual);
+    EXPECT(p_expected == p_actual);
+}
+
+// Optimals outside [min, max] are dropped (would otherwise be unreachable).
+TEST_CASE(dynamic_batch_bucket_filters_out_of_range_optimals)
+{
+    // 999 dropped; 5, 7 kept; plus min=2, max=10 -> 4 buckets.
+    auto p_expected = build_bucket_add_golden({2, 5, 7, 10}, 2, 10);
+
+    migraphx::shape::dynamic_dimension dd{2, 10, std::set<std::size_t>{5, 7, 999}};
+    auto p_actual = build_bucket_add_input(dd);
+    run_pass_bucket(p_actual);
+
+    EXPECT(p_expected == p_actual);
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
For models with a single non-fixed dynamic dimension, today's split_single_dyn_dim pass enumerates every integer in [min, max] and stamps out one static-shape submodule per integer, regardless of dynamic_dimension::optimals. Combined with a per-inference linear scan inside select_module::compute(), this makes wide [min, max] ranges (e.g. {1, 5000000, opt:[400000]}) unusable: ~16 days of compile, ~40 GB engine and +80 - 100 us of per-inference host overhead vs a hand-static engine on MI308X.

This change introduces three layered, opt-in / auto-guarded optimizations:

  1. MIGRAPHX_DYN_DIM_BUCKET_BY_OPTIMALS=1 makes split_single_dyn_dim honour dynamic_dimension::optimals (one submodule per optimal plus min/max endpoints) and adds a smallest-compatible-bucket fallback in select_module::compute() (zero-pads on the ref backend). Collapses compile time and .mxr size to O(|optimals|).

  2. MIGRAPHX_DYN_DIM_FREEZE_TO=<N> adds a new freeze_dyn_dim pass that runs before split_single_dyn_dim and rewrites every non-fixed dynamic parameter to a static shape at size N. Downstream sees a fully-static program -- no submodules, no select_module, no per-inference dispatch. Matches hand-written-static inference latency.

  3. select_module::compute() gets a per-instance dispatch cache. Hot loops with stable input shape skip the linear scan and the per-call get_input_parameter_names / get_parameter_shapes allocations. Auto-activates when select_module has 4+ submodules; kill-switch MIGRAPHX_DISABLE_SELECT_MODULE_CACHE=1 for A/B benchmarks and emergency rollback.

Validated on MI308X (gfx942, ROCm 7.2.0):

  - Pointwise compile: 40.5 s (legacy max=256) -> 0.48 s (bucket max=5M).
  - Pointwise inference: 215 us legacy -> 121 us bucket + cache ->
    115 us freeze (= true-static control at 115 us).
  - All existing unit + ref tests pass, plus 16 new test cases: 4 split_single_dyn_dim, 4 freeze_dyn_dim, 2 ref/freeze_dyn_dim, 6 ref/select_module (incl. cache hot-loop and alternating-shape regression). Validation ran with cache enabled and with the kill-switch on; bitwise-identical outputs verified across frozen / bucket / static engines.

Addresses ROCm/AMDMIGraphX#1023 (Dynamic Shape Support umbrella) and ROCm/AMDMIGraphX#4618 (ONNX-Runtime MIGraphX EP recompiling per shape).

## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
