### PR TITLE
fix bug with simplify reshapes and multi reduction axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Full documentation for MIGraphX is available at
 * Fixed `nonzero` GPU JIT kernel `block_scan` accumulator overflow that silently produced out-of-bounds writes for inputs with more than 255 nonzero elements; widened the predicate to `index_int`.
 * Fixed `scatternd_`* GPU JIT kernel and host reference op to read the `indices` tensor stride-aware (`begin_at`), so non-packed layouts produced by upstream `transpose`/`slice`/`concat` no longer collapse every write into the same output cell.
 * Fixed a regression in `simplify_reshapes` where `find_slice_shape_transforms` could trigger `same_dims: Dimensions do not match` when a slice's shape descriptor absorbed a `multibroadcast` on the sliced axis.
+* Fixed a crash in `simplify_reshapes` when a reshape splits an `argmax`/`argmin` reduction axis (#5010).
 * Fixed `QLinearConv` parsing for models with a bias and per-tensor weight quantization, which previously threw `same_dims: dequantizelinear: Dimensions do not match` (e.g. `resnet50_int8`); the bias scale is now broadcast to the bias shape before dequantizing.
 * Fixed the GPU problem cache failing to find entries after reload for pooling operator, resulting in redundant re-benchmarking when using a saved `MIGRAPHX_PROBLEM_CACHE`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ Full documentation for MIGraphX is available at
 * Fixed `nonzero` GPU JIT kernel `block_scan` accumulator overflow that silently produced out-of-bounds writes for inputs with more than 255 nonzero elements; widened the predicate to `index_int`.
 * Fixed `scatternd_`* GPU JIT kernel and host reference op to read the `indices` tensor stride-aware (`begin_at`), so non-packed layouts produced by upstream `transpose`/`slice`/`concat` no longer collapse every write into the same output cell.
 * Fixed a regression in `simplify_reshapes` where `find_slice_shape_transforms` could trigger `same_dims: Dimensions do not match` when a slice's shape descriptor absorbed a `multibroadcast` on the sliced axis.
-* Fixed a crash in `simplify_reshapes` when a reshape splits an `argmax`/`argmin` reduction axis (#5010).
+* Fixed a crash in `simplify_reshapes` when a reshape splits an `argmax`/`argmin` reduction axis (#5013).
 * Fixed `QLinearConv` parsing for models with a bias and per-tensor weight quantization, which previously threw `same_dims: dequantizelinear: Dimensions do not match` (e.g. `resnet50_int8`); the bias scale is now broadcast to the bias shape before dequantizing.
 * Fixed the GPU problem cache failing to find entries after reload for pooling operator, resulting in redundant re-benchmarking when using a saved `MIGRAPHX_PROBLEM_CACHE`.
 

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -303,7 +303,8 @@ struct find_op_shape_transform_op
                 auto ndim            = ins->inputs().front()->get_shape().ndim();
                 auto op_axis         = axis_val < 0 ? axis_val + ndim : axis_val;
                 const auto& new_axes = am.at(op_axis);
-                v["axis"]            = new_axes.front();
+                assert(new_axes.size() == 1);
+                v["axis"] = new_axes.front();
                 return m.insert_instruction(
                     ins, make_op(ins->name(), v), inputs, ins->module_inputs());
             }
@@ -334,7 +335,7 @@ struct find_op_shape_transform_op
         return m.insert_instruction(ins, ins->get_operator(), inputs, ins->module_inputs());
     }
 
-    // argmin/argmax reduce a single axis; it must map to exactly one common axis
+    // argmin/argmax reduce a single axis; it must be in range and map to exactly one common axis
     static bool argmax_axis_unsplit(instruction_ref ins,
                                     const std::vector<std::vector<std::size_t>>& axes_map)
     {
@@ -342,7 +343,7 @@ struct find_op_shape_transform_op
         auto axis_val = v.at("axis").to<int64_t>();
         auto ndim     = ins->inputs().front()->get_shape().ndim();
         auto axis     = axis_val < 0 ? axis_val + ndim : axis_val;
-        return axis >= axes_map.size() or axes_map[axis].size() == 1;
+        return axis < axes_map.size() and axes_map[axis].size() == 1;
     }
 
     static bool is_valid(instruction_ref ins, const shape_transform_descriptor& desc)

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -303,9 +303,7 @@ struct find_op_shape_transform_op
                 auto ndim            = ins->inputs().front()->get_shape().ndim();
                 auto op_axis         = axis_val < 0 ? axis_val + ndim : axis_val;
                 const auto& new_axes = am.at(op_axis);
-                // is_valid ensures single axis mapping for argmin/argmax
-                assert(new_axes.size() == 1);
-                v["axis"] = new_axes.front();
+                v["axis"]            = new_axes.front();
                 return m.insert_instruction(
                     ins, make_op(ins->name(), v), inputs, ins->module_inputs());
             }
@@ -336,6 +334,17 @@ struct find_op_shape_transform_op
         return m.insert_instruction(ins, ins->get_operator(), inputs, ins->module_inputs());
     }
 
+    // argmin/argmax reduce a single axis; it must map to exactly one common axis
+    static bool argmax_axis_unsplit(instruction_ref ins,
+                                    const std::vector<std::vector<std::size_t>>& axes_map)
+    {
+        auto v        = ins->get_operator().to_value();
+        auto axis_val = v.at("axis").to<int64_t>();
+        auto ndim     = ins->inputs().front()->get_shape().ndim();
+        auto axis     = axis_val < 0 ? axis_val + ndim : axis_val;
+        return axis >= axes_map.size() or axes_map[axis].size() == 1;
+    }
+
     static bool is_valid(instruction_ref ins, const shape_transform_descriptor& desc)
     {
         if(is_reduce(ins))
@@ -349,9 +358,7 @@ struct find_op_shape_transform_op
                 auto ndim     = ins->inputs().front()->get_shape().ndim();
                 auto axis     = axis_val < 0 ? axis_val + ndim : axis_val;
                 op_axes       = {static_cast<std::size_t>(axis)};
-                // argmin/argmax only support single axis
-                auto axes_map = desc.common_axes_map_from_src();
-                if(axis < axes_map.size() and axes_map[axis].size() != 1)
+                if(not argmax_axis_unsplit(ins, desc.common_axes_map_from_src()))
                     return false;
             }
             else
@@ -453,6 +460,11 @@ struct find_op_shape_transform_op
             return;
 
         if(not is_valid(x_ins, desc))
+            return;
+
+        // ins is remapped via the dst map; bail if its argmin/argmax axis splits
+        if(is_reduce(ins) and ins->get_operator().to_value().contains("axis") and
+           not argmax_axis_unsplit(ins, desc.common_axes_map_from_dst()))
             return;
 
         // If we already in the common dimension space then skip if there are other outputs to avoid

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -5038,6 +5038,24 @@ TEST_CASE(argmax_negative_axis_squeeze_pointwise)
     EXPECT(m1.get_output_shapes() == m2.get_output_shapes());
 }
 
+TEST_CASE(argmax_reshape_splits_reduction_axis)
+{
+    // reshape splits the argmax reduction axis; rewriting would squeeze on a non-1 axis
+    auto s = migraphx::shape{migraphx::shape::float_type, {2, 3, 4}};
+    migraphx::module m1;
+    {
+        auto x       = m1.add_parameter("x", s);
+        auto relu    = m1.add_instruction(migraphx::make_op("relu"), x);
+        auto reshape = m1.add_instruction(migraphx::make_op("reshape", {{"dims", {6, 4}}}), relu);
+        auto argmax  = m1.add_instruction(migraphx::make_op("argmax", {{"axis", 0}}), reshape);
+        auto squeeze = m1.add_instruction(migraphx::make_op("squeeze", {{"axes", {0}}}), argmax);
+        m1.add_return({squeeze});
+    }
+    migraphx::module m2 = m1;
+    run_pass(m1);
+    EXPECT(m1.sort() == m2.sort());
+}
+
 TEST_CASE(gather_strided_view_elements_mismatch)
 {
     migraphx::module m1;


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
A model had a bug with trying to squeeze a non-1 dimension. This was caused from the `simplify_reshapes` pass.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
Create a helper function `argmax_axis_unsplit` which can check both `x_ins` and `ins` to make sure the reshape doesn't create a scenario where there are multiple reduction axes. See test for example case which would otherwise crash on develop

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
