### PR TITLE
Encode benchmark MXR comment metadata as JSON

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -37,6 +37,7 @@
 #include <migraphx/builtin.hpp>
 #include <migraphx/load_save.hpp>
 #include <migraphx/filesystem.hpp>
+#include <migraphx/json.hpp>
 #include <migraphx/gpu/compiler.hpp>
 #include <migraphx/gpu/compile_ops.hpp>
 #include <migraphx/gpu/context.hpp>
@@ -489,8 +490,14 @@ struct compile_plan
             const auto& solution     = config->solutions[i];
             auto bench_prog          = results[i]->make_program();
             auto* mm                 = bench_prog.get_main_module();
-            std::string comment_text = preop.name() + " problem=" + to_string(config->problem) +
-                                       " solution=" + to_string(solution);
+
+            // Use json encoding for the comment used for benchmarking mxr files.
+            std::map<std::string, value> comment_map;
+            comment_map["op"]        = preop.name();
+            comment_map["problem"]   = config->problem;
+            comment_map["solution"]  = solution;
+            std::string comment_text = to_json_string(to_value(comment_map));
+
             mm->add_instruction(builtin::comment{comment_text}, {});
             auto problem_hash = std::hash<std::string>{}(to_string(config->problem));
             auto mxr_file     = mxr_dir / (preop.name() + "_" + std::to_string(i) + "_" +

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -492,11 +492,11 @@ struct compile_plan
             auto* mm                 = bench_prog.get_main_module();
 
             // Use json encoding for the comment used for benchmarking mxr files.
-            std::map<std::string, value> comment_map;
-            comment_map["op"]        = preop.name();
-            comment_map["problem"]   = config->problem;
-            comment_map["solution"]  = solution;
-            std::string comment_text = to_json_string(to_value(comment_map));
+            value comment_val = value::object{};
+            comment_val["op"]       = preop.name();
+            comment_val["problem"]  = config->problem;
+            comment_val["solution"] = solution;
+            std::string comment_text = to_json_string(comment_val);
 
             mm->add_instruction(builtin::comment{comment_text}, {});
             auto problem_hash = std::hash<std::string>{}(to_string(config->problem));

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -492,10 +492,10 @@ struct compile_plan
             auto* mm                 = bench_prog.get_main_module();
 
             // Use json encoding for the comment used for benchmarking mxr files.
-            value comment_val = value::object{};
-            comment_val["op"]       = preop.name();
-            comment_val["problem"]  = config->problem;
-            comment_val["solution"] = solution;
+            value comment_val        = value::object{};
+            comment_val["op"]        = preop.name();
+            comment_val["problem"]   = config->problem;
+            comment_val["solution"]  = solution;
             std::string comment_text = to_json_string(comment_val);
 
             mm->add_instruction(builtin::comment{comment_text}, {});


### PR DESCRIPTION
## Motivation
Using json encoding for comment metadata simplifies parsing
of dumped mxr files for benchmarking later.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
