### PR TITLE
Append model name to benchmark mxr files

### DIFF
--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -46,6 +46,7 @@
 #include <migraphx/json.hpp>
 #include <migraphx/version.h>
 #include <migraphx/env.hpp>
+#include <migraphx/filesystem.hpp>
 #include <migraphx/logger.hpp>
 
 #include <migraphx/dead_code_elimination.hpp>
@@ -760,6 +761,10 @@ struct compiler
             quantize_int4_weights(p);
         }
         log::info() << "Compiling ...";
+        // Derive name of the model so that it can be prepended
+        // to benchmark MXR files dumped by MIGRAPHX_GPU_DUMP_BENCHMARK_MXR.
+        if(co.model_name.empty() and not l.file.empty())
+            co.model_name = migraphx::fs::path(l.file).stem().string();
         p.compile(t, co);
         l.save(p);
         return p;

--- a/src/include/migraphx/compile_options.hpp
+++ b/src/include/migraphx/compile_options.hpp
@@ -26,6 +26,7 @@
 
 #include <migraphx/config.hpp>
 #include <migraphx/tracer.hpp>
+#include <string>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -40,6 +41,13 @@ struct compile_options
 
     bool fast_math       = true;
     bool exhaustive_tune = false;
+
+    /**
+     * Identifier for the model being compiled.
+     * One use is to prepend model name to MXR file names that are
+     * dumped via MIGRAPHX_GPU_DUMP_BENCHMARK_MXR). Empty by default.
+     */
+    std::string model_name;
 
     tracer trace{};
 };

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -477,10 +477,13 @@ struct compile_plan
         cr.replace.replace(m, cr.ins);
     }
 
-    void save_binaries(const fs::path& mxr_dir) const
+    void save_binaries(const fs::path& mxr_dir, const std::string& model_name) const
     {
         if(not config.has_value())
             return;
+        // Prepend "<model_name>-" so benchmark MXR files from different models
+        // dumped into the same directory can be identified by the model name.
+        const std::string prefix = model_name.empty() ? "" : model_name + "-";
         for(auto i : range(results.size()))
         {
             if(not results[i].has_value())
@@ -492,7 +495,7 @@ struct compile_plan
                                        " solution=" + to_string(solution);
             mm->add_instruction(builtin::comment{comment_text}, {});
             auto problem_hash = std::hash<std::string>{}(to_string(config->problem));
-            auto mxr_file     = mxr_dir / (preop.name() + "_" + std::to_string(i) + "_" +
+            auto mxr_file     = mxr_dir / (prefix + preop.name() + "_" + std::to_string(i) + "_" +
                                        std::to_string(problem_hash) + ".mxr");
             log::info() << "Saving benchmark binary: " << mxr_file;
             save(bench_prog, mxr_file.string());
@@ -515,6 +518,7 @@ struct compile_manager
 {
     std::vector<compile_plan> cps;
     bool exhaustive = false;
+    std::string model_name;
 
     template <class... Ts>
     void add_plan(Ts&&... xs)
@@ -550,7 +554,7 @@ struct compile_manager
                 continue;
             if(dump_mxr and cp.results.size() > 1)
             {
-                cp.save_binaries(fs::path(mxr_path));
+                cp.save_binaries(fs::path(mxr_path), model_name);
             }
             else
             {
@@ -583,6 +587,7 @@ void compile_ops::apply(module_pass_manager& mpm) const
     auto& m      = mpm.get_module();
     compile_manager cm;
     cm.exhaustive = exhaustive_tune;
+    cm.model_name = model_name;
     // Find all precompile ops
     for(auto ins : iterator_for(m))
     {

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -527,7 +527,7 @@ struct compile_manager
         par_compile(cps.size(), [&](auto i) { cps[i].update_config(exhaustive); });
     }
 
-    void compile(module& m)
+    void compile(module& m, bool is_root)
     {
         std::vector<std::function<void()>> compiles;
         for(auto& cp : cps)
@@ -558,7 +558,11 @@ struct compile_manager
             }
         }
 
-        if(dump_mxr)
+        // Only throw on the root module so that submodules (which are processed
+        // first by the pass manager and may legitimately have no precompile ops
+        // or no multi-solution candidates) don't abort compilation before the
+        // root module has had a chance to dump its benchmark MXR files.
+        if(dump_mxr and is_root)
         {
             MIGRAPHX_THROW(
                 "Benchmark MXR files dumped to " + mxr_path +
@@ -573,8 +577,10 @@ struct compile_manager
     }
 };
 
-void compile_ops::apply(module& m) const
+void compile_ops::apply(module_pass_manager& mpm) const
 {
+    bool is_root = &mpm.get_module() == mpm.get_root_module();
+    auto& m      = mpm.get_module();
     compile_manager cm;
     cm.exhaustive = exhaustive_tune;
     // Find all precompile ops
@@ -586,9 +592,9 @@ void compile_ops::apply(module& m) const
         cm.add_plan(ctx, preop, ins, &m);
     }
     cm.update_configs();
-    cm.compile(m);
+    cm.compile(m, is_root);
     // Compile already tuned configs
-    cm.compile(m);
+    cm.compile(m, is_root);
     assert(cm.cps.empty());
 }
 

--- a/src/targets/gpu/include/migraphx/gpu/compile_ops.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/compile_ops.hpp
@@ -40,6 +40,7 @@ struct MIGRAPHX_GPU_EXPORT compile_ops
 {
     context* ctx         = nullptr;
     bool exhaustive_tune = false;
+    std::string model_name;
     std::string name() const { return "gpu::compile_ops"; }
     void apply(module_pass_manager& mpm) const;
 };

--- a/src/targets/gpu/include/migraphx/gpu/compile_ops.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/compile_ops.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,7 @@
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
-struct module;
+struct module_pass_manager;
 
 namespace gpu {
 
@@ -41,7 +41,7 @@ struct MIGRAPHX_GPU_EXPORT compile_ops
     context* ctx         = nullptr;
     bool exhaustive_tune = false;
     std::string name() const { return "gpu::compile_ops"; }
-    void apply(module& m) const;
+    void apply(module_pass_manager& mpm) const;
 };
 
 } // namespace gpu

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -184,7 +184,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
         dead_code_elimination{},
         adjust_allocation{gpu_allocation_model{}},
         dead_code_elimination{},
-        compile_ops{&ctx, options.exhaustive_tune},
+        compile_ops{&ctx, options.exhaustive_tune, options.model_name},
         dead_code_elimination{},
         promote_literals{},
         dead_code_elimination{},


### PR DESCRIPTION
## Motivation
Prepends the input model's file name to benchmark MXR files dumped via MIGRAPHX_GPU_DUMP_BENCHMARK_MXR,
preventing collisions when multiple models share the same dump directory. 

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
