### PR TITLE
Fix FindParallelSTL MSVC compile check missing C++17 flag

### DIFF
--- a/cmake/FindParallelSTL.cmake
+++ b/cmake/FindParallelSTL.cmake
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,8 +27,9 @@ include(CheckCXXSourceCompiles)
 
 function(find_parallel_stl_check RESULT)
     set(CMAKE_REQUIRED_LIBRARIES ${ARGN})
-    set(CMAKE_REQUIRED_FLAGS)
-    if(NOT MSVC)
+    if(MSVC)
+        set(CMAKE_REQUIRED_FLAGS "/std:c++17")
+    else()
         set(CMAKE_REQUIRED_FLAGS "-std=c++17")
     endif()
     string(MD5 _flags_hash "${CMAKE_REQUIRED_FLAGS} ${CMAKE_REQUIRED_LIBRARIES}")


### PR DESCRIPTION
## Motivation
On MSVC, `MIGRAPHX_HAS_EXECUTORS` was always `OFF`, disabling parallel executor support on Windows builds

## Technical Details
The root cause was in cmake/FindParallelSTL.cmake. The function find_parallel_stl_check runs a small test compilation to detect whether the compiler supports <execution> (C++17 parallel STL). To do that correctly, it needs to pass the C++17 standard flag to the test compiler invocation via CMAKE_REQUIRED_FLAGS.
On MSVC, if(NOT MSVC) evaluates to false, so CMAKE_REQUIRED_FLAGS is left empty. The test compilation then runs without any C++17 flag. MSVC defaults to C++14 mode when no standard is specified, and <execution> is not available in C++14, so the test fails.
## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
