### PR TITLE
Reject zero-size operation name buffers

### DIFF
--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -2000,6 +2000,8 @@ migraphx_operation_name(char* out, size_t out_size, migraphx_operation_t operati
     auto api_error_result = migraphx::try_([&] {
         if(out == nullptr)
             MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter out: Null pointer");
+        if(out_size == 0)
+            MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter out_size: zero");
         if(operation == nullptr)
             MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter operation: Null pointer");
         auto&& api_result = (operation->object).name();

--- a/test/api/test_c_op_construct.c
+++ b/test/api/test_c_op_construct.c
@@ -22,7 +22,14 @@
  * THE SOFTWARE.
  */
 #include <migraphx/migraphx.h>
+#include <stdlib.h>
 #include <string.h>
+
+void expect_status(migraphx_status x, migraphx_status y)
+{
+    if(x != y)
+        abort();
+}
 
 void expect_equal(const char* x, const char* y)
 {
@@ -33,9 +40,16 @@ void expect_equal(const char* x, const char* y)
 int main(void)
 {
     char name[1024];
+    char truncated_name[2];
     migraphx_operation_t op;
-    migraphx_operation_create(&op, "add", 0);
-    migraphx_operation_name(name, 1024, op);
-    migraphx_operation_destroy(op);
+    expect_status(migraphx_operation_create(&op, "add", 0), migraphx_status_success);
+
+    expect_status(migraphx_operation_name(NULL, 1024, op), migraphx_status_bad_param);
+    expect_status(migraphx_operation_name(name, 0, op), migraphx_status_bad_param);
+    expect_status(migraphx_operation_name(truncated_name, 2, op), migraphx_status_success);
+    expect_equal(truncated_name, "a");
+
+    expect_status(migraphx_operation_name(name, 1024, op), migraphx_status_success);
+    expect_status(migraphx_operation_destroy(op), migraphx_status_success);
     expect_equal(name, "add");
 }

--- a/tools/api.py
+++ b/tools/api.py
@@ -191,9 +191,10 @@ class CFunction:
 
 
 class BadParam:
-    def __init__(self, cond: str, msg: str) -> None:
+    def __init__(self, cond: str, msg: str, name: Optional[str] = None) -> None:
         self.cond = cond
         self.msg = msg
+        self.name = name
 
 
 class Parameter:
@@ -219,7 +220,7 @@ class Parameter:
         self.virtual = virtual
         self.this = this
         self.hidden = hidden
-        self.bad_param_check: Optional[BadParam] = None
+        self.bad_param_checks: List[BadParam] = []
         self.virtual_read: Optional[List[str]] = None
         self.virtual_write: Optional[str] = None
 
@@ -267,8 +268,8 @@ class Parameter:
         else:
             self.add_param('size_t', self.size_name)
 
-    def bad_param(self, cond: str, msg: str) -> None:
-        self.bad_param_check = BadParam(cond, msg)
+    def bad_param(self, cond: str, msg: str, name: Optional[str] = None) -> None:
+        self.bad_param_checks.append(BadParam(cond, msg, name))
 
     def remove_size_param(self, name):
         p = None
@@ -395,11 +396,12 @@ class Parameter:
                 cfunction.add_vlist(name)
             else:
                 cfunction.add_param(self.substitute(t), self.substitute(name))
-        if self.bad_param_check:
+        for bad_param_check in self.bad_param_checks:
             msg = 'Bad parameter {name}: {msg}'.format(
-                name=self.name, msg=self.bad_param_check.msg)
+                name=self.substitute(bad_param_check.name or self.name),
+                msg=bad_param_check.msg)
             cfunction.add_statement('if ({cond}) {body}'.format(
-                cond=self.substitute(self.bad_param_check.cond),
+                cond=self.substitute(bad_param_check.cond),
                 body=bad_param_error(msg)))
 
 
@@ -1012,6 +1014,7 @@ def string_c_wrap(p: Parameter) -> None:
             p.add_param(t)
             p.add_param('size_t', p.name + '_size')
             p.bad_param('${name} == nullptr', 'Null pointer')
+            p.bad_param('${name}_size == 0', 'zero', '${name}_size')
     else:
         p.add_param(t)
         p.bad_param('${name} == nullptr', 'Null pointer')


### PR DESCRIPTION
## Summary

`migraphx_operation_name` accepted a non-null output pointer with `out_size == 0`, then computed `out_size - 1` before copying the operation name. That underflowed the limit used by `std::copy_n` and could write past the caller's buffer.

This change rejects zero-size output buffers with `migraphx_status_bad_param`, updates the API generator so regenerated C API output keeps the same guard, and extends the C API operation-construction test to cover null output, zero size, truncation, and normal success.

## Tests

- `git diff --check`
- `python3 -m py_compile tools/api.py src/api/migraphx.py`
- `python3 tools/api.py src/api/migraphx.py tools/api/api.cpp | rg -n "migraphx_operation_name|Bad parameter out|Bad parameter out_size|copy_n" -C 3`
- `cc -fsyntax-only -I <temporary export-header include> -I src/api/include test/api/test_c_op_construct.c`

Not run: full CMake/API test target. Local configure stops before target generation because `ROCmCMakeBuildTools` is not installed on this machine.
