### PR TITLE
Fix verify auto-print handler registration for late targets

### DIFF
--- a/test/verify/auto_print.cpp
+++ b/test/verify/auto_print.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/verify/auto_print.cpp
+++ b/test/verify/auto_print.cpp
@@ -45,7 +45,7 @@ std::function<void()>& auto_print::get_handler(const std::string& name)
 {
     // NOLINTNEXTLINE
     static handler_map handlers = create_handlers();
-    return handlers.at(name);
+    return handlers[name];
 }
 
 void auto_print::set_terminate_handler(const std::string& name)


### PR DESCRIPTION
## Motivation
Fixes `invalid map<K, T> key` error on Windows when running `test_verify`
## Technical Details
Allow auto-print handlers to be created lazily so targets registered after the initial handler map setup do not fail lookup.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
