### PR TITLE
[ROCM-26203] Modify existing tests to work with pytest

### DIFF
--- a/test/py/test_array.py
+++ b/test/py/test_array.py
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -80,7 +80,7 @@ def run(p):
     return p.run(params)
 
 
-def test_shape(shape):
+def _test_shape(shape):
     data = list(range(nelements(shape)))
     m = create_buffer('f', data, shape)
     a = migraphx.argument(m)
@@ -90,8 +90,8 @@ def test_shape(shape):
 
 def test_input():
     if sys.version_info >= (3, 0):
-        test_shape([4])
-        test_shape([2, 3])
+        _test_shape([4])
+        _test_shape([2, 3])
     else:
         data = list(range(4))
         m = create_buffer('f', data, [4])

--- a/test/py/test_save_load.py
+++ b/test/py/test_save_load.py
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,7 @@
 import migraphx, array, tempfile, sys
 
 
-def test_conv_relu(format):
+def _test_conv_relu(format):
     p1 = migraphx.parse_onnx("conv_relu_maxpool_test.onnx")
     print(p1)
 
@@ -39,6 +39,12 @@ def test_conv_relu(format):
 
         assert s1 == s2
         assert p1.sort() == p2.sort()
+
+def test_conv_relu_msgpack():
+    _test_conv_relu('msgpack')
+
+def test_conv_relu_json():
+    _test_conv_relu('json')
 
 def test_save_load_buffer():
     p1 = migraphx.parse_onnx("conv_relu_maxpool_test.onnx")
@@ -76,6 +82,6 @@ def test_load_save_arg():
 
 if __name__ == "__main__":
     test_load_save_arg()
-    test_conv_relu('msgpack')
-    test_conv_relu('json')
+    test_conv_relu_msgpack()
+    test_conv_relu_json()
     test_save_load_buffer()


### PR DESCRIPTION
## Motivation
Modifies some of our existing tests to work properly with pytest.

## Technical Details
By default, pytest picks up any functions in the format of `test_*` or `*_test` and runs them as tests. This PR adds an underscore prefix to any functions that are meant to be helpers and not actual tests.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
