### PR TITLE
[AIMIGRAPHX-1085] Add --cout option for driver output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Full documentation for MIGraphX is available at
 * Added find_concat_same_input matcher to convert concat(N*x) into multibroadcast(x) to reduce hipCopy() (#4981)
 * Added driver warnings when inputs dimensions and/or values are not set (#4850).
 * Added documentation for using debug symbols (#4945).
+* Added `--cout` flag to migraphx-driver to log to stdout instead of stderr (#4959).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Full documentation for MIGraphX is available at
 * Added find_concat_same_input matcher to convert concat(N*x) into multibroadcast(x) to reduce hipCopy() (#4981)
 * Added driver warnings when inputs dimensions and/or values are not set (#4850).
 * Added documentation for using debug symbols (#4945).
-* Added `--cout` flag to migraphx-driver to log to stdout instead of stderr (#4959).
+* Added `--log-stdout` flag to migraphx-driver to log to stdout instead of stderr (#4959).
 
 ### Changed
 

--- a/docs/migraphx-driver.rst
+++ b/docs/migraphx-driver.rst
@@ -139,6 +139,12 @@ To learn which options can be used with which commands, see the :ref:`MIGraphX d
       - Sets the number of iterations to run for perf report
    *  - --list | -l
       - Lists all the MIGraphX operators
+   *  - --log-level
+      - Sets the log level (none/0, error/1, warn/2, info/3, debug/4, trace/5)
+   *  - --log-file
+      - Logs to one or more files (``--log-file file1.log file2.log ...``)
+   *  - --log-stdout
+      - Logs to ``stdout`` in addition to the default ``stderr`` (warnings and errors still go to ``stderr``)
 
 Usage
 ----------

--- a/src/driver/argument_parser.hpp
+++ b/src/driver/argument_parser.hpp
@@ -700,7 +700,7 @@ struct argument_parser
     }
 
     template <class F>
-    void post_action(F f)
+    void post_action(const F& f)
     {
         actions.push_back(f);
     }

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -95,7 +95,8 @@ struct logger_options
 {
     std::string log_level;
     std::vector<std::string> log_files;
-    bool log_to_cout = false;
+    bool log_to_cout     = false;
+    bool cout_sink_added = false;
 
     void parse(migraphx::driver::argument_parser& ap)
     {
@@ -120,17 +121,27 @@ struct logger_options
            ap.append(),
            ap.nargs(2));
         ap(log_to_cout,
-           {"--cout"},
+           {"--log-stdout"},
            ap.help("Send info logs to std::cout, keeping warnings and errors on std::cerr"),
            ap.set_value(true));
         ap.post_action([this](auto&&) { this->apply(); });
     }
 
-    void apply() const
+    void add_cout_sink()
+    {
+        if(cout_sink_added)
+            return;
+        cout_sink_added = true;
+        migraphx::log::set_severity(
+            migraphx::log::severity::warn); // sets the severity of default (stderr) sink to warn
+        migraphx::log::add_sink(migraphx::log::make_io_sink(std::cout));
+    }
+
+    void apply()
     {
         if(log_to_cout)
         {
-            migraphx::log::set_info_stream(std::cout);
+            add_cout_sink();
         }
         if(not log_level.empty())
         {
@@ -1212,8 +1223,8 @@ int main(int argc, const char* argv[], const char* envp[])
         }
 
         // Needed so that the first two lines printed follow the requested sink
-        if(std::find(args.begin(), args.end(), "--cout") != args.end())
-            migraphx::log::set_info_stream(std::cout);
+        if(std::find(args.begin(), args.end(), "--log-stdout") != args.end())
+            log_opts.add_cout_sink();
 
         std::string driver_invocation =
             std::string(argv[0]) + " " + migraphx::to_string_range(original_args, " ");

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -121,7 +121,7 @@ struct logger_options
            ap.nargs(2));
         ap(log_to_cout,
            {"--cout"},
-           ap.help("Log to std::cout instead of the default std::cerr"),
+           ap.help("Send info logs to std::cout, keeping warnings and errors on std::cerr"),
            ap.set_value(true));
         ap.post_action([this](auto&&) { this->apply(); });
     }
@@ -130,7 +130,7 @@ struct logger_options
     {
         if(log_to_cout)
         {
-            migraphx::log::set_default_stream(std::cout);
+            migraphx::log::set_info_stream(std::cout);
         }
         if(not log_level.empty())
         {
@@ -1213,7 +1213,7 @@ int main(int argc, const char* argv[], const char* envp[])
 
         // Needed so that the first two lines printed follow the requested sink
         if(std::find(args.begin(), args.end(), "--cout") != args.end())
-            migraphx::log::set_default_stream(std::cout);
+            migraphx::log::set_info_stream(std::cout);
 
         std::string driver_invocation =
             std::string(argv[0]) + " " + migraphx::to_string_range(original_args, " ");

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -95,8 +95,7 @@ struct logger_options
 {
     std::string log_level;
     std::vector<std::string> log_files;
-    bool log_to_cout     = false;
-    bool cout_sink_added = false;
+    bool log_to_cout = false;
 
     void parse(migraphx::driver::argument_parser& ap)
     {
@@ -129,9 +128,6 @@ struct logger_options
 
     void add_cout_sink()
     {
-        if(cout_sink_added)
-            return;
-        cout_sink_added = true;
         migraphx::log::set_severity(
             migraphx::log::severity::warn); // sets the severity of default (stderr) sink to warn
         migraphx::log::add_sink(migraphx::log::make_io_sink(std::cout));
@@ -1213,22 +1209,11 @@ int main(int argc, const char* argv[], const char* envp[])
         logger_options log_opts;
         log_opts.parse(ap);
 
-        // Needed so that the first two lines printed follow the log level set
-        auto it = std::find(args.begin(), args.end(), "--log-level");
-        if(it != args.end() and std::next(it) != args.end())
-        {
-            auto level = logger_options::parse_log_level_string(*std::next(it));
-            if(level)
-                migraphx::log::set_severity(*level);
-        }
-
-        // Needed so that the first two lines printed follow the requested sink
-        if(std::find(args.begin(), args.end(), "--log-stdout") != args.end())
-            log_opts.add_cout_sink();
-
         std::string driver_invocation =
             std::string(argv[0]) + " " + migraphx::to_string_range(original_args, " ");
-        migraphx::log::info() << "Running [ " << get_version() << " ]: " << driver_invocation;
+        ap.post_action([driver_invocation](auto&&) {
+            migraphx::log::info() << "Running [ " << get_version() << " ]: " << driver_invocation;
+        });
 
         auto start_time = std::chrono::system_clock::now();
 

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -95,6 +95,7 @@ struct logger_options
 {
     std::string log_level;
     std::vector<std::string> log_files;
+    bool log_to_cout = false;
 
     void parse(migraphx::driver::argument_parser& ap)
     {
@@ -118,11 +119,19 @@ struct logger_options
            ap.help("Log to file(s) (--log-file file1.log file2.log ...)"),
            ap.append(),
            ap.nargs(2));
+        ap(log_to_cout,
+           {"--cout"},
+           ap.help("Log to std::cout instead of the default std::cerr"),
+           ap.set_value(true));
         ap.post_action([this](auto&&) { this->apply(); });
     }
 
     void apply() const
     {
+        if(log_to_cout)
+        {
+            migraphx::log::set_default_stream(std::cout);
+        }
         if(not log_level.empty())
         {
             auto level = parse_log_level_string(log_level);
@@ -1201,6 +1210,10 @@ int main(int argc, const char* argv[], const char* envp[])
             if(level)
                 migraphx::log::set_severity(*level);
         }
+
+        // Needed so that the first two lines printed follow the requested sink
+        if(std::find(args.begin(), args.end(), "--cout") != args.end())
+            migraphx::log::set_default_stream(std::cout);
 
         std::string driver_invocation =
             std::string(argv[0]) + " " + migraphx::to_string_range(original_args, " ");

--- a/src/include/migraphx/logger.hpp
+++ b/src/include/migraphx/logger.hpp
@@ -98,6 +98,14 @@ MIGRAPHX_EXPORT void set_severity(severity level, size_t id = 0);
  */
 MIGRAPHX_EXPORT size_t add_file_logger(std::string_view filename, severity level = severity::info);
 
+/**
+ * @brief Sets the output stream used by the default sink (sink 0).
+ *        Defaults to std::cerr.
+ *
+ * @param os The output stream the default sink should write to
+ */
+MIGRAPHX_EXPORT void set_default_stream(std::ostream& os);
+
 template <severity Severity>
 struct print
 {

--- a/src/include/migraphx/logger.hpp
+++ b/src/include/migraphx/logger.hpp
@@ -99,12 +99,12 @@ MIGRAPHX_EXPORT void set_severity(severity level, size_t id = 0);
 MIGRAPHX_EXPORT size_t add_file_logger(std::string_view filename, severity level = severity::info);
 
 /**
- * @brief Sets the output stream used by the default sink (sink 0).
- *        Defaults to std::cerr.
+ * @brief Routes informational output (info and more verbose) on the default sink (sink 0) to the
+ * given stream while keeping warnings and errors on std::cerr.
  *
- * @param os The output stream the default sink should write to
+ * @param os The output stream that info and more-verbose messages should be written to
  */
-MIGRAPHX_EXPORT void set_default_stream(std::ostream& os);
+MIGRAPHX_EXPORT void set_info_stream(std::ostream& os);
 
 template <severity Severity>
 struct print

--- a/src/include/migraphx/logger.hpp
+++ b/src/include/migraphx/logger.hpp
@@ -99,12 +99,12 @@ MIGRAPHX_EXPORT void set_severity(severity level, size_t id = 0);
 MIGRAPHX_EXPORT size_t add_file_logger(std::string_view filename, severity level = severity::info);
 
 /**
- * @brief Routes informational output (info and more verbose) on the default sink (sink 0) to the
- * given stream while keeping warnings and errors on std::cerr.
+ * @brief Creates a sink that writes log records to the given output stream.
  *
- * @param os The output stream that info and more-verbose messages should be written to
+ * @param os The output stream to write to
+ * @return A sink that can be passed to add_sink
  */
-MIGRAPHX_EXPORT void set_info_stream(std::ostream& os);
+MIGRAPHX_EXPORT sink make_io_sink(std::ostream& os);
 
 template <severity Severity>
 struct print

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -98,30 +98,15 @@ static color severity_color(severity s)
     return color::reset;
 }
 
-// Write a single log record to the given output stream
-static void write_record(std::ostream& os, severity s, std::string_view msg, source_location loc)
-{
-    for(auto&& line : split_string(std::string{msg}, '\n'))
-    {
-        os << severity_color(s) << format_timestamp() << " [" << to_string(s) << "] ["
-           << loc.file_name() << ":" << loc.line() << "] " << line << color::reset << std::endl;
-    }
-}
-
-// Create a sink that writes to the given output stream
-static sink make_ostream_sink(std::ostream& os)
+// Create a sink that writes log records to the given output stream
+sink make_io_sink(std::ostream& os)
 {
     return [&os](severity s, std::string_view msg, source_location loc) {
-        write_record(os, s, msg, loc);
-    };
-}
-
-// Create a sink that keeps warnings and errors on std::cerr while routing less-severe messages
-// (info and more verbose) to info_os.
-static sink make_split_sink(std::ostream& info_os)
-{
-    return [&info_os](severity s, std::string_view msg, source_location loc) {
-        write_record(s <= severity::warn ? std::cerr : info_os, s, msg, loc);
+        for(auto&& line : split_string(std::string{msg}, '\n'))
+        {
+            os << severity_color(s) << format_timestamp() << " [" << to_string(s) << "] ["
+               << loc.file_name() << ":" << loc.line() << "] " << line << color::reset << std::endl;
+        }
     };
 }
 
@@ -174,8 +159,7 @@ static void access_sinks(const std::function<void(std::vector<std::optional<sink
 
         // If MIGRAPHX_LOG_LEVEL is set, this will store the value into the atomic when first called
         max_enabled_level().store(level);
-        return std::vector<std::optional<sink_entry>>{
-            sink_entry{make_ostream_sink(std::cerr), level}};
+        return std::vector<std::optional<sink_entry>>{sink_entry{make_io_sink(std::cerr), level}};
     }();
     std::lock_guard<std::mutex> lock(m);
     f(sinks);
@@ -227,14 +211,6 @@ void set_severity(severity level, size_t id)
 size_t add_file_logger(std::string_view filename, severity level)
 {
     return add_sink(make_file_sink(std::string(filename)), level);
-}
-
-void set_info_stream(std::ostream& os)
-{
-    access_sinks([&](std::vector<std::optional<sink_entry>>& sinks) {
-        if(not sinks.empty() and sinks[0].has_value())
-            sinks[0]->callback = make_split_sink(os);
-    });
 }
 
 void record(severity s, std::string_view msg, source_location loc)

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -98,15 +98,30 @@ static color severity_color(severity s)
     return color::reset;
 }
 
+// Write a single log record to the given output stream
+static void write_record(std::ostream& os, severity s, std::string_view msg, source_location loc)
+{
+    for(auto&& line : split_string(std::string{msg}, '\n'))
+    {
+        os << severity_color(s) << format_timestamp() << " [" << to_string(s) << "] ["
+           << loc.file_name() << ":" << loc.line() << "] " << line << color::reset << std::endl;
+    }
+}
+
 // Create a sink that writes to the given output stream
 static sink make_ostream_sink(std::ostream& os)
 {
     return [&os](severity s, std::string_view msg, source_location loc) {
-        for(auto&& line : split_string(std::string{msg}, '\n'))
-        {
-            os << severity_color(s) << format_timestamp() << " [" << to_string(s) << "] ["
-               << loc.file_name() << ":" << loc.line() << "] " << line << color::reset << std::endl;
-        }
+        write_record(os, s, msg, loc);
+    };
+}
+
+// Create a sink that keeps warnings and errors on std::cerr while routing less-severe messages
+// (info and more verbose) to info_os.
+static sink make_split_sink(std::ostream& info_os)
+{
+    return [&info_os](severity s, std::string_view msg, source_location loc) {
+        write_record(s <= severity::warn ? std::cerr : info_os, s, msg, loc);
     };
 }
 
@@ -214,11 +229,11 @@ size_t add_file_logger(std::string_view filename, severity level)
     return add_sink(make_file_sink(std::string(filename)), level);
 }
 
-void set_default_stream(std::ostream& os)
+void set_info_stream(std::ostream& os)
 {
     access_sinks([&](std::vector<std::optional<sink_entry>>& sinks) {
         if(not sinks.empty() and sinks[0].has_value())
-            sinks[0]->callback = make_ostream_sink(os);
+            sinks[0]->callback = make_split_sink(os);
     });
 }
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -98,15 +98,14 @@ static color severity_color(severity s)
     return color::reset;
 }
 
-// Create the default stderr sink
-static sink make_stderr_sink()
+// Create a sink that writes to the given output stream
+static sink make_ostream_sink(std::ostream& os)
 {
-    return [](severity s, std::string_view msg, source_location loc) {
+    return [&os](severity s, std::string_view msg, source_location loc) {
         for(auto&& line : split_string(std::string{msg}, '\n'))
         {
-            std::cerr << severity_color(s) << format_timestamp() << " [" << to_string(s) << "] ["
-                      << loc.file_name() << ":" << loc.line() << "] " << line << color::reset
-                      << std::endl;
+            os << severity_color(s) << format_timestamp() << " [" << to_string(s) << "] ["
+               << loc.file_name() << ":" << loc.line() << "] " << line << color::reset << std::endl;
         }
     };
 }
@@ -160,7 +159,8 @@ static void access_sinks(const std::function<void(std::vector<std::optional<sink
 
         // If MIGRAPHX_LOG_LEVEL is set, this will store the value into the atomic when first called
         max_enabled_level().store(level);
-        return std::vector<std::optional<sink_entry>>{sink_entry{make_stderr_sink(), level}};
+        return std::vector<std::optional<sink_entry>>{
+            sink_entry{make_ostream_sink(std::cerr), level}};
     }();
     std::lock_guard<std::mutex> lock(m);
     f(sinks);
@@ -212,6 +212,14 @@ void set_severity(severity level, size_t id)
 size_t add_file_logger(std::string_view filename, severity level)
 {
     return add_sink(make_file_sink(std::string(filename)), level);
+}
+
+void set_default_stream(std::ostream& os)
+{
+    access_sinks([&](std::vector<std::optional<sink_entry>>& sinks) {
+        if(not sinks.empty() and sinks[0].has_value())
+            sinks[0]->callback = make_ostream_sink(os);
+    });
 }
 
 void record(severity s, std::string_view msg, source_location loc)


### PR DESCRIPTION
## Motivation
Performance tests are currently missing information since INFO statements are routed to `std::cerr` by default. This causes failures which results in them being disabled, but the information is still necessary.

## Technical Details
Adds a `--log-stdout` flag for the driver that will send info/debug/trace logs to `std::cout` instead of `std::cerr`. Warnings/errors are kept on `std::cerr`. Default behavior without the flag does not change.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [x] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
