### PR TITLE
symbolic shapes for gather and scatter

### DIFF
--- a/src/include/migraphx/op/gather.hpp
+++ b/src/include/migraphx/op/gather.hpp
@@ -63,48 +63,26 @@ struct gather
     shape normalize_compute_shape(std::vector<shape> inputs) const
     {
         check_shapes{inputs, *this, true}.has(2);
-        shape data    = inputs[0];
-        shape indices = inputs[1];
-        auto type     = data.type();
-        // If index_dims is dynamic, convert the data to dynamic too.
-        if(indices.dynamic())
-        {
-            data = data.to_dynamic();
-        }
+        const auto& indices = inputs[1];
+        auto type           = inputs[0].type();
         const bool scalar_indices =
             indices.ndim() == 1 and indices.scalar() and indices.elements() == 1;
-        if(data.dynamic())
+
+        auto unified = shape::to_dynamic(inputs);
+        auto dims    = unified[0].dyn_dims();
+        dims.erase(dims.begin() + axis);
+        if(not scalar_indices)
         {
-            auto dims = data.dyn_dims();
-            dims.erase(dims.begin() + axis);
-
-            if(not scalar_indices)
-            {
-                auto index_dims = indices.to_dynamic().dyn_dims();
-                dims.insert(dims.begin() + axis, index_dims.begin(), index_dims.end());
-            }
-            return {type, dims};
+            auto idx_dims = unified[1].dyn_dims();
+            dims.insert(dims.begin() + axis, idx_dims.begin(), idx_dims.end());
         }
-        else
-        {
-            // Both data and indices are static.  indices may be scalar
-            auto lens = data.lens();
-            lens.erase(lens.begin() + axis);
 
-            if(not scalar_indices)
-            {
-                auto ind_lens = indices.lens();
-                lens.insert(lens.begin() + axis, ind_lens.begin(), ind_lens.end());
-            }
-
-            // for scalar output
-            if(lens.empty())
-            {
-                return {type};
-            }
-
-            return {type, lens};
-        }
+        if(dims.empty())
+            return {type};
+        shape result{type, dims};
+        if(inputs[0].dynamic() or inputs[1].dynamic())
+            return result;
+        return result.to_static();
     }
 
     argument compute(const dyn_output& dyn_out, std::vector<argument> args) const
@@ -129,7 +107,7 @@ struct gather
                     auto in_index = indices.front();
                     in_index      = (in_index < 0) ? in_index + axis_dim_size : in_index;
                     check_index_range(in_index, axis_dim_size);
-                    output[0]     = data[in_index];
+                    output[0] = data[in_index];
                 }
                 else
                 {
@@ -137,12 +115,12 @@ struct gather
                     out_lens[axis] = indices.get_shape().elements();
                     migraphx::shape out_comp_shape{data.get_shape().type(), out_lens};
                     shape_for_each(out_comp_shape, [&](const auto& out_idx_v, size_t out_idx) {
-                        auto data_idx   = out_idx_v;
-                        auto in_index   = indices[data_idx[axis]];
-                        in_index        = (in_index < 0) ? in_index + axis_dim_size : in_index;
+                        auto data_idx = out_idx_v;
+                        auto in_index = indices[data_idx[axis]];
+                        in_index      = (in_index < 0) ? in_index + axis_dim_size : in_index;
                         // don't go out of bounds: https://github.com/ROCm/AMDMIGraphX/issues/2838
                         assert(in_index >= 0 and in_index < axis_dim_size);
-                        data_idx[axis]  = in_index;
+                        data_idx[axis] = in_index;
                         check_index_range(data_idx[axis], axis_dim_size);
                         output[out_idx] = data(data_idx.begin(), data_idx.end());
                     });

--- a/src/include/migraphx/op/gathernd.hpp
+++ b/src/include/migraphx/op/gathernd.hpp
@@ -90,56 +90,29 @@ struct gathernd
                            std::to_string(k));
         }
 
-        if(migraphx::none_of(inputs, [](auto v) { return v.dynamic(); }))
+        const bool any_dyn = data_shape.dynamic() or i_shape.dynamic();
+        if(output_ndim == 0)
         {
-            auto indices_lens_iter = i_shape.lens().begin();
-
-            // A rank 0 output is a scalar
-            if(output_ndim == 0)
-                return shape{data_shape.type(), {1}};
-
-            // Part of the output shape comes from indices tensor, part from data tensor
-            std::vector<std::size_t> output_lens(output_ndim);
-            std::copy(indices_lens_iter, indices_lens_iter + (q - 1), output_lens.begin());
-            // fill the rest of output shape from data tensor
-            if(k + batch_dims < r)
-            {
-                auto data_lens = data_shape.lens();
-                std::copy(data_lens.begin() + batch_dims + k,
-                          data_lens.end(),
-                          output_lens.begin() + q - 1);
-            }
-            shape output_shape{data_shape.type(), output_lens};
-            return output_shape;
-        }
-        else
-        {
-            // If one or both inputs are dynamic shapes, the output is dynamic.
-            // Make both inputs dynamic to simplify computations.
-            data_shape = data_shape.to_dynamic();
-            i_shape    = i_shape.to_dynamic();
-
-            // A rank 0 output is a scalar
-            if(output_ndim == 0)
+            if(any_dyn)
                 return shape(data_shape.type(), {shape::dynamic_dimension({1, 1})});
-
-            // Part of the output shape comes from indices tensor, part from data tensor
-            std::vector<shape::dynamic_dimension> output_dims(output_ndim);
-            std::copy(i_shape.dyn_dims().begin(),
-                      i_shape.dyn_dims().begin() + q - 1,
-                      output_dims.begin());
-
-            // fill the rest of output shape from data tensor
-            if(k + batch_dims < r)
-            {
-                auto data_dims = data_shape.dyn_dims();
-                std::copy(data_dims.begin() + batch_dims + k,
-                          data_dims.begin() + r,
-                          output_dims.begin() + q - 1);
-            }
-            shape output_shape(data_shape.type(), output_dims);
-            return output_shape;
+            return shape{data_shape.type(), {1}};
         }
+
+        auto unified   = shape::to_dynamic(inputs);
+        auto i_dims    = unified[1].dyn_dims();
+        auto data_dims = unified[0].dyn_dims();
+        std::vector<shape::dynamic_dimension> output_dims(output_ndim);
+        std::copy(i_dims.begin(), i_dims.begin() + (q - 1), output_dims.begin());
+        // fill the rest of output shape from data tensor
+        if(k + batch_dims < r)
+            std::copy(data_dims.begin() + batch_dims + k,
+                      data_dims.begin() + r,
+                      output_dims.begin() + q - 1);
+
+        shape output_shape(data_shape.type(), output_dims);
+        if(any_dyn)
+            return output_shape;
+        return output_shape.to_static();
     }
 
     argument compute(const dyn_output& dyn_out, std::vector<argument> args) const

--- a/src/include/migraphx/op/gathernd.hpp
+++ b/src/include/migraphx/op/gathernd.hpp
@@ -49,10 +49,10 @@ struct gathernd
     shape compute_shape(std::vector<shape> inputs) const
     {
         check_shapes{inputs, *this, true}.has(2);
-        auto i_shape    = inputs.back();
-        auto data_shape = inputs.front();
-        auto r          = data_shape.ndim();
-        auto q          = i_shape.ndim();
+        const auto& i_shape    = inputs.back();
+        const auto& data_shape = inputs.front();
+        auto r                 = data_shape.ndim();
+        auto q                 = i_shape.ndim();
 
         size_t k;
         if(i_shape.dynamic())

--- a/src/include/migraphx/op/gathernd.hpp
+++ b/src/include/migraphx/op/gathernd.hpp
@@ -90,27 +90,30 @@ struct gathernd
                            std::to_string(k));
         }
 
-        const bool any_dyn = data_shape.dynamic() or i_shape.dynamic();
-        if(output_ndim == 0)
-        {
-            if(any_dyn)
-                return shape(data_shape.type(), {shape::dynamic_dimension({1, 1})});
-            return shape{data_shape.type(), {1}};
-        }
-
         auto unified   = shape::to_dynamic(inputs);
         auto i_dims    = unified[1].dyn_dims();
         auto data_dims = unified[0].dyn_dims();
-        std::vector<shape::dynamic_dimension> output_dims(output_ndim);
-        std::copy(i_dims.begin(), i_dims.begin() + (q - 1), output_dims.begin());
-        // fill the rest of output shape from data tensor
-        if(k + batch_dims < r)
-            std::copy(data_dims.begin() + batch_dims + k,
-                      data_dims.begin() + r,
-                      output_dims.begin() + q - 1);
+        std::vector<shape::dynamic_dimension> output_dims;
+        if(output_ndim == 0)
+        {
+            // rank-0 result is represented as rank-1 size 1; pick the dd kind to
+            // match the lifted form so symbolic inputs stay symbolic.
+            output_dims.push_back(unified.front().symbolic() ? shape::dynamic_dimension{sym::lit(1)}
+                                                             : shape::dynamic_dimension{1, 1});
+        }
+        else
+        {
+            output_dims.resize(output_ndim);
+            std::copy(i_dims.begin(), i_dims.begin() + (q - 1), output_dims.begin());
+            // fill the rest of output shape from data tensor
+            if(k + batch_dims < r)
+                std::copy(data_dims.begin() + batch_dims + k,
+                          data_dims.begin() + r,
+                          output_dims.begin() + q - 1);
+        }
 
         shape output_shape(data_shape.type(), output_dims);
-        if(any_dyn)
+        if(data_shape.dynamic() or i_shape.dynamic())
             return output_shape;
         return output_shape.to_static();
     }

--- a/src/include/migraphx/op/scatter_op.hpp
+++ b/src/include/migraphx/op/scatter_op.hpp
@@ -26,6 +26,7 @@
 
 #include <array>
 #include <migraphx/check_shapes.hpp>
+#include <migraphx/dyn_output.hpp>
 #include <migraphx/shape_for_each.hpp>
 #include <migraphx/config.hpp>
 #include <migraphx/value.hpp>
@@ -65,9 +66,17 @@ struct scatter_op : op_name<Derived>
 
     shape normalize_compute_shape(std::vector<shape> inputs) const
     {
-        check_shapes{inputs, *this}.has(3);
-        // If non-packed, this converts to a packed output while preserving permutation of tensor
-        return inputs.front().with_lens(inputs.front().lens());
+        check_shapes{inputs, *this, true}.has(3);
+        const auto& data = inputs.front();
+        // range-dyn carries no permutation; passthrough
+        if(data.dynamic() and not data.symbolic())
+            return data;
+        // broadcasted: drop 0-strides and return packed default layout
+        if(data.broadcasted())
+            return data.symbolic() ? shape{data.type(), data.dyn_dims()}
+                                   : shape{data.type(), data.lens()};
+        // otherwise re-pack preserving data's permutation
+        return data.symbolic() ? data.with_lens(data.dyn_dims()) : data.with_lens(data.lens());
     }
 
     // iterate through items in shape
@@ -109,9 +118,9 @@ struct scatter_op : op_name<Derived>
         });
     }
 
-    argument compute(const shape& output_shape, std::vector<argument> args) const
+    argument compute(const dyn_output& dyn_out, std::vector<argument> args) const
     {
-        argument result{output_shape};
+        argument result{dyn_out.computed_shape};
 
         visit_all(result, args[0], args[2])([&](auto output, auto data, auto update) {
             std::copy(data.begin(), data.end(), output.begin());

--- a/src/include/migraphx/op/scatternd_op.hpp
+++ b/src/include/migraphx/op/scatternd_op.hpp
@@ -83,12 +83,12 @@ struct scatternd_op : op_name<Derived>
             MIGRAPHX_THROW("ScatterND: index of size " + std::to_string(k) +
                            " is too large for tensor of rank " + std::to_string(r));
 
-        // Convert all static shape dimensions to dynamic so they can be compared.
-        // It's possible for some of the 3 inputs to be dynamic shapes and some static,
-        // but any dynamic dimension that's compared to a static dimension must be fixed.
-        auto ind_dims  = index_shape.to_dynamic().dyn_dims();
-        auto upd_dims  = upd_shape.to_dynamic().dyn_dims();
-        auto data_dims = data_shape.to_dynamic().dyn_dims();
+        // Align all three inputs to a single representation so the dim comparisons work
+        // across any mix of static, symbolic, and range-dynamic shapes.
+        auto unified   = shape::to_dynamic(inputs);
+        auto data_dims = unified[0].dyn_dims();
+        auto ind_dims  = unified[1].dyn_dims();
+        auto upd_dims  = unified[2].dyn_dims();
 
         // Check that corresponding portions of tensor shapes match.
         // Brackets around q - 1 are placed for safeguarding against the breaking iterator out of
@@ -98,16 +98,16 @@ struct scatternd_op : op_name<Derived>
             MIGRAPHX_THROW("ScatterND: incorrect update shape. Update dimensions must match "
                            "indices and data.");
 
-        if(data_shape.dynamic())
+        // range-dyn carries no permutation; passthrough
+        if(data_shape.dynamic() and not data_shape.symbolic())
             return data_shape;
-        else if(data_shape.broadcasted())
-        {
-            return {data_shape.type(), data_shape.lens()};
-        }
-        else
-        {
-            return data_shape.with_lens(data_shape.lens());
-        }
+        // broadcasted: drop 0-strides and return packed default layout
+        if(data_shape.broadcasted())
+            return data_shape.symbolic() ? shape{data_shape.type(), data_shape.dyn_dims()}
+                                         : shape{data_shape.type(), data_shape.lens()};
+        // otherwise re-pack preserving data's permutation
+        return data_shape.symbolic() ? data_shape.with_lens(data_shape.dyn_dims())
+                                     : data_shape.with_lens(data_shape.lens());
     }
 
     argument compute(const dyn_output& dyn_out, std::vector<argument> args) const

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -5936,6 +5936,15 @@ TEST_CASE(gathernd_sym_indices_k_must_be_fixed)
     throws_shape(migraphx::make_op("gathernd"), data, indices);
 }
 
+TEST_CASE(gathernd_sym_scalar_output)
+{
+    auto n = var("n", {2, 8}, {4});
+    migraphx::shape data{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}};
+    migraphx::shape indices{migraphx::shape::int64_type, {2}};
+    migraphx::shape output{migraphx::shape::float_type, {dd{lit(1)}}};
+    expect_shape(output, migraphx::make_op("gathernd"), data, indices);
+}
+
 TEST_CASE(test_scatternd0)
 {
     // good

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -1818,6 +1818,64 @@ TEST_CASE(gather_dyn4)
                  indices);
 }
 
+TEST_CASE(gather_sym_data_on_axis)
+{
+    auto n = var("n", {2, 8}, {4});
+    migraphx::shape input{migraphx::shape::float_type, {dd{lit(3)}, dd{n}, dd{lit(5)}}};
+    migraphx::shape indices{migraphx::shape::int32_type, {2, 4}};
+    migraphx::shape output{migraphx::shape::float_type,
+                           {dd{lit(3)}, dd{lit(2)}, dd{lit(4)}, dd{lit(5)}}};
+    expect_shape(output, migraphx::make_op("gather", {{"axis", 1}}), input, indices);
+}
+
+TEST_CASE(gather_sym_data_off_axis)
+{
+    auto n = var("n", {2, 8}, {4});
+    migraphx::shape input{migraphx::shape::float_type, {dd{lit(3)}, dd{n}, dd{lit(5)}}};
+    migraphx::shape indices{migraphx::shape::int32_type, {2, 4}};
+    migraphx::shape output{migraphx::shape::float_type,
+                           {dd{lit(2)}, dd{lit(4)}, dd{n}, dd{lit(5)}}};
+    expect_shape(output, migraphx::make_op("gather", {{"axis", 0}}), input, indices);
+}
+
+TEST_CASE(gather_sym_indices)
+{
+    auto k = var("k", {1, 6}, {3});
+    migraphx::shape input{migraphx::shape::float_type, {4, 5, 6}};
+    migraphx::shape indices{migraphx::shape::int32_type, {dd{k}, dd{lit(3)}}};
+    migraphx::shape output{migraphx::shape::float_type,
+                           {dd{lit(4)}, dd{k}, dd{lit(3)}, dd{lit(6)}}};
+    expect_shape(output, migraphx::make_op("gather", {{"axis", 1}}), input, indices);
+}
+
+TEST_CASE(gather_sym_both)
+{
+    auto n = var("n", {2, 8}, {4});
+    auto k = var("k", {1, 6}, {3});
+    migraphx::shape input{migraphx::shape::float_type, {dd{n}, dd{lit(5)}}};
+    migraphx::shape indices{migraphx::shape::int32_type, {dd{k}, dd{lit(3)}}};
+    migraphx::shape output{migraphx::shape::float_type, {dd{n}, dd{k}, dd{lit(3)}}};
+    expect_shape(output, migraphx::make_op("gather", {{"axis", 1}}), input, indices);
+}
+
+TEST_CASE(gather_sym_scalar_indices)
+{
+    auto n = var("n", {2, 8}, {4});
+    migraphx::shape input{migraphx::shape::float_type, {dd{lit(3)}, dd{n}}};
+    migraphx::shape indices{migraphx::shape::int32_type, {1}, {0}};
+    migraphx::shape output{migraphx::shape::float_type, {dd{lit(3)}}};
+    expect_shape(output, migraphx::make_op("gather", {{"axis", 1}}), input, indices);
+}
+
+TEST_CASE(gather_sym_data_dyn_indices)
+{
+    auto n = var("n", {2, 8}, {4});
+    migraphx::shape input{migraphx::shape::float_type, {dd{n}, dd{lit(5)}}};
+    migraphx::shape indices{migraphx::shape::int32_type, {dd{1, 3, {2}}}};
+    migraphx::shape output{migraphx::shape::float_type, {dd{2, 8, {4}}, dd{1, 3, {2}}}};
+    expect_shape(output, migraphx::make_op("gather", {{"axis", 1}}), input, indices);
+}
+
 TEST_CASE(get_tuple_elem_test)
 {
     migraphx::shape s0{migraphx::shape::bool_type, {1, 1}};
@@ -5833,6 +5891,51 @@ TEST_CASE(test_gathernd_dynamic8)
     expect_shape(s0, migraphx::make_op("gathernd", {{"batch_dims", batch_dims}}), ds, is);
 }
 
+TEST_CASE(gathernd_sym_data)
+{
+    auto n = var("n", {2, 8}, {4});
+    migraphx::shape data{migraphx::shape::float_type, {dd{n}, dd{lit(3)}, dd{lit(5)}}};
+    migraphx::shape indices{migraphx::shape::int64_type, {4, 2}};
+    migraphx::shape output{migraphx::shape::float_type, {dd{lit(4)}, dd{lit(5)}}};
+    expect_shape(output, migraphx::make_op("gathernd"), data, indices);
+}
+
+TEST_CASE(gathernd_sym_indices_leading)
+{
+    auto m = var("m", {1, 6}, {3});
+    migraphx::shape data{migraphx::shape::float_type, {7, 3, 5}};
+    migraphx::shape indices{migraphx::shape::int64_type, {dd{m}, dd{lit(2)}}};
+    migraphx::shape output{migraphx::shape::float_type, {dd{m}, dd{lit(5)}}};
+    expect_shape(output, migraphx::make_op("gathernd"), data, indices);
+}
+
+TEST_CASE(gathernd_sym_both)
+{
+    auto n = var("n", {2, 8}, {4});
+    auto m = var("m", {1, 6}, {3});
+    migraphx::shape data{migraphx::shape::float_type, {dd{n}, dd{lit(3)}, dd{lit(5)}}};
+    migraphx::shape indices{migraphx::shape::int64_type, {dd{m}, dd{lit(2)}}};
+    migraphx::shape output{migraphx::shape::float_type, {dd{m}, dd{lit(5)}}};
+    expect_shape(output, migraphx::make_op("gathernd"), data, indices);
+}
+
+TEST_CASE(gathernd_sym_batch_dims)
+{
+    auto n = var("n", {2, 6}, {4});
+    migraphx::shape data{migraphx::shape::float_type, {dd{n}, dd{lit(3)}, dd{lit(5)}}};
+    migraphx::shape indices{migraphx::shape::int64_type, {dd{n}, dd{lit(4)}, dd{lit(1)}}};
+    migraphx::shape output{migraphx::shape::float_type, {dd{n}, dd{lit(4)}, dd{lit(5)}}};
+    expect_shape(output, migraphx::make_op("gathernd", {{"batch_dims", 1}}), data, indices);
+}
+
+TEST_CASE(gathernd_sym_indices_k_must_be_fixed)
+{
+    auto k = var("k", {1, 3});
+    migraphx::shape data{migraphx::shape::float_type, {4, 3, 5}};
+    migraphx::shape indices{migraphx::shape::int64_type, {dd{lit(2)}, dd{k}}};
+    throws_shape(migraphx::make_op("gathernd"), data, indices);
+}
+
 TEST_CASE(test_scatternd0)
 {
     // good
@@ -5972,6 +6075,67 @@ TEST_CASE(test_scatternd_dyn5)
     migraphx::shape is{itype, {dd, dd}};
     migraphx::shape us{dtype, {dbad}};
     throws_shape(migraphx::make_op("scatternd_none"), ds, is, us);
+}
+
+TEST_CASE(scatternd_sym_data)
+{
+    auto n = var("n", {2, 8}, {4});
+    migraphx::shape data{migraphx::shape::float_type, {dd{n}, dd{lit(5)}}};
+    migraphx::shape indices{migraphx::shape::int64_type, {dd{lit(3)}, dd{lit(2)}}};
+    migraphx::shape updates{migraphx::shape::float_type, {dd{lit(3)}}};
+    expect_shape(data, migraphx::make_op("scatternd_none"), data, indices, updates);
+}
+
+TEST_CASE(scatternd_sym_partial_index)
+{
+    auto n = var("n", {2, 8}, {4});
+    migraphx::shape data{migraphx::shape::float_type, {dd{n}, dd{lit(5)}}};
+    migraphx::shape indices{migraphx::shape::int64_type, {dd{lit(3)}, dd{lit(1)}}};
+    migraphx::shape updates{migraphx::shape::float_type, {dd{lit(3)}, dd{lit(5)}}};
+    expect_shape(data, migraphx::make_op("scatternd_none"), data, indices, updates);
+}
+
+TEST_CASE(scatternd_sym_mismatch_throws)
+{
+    auto n = var("n", {2, 8}, {4});
+    migraphx::shape data{migraphx::shape::float_type, {dd{n}, dd{lit(5)}}};
+    migraphx::shape indices{migraphx::shape::int64_type, {dd{lit(3)}, dd{lit(1)}}};
+    migraphx::shape updates{migraphx::shape::float_type, {dd{lit(3)}, dd{lit(4)}}};
+    throws_shape(migraphx::make_op("scatternd_none"), data, indices, updates);
+}
+
+TEST_CASE(scatter_static)
+{
+    migraphx::shape data{migraphx::shape::float_type, {3, 5}};
+    migraphx::shape indices{migraphx::shape::int32_type, {2, 5}};
+    migraphx::shape updates{migraphx::shape::float_type, {2, 5}};
+    expect_shape(data, migraphx::make_op("scatter_none", {{"axis", 0}}), data, indices, updates);
+}
+
+TEST_CASE(scatter_dyn)
+{
+    migraphx::shape data{migraphx::shape::float_type, {{2, 6, {4}}, {5, 5}}};
+    migraphx::shape indices{migraphx::shape::int32_type, {{1, 4}, {5, 5}}};
+    migraphx::shape updates{migraphx::shape::float_type, {{1, 4}, {5, 5}}};
+    expect_shape(data, migraphx::make_op("scatter_none", {{"axis", 0}}), data, indices, updates);
+}
+
+TEST_CASE(scatter_sym)
+{
+    auto n = var("n", {2, 6}, {4});
+    migraphx::shape data{migraphx::shape::float_type, {dd{n}, dd{lit(5)}}};
+    migraphx::shape indices{migraphx::shape::int32_type, {dd{n}, dd{lit(5)}}};
+    migraphx::shape updates{migraphx::shape::float_type, {dd{n}, dd{lit(5)}}};
+    expect_shape(data, migraphx::make_op("scatter_none", {{"axis", 0}}), data, indices, updates);
+}
+
+TEST_CASE(scatter_dyn_data_sym_indices)
+{
+    auto n = var("n", {1, 4}, {2});
+    migraphx::shape data{migraphx::shape::float_type, {{2, 6, {4}}, {5, 5}}};
+    migraphx::shape indices{migraphx::shape::int32_type, {dd{n}, dd{lit(5)}}};
+    migraphx::shape updates{migraphx::shape::float_type, {dd{n}, dd{lit(5)}}};
+    expect_shape(data, migraphx::make_op("scatter_none", {{"axis", 0}}), data, indices, updates);
 }
 
 TEST_CASE(test_squeeze)


### PR DESCRIPTION
## Motivation
Update compute shapes methods for gather and scatter ops to propagate symbolic shapes.

## Technical Details


## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
