### PR TITLE
Remove rocm-cmake dependency in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     hipsparse \
     rccl \
     rocm-smi-lib \
+    rocminfo \
     roctracer-dev \
     hipcub  \
     hipblas  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     hipsparse \
     rccl \
     rocm-smi-lib \
-    rocm-dev \
     roctracer-dev \
     hipcub  \
     hipblas  \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,7 @@ def cmake_build = { bconf ->
         export MIGRAPHX_GPU_DEBUG=${gpu_debug}
         export CXX=${compiler}
         export CXXFLAGS='-Werror'
-        rocminfo
+        /opt/rocm/bin/rocminfo
         env
         rm -rf build
         mkdir build

--- a/tools/install_prereqs.sh
+++ b/tools/install_prereqs.sh
@@ -42,7 +42,6 @@ if [[ ("${ID}" == "sles") ]]; then
     python3-devel \
     python3-pip \
     rocblas-devel \
-    rocm-cmake \
     libgfortran5 \
     hipblas-devel \
     hipblaslt-devel
@@ -61,7 +60,6 @@ else
     hipblas-dev \
     hipblaslt-dev \
     hipcc \
-    rocm-cmake \
     rocm-llvm-dev \
     libtbb-dev
 fi

--- a/tools/install_prereqs.sh
+++ b/tools/install_prereqs.sh
@@ -3,7 +3,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Motivation
The rocm-cmake version in rocm clashes with the version used in the requirements.txt.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
