### PR TITLE
Skip fuse_horizontal pass on dynamic shaped inputs

### DIFF
--- a/src/fuse_horizontal.cpp
+++ b/src/fuse_horizontal.cpp
@@ -184,14 +184,14 @@ struct same_table_gather_horizontal_fusion
         if(ins->get_operator().to_value()["axis"].to<int>() != 0)
             return false;
     
-        // Skip on any dynamic shaped inputs
-        if(std::any_of(ins->inputs().begin(), ins->inputs().end(), [&](auto inp){return inp->get_shape().dynamic();}))
-        {
+        // Skip dynamic shapes: this fusion relies on static `lens()` on inputs.
+        const auto& inputs = ins->inputs();
+        if(std::any_of(inputs.begin(), inputs.end(),
+                       [](const auto& inp) { return inp->get_shape().dynamic(); }))
             return false;
-        }
 
-        auto data = ins->inputs().at(0);
-        auto idx  = ins->inputs().at(1);
+        auto data = inputs.at(0);
+        auto idx  = inputs.at(1);
 
         // Embedding must be a 2D constant: {num_rows, embedding_dim}
         if(data->get_shape().lens().size() != 2)

--- a/src/fuse_horizontal.cpp
+++ b/src/fuse_horizontal.cpp
@@ -183,6 +183,12 @@ struct same_table_gather_horizontal_fusion
 
         if(ins->get_operator().to_value()["axis"].to<int>() != 0)
             return false;
+    
+        // Skip on any dynamic shaped inputs
+        if(std::any_of(ins->inputs().begin(), ins->inputs().end(), [&](auto inp){return inp->get_shape().dynamic();}))
+        {
+            return false;
+        }
 
         auto data = ins->inputs().at(0);
         auto idx  = ins->inputs().at(1);
@@ -261,6 +267,12 @@ struct gather_horizontal_fusion
 
         if(ins->get_operator().to_value()["axis"].to<int>() != 0)
             return false;
+
+        // Skip on any dynamic shaped inputs
+        if(std::any_of(ins->inputs().begin(), ins->inputs().end(), [&](auto inp){return inp->get_shape().dynamic();}))
+        {
+            return false;
+        }
 
         auto data = ins->inputs().at(0);
         auto idx  = ins->inputs().at(1);

--- a/src/fuse_horizontal.cpp
+++ b/src/fuse_horizontal.cpp
@@ -268,14 +268,14 @@ struct gather_horizontal_fusion
         if(ins->get_operator().to_value()["axis"].to<int>() != 0)
             return false;
 
-        // Skip on any dynamic shaped inputs
-        if(std::any_of(ins->inputs().begin(), ins->inputs().end(), [&](auto inp){return inp->get_shape().dynamic();}))
-        {
+        // Skip dynamic shapes: this fusion relies on static `lens()` on inputs.
+        const auto& inputs = ins->inputs();
+        if(std::any_of(inputs.begin(), inputs.end(),
+                       [](const auto& inp) { return inp->get_shape().dynamic(); }))
             return false;
-        }
 
-        auto data = ins->inputs().at(0);
-        auto idx  = ins->inputs().at(1);
+        auto data = inputs.at(0);
+        auto idx  = inputs.at(1);
 
         // Embedding must be 2D: {num_rows, embedding_dim}
         if(data->get_shape().lens().size() != 2)

--- a/src/fuse_horizontal.cpp
+++ b/src/fuse_horizontal.cpp
@@ -183,11 +183,12 @@ struct same_table_gather_horizontal_fusion
 
         if(ins->get_operator().to_value()["axis"].to<int>() != 0)
             return false;
-    
+
         // Skip dynamic shapes: this fusion relies on static `lens()` on inputs.
         const auto& inputs = ins->inputs();
-        if(std::any_of(inputs.begin(), inputs.end(),
-                       [](const auto& inp) { return inp->get_shape().dynamic(); }))
+        if(std::any_of(inputs.begin(), inputs.end(), [](const auto& inp) {
+               return inp->get_shape().dynamic();
+           }))
             return false;
 
         auto data = inputs.at(0);
@@ -270,8 +271,9 @@ struct gather_horizontal_fusion
 
         // Skip dynamic shapes: this fusion relies on static `lens()` on inputs.
         const auto& inputs = ins->inputs();
-        if(std::any_of(inputs.begin(), inputs.end(),
-                       [](const auto& inp) { return inp->get_shape().dynamic(); }))
+        if(std::any_of(inputs.begin(), inputs.end(), [](const auto& inp) {
+               return inp->get_shape().dynamic();
+           }))
             return false;
 
         auto data = inputs.at(0);

--- a/test/fuse_horizontal_test.cpp
+++ b/test/fuse_horizontal_test.cpp
@@ -1061,4 +1061,64 @@ TEST_CASE(same_table_gathers_idempotent)
     EXPECT(m1.sort() == snapshot.sort());
 }
 
+// Same-table gathers with dynamic-shaped indices → no fusion.
+TEST_CASE(same_table_gathers_no_rewrite_dynamic_index)
+{
+    using dd = migraphx::shape::dynamic_dimension;
+    migraphx::shape idx_s{migraphx::shape::int32_type, {dd{4, 8}}};
+
+    migraphx::module m1;
+    {
+        auto emb =
+            m1.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {6, 2}}, 0));
+
+        auto idx1 = m1.add_parameter("idx1", idx_s);
+        auto idx2 = m1.add_parameter("idx2", idx_s);
+        auto idx3 = m1.add_parameter("idx3", idx_s);
+
+        auto g1 = m1.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), emb, idx1);
+        auto g2 = m1.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), emb, idx2);
+        auto g3 = m1.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), emb, idx3);
+
+        m1.add_return({g1, g2, g3});
+    }
+    auto m2 = m1;
+    run_pass(m1);
+    EXPECT(m1 == m2);
+}
+
+// Cross-embedding fusion candidates with dynamic-shaped indices → no fusion.
+TEST_CASE(gather_horiz_no_fusion_dynamic_index)
+{
+    using dd = migraphx::shape::dynamic_dimension;
+    migraphx::shape idx_s{migraphx::shape::int32_type, {dd{1, 8}}};
+
+    migraphx::module m1;
+    {
+        auto emb1 =
+            m1.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {3, 2}}, 0));
+        auto emb2 =
+            m1.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {4, 2}}, 1));
+        auto emb3 =
+            m1.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {2, 2}}, 2));
+        auto emb4 =
+            m1.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {5, 2}}, 3));
+
+        auto idx1 = m1.add_parameter("idx1", idx_s);
+        auto idx2 = m1.add_parameter("idx2", idx_s);
+        auto idx3 = m1.add_parameter("idx3", idx_s);
+        auto idx4 = m1.add_parameter("idx4", idx_s);
+
+        auto g1 = m1.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), emb1, idx1);
+        auto g2 = m1.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), emb2, idx2);
+        auto g3 = m1.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), emb3, idx3);
+        auto g4 = m1.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), emb4, idx4);
+
+        m1.add_return({g1, g2, g3, g4});
+    }
+    auto m2 = m1;
+    run_pass(m1);
+    EXPECT(m1 == m2);
+}
+
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
* Hitting an error when compiling dynamic shapes model with `fuse_horizontal` calling `lens()` on a dynamic shape.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
