### PR TITLE
simplify_reshapes: skip find_reshape_dot when it would change element…

### DIFF
--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -1771,6 +1771,14 @@ struct find_reshape_dot
         {
             new_dot = m.insert_instruction(dot, make_op("dot"), inp, new_other);
         }
+        // Moving the reshape across the dot is only valid when the element count is
+        // preserved; otherwise the trailing reshape back to the original dot shape is
+        // invalid (observed creating an N->M element reshape that aborts compilation).
+        if(new_dot->get_shape().elements() != dot->get_shape().elements())
+        {
+            m.remove_instruction(new_dot);
+            return;
+        }
         m.replace_instruction(
             dot, make_op("reshape", {{"dims", dot->get_shape().lens()}}), new_dot);
     }

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -4549,6 +4549,32 @@ TEST_CASE(reshape_dot_broadcast_2)
     EXPECT(m1.sort() == m2.sort());
 }
 
+TEST_CASE(reshape_dot_changed_element_count)
+{
+    // find_reshape_dot would move the reshapes across the dot and then reshape the new
+    // dot's output back to the original dot's shape. Here the second input's reshape
+    // preserves its contraction axis (second-to-last dim) but changes the free (N) dim,
+    // so the rewrite changes the dot's total element count and that trailing reshape is
+    // invalid (the "Reshape: Wrong number of elements" abort observed on an RT-DETR
+    // detection model on gfx1150). The pass must leave the module unchanged.
+    migraphx::shape s_x{migraphx::shape::float_type, {2, 4, 4}};
+    migraphx::shape s_w{migraphx::shape::float_type, {2, 4, 6}};
+
+    migraphx::module m1;
+    {
+        auto x     = m1.add_parameter("x", s_x);
+        auto w     = m1.add_parameter("w", s_w);
+        auto x_rsp = m1.add_instruction(migraphx::make_op("reshape", {{"dims", {1, 8, 4}}}), x);
+        auto w_rsp = m1.add_instruction(migraphx::make_op("reshape", {{"dims", {1, 4, 12}}}), w);
+        auto dot   = m1.add_instruction(migraphx::make_op("dot"), x_rsp, w_rsp);
+        m1.add_return({dot});
+    };
+
+    migraphx::module m2 = m1;
+    run_pass(m1);
+    EXPECT(m1.sort() == m2.sort());
+}
+
 TEST_CASE(mul_transpose)
 {
     migraphx::shape s{migraphx::shape::float_type, {2, 32, 64, 64}};


### PR DESCRIPTION
… count

find_reshape_dot moves a reshape across a dot and then reshapes the new dot's output back to the original dot's shape. When the rewrite changes the total element count (e.g. the second input's reshape preserves its contraction axis but changes N), that trailing reshape is invalid and compilation aborts with "Reshape: Wrong number of elements" (observed on an RT-DETR detection model on gfx1150).

Skip the rewrite, and drop the speculatively-created dot, when the new dot's element count differs from the original dot's.

## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
