### PR TITLE
Moving RockEnums.h inside header guard

### DIFF
--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -32,12 +32,12 @@
 #include <migraphx/pass_manager.hpp>
 #include <migraphx/gpu/mlir.hpp>
 #include <migraphx/gpu/prepare_mlir.hpp>
-#include <mlir-c/Dialect/RockEnums.h>
 #include <numeric>
 #include <ostream>
 #include <tuple>
 
 #ifdef MIGRAPHX_MLIR
+#include <mlir-c/Dialect/RockEnums.h>
 #include <mlir-c/IR.h>
 #include <mlir-c/BuiltinAttributes.h>
 #include <mlir-c/BuiltinTypes.h>


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
While working on https://github.com/ROCm/TheRock/pull/5824 I had to disable MLIR by passing [-DMIGRAPHX_ENABLE_MLIR](https://github.com/ROCm/AMDMIGraphX/blob/f85888474a0f4da027996de690cef6ce427c047b/src/targets/gpu/CMakeLists.txt#L304)=OFF, which lead to build failure.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
The fix is one liner (moving `#include <mlir-c/Dialect/RockEnums.h>` line inside `#ifdef MIGRAPHX_MLIR`).

## Steps to reproduce

1. docker build -t migraphx .
2. docker run --device='/dev/kfd' --device='/dev/dri' -v=`pwd`:/code/AMDMIGraphX -w /code/AMDMIGraphX --group-add video -it migraphx
3. rbuild prepare -d depend
4. mkdir build
5. cd build
6. CXX=/opt/rocm/llvm/bin/clang++ cmake .. **-DMIGRAPHX_ENABLE_MLIR=OFF** -DGPU_TARGETS=$(/opt/rocm/bin/rocminfo | grep -o -m1 'gfx.*')
7. make -j$(nproc) 2>&1 | tee error-log/b1.log

## Error

```
[ 42%] Building CXX object src/targets/gpu/CMakeFiles/migraphx_gpu.dir/ops/migraphx_gpu_convolution_hpp.cpp.o
/code/AMDMIGraphX/src/targets/gpu/mlir.cpp:35:10: fatal error: 'mlir-c/Dialect/RockEnums.h' file not found
   35 | #include <mlir-c/Dialect/RockEnums.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
