### PR TITLE
Propagate layout with reshape after lowering

### DIFF
--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -234,6 +234,7 @@ add_library(migraphx_gpu
     prepare_reduce.cpp
     pooling.cpp
     problem_cache.cpp
+    propagate_reshape_layout.cpp
     rocblas.cpp
     schedule_model.cpp
     sync_device.cpp

--- a/src/targets/gpu/include/migraphx/gpu/propagate_reshape_layout.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/propagate_reshape_layout.hpp
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MIGRAPHX_GUARD_GPU_PROPAGATE_RESHAPE_LAYOUT_HPP
+#define MIGRAPHX_GUARD_GPU_PROPAGATE_RESHAPE_LAYOUT_HPP
+
+#include <migraphx/gpu/config.hpp>
+#include <string>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+
+struct module;
+
+namespace gpu {
+
+/**
+ * Propagate the permutation that a `reshape` would produce through its lowered
+ * `reshape_lazy`.
+ *
+ * Lowering turns `reshape` into `gpu::contiguous -> reshape_lazy -> gpu::contiguous`,
+ * and `eliminate_contiguous` drops the leading contiguous whenever `reshape_lazy` can
+ * alias its input directly. When it cannot, the contiguous is kept and forces a
+ * *standard* layout, discarding the permutation the original `reshape` would have
+ * propagated (e.g. NHWC into a following pooling op).
+ *
+ * This pass runs after `eliminate_contiguous`, where the real input layout is finally
+ * known. For each surviving `gpu::contiguous -> reshape_lazy` over a non-standard
+ * input, it replaces the standardizing contiguous with a `layout` that repacks the
+ * input into the exact memory order `reshape_lazy` needs to alias straight to the
+ * permuted output. The `layout` reuses the existing pointwise copy kernel, so no
+ * reshape kernel is generated, and the kernel count is unchanged from the previous
+ * standardizing contiguous.
+ */
+struct MIGRAPHX_GPU_EXPORT propagate_reshape_layout
+{
+    std::string name() const { return "gpu::propagate_reshape_layout"; }
+    void apply(module& m) const;
+};
+
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+
+#endif // MIGRAPHX_GUARD_GPU_PROPAGATE_RESHAPE_LAYOUT_HPP

--- a/src/targets/gpu/propagate_reshape_layout.cpp
+++ b/src/targets/gpu/propagate_reshape_layout.cpp
@@ -22,62 +22,66 @@
  * THE SOFTWARE.
  */
 #include <migraphx/gpu/propagate_reshape_layout.hpp>
+#include <migraphx/matcher.hpp>
 #include <migraphx/module.hpp>
 #include <migraphx/instruction.hpp>
-#include <migraphx/iterator_for.hpp>
 #include <migraphx/make_op.hpp>
 #include <migraphx/permutation.hpp>
 #include <migraphx/reshape_dims.hpp>
 #include <migraphx/value.hpp>
-#include <vector>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
-void propagate_reshape_layout::apply(module& m) const
+namespace {
+struct find_reshape_lazy_contiguous
 {
-    std::vector<instruction_ref> reshapes;
-    for(auto ins : iterator_for(m))
+    // eliminate_contiguous only leaves a standardizing gpu::contiguous in front of a
+    // reshape_lazy when it could not alias the input directly; that is the only case where a
+    // permutation was discarded.
+    auto matcher() const
     {
-        if(ins->name() == "reshape_lazy")
-            reshapes.push_back(ins);
+        return match::name("reshape_lazy")(
+            match::arg(0)(match::name("gpu::contiguous").bind("contiguous")));
     }
 
-    for(auto rl : reshapes)
+    void apply(module& m, const match::matcher_result& r) const
     {
-        auto c = rl->inputs().front();
-        // eliminate_contiguous only leaves a standardizing gpu::contiguous in front of
-        // reshape_lazy when it could not alias the input directly; that is the only case
-        // where a permutation was discarded.
-        if(c->name() != "gpu::contiguous")
-            continue;
-        auto input = c->inputs().front();
-        auto s     = input->get_shape();
+        auto rl       = r.result;
+        auto cont     = r.instructions["contiguous"];
+        auto input    = cont->inputs().front();
+        const auto& s = input->get_shape();
         // A standard input carries no permutation to propagate.
         if(s.dynamic() or s.standard())
-            continue;
+            return;
 
-        auto rdims = rl->get_shape().lens();
-        // The permuted, packed output the original reshape would have produced from the
-        // real (non-standard) input. reshape_dims does not verify the element count, so guard
-        // it here the same way reshape_lazy::compute_shape does.
+        const auto& rdims = rl->get_shape().lens();
+        // The permuted, packed output the original reshape would have produced from the real
+        // (non-standard) input. reshape_dims does not verify the element count, so guard it here
+        // the same way reshape_lazy::compute_shape does.
         auto permuted = reshape_dims(s, rdims, {.lazy = false});
         if(not permuted or permuted->standard() or permuted->elements() != s.elements())
-            continue;
+            return;
         // The packed layout that reshape_lazy can alias straight to that output.
         auto relayout = reshape_dims(*permuted, s.lens(), {.lazy = true});
         if(not relayout)
-            continue;
+            return;
 
         auto layout_op    = make_op("layout", {{"permutation", find_permutation(*relayout)}});
-        auto layout_shape = layout_op.compute_shape(std::vector<shape>{s});
+        auto layout_shape = layout_op.compute_shape({s});
         auto alloc =
             m.insert_instruction(rl, make_op("allocate", {{"shape", to_value(layout_shape)}}));
         auto layout = m.insert_instruction(
             rl, make_op("gpu::precompile_op", {{"op", to_value(layout_op)}}), input, alloc);
-        instruction::replace_argument(rl, c, layout);
+        instruction::replace_argument(rl, cont, layout);
     }
+};
+} // namespace
+
+void propagate_reshape_layout::apply(module& m) const
+{
+    match::find_matches(m, find_reshape_lazy_contiguous{});
 }
 
 } // namespace gpu

--- a/src/targets/gpu/propagate_reshape_layout.cpp
+++ b/src/targets/gpu/propagate_reshape_layout.cpp
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/gpu/propagate_reshape_layout.hpp>
+#include <migraphx/module.hpp>
+#include <migraphx/instruction.hpp>
+#include <migraphx/iterator_for.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/permutation.hpp>
+#include <migraphx/reshape_dims.hpp>
+#include <migraphx/value.hpp>
+#include <vector>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
+
+void propagate_reshape_layout::apply(module& m) const
+{
+    std::vector<instruction_ref> reshapes;
+    for(auto ins : iterator_for(m))
+    {
+        if(ins->name() == "reshape_lazy")
+            reshapes.push_back(ins);
+    }
+
+    for(auto rl : reshapes)
+    {
+        auto c = rl->inputs().front();
+        // eliminate_contiguous only leaves a standardizing gpu::contiguous in front of
+        // reshape_lazy when it could not alias the input directly; that is the only case
+        // where a permutation was discarded.
+        if(c->name() != "gpu::contiguous")
+            continue;
+        auto input = c->inputs().front();
+        auto s     = input->get_shape();
+        // A standard input carries no permutation to propagate.
+        if(s.dynamic() or s.standard())
+            continue;
+
+        auto rdims = rl->get_shape().lens();
+        // The permuted, packed output the original reshape would have produced from the
+        // real (non-standard) input. reshape_dims does not verify the element count, so guard
+        // it here the same way reshape_lazy::compute_shape does.
+        auto permuted = reshape_dims(s, rdims, {.lazy = false});
+        if(not permuted or permuted->standard() or permuted->elements() != s.elements())
+            continue;
+        // The packed layout that reshape_lazy can alias straight to that output.
+        auto relayout = reshape_dims(*permuted, s.lens(), {.lazy = true});
+        if(not relayout)
+            continue;
+
+        auto layout_op    = make_op("layout", {{"permutation", find_permutation(*relayout)}});
+        auto layout_shape = layout_op.compute_shape(std::vector<shape>{s});
+        auto alloc =
+            m.insert_instruction(rl, make_op("allocate", {{"shape", to_value(layout_shape)}}));
+        auto layout = m.insert_instruction(
+            rl, make_op("gpu::precompile_op", {{"op", to_value(layout_op)}}), input, alloc);
+        instruction::replace_argument(rl, c, layout);
+    }
+}
+
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -75,6 +75,7 @@
 #include <migraphx/gpu/fuse_ops.hpp>
 #include <migraphx/gpu/prefuse_ops.hpp>
 #include <migraphx/gpu/lowering.hpp>
+#include <migraphx/gpu/propagate_reshape_layout.hpp>
 #include <migraphx/gpu/schedule_model.hpp>
 #include <migraphx/gpu/sync_device.hpp>
 #include <migraphx/gpu/target.hpp>
@@ -206,6 +207,8 @@ struct pipeline_factory
             dead_code_elimination{},
             lowering{get_context(), options.offload_copy},
             eliminate_contiguous{"gpu::contiguous"},
+            dead_code_elimination{},
+            propagate_reshape_layout{},
             dead_code_elimination{},
             adjust_allocation{gpu_allocation_model{.use_hip_allocate = false}},
             dead_code_elimination{},

--- a/test/gpu/propagate_reshape_layout.cpp
+++ b/test/gpu/propagate_reshape_layout.cpp
@@ -99,7 +99,8 @@ TEST_CASE(no_permutation_noop)
     migraphx::module m1;
     {
         auto x = m1.add_parameter("x", {migraphx::shape::float_type, {2, 3, 4}});
-        auto t = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), x);
+        auto t =
+            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), x);
         auto alloc = m1.add_instruction(
             migraphx::make_op("allocate",
                               {{"shape",

--- a/test/gpu/propagate_reshape_layout.cpp
+++ b/test/gpu/propagate_reshape_layout.cpp
@@ -96,23 +96,20 @@ TEST_CASE(propagate_permutation)
 // permutation to propagate, so the pass must leave the graph unchanged.
 TEST_CASE(no_permutation_noop)
 {
-    auto create = [] {
-        migraphx::module m;
-        auto x = m.add_parameter("x", {migraphx::shape::float_type, {2, 3, 4}});
-        auto t = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), x);
-        auto alloc = m.add_instruction(
+    migraphx::module m1;
+    {
+        auto x = m1.add_parameter("x", {migraphx::shape::float_type, {2, 3, 4}});
+        auto t = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), x);
+        auto alloc = m1.add_instruction(
             migraphx::make_op("allocate",
                               {{"shape",
                                 migraphx::to_value(migraphx::shape{migraphx::shape::float_type,
                                                                    t->get_shape().lens()})}}));
-        auto c  = m.add_instruction(migraphx::make_op("gpu::contiguous"), t, alloc);
-        auto rl = m.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {6, 4}}}), c);
-        m.add_return({rl});
-        return m;
-    };
-
-    auto m1 = create();
-    auto m2 = create();
+        auto c  = m1.add_instruction(migraphx::make_op("gpu::contiguous"), t, alloc);
+        auto rl = m1.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {6, 4}}}), c);
+        m1.add_return({rl});
+    }
+    migraphx::module m2 = m1;
     run_pass(m1);
     EXPECT(m1 == m2);
 }

--- a/test/gpu/propagate_reshape_layout.cpp
+++ b/test/gpu/propagate_reshape_layout.cpp
@@ -51,12 +51,12 @@ TEST_CASE(propagate_permutation)
         auto t = m1.add_instruction(
             migraphx::make_op("transpose", {{"permutation", {0, 2, 4, 1, 3}}}), r);
         // post-eliminate_contiguous state: a standardizing gpu::contiguous feeds reshape_lazy
-        auto alloc = m1.add_instruction(migraphx::make_op(
-            "allocate",
-            {{"shape",
-              migraphx::to_value(migraphx::shape{migraphx::shape::float_type,
-                                                 t->get_shape().lens()})}}));
-        auto c  = m1.add_instruction(migraphx::make_op("gpu::contiguous"), t, alloc);
+        auto alloc = m1.add_instruction(
+            migraphx::make_op("allocate",
+                              {{"shape",
+                                migraphx::to_value(migraphx::shape{migraphx::shape::float_type,
+                                                                   t->get_shape().lens()})}}));
+        auto c = m1.add_instruction(migraphx::make_op("gpu::contiguous"), t, alloc);
         auto rl =
             m1.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {1, 16, 256, 256}}}), c);
         m1.add_return({rl});
@@ -99,13 +99,12 @@ TEST_CASE(no_permutation_noop)
     auto create = [] {
         migraphx::module m;
         auto x = m.add_parameter("x", {migraphx::shape::float_type, {2, 3, 4}});
-        auto t =
-            m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), x);
-        auto alloc = m.add_instruction(migraphx::make_op(
-            "allocate",
-            {{"shape",
-              migraphx::to_value(migraphx::shape{migraphx::shape::float_type,
-                                                 t->get_shape().lens()})}}));
+        auto t = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), x);
+        auto alloc = m.add_instruction(
+            migraphx::make_op("allocate",
+                              {{"shape",
+                                migraphx::to_value(migraphx::shape{migraphx::shape::float_type,
+                                                                   t->get_shape().lens()})}}));
         auto c  = m.add_instruction(migraphx::make_op("gpu::contiguous"), t, alloc);
         auto rl = m.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {6, 4}}}), c);
         m.add_return({rl});

--- a/test/gpu/propagate_reshape_layout.cpp
+++ b/test/gpu/propagate_reshape_layout.cpp
@@ -1,0 +1,121 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/gpu/propagate_reshape_layout.hpp>
+#include <migraphx/dead_code_elimination.hpp>
+#include <migraphx/pass_manager.hpp>
+#include <migraphx/instruction.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/module.hpp>
+#include <test.hpp>
+#include "make_precompile_op.hpp"
+
+static void run_pass(migraphx::module& m)
+{
+    migraphx::run_passes(
+        m, {migraphx::gpu::propagate_reshape_layout{}, migraphx::dead_code_elimination{}});
+}
+
+// A reshape_lazy that cannot alias its non-standard input keeps a standardizing
+// gpu::contiguous after eliminate_contiguous. The pass should replace it with a layout
+// that repacks the input into the order reshape_lazy needs to propagate the permutation.
+TEST_CASE(propagate_permutation)
+{
+    migraphx::shape in{migraphx::shape::float_type, {1, 1, 1024, 1024}};
+
+    migraphx::module m1;
+    {
+        auto x = m1.add_parameter("x", in);
+        auto r =
+            m1.add_instruction(migraphx::make_op("reshape", {{"dims", {1, 256, 4, 256, 4}}}), x);
+        auto t = m1.add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 2, 4, 1, 3}}}), r);
+        // post-eliminate_contiguous state: a standardizing gpu::contiguous feeds reshape_lazy
+        auto alloc = m1.add_instruction(migraphx::make_op(
+            "allocate",
+            {{"shape",
+              migraphx::to_value(migraphx::shape{migraphx::shape::float_type,
+                                                 t->get_shape().lens()})}}));
+        auto c  = m1.add_instruction(migraphx::make_op("gpu::contiguous"), t, alloc);
+        auto rl =
+            m1.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {1, 16, 256, 256}}}), c);
+        m1.add_return({rl});
+    }
+    run_pass(m1);
+
+    migraphx::module m2;
+    {
+        auto x = m2.add_parameter("x", in);
+        auto r =
+            m2.add_instruction(migraphx::make_op("reshape", {{"dims", {1, 256, 4, 256, 4}}}), x);
+        auto t = m2.add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 2, 4, 1, 3}}}), r);
+        // layout repacks the transpose into the packed memory order reshape_lazy can alias
+        auto l_shape = migraphx::shape::from_permutation(
+            migraphx::shape::float_type, {1, 4, 4, 256, 256}, {0, 3, 4, 1, 2});
+        auto alloc = m2.add_instruction(
+            migraphx::make_op("allocate", {{"shape", migraphx::to_value(l_shape)}}));
+        auto layout = m2.add_instruction(
+            make_precompile_op(migraphx::make_op("layout", {{"permutation", {0, 3, 4, 1, 2}}})),
+            t,
+            alloc);
+        auto rl = m2.add_instruction(
+            migraphx::make_op("reshape_lazy", {{"dims", {1, 16, 256, 256}}}), layout);
+        m2.add_return({rl});
+    }
+
+    EXPECT(m1 == m2);
+    // reshape_lazy now produces the permuted (NHWC-like) output rather than a standard one
+    auto rl1 = std::prev(m1.end())->inputs().front();
+    EXPECT(rl1->name() == "reshape_lazy");
+    EXPECT(not rl1->get_shape().standard());
+    EXPECT(rl1->get_shape().lens() == std::vector<std::size_t>{1, 16, 256, 256});
+}
+
+// When the reshape collapses the non-standard input back to a standard layout there is no
+// permutation to propagate, so the pass must leave the graph unchanged.
+TEST_CASE(no_permutation_noop)
+{
+    auto create = [] {
+        migraphx::module m;
+        auto x = m.add_parameter("x", {migraphx::shape::float_type, {2, 3, 4}});
+        auto t =
+            m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), x);
+        auto alloc = m.add_instruction(migraphx::make_op(
+            "allocate",
+            {{"shape",
+              migraphx::to_value(migraphx::shape{migraphx::shape::float_type,
+                                                 t->get_shape().lens()})}}));
+        auto c  = m.add_instruction(migraphx::make_op("gpu::contiguous"), t, alloc);
+        auto rl = m.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {6, 4}}}), c);
+        m.add_return({rl});
+        return m;
+    };
+
+    auto m1 = create();
+    auto m2 = create();
+    run_pass(m1);
+    EXPECT(m1 == m2);
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation
Even though `reshape` propagates the permutation after lowering its get lowered to contiguous->reshape_lazy, which will always use standard shape. Instead this adds a pass to insert a `layout` so it will propagate the permutation in `reshape_lazy`.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
