### PR TITLE
Vectorize Resize

### DIFF
--- a/src/targets/gpu/jit/resize.cpp
+++ b/src/targets/gpu/jit/resize.cpp
@@ -133,9 +133,10 @@ struct resize_compiler : compiler<resize_compiler>
             float_equal(scales[vec.axis], 1.0f) and
             contains({"half_pixel", "pytorch_half_pixel", "align_corners", "asymmetric"},
                      coord_mode);
-gen::vectorize in_vec =
-    axis_passthrough ? gen::vectorize::elements(vec.axis, {options.virtual_inputs.front()}, {vec.size})
-                     : gen::vectorize{1, vec.axis};
+        gen::vectorize in_vec =
+            axis_passthrough
+                ? gen::vectorize::elements(vec.axis, {options.virtual_inputs.front()}, {vec.size})
+                : gen::vectorize{1, vec.axis};
 
         std::string resize_func     = "resize_" + mode;
         std::string coord_transform = "coord_transform_" + coord_mode;

--- a/src/targets/gpu/jit/resize.cpp
+++ b/src/targets/gpu/jit/resize.cpp
@@ -90,9 +90,8 @@ struct resize_compiler : compiler<resize_compiler>
         std::string mode       = v.get("mode", "nearest");
         std::string coord_mode = v.get("coordinate_transformation_mode", "half_pixel");
 
-        // The output store is vectorized along the fastest axis. Pick the size/axis with the
-        // shared vectorize helper and launch one thread per vectorized element. Resize is faster
-        // with a width-4 store than the half2 default, so the candidate sizes are given explicitly.
+        // Vectorize the output store along the fast axis, one thread per vectorized element.
+        // Width-4 beats the half2 default for resize, so request {4, 2} explicitly.
         auto vec = gen::vectorize::elements(gen::find_fast_axis(options.virtual_inputs.back()),
                                             {options.virtual_inputs.back()},
                                             {4, 2});
@@ -118,16 +117,13 @@ struct resize_compiler : compiler<resize_compiler>
             scales = reorder_dims(scales, permutation);
         }
 
-        // The input is gathered, so it can share the output's vectorization only when the fast
-        // axis is a genuine pass-through (its input index equals its output index): equal length,
-        // unit scale, contiguous, and an identity-at-unit-scale coordinate transform. Otherwise
-        // the input transformer is the identity and the input is gathered scalar-wise.
+        // The gathered input shares the output's vectorization only on a pass-through fast axis
+        // (input index == output index): equal length, unit scale, contiguous, and an
+        // identity-at-unit-scale coord transform. Otherwise the input gathers scalar-wise.
         //
-        // The mode list below is exactly the coord_transform_* function objects in
-        // kernels/resize.hpp whose operator() maps idx -> idx at unit scale (every mode except
-        // tf_half_pixel_for_nn); keep it in sync if a coordinate transform is added or changed. An
-        // omission is safe (it just falls back to a scalar gather), but listing a non-identity mode
-        // would be incorrect.
+        // The mode list is exactly the coord_transform_* objects mapping idx -> idx at unit scale
+        // (all but tf_half_pixel_for_nn); keep in sync. Omitting one is safe (scalar gather),
+        // listing a non-identity mode is not.
         const bool axis_passthrough =
             in_lens[vec.axis] == out_lens[vec.axis] and in_strides[vec.axis] == 1 and
             float_equal(scales[vec.axis], 1.0f) and

--- a/src/targets/gpu/jit/resize.cpp
+++ b/src/targets/gpu/jit/resize.cpp
@@ -48,7 +48,10 @@ extern "C" {
 MIGRAPHX_GLOBAL void resize(void* in_data, void* output)
 {
     make_tensors()(in_data, output)([](auto input, auto out) {
-        ${resize_func}<${coord_transform}, ${nearest_op}${vec_targs}>(input, out, ${scales}${cubic_coeff_arg});
+        ${vectorize}(out)([&](auto outv) {
+            ${resize_func}<${coord_transform}, ${nearest_op}, ${axis}>(
+                input, out, outv, ${scales}${cubic_coeff_arg});
+        });
     });
 }
 
@@ -82,16 +85,13 @@ struct resize_compiler : compiler<resize_compiler>
 
         std::string mode = v.get("mode", "nearest");
 
-        // The linear kernel vectorizes the output store along its fastest axis (the input is
-        // gathered, so only the output is vectorized). Pick the size/axis with the shared
-        // vectorize helper and launch one thread per vectorized element. Resize is faster with
-        // a width-4 store than the half2 default, so the candidate sizes are given explicitly.
-        // Other modes are scalar.
-        gen::vectorize vec{1, 0};
-        if(mode == "linear")
-            vec = gen::vectorize::elements(gen::find_fast_axis(options.virtual_inputs.back()),
-                                           {options.virtual_inputs.back()},
-                                           {4, 2});
+        // Every mode vectorizes the output store along its fastest axis (the input is gathered,
+        // so only the output is vectorized). Pick the size/axis with the shared vectorize helper
+        // and launch one thread per vectorized element. Resize is faster with a width-4 store
+        // than the half2 default, so the candidate sizes are given explicitly.
+        auto vec = gen::vectorize::elements(gen::find_fast_axis(options.virtual_inputs.back()),
+                                            {options.virtual_inputs.back()},
+                                            {4, 2});
         options.set_launch_params(
             v, compute_global_for(ctx, inputs.back().elements() / vec.size, 1024));
 
@@ -113,12 +113,7 @@ struct resize_compiler : compiler<resize_compiler>
             scales = reorder_dims(scales, permutation);
         }
 
-        // The linear kernel takes the vector axis and size as trailing template arguments;
-        // other modes use the plain signature.
         std::string resize_func = "resize_" + mode;
-        std::string vec_targs =
-            (mode == "linear") ? (", " + std::to_string(vec.axis) + ", " + std::to_string(vec.size))
-                               : "";
 
         // Get coordinate transformation mode
         std::string coord_transform =
@@ -140,7 +135,8 @@ struct resize_compiler : compiler<resize_compiler>
                                        {"nearest_op", nearest_op},
                                        {"scales", scales_to_string(scales)},
                                        {"resize_func", resize_func},
-                                       {"vec_targs", vec_targs},
+                                       {"vectorize", vec.str()},
+                                       {"axis", std::to_string(vec.axis)},
                                        {"cubic_coeff_arg", cubic_coeff_arg}});
 
         return compile_hip_code_object(ctx, src, options);

--- a/src/targets/gpu/jit/resize.cpp
+++ b/src/targets/gpu/jit/resize.cpp
@@ -28,6 +28,8 @@
 #include <migraphx/gpu/compile_hip.hpp>
 #include <migraphx/transform_view.hpp>
 #include <migraphx/stringutils.hpp>
+#include <migraphx/ranges.hpp>
+#include <migraphx/float_equal.hpp>
 #include <sstream>
 
 namespace migraphx {
@@ -48,9 +50,11 @@ extern "C" {
 MIGRAPHX_GLOBAL void resize(void* in_data, void* output)
 {
     make_tensors()(in_data, output)([](auto input, auto out) {
-        ${vectorize}(out)([&](auto outv) {
-            ${resize_func}<${coord_transform}, ${nearest_op}, ${axis}>(
-                input, out, outv, ${scales}${cubic_coeff_arg});
+        ${in_vectorize}(input)([&](auto inv) {
+            ${vectorize}(out)([&](auto outv) {
+                ${resize_func}<${coord_transform}, ${nearest_op}, ${axis}>(
+                    inv, out, outv, ${scales}${cubic_coeff_arg});
+            });
         });
     });
 }
@@ -83,12 +87,12 @@ struct resize_compiler : compiler<resize_compiler>
         options.kernel_name    = "resize";
         options.virtual_inputs = normalize_permutation(inputs, &permutation);
 
-        std::string mode = v.get("mode", "nearest");
+        std::string mode       = v.get("mode", "nearest");
+        std::string coord_mode = v.get("coordinate_transformation_mode", "half_pixel");
 
-        // Every mode vectorizes the output store along its fastest axis (the input is gathered,
-        // so only the output is vectorized). Pick the size/axis with the shared vectorize helper
-        // and launch one thread per vectorized element. Resize is faster with a width-4 store
-        // than the half2 default, so the candidate sizes are given explicitly.
+        // The output store is vectorized along the fastest axis. Pick the size/axis with the
+        // shared vectorize helper and launch one thread per vectorized element. Resize is faster
+        // with a width-4 store than the half2 default, so the candidate sizes are given explicitly.
         auto vec = gen::vectorize::elements(gen::find_fast_axis(options.virtual_inputs.back()),
                                             {options.virtual_inputs.back()},
                                             {4, 2});
@@ -97,6 +101,7 @@ struct resize_compiler : compiler<resize_compiler>
 
         // Compute scales from shapes
         const auto& in_lens       = options.virtual_inputs.front().lens();
+        const auto& in_strides    = options.virtual_inputs.front().strides();
         const auto& out_lens      = options.virtual_inputs.back().lens();
         std::vector<float> scales = v.at("scales").to_vector<float>();
         if(scales.size() != in_lens.size())
@@ -113,11 +118,19 @@ struct resize_compiler : compiler<resize_compiler>
             scales = reorder_dims(scales, permutation);
         }
 
-        std::string resize_func = "resize_" + mode;
+        // The input is gathered, so it can share the output's vectorization only when the fast
+        // axis is a genuine pass-through (its input index equals its output index): equal length,
+        // unit scale, contiguous, and an identity-at-unit-scale coordinate transform. Otherwise
+        // the input transformer is the identity and the input is gathered scalar-wise.
+        const bool axis_passthrough =
+            in_lens[vec.axis] == out_lens[vec.axis] and in_strides[vec.axis] == 1 and
+            float_equal(scales[vec.axis], 1.0f) and
+            contains({"half_pixel", "pytorch_half_pixel", "align_corners", "asymmetric"},
+                     coord_mode);
+        gen::vectorize in_vec = axis_passthrough ? vec : gen::vectorize{1, vec.axis};
 
-        // Get coordinate transformation mode
-        std::string coord_transform =
-            "coord_transform_" + v.get("coordinate_transformation_mode", "half_pixel");
+        std::string resize_func     = "resize_" + mode;
+        std::string coord_transform = "coord_transform_" + coord_mode;
 
         // Get nearest mode (only used for nearest interpolation)
         std::string nearest_op = "nearest_" + v.get("nearest_mode", "floor");
@@ -136,6 +149,7 @@ struct resize_compiler : compiler<resize_compiler>
                                        {"scales", scales_to_string(scales)},
                                        {"resize_func", resize_func},
                                        {"vectorize", vec.str()},
+                                       {"in_vectorize", in_vec.str()},
                                        {"axis", std::to_string(vec.axis)},
                                        {"cubic_coeff_arg", cubic_coeff_arg}});
 

--- a/src/targets/gpu/jit/resize.cpp
+++ b/src/targets/gpu/jit/resize.cpp
@@ -122,6 +122,12 @@ struct resize_compiler : compiler<resize_compiler>
         // axis is a genuine pass-through (its input index equals its output index): equal length,
         // unit scale, contiguous, and an identity-at-unit-scale coordinate transform. Otherwise
         // the input transformer is the identity and the input is gathered scalar-wise.
+        //
+        // The mode list below is exactly the coord_transform_* function objects in
+        // kernels/resize.hpp whose operator() maps idx -> idx at unit scale (every mode except
+        // tf_half_pixel_for_nn); keep it in sync if a coordinate transform is added or changed. An
+        // omission is safe (it just falls back to a scalar gather), but listing a non-identity mode
+        // would be incorrect.
         const bool axis_passthrough =
             in_lens[vec.axis] == out_lens[vec.axis] and in_strides[vec.axis] == 1 and
             float_equal(scales[vec.axis], 1.0f) and

--- a/src/targets/gpu/jit/resize.cpp
+++ b/src/targets/gpu/jit/resize.cpp
@@ -23,6 +23,7 @@
  */
 #include <migraphx/gpu/compiler.hpp>
 #include <migraphx/gpu/compile_hip_code_object.hpp>
+#include <migraphx/gpu/compile_gen.hpp>
 #include <migraphx/gpu/context.hpp>
 #include <migraphx/gpu/compile_hip.hpp>
 #include <migraphx/transform_view.hpp>
@@ -47,7 +48,7 @@ extern "C" {
 MIGRAPHX_GLOBAL void resize(void* in_data, void* output)
 {
     make_tensors()(in_data, output)([](auto input, auto out) {
-        ${resize_func}<${coord_transform}, ${nearest_op}>(input, out, ${scales}${cubic_coeff_arg});
+        ${resize_func}<${coord_transform}, ${nearest_op}${vec_targs}>(input, out, ${scales}${cubic_coeff_arg});
     });
 }
 
@@ -67,29 +68,6 @@ struct resize_compiler : compiler<resize_compiler>
                to_string_range(views::transform(scales, MIGRAPHX_LIFT(to_hex_float))) + ")";
     }
 
-    // Mirror find_vector_axis / find_vectorize_size in kernels/vectorize.hpp so the launch
-    // grid matches the vectorization the linear kernel applies along the fastest axis.
-    static std::size_t vectorize_size(const shape& s)
-    {
-        const auto& strides = s.strides();
-        const auto& lens    = s.lens();
-        std::size_t axis    = 0;
-        for(std::size_t i = 1; i < lens.size(); ++i)
-        {
-            if(strides[i] == 0)
-                continue;
-            if(strides[axis] == 0 or
-               std::make_pair(strides[i], lens[i]) < std::make_pair(strides[axis], lens[axis]))
-                axis = i;
-        }
-        if(lens.empty() or strides[axis] != 1)
-            return 1;
-        for(std::size_t n : {4, 2})
-            if(lens[axis] % n == 0)
-                return n;
-        return 1;
-    }
-
     operation compile_op(context& ctx, const std::vector<shape>& inputs, const value& v) const
     {
         if(inputs.size() != 2)
@@ -102,13 +80,20 @@ struct resize_compiler : compiler<resize_compiler>
         options.kernel_name    = "resize";
         options.virtual_inputs = normalize_permutation(inputs, &permutation);
 
-        // The linear kernel writes a contiguous run of vec_size elements per thread, so
-        // launch one thread per vectorized element. Other modes are scalar (vec_size == 1).
-        std::size_t vec_size = (v.get("mode", "nearest") == "linear")
-                                   ? vectorize_size(options.virtual_inputs.back())
-                                   : 1;
+        std::string mode = v.get("mode", "nearest");
+
+        // The linear kernel vectorizes the output store along its fastest axis (the input is
+        // gathered, so only the output is vectorized). Pick the size/axis with the shared
+        // vectorize helper and launch one thread per vectorized element. Resize is faster with
+        // a width-4 store than the half2 default, so the candidate sizes are given explicitly.
+        // Other modes are scalar.
+        gen::vectorize vec{1, 0};
+        if(mode == "linear")
+            vec = gen::vectorize::elements(gen::find_fast_axis(options.virtual_inputs.back()),
+                                           {options.virtual_inputs.back()},
+                                           {4, 2});
         options.set_launch_params(
-            v, compute_global_for(ctx, inputs.back().elements() / vec_size, 1024));
+            v, compute_global_for(ctx, inputs.back().elements() / vec.size, 1024));
 
         // Compute scales from shapes
         const auto& in_lens       = options.virtual_inputs.front().lens();
@@ -128,9 +113,12 @@ struct resize_compiler : compiler<resize_compiler>
             scales = reorder_dims(scales, permutation);
         }
 
-        // Get mode (nearest, linear, or cubic)
-        std::string mode        = v.get("mode", "nearest");
+        // The linear kernel takes the vector axis and size as trailing template arguments;
+        // other modes use the plain signature.
         std::string resize_func = "resize_" + mode;
+        std::string vec_targs =
+            (mode == "linear") ? (", " + std::to_string(vec.axis) + ", " + std::to_string(vec.size))
+                               : "";
 
         // Get coordinate transformation mode
         std::string coord_transform =
@@ -152,6 +140,7 @@ struct resize_compiler : compiler<resize_compiler>
                                        {"nearest_op", nearest_op},
                                        {"scales", scales_to_string(scales)},
                                        {"resize_func", resize_func},
+                                       {"vec_targs", vec_targs},
                                        {"cubic_coeff_arg", cubic_coeff_arg}});
 
         return compile_hip_code_object(ctx, src, options);

--- a/src/targets/gpu/jit/resize.cpp
+++ b/src/targets/gpu/jit/resize.cpp
@@ -133,7 +133,9 @@ struct resize_compiler : compiler<resize_compiler>
             float_equal(scales[vec.axis], 1.0f) and
             contains({"half_pixel", "pytorch_half_pixel", "align_corners", "asymmetric"},
                      coord_mode);
-        gen::vectorize in_vec = axis_passthrough ? vec : gen::vectorize{1, vec.axis};
+gen::vectorize in_vec =
+    axis_passthrough ? gen::vectorize::elements(vec.axis, {options.virtual_inputs.front()}, {vec.size})
+                     : gen::vectorize{1, vec.axis};
 
         std::string resize_func     = "resize_" + mode;
         std::string coord_transform = "coord_transform_" + coord_mode;

--- a/src/targets/gpu/jit/resize.cpp
+++ b/src/targets/gpu/jit/resize.cpp
@@ -67,6 +67,29 @@ struct resize_compiler : compiler<resize_compiler>
                to_string_range(views::transform(scales, MIGRAPHX_LIFT(to_hex_float))) + ")";
     }
 
+    // Mirror find_vector_axis / find_vectorize_size in kernels/vectorize.hpp so the launch
+    // grid matches the vectorization the linear kernel applies along the fastest axis.
+    static std::size_t vectorize_size(const shape& s)
+    {
+        const auto& strides = s.strides();
+        const auto& lens    = s.lens();
+        std::size_t axis    = 0;
+        for(std::size_t i = 1; i < lens.size(); ++i)
+        {
+            if(strides[i] == 0)
+                continue;
+            if(strides[axis] == 0 or
+               std::make_pair(strides[i], lens[i]) < std::make_pair(strides[axis], lens[axis]))
+                axis = i;
+        }
+        if(lens.empty() or strides[axis] != 1)
+            return 1;
+        for(std::size_t n : {4, 2})
+            if(lens[axis] % n == 0)
+                return n;
+        return 1;
+    }
+
     operation compile_op(context& ctx, const std::vector<shape>& inputs, const value& v) const
     {
         if(inputs.size() != 2)
@@ -74,11 +97,18 @@ struct resize_compiler : compiler<resize_compiler>
 
         std::vector<int64_t> permutation;
         hip_compile_options options;
-        options.set_launch_params(v, compute_global_for(ctx, inputs.back().elements(), 1024));
         options.output         = inputs.back();
         options.inputs         = inputs;
         options.kernel_name    = "resize";
         options.virtual_inputs = normalize_permutation(inputs, &permutation);
+
+        // The linear kernel writes a contiguous run of vec_size elements per thread, so
+        // launch one thread per vectorized element. Other modes are scalar (vec_size == 1).
+        std::size_t vec_size = (v.get("mode", "nearest") == "linear")
+                                   ? vectorize_size(options.virtual_inputs.back())
+                                   : 1;
+        options.set_launch_params(
+            v, compute_global_for(ctx, inputs.back().elements() / vec_size, 1024));
 
         // Compute scales from shapes
         const auto& in_lens       = options.virtual_inputs.front().lens();

--- a/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
@@ -37,7 +37,7 @@
 
 namespace migraphx {
 
-// Coordinate transformation mode functions
+// Coordinate transformation mode function objects
 struct coord_transform_half_pixel
 {
     MIGRAPHX_DEVICE_CONSTEXPR float operator()(index_int, index_int, float idx, float scale) const
@@ -84,7 +84,7 @@ struct coord_transform_tf_half_pixel_for_nn
     }
 };
 
-// Nearest mode functions
+// Nearest mode function objects
 struct nearest_floor
 {
     MIGRAPHX_DEVICE_CONSTEXPR index_int operator()(index_int d_in, float val) const
@@ -210,19 +210,18 @@ template <index_int Axis, class Input, class Output, class Outv, class Compute>
 __device__ void resize_apply(Input input, Output out, Outv outv, Compute compute)
 {
     auto idx                = make_index();
-    constexpr index_int ivn = tensor_vec_size<Input>(); // > 0 only for a pass-through fast axis
+    constexpr index_int ivn = tensor_vec_size<Input>(); // >= 2 only for a pass-through fast axis
     constexpr index_int ovn = tensor_vec_size<Outv>();
+    // Reading a vectorized input gathers a vec<float, ivn>; a scalar input gathers a float.
+    auto read = [&](auto in_multi) { return migraphx::convert<float>(input[in_multi]); };
 
     if constexpr(ivn >= 2)
     {
-        const auto in_red  = input.get_shape();
-        const auto out_red = outv.get_shape();
-        auto read          = [&](auto in_multi) {
-            return __builtin_convertvector(input[in_multi], vec<float, ivn>);
-        };
-        idx.global_stride(out_red.elements(), [&](auto vidx) {
-            auto vmulti = out_red.multi(vidx);
-            outv[vidx]  = implicit_conversion(compute(in_red, out_red, vmulti, read));
+        const auto in_shape  = input.get_shape();
+        const auto out_shape = outv.get_shape();
+        idx.global_stride(out_shape.elements(), [&](auto vidx) {
+            auto vmulti = out_shape.multi(vidx);
+            outv[vidx]  = implicit_conversion(compute(in_shape, out_shape, vmulti, read));
         });
     }
     else
@@ -230,7 +229,6 @@ __device__ void resize_apply(Input input, Output out, Outv outv, Compute compute
         auto in_shape     = input.get_shape();
         auto out_shape    = out.get_shape();
         const auto vshape = outv.get_shape();
-        auto read = [&](auto in_multi) { return migraphx::convert<float>(input[in_multi]); };
         idx.global_stride(vshape.elements(), [&](auto vidx) {
             auto vmulti = vshape.multi(vidx);
             if constexpr(ovn < 2)
@@ -239,6 +237,10 @@ __device__ void resize_apply(Input input, Output out, Outv outv, Compute compute
             }
             else
             {
+                // outv is `out` vectorized by ovn along Axis, so the lane index reconstructs
+                // the real output coordinate.
+                static_assert(get_shape_c<Outv>{}.lens[Axis] * ovn ==
+                              get_shape_c<Output>{}.lens[Axis]);
                 using out_type = vec_type<typename Outv::type>;
                 outv[vidx]     = generate_vec(_c<ovn>, [&](auto lane) {
                     auto out_multi  = vmulti;
@@ -263,14 +265,10 @@ __device__ void resize_nearest(Input input, Output out, Outv outv, Scales scales
 {
     resize_apply<Axis>(
         input, out, outv, [&](auto in_shape, auto out_shape, auto out_multi, auto read) {
-            constexpr auto ndim = get_shape_c<Input>{}.lens.size();
-            array<index_int, ndim> in_multi{};
-            for(index_int i = 0; i < ndim; ++i)
-            {
-                auto coord =
-                    CoordOp{}(in_shape.lens[i], out_shape.lens[i], out_multi[i], scales[i]);
-                in_multi[i] = NearestOp{}(in_shape.lens[i], coord);
-            }
+            auto in_multi = array_transform(in_shape.lens, out_shape.lens, out_multi, scales)(
+                [](auto l_in, auto l_out, auto o, auto s) {
+                    return NearestOp{}(l_in, CoordOp{}(l_in, l_out, o, s));
+                });
             return read(in_multi);
         });
 }

--- a/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
@@ -117,24 +117,6 @@ struct nearest_round_prefer_ceil
     }
 };
 
-// Compute input indices for nearest neighbor mode
-template <class CoordOp, class NearestOp, class InShape, class OutShape, class Scales>
-MIGRAPHX_DEVICE_CONSTEXPR auto
-compute_nearest_idx(InShape in_shape, OutShape out_shape, index_int out_idx, const Scales& scales)
-{
-    auto out_multi      = out_shape.multi(out_idx);
-    constexpr auto ndim = InShape{}.lens.size();
-    array<index_int, ndim> in_multi{};
-
-    for(index_int i = 0; i < ndim; ++i)
-    {
-        auto coord  = CoordOp{}(in_shape.lens[i], out_shape.lens[i], out_multi[i], scales[i]);
-        in_multi[i] = NearestOp{}(in_shape.lens[i], coord);
-    }
-
-    return in_multi;
-}
-
 // Compute interpolation parameters for linear mode
 struct interp_params
 {
@@ -215,109 +197,117 @@ MIGRAPHX_DEVICE_CONSTEXPR cubic_params compute_cubic_params_1d(
     return result;
 }
 
-// Resize nearest kernel
-template <class CoordOp, class NearestOp, class Input, class Output, class Scales>
-__device__ void resize_nearest(Input input, Output output, Scales scales)
+// Drive a resize over the (possibly vectorized) output `outv`, calling compute(out_multi) for
+// each output element. When the output is vectorized along `Axis` it produces a run of `Vn`
+// consecutive lanes per vectorized store; when it is scalar (Vn < 2) it writes one element.
+// The output is vectorized in the global wrapper with vectorize<Vn, Axis>() (identity when
+// Vn < 2), so this same driver serves every mode. The input is always gathered scalar-wise.
+template <index_int Axis, class Outv, class Compute>
+__device__ void resize_apply(Outv outv, Compute compute)
 {
-    auto idx       = make_index();
-    auto in_shape  = input.get_shape();
-    auto out_shape = output.get_shape();
-
-    idx.global_stride(out_shape.elements(), [&](auto out_idx) {
-        auto in_idx = compute_nearest_idx<CoordOp, NearestOp>(in_shape, out_shape, out_idx, scales);
-        output[out_idx] = input[in_idx];
+    auto idx               = make_index();
+    constexpr index_int vn = tensor_vec_size<Outv>();
+    const auto vshape      = outv.get_shape();
+    idx.global_stride(vshape.elements(), [&](auto vidx) {
+        auto vmulti = vshape.multi(vidx);
+        if constexpr(vn < 2)
+        {
+            outv[vidx] = implicit_conversion(compute(vmulti));
+        }
+        else
+        {
+            using out_type = vec_type<typename Outv::type>;
+            outv[vidx]     = generate_vec(_c<vn>, [&](auto lane) {
+                auto out_multi  = vmulti;
+                out_multi[Axis] = vmulti[Axis] * vn + lane;
+                return out_type(implicit_conversion(compute(out_multi)));
+            });
+        }
     });
 }
 
-// Compute the linearly interpolated value for a single output element (given by out_multi).
-// Optimized to only iterate over 2^k corners where k is the number of dimensions that
-// actually need interpolation (i.e., where scale != 1).
-template <class CoordOp, class Input, class InShape, class OutShape, class Multi, class Scales>
-MIGRAPHX_DEVICE_CONSTEXPR float resize_linear_value(
-    Input input, InShape in_shape, OutShape out_shape, Multi out_multi, const Scales& scales)
-{
-    constexpr auto ndim = get_shape_c<Input>{}.lens.size();
-    auto params         = array_transform(in_shape.lens, out_shape.lens, out_multi, scales)(
-        [](auto... xs) { return compute_interp_params_1d<CoordOp>(xs...); });
-    index_int active_count =
-        count_if(scales.begin(), scales.end(), [](auto scale) { return scale != 1.0f; });
-    MIGRAPHX_ASSERT(active_count < 32);
-    auto in_multi           = array_transform(params)([](const interp_params& p) { return p.i0; });
-    const index_int corners = (1u << active_count);
-    float acc               = 0.0f;
-    for(index_int subset = 0; subset < corners; ++subset)
-    {
-        float w              = 1.0f;
-        index_int active_bit = 0;
-        for(index_int d = 0; d < ndim; ++d)
-        {
-            if(scales[d] == 1.0f)
-                continue;
-            const bool use_high = get_bit(subset, active_bit);
-            w *= use_high ? params[d].weight : (1.0f - params[d].weight);
-            in_multi[d] = use_high ? params[d].i1 : params[d].i0;
-            ++active_bit;
-        }
-        acc += w * migraphx::convert<float>(input[in_multi]);
-    }
-    return acc;
-}
-
-// Resize linear kernel.
-// Each thread produces a run of `Vn` consecutive output elements along axis `Axis` (the
-// fastest output axis, chosen on the host) and writes them with a single vectorized store.
-// This cuts the number of threads (and per-thread index setup) by `Vn` and lets the compiler
-// share the coordinate math for the remaining axes across the run. The output is vectorized
-// with the shared `vectorize<Vn, Axis>()` transformer, which is the identity when Vn < 2.
+// Resize nearest kernel
 template <class CoordOp,
           class NearestOp,
           index_int Axis,
-          index_int Vn,
           class Input,
           class Output,
+          class Outv,
           class Scales>
-__device__ void resize_linear(Input input, Output output, Scales scales)
+__device__ void resize_nearest(Input input, Output out, Outv outv, Scales scales)
 {
-    auto idx       = make_index();
-    auto in_shape  = input.get_shape();
-    auto out_shape = output.get_shape();
+    auto in_shape       = input.get_shape();
+    auto out_shape      = out.get_shape();
+    constexpr auto ndim = get_shape_c<Input>{}.lens.size();
+    resize_apply<Axis>(outv, [&](auto out_multi) {
+        array<index_int, ndim> in_multi{};
+        for(index_int i = 0; i < ndim; ++i)
+        {
+            auto coord  = CoordOp{}(in_shape.lens[i], out_shape.lens[i], out_multi[i], scales[i]);
+            in_multi[i] = NearestOp{}(in_shape.lens[i], coord);
+        }
+        return input[in_multi];
+    });
+}
 
-    vectorize<Vn, Axis>()(output)([&](auto outv) {
-        const auto vshape = outv.get_shape();
-        idx.global_stride(vshape.elements(), [&](auto vidx) {
-            auto vmulti = vshape.multi(vidx);
-            if constexpr(Vn < 2)
+// Resize linear kernel.
+// Optimized to only iterate over 2^k corners where k is the number of dimensions that
+// actually need interpolation (i.e., where scale != 1).
+template <class CoordOp,
+          class NearestOp,
+          index_int Axis,
+          class Input,
+          class Output,
+          class Outv,
+          class Scales>
+__device__ void resize_linear(Input input, Output out, Outv outv, Scales scales)
+{
+    auto in_shape       = input.get_shape();
+    auto out_shape      = out.get_shape();
+    constexpr auto ndim = get_shape_c<Input>{}.lens.size();
+    resize_apply<Axis>(outv, [&](auto out_multi) {
+        auto params = array_transform(in_shape.lens, out_shape.lens, out_multi, scales)(
+            [](auto... xs) { return compute_interp_params_1d<CoordOp>(xs...); });
+        index_int active_count =
+            count_if(scales.begin(), scales.end(), [](auto scale) { return scale != 1.0f; });
+        MIGRAPHX_ASSERT(active_count < 32);
+        auto in_multi = array_transform(params)([](const interp_params& p) { return p.i0; });
+        const index_int corners = (1u << active_count);
+        float acc               = 0.0f;
+        for(index_int subset = 0; subset < corners; ++subset)
+        {
+            float w              = 1.0f;
+            index_int active_bit = 0;
+            for(index_int d = 0; d < ndim; ++d)
             {
-                outv[vidx] = implicit_conversion(
-                    resize_linear_value<CoordOp>(input, in_shape, out_shape, vmulti, scales));
+                if(scales[d] == 1.0f)
+                    continue;
+                const bool use_high = get_bit(subset, active_bit);
+                w *= use_high ? params[d].weight : (1.0f - params[d].weight);
+                in_multi[d] = use_high ? params[d].i1 : params[d].i0;
+                ++active_bit;
             }
-            else
-            {
-                using out_type = typename Output::type;
-                outv[vidx]     = generate_vec(_c<Vn>, [&](auto lane) {
-                    auto out_multi  = vmulti;
-                    out_multi[Axis] = vmulti[Axis] * Vn + lane;
-                    return out_type(implicit_conversion(resize_linear_value<CoordOp>(
-                        input, in_shape, out_shape, out_multi, scales)));
-                });
-            }
-        });
+            acc += w * migraphx::convert<float>(input[in_multi]);
+        }
+        return acc;
     });
 }
 
 // Resize cubic kernel
-// Uses separable bicubic interpolation with 4 neighbors per dimension
-template <class CoordOp, class NearestOp, class Input, class Output, class Scales>
-__device__ void resize_cubic(Input input, Output output, Scales scales, float cubic_coeff)
+// Uses separable cubic interpolation with 4 neighbors per resized dimension.
+template <class CoordOp,
+          class NearestOp,
+          index_int Axis,
+          class Input,
+          class Output,
+          class Outv,
+          class Scales>
+__device__ void resize_cubic(Input input, Output out, Outv outv, Scales scales, float cubic_coeff)
 {
-    auto idx            = make_index();
     auto in_shape       = input.get_shape();
-    auto out_shape      = output.get_shape();
+    auto out_shape      = out.get_shape();
     constexpr auto ndim = get_shape_c<Input>{}.lens.size();
-
-    idx.global_stride(out_shape.elements(), [&](auto out_idx) {
-        auto out_multi = out_shape.multi(out_idx);
-
+    resize_apply<Axis>(outv, [&](auto out_multi) {
         // Precompute cubic interpolation parameters for each dimension
         array<cubic_params, ndim> params{};
         for(index_int d = 0; d < ndim; ++d)
@@ -340,14 +330,7 @@ __device__ void resize_cubic(Input input, Output output, Scales scales, float cu
         array<index_int, ndim> in_multi{};
         for(index_int d = 0; d < ndim; ++d)
         {
-            if(scales[d] == 1.0f)
-            {
-                in_multi[d] = out_multi[d];
-            }
-            else
-            {
-                in_multi[d] = params[d].indices[0];
-            }
+            in_multi[d] = (scales[d] == 1.0f) ? out_multi[d] : params[d].indices[0];
         }
 
         // Build combo shape: 4 for interpolated dims, 1 otherwise
@@ -361,7 +344,7 @@ __device__ void resize_cubic(Input input, Output output, Scales scales, float cu
         {
             auto combo_multi = combo_lens.multi(combo);
 
-            // 2. Compute the combined weight as a product of per-dimension weights
+            // Compute the combined weight as a product of per-dimension weights
             float w = inner_product(
                 active_dims.begin(),
                 active_dims.begin() + active_count,
@@ -370,7 +353,7 @@ __device__ void resize_cubic(Input input, Output output, Scales scales, float cu
                 [](float a, float b) { return a * b; },
                 [&](index_int d, index_int) { return params[d].weights[combo_multi[d]]; });
 
-            // 3. Set in_multi for each active dimension from the neighbor indices
+            // Set in_multi for each active dimension from the neighbor indices
             for(index_int i = 0; i < active_count; ++i)
             {
                 index_int d = active_dims[i];
@@ -383,7 +366,7 @@ __device__ void resize_cubic(Input input, Output output, Scales scales, float cu
             }
         }
 
-        output[out_idx] = implicit_conversion(acc);
+        return acc;
     });
 }
 

--- a/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
@@ -37,12 +37,9 @@
 
 namespace migraphx {
 
-// Coordinate transformation mode functors.
-// is_identity_unit is true when the transform maps an output index back to the same input
-// index at unit scale (so an unresized axis is a pass-through that can be gathered as a vector).
+// Coordinate transformation mode functors
 struct coord_transform_half_pixel
 {
-    static constexpr bool is_identity_unit = true;
     MIGRAPHX_DEVICE_CONSTEXPR float operator()(index_int, index_int, float idx, float scale) const
     {
         MIGRAPHX_ASSERT(scale > 0 or scale < 0);
@@ -52,7 +49,6 @@ struct coord_transform_half_pixel
 
 struct coord_transform_pytorch_half_pixel
 {
-    static constexpr bool is_identity_unit = true;
     MIGRAPHX_DEVICE_CONSTEXPR float
     operator()(index_int, index_int l_out, float idx, float scale) const
     {
@@ -63,7 +59,6 @@ struct coord_transform_pytorch_half_pixel
 
 struct coord_transform_align_corners
 {
-    static constexpr bool is_identity_unit = true;
     MIGRAPHX_DEVICE_CONSTEXPR float
     operator()(index_int l_in, index_int l_out, float idx, float) const
     {
@@ -73,7 +68,6 @@ struct coord_transform_align_corners
 
 struct coord_transform_asymmetric
 {
-    static constexpr bool is_identity_unit = true;
     MIGRAPHX_DEVICE_CONSTEXPR float operator()(index_int, index_int, float idx, float scale) const
     {
         MIGRAPHX_ASSERT(scale > 0 or scale < 0);
@@ -83,8 +77,6 @@ struct coord_transform_asymmetric
 
 struct coord_transform_tf_half_pixel_for_nn
 {
-    // Maps idx -> idx + 0.5 even at unit scale, so it is not a pass-through.
-    static constexpr bool is_identity_unit = false;
     MIGRAPHX_DEVICE_CONSTEXPR float operator()(index_int, index_int, float idx, float scale) const
     {
         MIGRAPHX_ASSERT(scale > 0 or scale < 0);
@@ -206,70 +198,57 @@ MIGRAPHX_DEVICE_CONSTEXPR cubic_params compute_cubic_params_1d(
 }
 
 // Drive a resize over the output `outv`, calling compute(in_shape, out_shape, out_multi, read)
-// for each output element; read(in_multi) gathers one input element. The output is vectorized
-// in the global wrapper with vectorize<Vn, Axis>() (identity when Vn < 2).
+// for each output element; read(in_multi) gathers one input element. The global wrapper applies
+// the vectorize<Vn, Axis>() arg transformer to both the input and the output (identity when
+// Vn < 2).
 //
-// When the vectorized axis is a pass-through (its input index equals its output index: same
-// length, identity coordinate transform, unit scale, contiguous), the input is vectorized along
-// it too, so each corner is read as one coalesced vec<T, Vn> load shared across the Vn lanes
-// (read returns a vector) instead of Vn scalar gathers. Otherwise each lane is gathered scalar.
-template <index_int Axis,
-          class CoordOp,
-          class Input,
-          class Output,
-          class Outv,
-          class Scales,
-          class Compute>
-__device__ void
-resize_apply(Input input, Output out, Outv outv, const Scales& scales, Compute compute)
+// The host vectorizes the input only when the fast axis is a genuine pass-through (its input
+// index equals its output index). So when the input arrives vectorized, each corner is read as
+// one coalesced vec<T, Vn> load shared across the Vn lanes (read returns a vector); otherwise
+// each lane is gathered scalar-wise and the output is filled lane-by-lane.
+template <index_int Axis, class Input, class Output, class Outv, class Compute>
+__device__ void resize_apply(Input input, Output out, Outv outv, Compute compute)
 {
-    auto idx                  = make_index();
-    constexpr index_int vn    = tensor_vec_size<Outv>();
-    constexpr auto in_s       = get_shape_c<Input>{};
-    constexpr auto out_s      = get_shape_c<Output>{};
-    constexpr bool vec_gather = vn >= 2 and CoordOp::is_identity_unit and
-                                in_s.lens[Axis] == out_s.lens[Axis] and in_s.strides[Axis] == 1;
+    auto idx                = make_index();
+    constexpr index_int ivn = tensor_vec_size<Input>(); // > 0 only for a pass-through fast axis
+    constexpr index_int ovn = tensor_vec_size<Outv>();
 
-    if constexpr(vec_gather)
+    if constexpr(ivn >= 2)
     {
-        // The runtime scale check folds to a constant; it guards the rare case of equal lengths
-        // with a non-unit scale, which would not actually be a pass-through.
-        if(scales[Axis] == 1.0f)
-        {
-            auto inputv        = as_vec<vn>(input, _c<Axis>);
-            const auto in_red  = inputv.get_shape();
-            const auto out_red = outv.get_shape();
-            auto read          = [&](auto in_multi) {
-                return __builtin_convertvector(inputv[in_multi], vec<float, vn>);
-            };
-            idx.global_stride(out_red.elements(), [&](auto vidx) {
-                auto vmulti = out_red.multi(vidx);
-                outv[vidx]  = implicit_conversion(compute(in_red, out_red, vmulti, read));
-            });
-            return;
-        }
+        const auto in_red  = input.get_shape();
+        const auto out_red = outv.get_shape();
+        auto read          = [&](auto in_multi) {
+            return __builtin_convertvector(input[in_multi], vec<float, ivn>);
+        };
+        idx.global_stride(out_red.elements(), [&](auto vidx) {
+            auto vmulti = out_red.multi(vidx);
+            outv[vidx]  = implicit_conversion(compute(in_red, out_red, vmulti, read));
+        });
     }
-
-    auto in_shape     = input.get_shape();
-    auto out_shape    = out.get_shape();
-    const auto vshape = outv.get_shape();
-    auto read         = [&](auto in_multi) { return migraphx::convert<float>(input[in_multi]); };
-    idx.global_stride(vshape.elements(), [&](auto vidx) {
-        auto vmulti = vshape.multi(vidx);
-        if constexpr(vn < 2)
-        {
-            outv[vidx] = implicit_conversion(compute(in_shape, out_shape, vmulti, read));
-        }
-        else
-        {
-            using out_type = vec_type<typename Outv::type>;
-            outv[vidx]     = generate_vec(_c<vn>, [&](auto lane) {
-                auto out_multi  = vmulti;
-                out_multi[Axis] = vmulti[Axis] * vn + lane;
-                return out_type(implicit_conversion(compute(in_shape, out_shape, out_multi, read)));
-            });
-        }
-    });
+    else
+    {
+        auto in_shape     = input.get_shape();
+        auto out_shape    = out.get_shape();
+        const auto vshape = outv.get_shape();
+        auto read = [&](auto in_multi) { return migraphx::convert<float>(input[in_multi]); };
+        idx.global_stride(vshape.elements(), [&](auto vidx) {
+            auto vmulti = vshape.multi(vidx);
+            if constexpr(ovn < 2)
+            {
+                outv[vidx] = implicit_conversion(compute(in_shape, out_shape, vmulti, read));
+            }
+            else
+            {
+                using out_type = vec_type<typename Outv::type>;
+                outv[vidx]     = generate_vec(_c<ovn>, [&](auto lane) {
+                    auto out_multi  = vmulti;
+                    out_multi[Axis] = vmulti[Axis] * ovn + lane;
+                    return out_type(
+                        implicit_conversion(compute(in_shape, out_shape, out_multi, read)));
+                });
+            }
+        });
+    }
 }
 
 // Resize nearest kernel
@@ -282,8 +261,8 @@ template <class CoordOp,
           class Scales>
 __device__ void resize_nearest(Input input, Output out, Outv outv, Scales scales)
 {
-    resize_apply<Axis, CoordOp>(
-        input, out, outv, scales, [&](auto in_shape, auto out_shape, auto out_multi, auto read) {
+    resize_apply<Axis>(
+        input, out, outv, [&](auto in_shape, auto out_shape, auto out_multi, auto read) {
             constexpr auto ndim = get_shape_c<Input>{}.lens.size();
             array<index_int, ndim> in_multi{};
             for(index_int i = 0; i < ndim; ++i)
@@ -308,8 +287,8 @@ template <class CoordOp,
           class Scales>
 __device__ void resize_linear(Input input, Output out, Outv outv, Scales scales)
 {
-    resize_apply<Axis, CoordOp>(
-        input, out, outv, scales, [&](auto in_shape, auto out_shape, auto out_multi, auto read) {
+    resize_apply<Axis>(
+        input, out, outv, [&](auto in_shape, auto out_shape, auto out_multi, auto read) {
             constexpr auto ndim = get_shape_c<Input>{}.lens.size();
             auto params         = array_transform(in_shape.lens, out_shape.lens, out_multi, scales)(
                 [](auto... xs) { return compute_interp_params_1d<CoordOp>(xs...); });
@@ -349,8 +328,8 @@ template <class CoordOp,
           class Scales>
 __device__ void resize_cubic(Input input, Output out, Outv outv, Scales scales, float cubic_coeff)
 {
-    resize_apply<Axis, CoordOp>(
-        input, out, outv, scales, [&](auto in_shape, auto out_shape, auto out_multi, auto read) {
+    resize_apply<Axis>(
+        input, out, outv, [&](auto in_shape, auto out_shape, auto out_multi, auto read) {
             constexpr auto ndim = get_shape_c<Input>{}.lens.size();
 
             // Precompute cubic interpolation parameters for each dimension

--- a/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
@@ -33,6 +33,7 @@
 #include <migraphx/kernels/bit.hpp>
 #include <migraphx/kernels/algorithm.hpp>
 #include <migraphx/kernels/ranges.hpp>
+#include <migraphx/kernels/vectorize.hpp>
 
 namespace migraphx {
 
@@ -228,56 +229,79 @@ __device__ void resize_nearest(Input input, Output output, Scales scales)
     });
 }
 
-// Resize linear kernel
-// Optimized to only iterate over 2^k corners where k is the number of dimensions
-// that actually need interpolation (i.e., where i0 != i1)
+// Compute the linearly interpolated value for a single output element (given by out_multi).
+// Optimized to only iterate over 2^k corners where k is the number of dimensions that
+// actually need interpolation (i.e., where scale != 1).
+template <class CoordOp, class Input, class InShape, class OutShape, class Multi, class Scales>
+MIGRAPHX_DEVICE_CONSTEXPR float resize_linear_value(
+    Input input, InShape in_shape, OutShape out_shape, Multi out_multi, const Scales& scales)
+{
+    constexpr auto ndim = get_shape_c<Input>{}.lens.size();
+    auto params         = array_transform(in_shape.lens, out_shape.lens, out_multi, scales)(
+        [](auto... xs) { return compute_interp_params_1d<CoordOp>(xs...); });
+    index_int active_count =
+        count_if(scales.begin(), scales.end(), [](auto scale) { return scale != 1.0f; });
+    MIGRAPHX_ASSERT(active_count < 32);
+    auto in_multi           = array_transform(params)([](const interp_params& p) { return p.i0; });
+    const index_int corners = (1u << active_count);
+    float acc               = 0.0f;
+    for(index_int subset = 0; subset < corners; ++subset)
+    {
+        float w              = 1.0f;
+        index_int active_bit = 0;
+        for(index_int d = 0; d < ndim; ++d)
+        {
+            if(scales[d] == 1.0f)
+                continue;
+            const bool use_high = get_bit(subset, active_bit);
+            w *= use_high ? params[d].weight : (1.0f - params[d].weight);
+            in_multi[d] = use_high ? params[d].i1 : params[d].i0;
+            ++active_bit;
+        }
+        acc += w * migraphx::convert<float>(input[in_multi]);
+    }
+    return acc;
+}
+
+// Resize linear kernel.
+// Each thread produces a run of `vn` consecutive output elements along the fastest
+// (stride-1) output axis and writes them with a single vectorized store. This cuts the
+// number of threads (and the per-thread index setup) by `vn` and lets the compiler share
+// the coordinate math for the remaining axes across the run.
 template <class CoordOp, class NearestOp, class Input, class Output, class Scales>
 __device__ void resize_linear(Input input, Output output, Scales scales)
 {
-    auto idx            = make_index();
-    auto in_shape       = input.get_shape();
-    auto out_shape      = output.get_shape();
-    constexpr auto ndim = get_shape_c<Input>{}.lens.size();
+    auto idx       = make_index();
+    auto in_shape  = input.get_shape();
+    auto out_shape = output.get_shape();
+    using out_type = typename Output::type;
 
-    idx.global_stride(out_shape.elements(), [&](auto out_idx) {
-        auto out_multi = out_shape.multi(out_idx);
+    constexpr auto vaxis = find_vector_axis(get_shape_c<Output>{});
+    constexpr auto vn    = find_vectorize_size(
+        [&](auto i) { return is_vectorizable<i>(vaxis, get_shape_c<Output>{}); });
 
-        // Precompute interpolation parameters for each dimension
-        auto params = array_transform(in_shape.lens, out_shape.lens, out_multi, scales)(
-            [](auto... xs) { return compute_interp_params_1d<CoordOp>(xs...); });
-
-        index_int active_count =
-            count_if(scales.begin(), scales.end(), [](auto scale) { return scale != 1.0f; });
-        MIGRAPHX_ASSERT(active_count < 32);
-
-        // Initialize in_multi with non-interpolated dimensions (where i0 == i1)
-        auto in_multi = array_transform(params)([](const interp_params& p) { return p.i0; });
-
-        // Accumulate over 2^active_count corners instead of 2^ndim
-        const index_int corners = (1u << active_count);
-        float acc               = 0.0f;
-
-        for(index_int subset = 0; subset < corners; ++subset)
-        {
-            float w              = 1.0f;
-            index_int active_bit = 0;
-
-            for(index_int d = 0; d < ndim; ++d)
-            {
-                if(scales[d] == 1.0f)
-                    continue;
-                // This dimension needs interpolation
-                const bool use_high = get_bit(subset, active_bit);
-                w *= use_high ? params[d].weight : (1.0f - params[d].weight);
-                in_multi[d] = use_high ? params[d].i1 : params[d].i0;
-                ++active_bit;
-            }
-
-            acc += w * migraphx::convert<float>(input[in_multi]);
-        }
-
-        output[out_idx] = implicit_conversion(acc);
-    });
+    if constexpr(vn < 2)
+    {
+        idx.global_stride(out_shape.elements(), [&](auto out_idx) {
+            auto out_multi  = out_shape.multi(out_idx);
+            output[out_idx] = implicit_conversion(
+                resize_linear_value<CoordOp>(input, in_shape, out_shape, out_multi, scales));
+        });
+    }
+    else
+    {
+        auto outv             = as_vec<vn>(output, vaxis);
+        const auto outv_shape = outv.get_shape();
+        idx.global_stride(outv_shape.elements(), [&](auto vidx) {
+            auto vmulti = outv_shape.multi(vidx);
+            outv[vidx]  = generate_vec(vn, [&](auto lane) {
+                auto out_multi   = vmulti;
+                out_multi[vaxis] = vmulti[vaxis] * vn + lane;
+                return out_type(implicit_conversion(
+                    resize_linear_value<CoordOp>(input, in_shape, out_shape, out_multi, scales)));
+            });
+        });
+    }
 }
 
 // Resize cubic kernel

--- a/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
@@ -197,22 +197,19 @@ MIGRAPHX_DEVICE_CONSTEXPR cubic_params compute_cubic_params_1d(
     return result;
 }
 
-// Drive a resize over the output `outv`, calling compute(in_shape, out_shape, out_multi, read)
-// for each output element; read(in_multi) gathers one input element. The global wrapper applies
-// the vectorize<Vn, Axis>() arg transformer to both the input and the output (identity when
-// Vn < 2).
+// Drive a resize over `outv`, calling compute(in_shape, out_shape, out_multi, read) per output
+// element; read(in_multi) gathers one input element. The wrapper vectorizes input and output via
+// vectorize<Vn, Axis>() (identity when Vn < 2).
 //
-// The host vectorizes the input only when the fast axis is a genuine pass-through (its input
-// index equals its output index). So when the input arrives vectorized, each corner is read as
-// one coalesced vec<T, Vn> load shared across the Vn lanes (read returns a vector); otherwise
-// each lane is gathered scalar-wise and the output is filled lane-by-lane.
+// The input is vectorized only on a pass-through fast axis, so a vectorized input reads each
+// corner as one coalesced vec<T, Vn> shared across lanes; otherwise lanes gather scalar-wise.
 template <index_int Axis, class Input, class Output, class Outv, class Compute>
 __device__ void resize_apply(Input input, Output out, Outv outv, Compute compute)
 {
     auto idx                = make_index();
     constexpr index_int ivn = tensor_vec_size<Input>(); // >= 2 only for a pass-through fast axis
     constexpr index_int ovn = tensor_vec_size<Outv>();
-    // Reading a vectorized input gathers a vec<float, ivn>; a scalar input gathers a float.
+    // Vectorized input gathers a vec<float, ivn>; scalar input gathers a float.
     auto read = [&](auto in_multi) { return migraphx::convert<float>(input[in_multi]); };
 
     if constexpr(ivn >= 2)
@@ -237,8 +234,7 @@ __device__ void resize_apply(Input input, Output out, Outv outv, Compute compute
             }
             else
             {
-                // outv is `out` vectorized by ovn along Axis, so the lane index reconstructs
-                // the real output coordinate.
+                // outv is `out` vectorized by ovn along Axis; lane reconstructs the output coord.
                 static_assert(get_shape_c<Outv>{}.lens[Axis] * ovn ==
                               get_shape_c<Output>{}.lens[Axis]);
                 using out_type = vec_type<typename Outv::type>;

--- a/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
@@ -264,44 +264,45 @@ MIGRAPHX_DEVICE_CONSTEXPR float resize_linear_value(
 }
 
 // Resize linear kernel.
-// Each thread produces a run of `vn` consecutive output elements along the fastest
-// (stride-1) output axis and writes them with a single vectorized store. This cuts the
-// number of threads (and the per-thread index setup) by `vn` and lets the compiler share
-// the coordinate math for the remaining axes across the run.
-template <class CoordOp, class NearestOp, class Input, class Output, class Scales>
+// Each thread produces a run of `Vn` consecutive output elements along axis `Axis` (the
+// fastest output axis, chosen on the host) and writes them with a single vectorized store.
+// This cuts the number of threads (and per-thread index setup) by `Vn` and lets the compiler
+// share the coordinate math for the remaining axes across the run. The output is vectorized
+// with the shared `vectorize<Vn, Axis>()` transformer, which is the identity when Vn < 2.
+template <class CoordOp,
+          class NearestOp,
+          index_int Axis,
+          index_int Vn,
+          class Input,
+          class Output,
+          class Scales>
 __device__ void resize_linear(Input input, Output output, Scales scales)
 {
     auto idx       = make_index();
     auto in_shape  = input.get_shape();
     auto out_shape = output.get_shape();
-    using out_type = typename Output::type;
 
-    constexpr auto vaxis = find_vector_axis(get_shape_c<Output>{});
-    constexpr auto vn    = find_vectorize_size(
-        [&](auto i) { return is_vectorizable<i>(vaxis, get_shape_c<Output>{}); });
-
-    if constexpr(vn < 2)
-    {
-        idx.global_stride(out_shape.elements(), [&](auto out_idx) {
-            auto out_multi  = out_shape.multi(out_idx);
-            output[out_idx] = implicit_conversion(
-                resize_linear_value<CoordOp>(input, in_shape, out_shape, out_multi, scales));
+    vectorize<Vn, Axis>()(output)([&](auto outv) {
+        const auto vshape = outv.get_shape();
+        idx.global_stride(vshape.elements(), [&](auto vidx) {
+            auto vmulti = vshape.multi(vidx);
+            if constexpr(Vn < 2)
+            {
+                outv[vidx] = implicit_conversion(
+                    resize_linear_value<CoordOp>(input, in_shape, out_shape, vmulti, scales));
+            }
+            else
+            {
+                using out_type = typename Output::type;
+                outv[vidx]     = generate_vec(_c<Vn>, [&](auto lane) {
+                    auto out_multi  = vmulti;
+                    out_multi[Axis] = vmulti[Axis] * Vn + lane;
+                    return out_type(implicit_conversion(resize_linear_value<CoordOp>(
+                        input, in_shape, out_shape, out_multi, scales)));
+                });
+            }
         });
-    }
-    else
-    {
-        auto outv             = as_vec<vn>(output, vaxis);
-        const auto outv_shape = outv.get_shape();
-        idx.global_stride(outv_shape.elements(), [&](auto vidx) {
-            auto vmulti = outv_shape.multi(vidx);
-            outv[vidx]  = generate_vec(vn, [&](auto lane) {
-                auto out_multi   = vmulti;
-                out_multi[vaxis] = vmulti[vaxis] * vn + lane;
-                return out_type(implicit_conversion(
-                    resize_linear_value<CoordOp>(input, in_shape, out_shape, out_multi, scales)));
-            });
-        });
-    }
+    });
 }
 
 // Resize cubic kernel

--- a/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
@@ -37,9 +37,12 @@
 
 namespace migraphx {
 
-// Coordinate transformation mode functors
+// Coordinate transformation mode functors.
+// is_identity_unit is true when the transform maps an output index back to the same input
+// index at unit scale (so an unresized axis is a pass-through that can be gathered as a vector).
 struct coord_transform_half_pixel
 {
+    static constexpr bool is_identity_unit = true;
     MIGRAPHX_DEVICE_CONSTEXPR float operator()(index_int, index_int, float idx, float scale) const
     {
         MIGRAPHX_ASSERT(scale > 0 or scale < 0);
@@ -49,6 +52,7 @@ struct coord_transform_half_pixel
 
 struct coord_transform_pytorch_half_pixel
 {
+    static constexpr bool is_identity_unit = true;
     MIGRAPHX_DEVICE_CONSTEXPR float
     operator()(index_int, index_int l_out, float idx, float scale) const
     {
@@ -59,6 +63,7 @@ struct coord_transform_pytorch_half_pixel
 
 struct coord_transform_align_corners
 {
+    static constexpr bool is_identity_unit = true;
     MIGRAPHX_DEVICE_CONSTEXPR float
     operator()(index_int l_in, index_int l_out, float idx, float) const
     {
@@ -68,6 +73,7 @@ struct coord_transform_align_corners
 
 struct coord_transform_asymmetric
 {
+    static constexpr bool is_identity_unit = true;
     MIGRAPHX_DEVICE_CONSTEXPR float operator()(index_int, index_int, float idx, float scale) const
     {
         MIGRAPHX_ASSERT(scale > 0 or scale < 0);
@@ -77,6 +83,8 @@ struct coord_transform_asymmetric
 
 struct coord_transform_tf_half_pixel_for_nn
 {
+    // Maps idx -> idx + 0.5 even at unit scale, so it is not a pass-through.
+    static constexpr bool is_identity_unit = false;
     MIGRAPHX_DEVICE_CONSTEXPR float operator()(index_int, index_int, float idx, float scale) const
     {
         MIGRAPHX_ASSERT(scale > 0 or scale < 0);
@@ -197,22 +205,60 @@ MIGRAPHX_DEVICE_CONSTEXPR cubic_params compute_cubic_params_1d(
     return result;
 }
 
-// Drive a resize over the (possibly vectorized) output `outv`, calling compute(out_multi) for
-// each output element. When the output is vectorized along `Axis` it produces a run of `Vn`
-// consecutive lanes per vectorized store; when it is scalar (Vn < 2) it writes one element.
-// The output is vectorized in the global wrapper with vectorize<Vn, Axis>() (identity when
-// Vn < 2), so this same driver serves every mode. The input is always gathered scalar-wise.
-template <index_int Axis, class Outv, class Compute>
-__device__ void resize_apply(Outv outv, Compute compute)
+// Drive a resize over the output `outv`, calling compute(in_shape, out_shape, out_multi, read)
+// for each output element; read(in_multi) gathers one input element. The output is vectorized
+// in the global wrapper with vectorize<Vn, Axis>() (identity when Vn < 2).
+//
+// When the vectorized axis is a pass-through (its input index equals its output index: same
+// length, identity coordinate transform, unit scale, contiguous), the input is vectorized along
+// it too, so each corner is read as one coalesced vec<T, Vn> load shared across the Vn lanes
+// (read returns a vector) instead of Vn scalar gathers. Otherwise each lane is gathered scalar.
+template <index_int Axis,
+          class CoordOp,
+          class Input,
+          class Output,
+          class Outv,
+          class Scales,
+          class Compute>
+__device__ void
+resize_apply(Input input, Output out, Outv outv, const Scales& scales, Compute compute)
 {
-    auto idx               = make_index();
-    constexpr index_int vn = tensor_vec_size<Outv>();
-    const auto vshape      = outv.get_shape();
+    auto idx                  = make_index();
+    constexpr index_int vn    = tensor_vec_size<Outv>();
+    constexpr auto in_s       = get_shape_c<Input>{};
+    constexpr auto out_s      = get_shape_c<Output>{};
+    constexpr bool vec_gather = vn >= 2 and CoordOp::is_identity_unit and
+                                in_s.lens[Axis] == out_s.lens[Axis] and in_s.strides[Axis] == 1;
+
+    if constexpr(vec_gather)
+    {
+        // The runtime scale check folds to a constant; it guards the rare case of equal lengths
+        // with a non-unit scale, which would not actually be a pass-through.
+        if(scales[Axis] == 1.0f)
+        {
+            auto inputv        = as_vec<vn>(input, _c<Axis>);
+            const auto in_red  = inputv.get_shape();
+            const auto out_red = outv.get_shape();
+            auto read          = [&](auto in_multi) {
+                return __builtin_convertvector(inputv[in_multi], vec<float, vn>);
+            };
+            idx.global_stride(out_red.elements(), [&](auto vidx) {
+                auto vmulti = out_red.multi(vidx);
+                outv[vidx]  = implicit_conversion(compute(in_red, out_red, vmulti, read));
+            });
+            return;
+        }
+    }
+
+    auto in_shape     = input.get_shape();
+    auto out_shape    = out.get_shape();
+    const auto vshape = outv.get_shape();
+    auto read         = [&](auto in_multi) { return migraphx::convert<float>(input[in_multi]); };
     idx.global_stride(vshape.elements(), [&](auto vidx) {
         auto vmulti = vshape.multi(vidx);
         if constexpr(vn < 2)
         {
-            outv[vidx] = implicit_conversion(compute(vmulti));
+            outv[vidx] = implicit_conversion(compute(in_shape, out_shape, vmulti, read));
         }
         else
         {
@@ -220,7 +266,7 @@ __device__ void resize_apply(Outv outv, Compute compute)
             outv[vidx]     = generate_vec(_c<vn>, [&](auto lane) {
                 auto out_multi  = vmulti;
                 out_multi[Axis] = vmulti[Axis] * vn + lane;
-                return out_type(implicit_conversion(compute(out_multi)));
+                return out_type(implicit_conversion(compute(in_shape, out_shape, out_multi, read)));
             });
         }
     });
@@ -236,18 +282,18 @@ template <class CoordOp,
           class Scales>
 __device__ void resize_nearest(Input input, Output out, Outv outv, Scales scales)
 {
-    auto in_shape       = input.get_shape();
-    auto out_shape      = out.get_shape();
-    constexpr auto ndim = get_shape_c<Input>{}.lens.size();
-    resize_apply<Axis>(outv, [&](auto out_multi) {
-        array<index_int, ndim> in_multi{};
-        for(index_int i = 0; i < ndim; ++i)
-        {
-            auto coord  = CoordOp{}(in_shape.lens[i], out_shape.lens[i], out_multi[i], scales[i]);
-            in_multi[i] = NearestOp{}(in_shape.lens[i], coord);
-        }
-        return input[in_multi];
-    });
+    resize_apply<Axis, CoordOp>(
+        input, out, outv, scales, [&](auto in_shape, auto out_shape, auto out_multi, auto read) {
+            constexpr auto ndim = get_shape_c<Input>{}.lens.size();
+            array<index_int, ndim> in_multi{};
+            for(index_int i = 0; i < ndim; ++i)
+            {
+                auto coord =
+                    CoordOp{}(in_shape.lens[i], out_shape.lens[i], out_multi[i], scales[i]);
+                in_multi[i] = NearestOp{}(in_shape.lens[i], coord);
+            }
+            return read(in_multi);
+        });
 }
 
 // Resize linear kernel.
@@ -262,35 +308,34 @@ template <class CoordOp,
           class Scales>
 __device__ void resize_linear(Input input, Output out, Outv outv, Scales scales)
 {
-    auto in_shape       = input.get_shape();
-    auto out_shape      = out.get_shape();
-    constexpr auto ndim = get_shape_c<Input>{}.lens.size();
-    resize_apply<Axis>(outv, [&](auto out_multi) {
-        auto params = array_transform(in_shape.lens, out_shape.lens, out_multi, scales)(
-            [](auto... xs) { return compute_interp_params_1d<CoordOp>(xs...); });
-        index_int active_count =
-            count_if(scales.begin(), scales.end(), [](auto scale) { return scale != 1.0f; });
-        MIGRAPHX_ASSERT(active_count < 32);
-        auto in_multi = array_transform(params)([](const interp_params& p) { return p.i0; });
-        const index_int corners = (1u << active_count);
-        float acc               = 0.0f;
-        for(index_int subset = 0; subset < corners; ++subset)
-        {
-            float w              = 1.0f;
-            index_int active_bit = 0;
-            for(index_int d = 0; d < ndim; ++d)
+    resize_apply<Axis, CoordOp>(
+        input, out, outv, scales, [&](auto in_shape, auto out_shape, auto out_multi, auto read) {
+            constexpr auto ndim = get_shape_c<Input>{}.lens.size();
+            auto params         = array_transform(in_shape.lens, out_shape.lens, out_multi, scales)(
+                [](auto... xs) { return compute_interp_params_1d<CoordOp>(xs...); });
+            index_int active_count =
+                count_if(scales.begin(), scales.end(), [](auto scale) { return scale != 1.0f; });
+            MIGRAPHX_ASSERT(active_count < 32);
+            auto in_multi = array_transform(params)([](const interp_params& p) { return p.i0; });
+            const index_int corners = (1u << active_count);
+            decltype(read(in_multi)) acc{};
+            for(index_int subset = 0; subset < corners; ++subset)
             {
-                if(scales[d] == 1.0f)
-                    continue;
-                const bool use_high = get_bit(subset, active_bit);
-                w *= use_high ? params[d].weight : (1.0f - params[d].weight);
-                in_multi[d] = use_high ? params[d].i1 : params[d].i0;
-                ++active_bit;
+                float w              = 1.0f;
+                index_int active_bit = 0;
+                for(index_int d = 0; d < ndim; ++d)
+                {
+                    if(scales[d] == 1.0f)
+                        continue;
+                    const bool use_high = get_bit(subset, active_bit);
+                    w *= use_high ? params[d].weight : (1.0f - params[d].weight);
+                    in_multi[d] = use_high ? params[d].i1 : params[d].i0;
+                    ++active_bit;
+                }
+                acc = acc + w * read(in_multi);
             }
-            acc += w * migraphx::convert<float>(input[in_multi]);
-        }
-        return acc;
-    });
+            return acc;
+        });
 }
 
 // Resize cubic kernel
@@ -304,70 +349,71 @@ template <class CoordOp,
           class Scales>
 __device__ void resize_cubic(Input input, Output out, Outv outv, Scales scales, float cubic_coeff)
 {
-    auto in_shape       = input.get_shape();
-    auto out_shape      = out.get_shape();
-    constexpr auto ndim = get_shape_c<Input>{}.lens.size();
-    resize_apply<Axis>(outv, [&](auto out_multi) {
-        // Precompute cubic interpolation parameters for each dimension
-        array<cubic_params, ndim> params{};
-        for(index_int d = 0; d < ndim; ++d)
-        {
-            params[d] = compute_cubic_params_1d<CoordOp>(
-                in_shape.lens[d], out_shape.lens[d], out_multi[d], scales[d], cubic_coeff);
-        }
+    resize_apply<Axis, CoordOp>(
+        input, out, outv, scales, [&](auto in_shape, auto out_shape, auto out_multi, auto read) {
+            constexpr auto ndim = get_shape_c<Input>{}.lens.size();
 
-        // Count dimensions that need interpolation (scale != 1.0)
-        auto active_count =
-            count_if(scales.begin(), scales.end(), [](auto scale) { return scale != 1.0f; });
-        MIGRAPHX_ASSERT(active_count < 32);
-
-        array<index_int, ndim> active_dims{};
-        auto r = range(ndim);
-        copy_if(r.begin(), r.end(), active_dims.begin(), [&](auto d) { return scales[d] != 1.0f; });
-
-        // Initialize in_multi: for non-interpolated dimensions, use output index directly
-        // (since input and output sizes are the same for those dimensions)
-        array<index_int, ndim> in_multi{};
-        for(index_int d = 0; d < ndim; ++d)
-        {
-            in_multi[d] = (scales[d] == 1.0f) ? out_multi[d] : params[d].indices[0];
-        }
-
-        // Build combo shape: 4 for interpolated dims, 1 otherwise
-        auto combo_lens =
-            array_transform(scales)([](auto scale) -> index_int { return scale == 1.0f ? 1 : 4; });
-
-        index_int total_combos = combo_lens.product();
-        float acc              = 0.0f;
-
-        for(index_int combo = 0; combo < total_combos; ++combo)
-        {
-            auto combo_multi = combo_lens.multi(combo);
-
-            // Compute the combined weight as a product of per-dimension weights
-            float w = inner_product(
-                active_dims.begin(),
-                active_dims.begin() + active_count,
-                active_dims.begin(),
-                1.0f,
-                [](float a, float b) { return a * b; },
-                [&](index_int d, index_int) { return params[d].weights[combo_multi[d]]; });
-
-            // Set in_multi for each active dimension from the neighbor indices
-            for(index_int i = 0; i < active_count; ++i)
+            // Precompute cubic interpolation parameters for each dimension
+            array<cubic_params, ndim> params{};
+            for(index_int d = 0; d < ndim; ++d)
             {
-                index_int d = active_dims[i];
-                in_multi[d] = params[d].indices[combo_multi[d]];
+                params[d] = compute_cubic_params_1d<CoordOp>(
+                    in_shape.lens[d], out_shape.lens[d], out_multi[d], scales[d], cubic_coeff);
             }
 
-            if(migraphx::abs(w) > 1e-10f)
-            {
-                acc += w * migraphx::convert<float>(input[in_multi]);
-            }
-        }
+            // Count dimensions that need interpolation (scale != 1.0)
+            auto active_count =
+                count_if(scales.begin(), scales.end(), [](auto scale) { return scale != 1.0f; });
+            MIGRAPHX_ASSERT(active_count < 32);
 
-        return acc;
-    });
+            array<index_int, ndim> active_dims{};
+            auto r = range(ndim);
+            copy_if(
+                r.begin(), r.end(), active_dims.begin(), [&](auto d) { return scales[d] != 1.0f; });
+
+            // Initialize in_multi: for non-interpolated dimensions, use output index directly
+            // (since input and output sizes are the same for those dimensions)
+            array<index_int, ndim> in_multi{};
+            for(index_int d = 0; d < ndim; ++d)
+            {
+                in_multi[d] = (scales[d] == 1.0f) ? out_multi[d] : params[d].indices[0];
+            }
+
+            // Build combo shape: 4 for interpolated dims, 1 otherwise
+            auto combo_lens = array_transform(scales)(
+                [](auto scale) -> index_int { return scale == 1.0f ? 1 : 4; });
+
+            index_int total_combos = combo_lens.product();
+            decltype(read(in_multi)) acc{};
+
+            for(index_int combo = 0; combo < total_combos; ++combo)
+            {
+                auto combo_multi = combo_lens.multi(combo);
+
+                // Compute the combined weight as a product of per-dimension weights
+                float w = inner_product(
+                    active_dims.begin(),
+                    active_dims.begin() + active_count,
+                    active_dims.begin(),
+                    1.0f,
+                    [](float a, float b) { return a * b; },
+                    [&](index_int d, index_int) { return params[d].weights[combo_multi[d]]; });
+
+                // Set in_multi for each active dimension from the neighbor indices
+                for(index_int i = 0; i < active_count; ++i)
+                {
+                    index_int d = active_dims[i];
+                    in_multi[d] = params[d].indices[combo_multi[d]];
+                }
+
+                if(migraphx::abs(w) > 1e-10f)
+                {
+                    acc = acc + w * read(in_multi);
+                }
+            }
+
+            return acc;
+        });
 }
 
 } // namespace migraphx

--- a/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/resize.hpp
@@ -37,7 +37,7 @@
 
 namespace migraphx {
 
-// Coordinate transformation mode functors
+// Coordinate transformation mode functions
 struct coord_transform_half_pixel
 {
     MIGRAPHX_DEVICE_CONSTEXPR float operator()(index_int, index_int, float idx, float scale) const
@@ -84,7 +84,7 @@ struct coord_transform_tf_half_pixel_for_nn
     }
 };
 
-// Nearest mode functors
+// Nearest mode functions
 struct nearest_floor
 {
     MIGRAPHX_DEVICE_CONSTEXPR index_int operator()(index_int d_in, float val) const


### PR DESCRIPTION
## Motivation
Enable vectorization for resize which help improve the performance of the kernel.

## Technical Details
Since the input and output are different sizes the `vectorize` arg transformer cannot be applied across all tensors. Instead, we vectorize the output and input differently. Ouput vectorization can be easily applied for most cases but input vectorization can only be applied when its not resizing the fastest axis. So it mainly helps for cases like NHWC. 

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [x] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
