### PR TITLE
Fix redundant re-benchmarking for pooling when using problem cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Full documentation for MIGraphX is available at
 * Fixed `scatternd_`* GPU JIT kernel and host reference op to read the `indices` tensor stride-aware (`begin_at`), so non-packed layouts produced by upstream `transpose`/`slice`/`concat` no longer collapse every write into the same output cell.
 * Fixed a regression in `simplify_reshapes` where `find_slice_shape_transforms` could trigger `same_dims: Dimensions do not match` when a slice's shape descriptor absorbed a `multibroadcast` on the sliced axis.
 * Fixed `QLinearConv` parsing for models with a bias and per-tensor weight quantization, which previously threw `same_dims: dequantizelinear: Dimensions do not match` (e.g. `resnet50_int8`); the bias scale is now broadcast to the bias shape before dequantizing.
+* Fixed the GPU problem cache failing to find entries after reload for pooling operator, resulting in redundant re-benchmarking when using a saved `MIGRAPHX_PROBLEM_CACHE`.
 
 ### Optimized
 * Enabled tensor vectorization for GPU fused `argmin` and `argmax` (`gpu::arg_reduce`) (#4790).

--- a/src/include/migraphx/value.hpp
+++ b/src/include/migraphx/value.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/value.hpp
+++ b/src/include/migraphx/value.hpp
@@ -348,6 +348,8 @@ struct MIGRAPHX_EXPORT value
     value with_key(const std::string& pkey) const;
     value without_key() const;
 
+    value normalize() const;
+
     template <class Visitor>
     void visit(Visitor v) const
     {

--- a/src/targets/gpu/problem_cache.cpp
+++ b/src/targets/gpu/problem_cache.cpp
@@ -30,12 +30,30 @@
 #include <migraphx/file_buffer.hpp>
 #include <migraphx/logger.hpp>
 #include <iostream>
+#include <limits>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_PROBLEM_CACHE)
+
+// Normalize integer scalars to a signed representation: any unsigned value that
+// fits in int64 is stored as int64.
+static void normalize(value& v)
+{
+    if(v.is_array() or v.is_object())
+    {
+        for(auto& child : v)
+            normalize(child);
+    }
+    else if(v.is_uint64())
+    {
+        auto u = v.get_uint64();
+        if(u <= static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()))
+            v = static_cast<std::int64_t>(u);
+    }
+}
 
 void problem_cache::load()
 {
@@ -48,7 +66,9 @@ void problem_cache::load()
         save();
         return;
     }
-    from_value(from_json_string(read_string(pc_path)), cache);
+    auto v = from_json_string(read_string(pc_path));
+    normalize(v);
+    from_value(v, cache);
 }
 void problem_cache::save() const
 {
@@ -60,7 +80,9 @@ void problem_cache::save() const
 
 static value create_key(const std::string& name, const value& problem)
 {
-    return {{"name", name}, {"problem", problem}};
+    value key = {{"name", name}, {"problem", problem}};
+    normalize(key);
+    return key;
 }
 
 bool problem_cache::has(const std::string& name, const value& problem) const

--- a/src/targets/gpu/problem_cache.cpp
+++ b/src/targets/gpu/problem_cache.cpp
@@ -58,6 +58,7 @@ void problem_cache::load()
     for(const auto& [key, solution] : unnormalized_cache)
         cache[create_key(key.at("name").to<std::string>(), key.at("problem"))] = solution;
 }
+
 void problem_cache::save() const
 {
     auto pc_path = string_value_of(MIGRAPHX_PROBLEM_CACHE{});

--- a/src/targets/gpu/problem_cache.cpp
+++ b/src/targets/gpu/problem_cache.cpp
@@ -30,7 +30,6 @@
 #include <migraphx/file_buffer.hpp>
 #include <migraphx/logger.hpp>
 #include <iostream>
-#include <limits>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -38,21 +37,9 @@ namespace gpu {
 
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_PROBLEM_CACHE)
 
-// Normalize integer scalars to a signed representation: any unsigned value that
-// fits in int64 is stored as int64.
-static void normalize(value& v)
+static value create_key(const std::string& name, const value& problem)
 {
-    if(v.is_array() or v.is_object())
-    {
-        for(auto& child : v)
-            normalize(child);
-    }
-    else if(v.is_uint64())
-    {
-        auto u = v.get_uint64();
-        if(u <= static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()))
-            v = static_cast<std::int64_t>(u);
-    }
+    return {{"name", name}, {"problem", problem.normalize()}};
 }
 
 void problem_cache::load()
@@ -66,9 +53,10 @@ void problem_cache::load()
         save();
         return;
     }
-    auto v = from_json_string(read_string(pc_path));
-    normalize(v);
-    from_value(v, cache);
+    std::unordered_map<value, value> unnormalized_cache;
+    from_value(from_json_string(read_string(pc_path)), unnormalized_cache);
+    for(const auto& [key, solution] : unnormalized_cache)
+        cache[create_key(key.at("name").to<std::string>(), key.at("problem"))] = solution;
 }
 void problem_cache::save() const
 {
@@ -76,13 +64,6 @@ void problem_cache::save() const
     if(pc_path.empty())
         return;
     write_string(pc_path, to_pretty_json_string(to_value(cache)));
-}
-
-static value create_key(const std::string& name, const value& problem)
-{
-    value key = {{"name", name}, {"problem", problem}};
-    normalize(key);
-    return key;
 }
 
 bool problem_cache::has(const std::string& name, const value& problem) const

--- a/src/targets/gpu/problem_cache.cpp
+++ b/src/targets/gpu/problem_cache.cpp
@@ -37,11 +37,6 @@ namespace gpu {
 
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_PROBLEM_CACHE)
 
-static value create_key(const std::string& name, const value& problem)
-{
-    return {{"name", name}, {"problem", problem.normalize()}};
-}
-
 void problem_cache::load()
 {
     auto pc_path = string_value_of(MIGRAPHX_PROBLEM_CACHE{});
@@ -53,10 +48,7 @@ void problem_cache::load()
         save();
         return;
     }
-    std::unordered_map<value, value> unnormalized_cache;
-    from_value(from_json_string(read_string(pc_path)), unnormalized_cache);
-    for(const auto& [key, solution] : unnormalized_cache)
-        cache[create_key(key.at("name").to<std::string>(), key.at("problem"))] = solution;
+    from_value(from_json_string(read_string(pc_path)).normalize(), cache);
 }
 
 void problem_cache::save() const
@@ -65,6 +57,11 @@ void problem_cache::save() const
     if(pc_path.empty())
         return;
     write_string(pc_path, to_pretty_json_string(to_value(cache)));
+}
+
+static value create_key(const std::string& name, const value& problem)
+{
+    return {{"name", name}, {"problem", problem.normalize()}};
 }
 
 bool problem_cache::has(const std::string& name, const value& problem) const

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -21,8 +21,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <algorithm>
 #include <cassert>
 #include <iostream>
+#include <iterator>
 #include <limits>
 #include <migraphx/cloneable.hpp>
 #include <migraphx/errors.hpp>
@@ -453,15 +455,17 @@ value value::normalize() const
     if(this->is_array())
     {
         value result = value::array{};
-        for(const auto& child : *this)
-            result.push_back(child.normalize());
+        std::transform(this->begin(),
+                       this->end(),
+                       std::back_inserter(result),
+                       [](const value& child) { return child.normalize(); });
         return result;
     }
     if(this->is_uint64())
     {
         auto u = this->get_uint64();
         if(u <= std::numeric_limits<std::int64_t>::max())
-            return value(static_cast<std::int64_t>(u));
+            return static_cast<std::int64_t>(u);
     }
     return *this;
 }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -460,7 +460,7 @@ value value::normalize() const
     if(this->is_uint64())
     {
         auto u = this->get_uint64();
-        if(u <= static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()))
+        if(u <= std::numeric_limits<std::int64_t>::max())
             return value(static_cast<std::int64_t>(u));
     }
     return *this;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -23,6 +23,7 @@
  */
 #include <cassert>
 #include <iostream>
+#include <limits>
 #include <migraphx/cloneable.hpp>
 #include <migraphx/errors.hpp>
 #include <migraphx/stringutils.hpp>
@@ -436,6 +437,33 @@ value value::without_key() const
     value result = *this;
     result.key   = "";
     return result;
+}
+
+// Normalize integer scalars to a signed representation: any uint64 value that
+// fits in int64 is converted to int64.
+value value::normalize() const
+{
+    if(this->is_object())
+    {
+        value result = value::object{};
+        for(const auto& child : *this)
+            result[child.get_key()] = child.normalize();
+        return result;
+    }
+    if(this->is_array())
+    {
+        value result = value::array{};
+        for(const auto& child : *this)
+            result.push_back(child.normalize());
+        return result;
+    }
+    if(this->is_uint64())
+    {
+        auto u = this->get_uint64();
+        if(u <= static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()))
+            return value(static_cast<std::int64_t>(u));
+    }
+    return *this;
 }
 
 value value::with_key(const std::string& pkey) const

--- a/test/value_test.cpp
+++ b/test/value_test.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/value_test.cpp
+++ b/test/value_test.cpp
@@ -24,6 +24,8 @@
 #include <migraphx/value.hpp>
 #include <migraphx/float_equal.hpp>
 #include <migraphx/ranges.hpp>
+#include <cstdint>
+#include <limits>
 #include <unordered_set>
 #include <test.hpp>
 
@@ -1015,6 +1017,59 @@ TEST_CASE(value_object_as_hash_key2)
     EXPECT(migraphx::contains(set, v3));
     EXPECT(migraphx::contains(set, v4));
     EXPECT(set.size() == 3);
+}
+
+TEST_CASE(value_normalize_unsigned_to_signed)
+{
+    migraphx::value v = std::uint64_t{5};
+    auto n            = v.normalize();
+    EXPECT(n == migraphx::value(std::int64_t{5}));
+    // Original is unchanged (normalize returns a new value).
+    EXPECT(v.is_uint64());
+    EXPECT(v == migraphx::value(std::uint64_t{5}));
+}
+
+TEST_CASE(value_normalize_large_unsigned_unchanged)
+{
+    // A value that does not fit in int64 stays unsigned.
+    auto big          = std::numeric_limits<std::uint64_t>::max();
+    migraphx::value v = big;
+    auto n            = v.normalize();
+    EXPECT(n == migraphx::value(big));
+    EXPECT(n.is_uint64());
+}
+
+TEST_CASE(value_normalize_signed_unchanged)
+{
+    migraphx::value v = std::int64_t{-3};
+    EXPECT(v.normalize() == v);
+}
+
+TEST_CASE(value_normalize_non_integers_unchanged)
+{
+    migraphx::value d = 1.5;
+    EXPECT(d.normalize() == d);
+    migraphx::value s = "abc";
+    EXPECT(s.normalize() == s);
+}
+
+TEST_CASE(value_normalize_object_preserves_keys)
+{
+    migraphx::value obj;
+    obj["a"] = std::uint64_t{1};
+    obj["b"] = "x";
+    auto n   = obj.normalize();
+    EXPECT(n.at("a").get_key() == "a");
+    EXPECT(n.at("a").without_key() == migraphx::value(std::int64_t{1}));
+    EXPECT(n.at("b").to<std::string>() == "x");
+}
+
+TEST_CASE(value_normalize_nested_array)
+{
+    migraphx::value arr = {std::uint64_t{2}, std::uint64_t{3}};
+    auto n              = arr.normalize();
+    EXPECT(n[0] == migraphx::value(std::int64_t{2}));
+    EXPECT(n[1] == migraphx::value(std::int64_t{3}));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation
Fixed the GPU problem cache failing to find entries after reload for pooling operator, resulting in redundant re-benchmarking when using a saved `MIGRAPHX_PROBLEM_CACHE`

## Technical Details
Normalize integer scalars to a signed representation to ensure we compare the same type. JSON parser treats non-negative integers as unsigned and problem keys for pooling are signed; this causes equality check to fail and re-benchmarking even though we have the entry in the problem cache.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
