### PR TITLE
Change amdmlss option to be activated via compile option

### DIFF
--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -174,6 +174,11 @@ static void set_exhaustive_tune_flag(compile_options& options, bool value)
     options.exhaustive_tune = value;
 }
 
+static void set_mlss_use_specific_ops(compile_options& options, const char* value)
+{
+    options.mlss_use_specific_ops = value == nullptr ? "" : value;
+}
+
 static void set_file_format(file_options& options, const char* format) { options.format = format; }
 
 static void set_default_dim_value(onnx_options& options, size_t value)
@@ -2244,6 +2249,19 @@ migraphx_compile_options_set_exhaustive_tune_flag(migraphx_compile_options_t com
             MIGRAPHX_THROW(migraphx_status_bad_param,
                            "Bad parameter compile_options: Null pointer");
         migraphx::set_exhaustive_tune_flag((compile_options->object), (value));
+    });
+    return api_error_result;
+}
+
+extern "C" migraphx_status
+migraphx_compile_options_set_mlss_use_specific_ops(migraphx_compile_options_t compile_options,
+                                                   const char* value)
+{
+    auto api_error_result = migraphx::try_([&] {
+        if(compile_options == nullptr)
+            MIGRAPHX_THROW(migraphx_status_bad_param,
+                           "Bad parameter compile_options: Null pointer");
+        migraphx::set_mlss_use_specific_ops((compile_options->object), (value));
     });
     return api_error_result;
 }

--- a/src/api/include/migraphx/migraphx.h
+++ b/src/api/include/migraphx/migraphx.h
@@ -600,6 +600,9 @@ migraphx_compile_options_set_fast_math(migraphx_compile_options_t compile_option
 MIGRAPHX_C_EXPORT migraphx_status migraphx_compile_options_set_exhaustive_tune_flag(
     migraphx_compile_options_t compile_options, bool value);
 
+MIGRAPHX_C_EXPORT migraphx_status migraphx_compile_options_set_mlss_use_specific_ops(
+    migraphx_compile_options_t compile_options, const char* value);
+
 MIGRAPHX_C_EXPORT migraphx_status migraphx_parse_onnx(migraphx_program_t* out,
                                                       const char* name,
                                                       migraphx_onnx_options_t options);

--- a/src/api/include/migraphx/migraphx.hpp
+++ b/src/api/include/migraphx/migraphx.hpp
@@ -1204,6 +1204,13 @@ struct compile_options : MIGRAPHX_HANDLE_BASE(compile_options)
     {
         call(&migraphx_compile_options_set_exhaustive_tune_flag, this->get_handle_ptr(), value);
     }
+
+    /// Force specific ops (comma-separated, e.g. "conv") onto AMDMLSS. Empty lets
+    /// MIGraphX decide. Mirrors the MIGRAPHX_MLSS_USE_SPECIFIC_OPS env var.
+    void set_mlss_use_specific_ops(const char* value)
+    {
+        call(&migraphx_compile_options_set_mlss_use_specific_ops, this->get_handle_ptr(), value);
+    }
 };
 
 /// A program represents the all computation graphs to be compiled and executed

--- a/src/api/migraphx.py
+++ b/src/api/migraphx.py
@@ -436,6 +436,9 @@ def compile_options(h):
     h.method('set_exhaustive_tune_flag',
              api.params(value='bool'),
              invoke='migraphx::set_exhaustive_tune_flag($@)')
+    h.method('set_mlss_use_specific_ops',
+             api.params(value='const char*'),
+             invoke='migraphx::set_mlss_use_specific_ops($@)')
 
 
 api.add_function('migraphx_parse_onnx',

--- a/src/include/migraphx/compile_options.hpp
+++ b/src/include/migraphx/compile_options.hpp
@@ -24,6 +24,7 @@
 #ifndef MIGRAPHX_GUARD_RTGLIB_COMPILE_OPTIONS_HPP
 #define MIGRAPHX_GUARD_RTGLIB_COMPILE_OPTIONS_HPP
 
+#include <string>
 #include <migraphx/config.hpp>
 #include <migraphx/tracer.hpp>
 
@@ -40,6 +41,10 @@ struct compile_options
 
     bool fast_math       = true;
     bool exhaustive_tune = false;
+
+    // Comma-separated list of ops to force onto AMDMLSS (e.g. "conv"). Empty lets
+    // MIGraphX decide. Mirrors the MIGRAPHX_MLSS_USE_SPECIFIC_OPS env var.
+    std::string mlss_use_specific_ops = "";
 
     tracer trace{};
 };

--- a/src/targets/gpu/fuse_mlss.cpp
+++ b/src/targets/gpu/fuse_mlss.cpp
@@ -54,12 +54,17 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_MLSS_USE_SPECIFIC_OPS);
 
 #ifdef MIGRAPHX_USE_AMDMLSS
 
-static bool mlss_specific_op(std::string_view op_name)
+static bool op_in_list(const std::string& list, std::string_view op_name)
 {
-    static const auto options =
-        split_string(string_value_of(MIGRAPHX_MLSS_USE_SPECIFIC_OPS{}, ""), ',');
+    const auto options = split_string(list, ',');
     return std::any_of(
         options.begin(), options.end(), [&](const auto& opt) { return opt == op_name; });
+}
+
+static bool mlss_specific_op(std::string_view op_name)
+{
+    static const std::string env = string_value_of(MIGRAPHX_MLSS_USE_SPECIFIC_OPS{}, "");
+    return op_in_list(env, op_name);
 }
 
 // ---------------------------------------------------------------------------
@@ -382,7 +387,7 @@ struct find_mlss_conv_bias_leaky_relu
 void fuse_mlss::apply(module_pass_manager& mpm) const
 {
 #ifdef MIGRAPHX_USE_AMDMLSS
-    if(enable_conv or mlss_specific_op("conv"))
+    if(op_in_list(use_specific_ops, "conv") or mlss_specific_op("conv"))
     {
         // Match most-specific patterns first to avoid partial consumption.
         match::find_matches(mpm, find_mlss_conv_bias_relu{ctx});

--- a/src/targets/gpu/include/migraphx/gpu/fuse_mlss.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/fuse_mlss.hpp
@@ -37,9 +37,9 @@ namespace gpu {
 struct MIGRAPHX_GPU_EXPORT fuse_mlss
 {
     context* ctx = nullptr;
-    // Force-enable conv fusion regardless of env-var configuration; used by tests
-    // so they don't have to mutate the process environment.
-    bool enable_conv = false;
+    // Comma-separated list of ops to force onto AMDMLSS (e.g. "conv"), supplied via
+    // compile_options. Takes effect in addition to MIGRAPHX_MLSS_USE_SPECIFIC_OPS.
+    std::string use_specific_ops = "";
     std::string name() const { return "gpu::fuse_mlss"; }
     void apply(module_pass_manager& mpm) const;
 };

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -184,7 +184,7 @@ struct pipeline_factory
                                        .flash_decoding_enabled = mlir_flash_decoding_enabled()}),
             dead_code_elimination{},
             optimize_module{},
-            fuse_mlss{get_context()},
+            fuse_mlss{.ctx = get_context(), .use_specific_ops = options.mlss_use_specific_ops},
             fuse_pointwise_reduce{},
             dead_code_elimination{},
 #ifndef _WIN32

--- a/test/gpu/fuse_mlss.cpp
+++ b/test/gpu/fuse_mlss.cpp
@@ -43,7 +43,7 @@ static migraphx::gpu::context& get_context()
 static void run_pass(migraphx::program& p)
 {
     migraphx::run_passes(p,
-                         {migraphx::gpu::fuse_mlss{&get_context(), /*enable_conv=*/true},
+                         {migraphx::gpu::fuse_mlss{.ctx = &get_context(), .use_specific_ops = "conv"},
                           migraphx::dead_code_elimination{}});
 }
 

--- a/tools/api/api.cpp
+++ b/tools/api/api.cpp
@@ -174,6 +174,11 @@ static void set_exhaustive_tune_flag(compile_options& options, bool value)
     options.exhaustive_tune = value;
 }
 
+static void set_mlss_use_specific_ops(compile_options& options, const char* value)
+{
+    options.mlss_use_specific_ops = value == nullptr ? "" : value;
+}
+
 static void set_file_format(file_options& options, const char* format) { options.format = format; }
 
 static void set_default_dim_value(onnx_options& options, size_t value)


### PR DESCRIPTION
Make AMDMLSS op selection controllable through MIGraphX's compile_options instead of only the MIGRAPHX_MLSS_USE_SPECIFIC_OPS environment variable. Under static-CRT linking, the EP's runtime env-var writes never reached MIGraphX's getenv.
Also used the std::string mlss_use_specific_ops field in the fuse_mlss pass (replacing the test-only enable_conv bool with a use_specific_ops string)