### PR TITLE
parse_where: broadcast dynamic ternary inputs via add_common_op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Full documentation for MIGraphX is available at
 
 ### Resolved issues
 
+* Fixed ONNX `Where` parsing for dynamic-shape inputs that require broadcasting (including mixed static and dynamic inputs), which previously threw `same_dims: where: Dimensions do not match` (#4925).
 * Fixed a regression in `simplify_algebra` where `find_conv_broadcast_input` could trigger `Dimensions do not match` for padded broadcast-convolution rewrites in no-interior spatial cases (#4738).
 * Fixed a bug with operators `pack_fp4`, `unpack_fp4`, and the `fuse_mlir` pass handling non-standard input shapes (#4560).
 * Fixed an issue in `propagate_precision` pass where precision could be incorrectly propagated across type boundaries (e.g., from integral to floating-point) (#4603).

--- a/src/onnx/parse_where.cpp
+++ b/src/onnx/parse_where.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,45 +40,26 @@ struct parse_where : op_parser<parse_where>
                           const onnx_parser::node_info& info,
                           std::vector<instruction_ref> args) const
     {
-        // TODO: broadcasting for dynamic shapes is only implemented
-        // for binary ops at time of writing, not ternary ops.
-        //   When it becomes available, add multibroadcasting steps in the dynamic shape case.
-        // For now for dynamic shapes, just insert the Where op.  All shapes must be the
-        // same for it to succeed.
-        if(std::all_of(args.begin(), args.end(), [](auto v) { return v->get_shape().dynamic(); }))
-        {
+        // Fast path: when all three inputs already share the same dims, emit
+        // where() directly (no redundant broadcast). This keeps the common
+        // same-shape case -- including all-dynamic identical shapes -- as a
+        // bare where op.
+        const auto s0 = args[0]->get_shape();
+        if(shape::same_lens(args[1]->get_shape(), s0) and
+           shape::same_lens(args[2]->get_shape(), s0))
             return info.add_instruction(make_op("where"), args[0], args[1], args[2]);
-        }
-        else if(std::none_of(
-                    args.begin(), args.end(), [](auto v) { return v->get_shape().dynamic(); }))
-        {
-            // If shapes are static and any are broadcasted, insert multibroadcast ops
-            auto lens =
-                compute_broadcasted_lens(args[0]->get_shape().lens(), args[1]->get_shape().lens());
-            lens = compute_broadcasted_lens(lens, args[2]->get_shape().lens());
 
-            if(args[0]->get_shape().lens() != lens)
-            {
-                args[0] =
-                    info.add_instruction(make_op("multibroadcast", {{"out_lens", lens}}), args[0]);
-            }
-
-            if(args[1]->get_shape().lens() != lens)
-            {
-                args[1] =
-                    info.add_instruction(make_op("multibroadcast", {{"out_lens", lens}}), args[1]);
-            }
-
-            if(args[2]->get_shape().lens() != lens)
-            {
-                args[2] =
-                    info.add_instruction(make_op("multibroadcast", {{"out_lens", lens}}), args[2]);
-            }
-
-            return info.add_instruction(make_op("where"), args[0], args[1], args[2]);
-        }
-        else
-            MIGRAPHX_THROW("PARSE_WHERE: doesn't support mixed static and dynamic shape inputs");
+        // Otherwise broadcast the three inputs to a common shape. where()
+        // must NOT unify element types (args[0] is the bool condition while
+        // args[1]/args[2] carry the data type), so add_common_op is called
+        // with common_type=false. This handles static, dynamic, and mixed
+        // inputs uniformly; the dynamic path goes through
+        // compute_common_dyn_dims, so an unconstrained input (e.g. a
+        // broadcast_with_dims / ONNX Expand output {0, SIZE_MAX}) is
+        // intersected with the other operands instead of requiring every
+        // input to already share an identical dynamic shape.
+        return migraphx::add_common_op(
+            *info.mod, make_op("where"), args, {/*common_type=*/false, /*common_lens=*/true});
     }
 };
 

--- a/test/onnx/gen_onnx.py
+++ b/test/onnx/gen_onnx.py
@@ -18755,7 +18755,6 @@ def where_dyn_test():
 
 @onnx_test()
 def where_mixed_test():
-    # mixture of static and dynamic input shapes is not supported
     c = helper.make_tensor_value_info('c', TensorProto.BOOL, [None, 2, 2])
     x = helper.make_tensor_value_info('x', TensorProto.FLOAT, [None, 2, 2])
     y = helper.make_tensor_value_info('y', TensorProto.FLOAT, [3, 2, 2])

--- a/test/onnx/parse/where_dyn_test.cpp
+++ b/test/onnx/parse/where_dyn_test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,8 +26,9 @@
 
 TEST_CASE(where_dyn_test)
 {
-    // TODO: broadcasting for dynamic shapes isn't implemented at time of writing.
-    // Update this test case to use shapes that require broadcasting, when available.
+    // All three inputs already share the same dynamic dims, so parse_where
+    // emits a bare where op (no broadcast needed). The broadcasting path for
+    // mismatched dynamic shapes is covered by where_mixed_test.
     migraphx::program p;
     auto* mm = p.get_main_module();
     auto lc  = mm->add_parameter(

--- a/test/onnx/parse/where_mixed_test.cpp
+++ b/test/onnx/parse/where_mixed_test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,8 +26,16 @@
 
 TEST_CASE(where_mixed_test)
 {
-    //  mixture of static and dynamic input shapes is not supported
+    // Mixed static + dynamic where inputs broadcast to a common
+    // shape via add_common_op(). The static
+    // input y={3,2,2} pins the broadcasted dimension, so the result has
+    // fixed dims {3,2,2}.
     migraphx::onnx_options options;
     options.default_dyn_dim_value = {1, 4};
-    EXPECT(test::throws([&] { read_onnx("where_mixed_test.onnx", options); }));
+    auto prog                     = read_onnx("where_mixed_test.onnx", options);
+
+    auto out_shapes = prog.get_output_shapes();
+    EXPECT(out_shapes.size() == 1);
+    migraphx::shape expected{migraphx::shape::float_type, {{3, 3}, {2, 2}, {2, 2}}};
+    EXPECT(out_shapes.front() == expected);
 }


### PR DESCRIPTION
The ONNX Where parser had a long-standing limitation: for all-dynamic inputs it inserted the where op directly with no broadcasting and threw outright on a static/dynamic mix. That meant a dynamic Where whose inputs were not already identically shaped (e.g. one input is a broadcast_with_dims / ONNX Expand output {0, SIZE_MAX}) failed at parse with "same_dims: where: Dimensions do not match".

Route the three inputs through add_common_op (common_type=false so the bool condition and the data-type branches keep their own types), exactly as binary ops already do. This handles static, dynamic, and mixed inputs uniformly; the dynamic path goes through compute_common_dyn_dims so unconstrained inputs intersect with their peers instead of requiring an exact shape match. A fast path keeps the common same-dims case (including all-dynamic identical shapes) as a bare where op, so existing IR is unchanged there.

Tests:
- where_test (static broadcast) and where_dyn_test (identical dynamic): unchanged, still pass.
- where_mixed_test: previously asserted "throws"; now asserts the mixed static+dynamic inputs broadcast to the expected {3,2,2} result. Full test_onnx_test (882 cases) and ref where verify tests pass.

## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
