### PR TITLE
Add opt-in parallel finalization of independent operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Full documentation for MIGraphX is available at
 
 ### Added
 
+* Added environment variable `MIGRAPHX_FINALIZE_PARALLEL` which, when set to N > 0, finalizes operations that opt in via a `parallel_finalize` attribute across up to N worker threads (#PR_NUMBER) (default off = serial finalization).
 * Added `ArrayFeatureExtractor` ONNX operator support (#4742).
 * Added YOLO26 object detection example notebook.
 * Added `auto_pad` attribute support for the ONNX `ConvTranspose` operator, supporting `SAME_UPPER`, `SAME_LOWER`, and `VALID` padding modes for static shapes (#4638).

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -30,6 +30,7 @@
 #include <migraphx/instruction.hpp>
 #include <migraphx/target.hpp>
 #include <migraphx/env.hpp>
+#include <migraphx/par_for.hpp>
 #include <migraphx/ranges.hpp>
 #include <migraphx/time.hpp>
 #include <migraphx/iterator_for.hpp>
@@ -53,6 +54,10 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_TRACE_FINALIZE)
+// Finalizes ops that opt in via the "parallel_finalize" attribute concurrently.
+// 0/unset = serial (original behavior); N > 0 = use up to N worker threads. The
+// effective count is capped by the number of such ops and the hardware concurrency.
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_FINALIZE_PARALLEL)
 
 struct module_impl
 {
@@ -1114,17 +1119,64 @@ void module::finalize(std::vector<context>& contexts)
 {
     assert(not contexts.empty());
     const bool trace = enabled(MIGRAPHX_TRACE_FINALIZE{});
-    for(auto ins : iterator_for(*this))
+
+    // An op may declare the "parallel_finalize" attribute to opt into being
+    // finalized concurrently: it promises that its finalize() writes only its own
+    // instance and does not touch the shared context, so finalizing many such ops
+    // in parallel is safe. When MIGRAPHX_FINALIZE_PARALLEL is set, those ops are
+    // finalized first across worker threads (this hides per-op finalize latency,
+    // e.g. GPU module loads), then the remaining ops are finalized serially.
+    // Default unset = the original serial behavior below.
+    const auto can_parallel_finalize = [](instruction_ref ins) {
+        return ins->module_inputs().empty() and
+               ins->get_operator().attributes().get("parallel_finalize", false);
+    };
+    const std::size_t par_degree = value_of(MIGRAPHX_FINALIZE_PARALLEL{});
+    if(par_degree != 0 and not trace)
     {
-        if(trace)
+        std::vector<instruction_ref> parallel_ins;
+        for(auto ins : iterator_for(*this))
         {
-            std::cout << "Finalize: ";
-            this->debug_print(ins);
+            if(can_parallel_finalize(ins))
+                parallel_ins.push_back(ins);
         }
-        ins->finalize(contexts[ins->get_target_id()]);
-        for(const auto& smod : ins->module_inputs())
+        if(not parallel_ins.empty())
         {
-            smod->finalize(contexts);
+            const std::size_t n = parallel_ins.size();
+            // par_for's second argument is the minimum grain (items per thread);
+            // n / threads gives roughly `threads` workers. Cap the requested
+            // thread count at the number of ops to finalize.
+            const std::size_t threads   = std::min(par_degree, n);
+            const std::size_t min_grain = n / threads;
+            par_for(n, min_grain, [&](auto i) {
+                parallel_ins[i]->finalize(contexts[parallel_ins[i]->get_target_id()]);
+            });
+        }
+        // Serial pass for the remaining instructions and submodules; the ops
+        // finalized in parallel above are skipped here.
+        for(auto ins : iterator_for(*this))
+        {
+            if(can_parallel_finalize(ins))
+                continue;
+            ins->finalize(contexts[ins->get_target_id()]);
+            for(const auto& smod : ins->module_inputs())
+                smod->finalize(contexts);
+        }
+    }
+    else
+    {
+        for(auto ins : iterator_for(*this))
+        {
+            if(trace)
+            {
+                std::cout << "Finalize: ";
+                this->debug_print(ins);
+            }
+            ins->finalize(contexts[ins->get_target_id()]);
+            for(const auto& smod : ins->module_inputs())
+            {
+                smod->finalize(contexts);
+            }
         }
     }
 

--- a/src/targets/gpu/include/migraphx/gpu/code_object_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/code_object_op.hpp
@@ -69,7 +69,11 @@ struct code_object_op
                     f(self.kernel_args, "kernel_args"));
     }
 
-    value attributes() const { return {{"group", group()}}; }
+    // "parallel_finalize" opts this op into module::finalize's parallel pass:
+    // its finalize() loads a GPU module and writes only its own instance (it does
+    // not touch the shared context), so finalizing many of them concurrently is
+    // safe and hides the per-module load latency.
+    value attributes() const { return {{"group", group()}, {"parallel_finalize", true}}; }
 
     std::string group() const { return "gpu::code_object::" + symbol_name; }
 

--- a/test/module_finalize_parallel_test.cpp
+++ b/test/module_finalize_parallel_test.cpp
@@ -1,0 +1,222 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <migraphx/program.hpp>
+#include <migraphx/module.hpp>
+#include <migraphx/context.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/iterator_for.hpp>
+#include <atomic>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+#include "test.hpp"
+
+// Exercises the parallel path in module::finalize, gated by the
+// MIGRAPHX_FINALIZE_PARALLEL environment variable (set in main() below because
+// the value is read once and cached). An op opts into being finalized on a
+// worker thread by exposing the "parallel_finalize" attribute.
+//
+// The ops must be empty (no data members) to satisfy the operation
+// type-erasure requirements, so instead of instance state they count their
+// finalize() calls into the target's context, which module::finalize passes to
+// each op. The counters live in shared_ptrs so the copies of the context made
+// during finalize all update the same counts; they are atomic because the
+// parallel pass finalizes on multiple threads.
+
+// A minimal target whose context carries the finalize counters. module::finalize
+// consumes a vector of these contexts.
+struct final_target
+{
+    struct context
+    {
+        std::shared_ptr<std::atomic<int>> parallel_count = std::make_shared<std::atomic<int>>(0);
+        std::shared_ptr<std::atomic<int>> serial_count   = std::make_shared<std::atomic<int>>(0);
+        void finish() const {}
+    };
+    context ctx{};
+
+    template <class Self, class F>
+    static auto reflect(Self&, F)
+    {
+        return migraphx::pack();
+    }
+
+    std::string name() const { return "final"; }
+    std::vector<migraphx::pass> get_passes(migraphx::context&,
+                                           const migraphx::compile_options&) const
+    {
+        return {};
+    }
+    migraphx::context get_context() const { return ctx; }
+};
+
+// Opts into the parallel finalize pass; counts its finalize() calls in the ctx.
+struct parallel_final_op
+{
+    std::string name() const { return "parallel_final_op"; }
+    migraphx::value attributes() const { return {{"parallel_finalize", true}}; }
+
+    migraphx::argument compute(const migraphx::shape&, std::vector<migraphx::argument> args) const
+    {
+        if(args.empty())
+            return {};
+        return args.front();
+    }
+    void finalize(final_target::context& ctx,
+                  const migraphx::shape&,
+                  const std::vector<migraphx::shape>&)
+    {
+        ++(*ctx.parallel_count);
+    }
+    migraphx::shape compute_shape(std::vector<migraphx::shape> inputs) const
+    {
+        if(inputs.empty())
+            return {};
+        return inputs.front();
+    }
+    std::vector<std::size_t> output_alias(const std::vector<migraphx::shape>&) const { return {0}; }
+};
+
+// Does NOT opt in; must be handled by the serial pass.
+struct serial_final_op
+{
+    std::string name() const { return "serial_final_op"; }
+
+    migraphx::argument compute(const migraphx::shape&, std::vector<migraphx::argument> args) const
+    {
+        if(args.empty())
+            return {};
+        return args.front();
+    }
+    void finalize(final_target::context& ctx,
+                  const migraphx::shape&,
+                  const std::vector<migraphx::shape>&)
+    {
+        ++(*ctx.serial_count);
+    }
+    migraphx::shape compute_shape(std::vector<migraphx::shape> inputs) const
+    {
+        if(inputs.empty())
+            return {};
+        return inputs.front();
+    }
+    std::vector<std::size_t> output_alias(const std::vector<migraphx::shape>&) const { return {0}; }
+};
+
+// Covers the parallel pass: every opted-in op is finalized across worker threads.
+TEST_CASE(parallel_finalize_runs_all_opted_in_ops)
+{
+    final_target t{};
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    auto lit = mm->add_literal(1);
+
+    const int n = 64;
+    for(int i = 0; i < n; ++i)
+        mm->add_instruction(parallel_final_op{}, lit);
+
+    p.finalize(t);
+
+    EXPECT(t.ctx.parallel_count->load() == n);
+    EXPECT(p.is_compiled());
+}
+
+// Covers the serial pass for non-opted-in ops running alongside opted-in ops.
+TEST_CASE(parallel_finalize_serial_pass_handles_non_opted_in_ops)
+{
+    final_target t{};
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    auto lit = mm->add_literal(1);
+
+    mm->add_instruction(parallel_final_op{}, lit);
+    mm->add_instruction(serial_final_op{}, lit);
+
+    p.finalize(t);
+
+    // The opted-in op is finalized by the parallel pass; the non-opted-in op is
+    // finalized by the serial pass. Both must run exactly once.
+    EXPECT(t.ctx.parallel_count->load() == 1);
+    EXPECT(t.ctx.serial_count->load() == 1);
+}
+
+// Covers the serial pass recursing into submodules (ops with module_inputs are
+// excluded from the parallel pass and finalized serially, including submodules).
+TEST_CASE(parallel_finalize_recurses_into_submodules)
+{
+    final_target t{};
+    migraphx::shape cond_s{migraphx::shape::bool_type};
+
+    migraphx::program p;
+    auto* mm  = p.get_main_module();
+    auto cond = mm->add_parameter("cond", cond_s);
+    auto lit  = mm->add_literal(1);
+
+    auto* then_mod = p.create_module("then");
+    auto then_r    = then_mod->add_instruction(parallel_final_op{}, lit);
+    then_mod->add_return({then_r});
+
+    auto* else_mod = p.create_module("else");
+    auto else_r    = else_mod->add_instruction(parallel_final_op{}, lit);
+    else_mod->add_return({else_r});
+
+    // The "if" op carries module_inputs, so it is excluded from the parallel pass
+    // and finalized serially; the serial pass then finalizes its submodules.
+    mm->add_instruction(migraphx::make_op("if"), {cond}, {then_mod, else_mod});
+
+    p.finalize(t);
+
+    // Both submodule ops are reached via the serial submodule recursion, even
+    // though they declare "parallel_finalize".
+    EXPECT(t.ctx.parallel_count->load() == 2);
+    EXPECT(p.is_compiled());
+}
+
+// Covers correctness: forcing the parallel path on must not change evaluation.
+TEST_CASE(parallel_finalize_output_matches_serial)
+{
+    final_target t{};
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    auto lit = mm->add_literal(migraphx::literal{7});
+    mm->add_instruction(parallel_final_op{}, lit);
+
+    p.finalize(t);
+
+    auto result = p.eval({}).back();
+    EXPECT(result == migraphx::literal{7});
+}
+
+int main(int argc, const char* argv[])
+{
+    // module::finalize reads MIGRAPHX_FINALIZE_PARALLEL once and caches it, so it
+    // must be set before the first finalize call in this process.
+#ifdef _WIN32
+    _putenv_s("MIGRAPHX_FINALIZE_PARALLEL", "4");
+#else
+    setenv("MIGRAPHX_FINALIZE_PARALLEL", "4", 1);
+#endif
+    test::run(argc, argv);
+}


### PR DESCRIPTION
## Motivation
`module::finalize` finalizes a program's operations one at a time. For programs with many GPU code objects (each of which loads a compiled module onto the device), these loads are independent of one another but still run back-to-back, so their per-load latency accumulates into a noticeable one-time cost the first time a program runs. This cost is paid on the first inference and is a visible part of time-to-first-token for LLM workloads. 

This change lets operations that are safe to finalize concurrently be finalized across worker threads, so finalization stops scaling with the number of such operations.

## Technical Details
The change is split so that core stays target-agnostic and the GPU-specific knowledge lives in the GPU target. 
- `src/include/.../code_object_op.hpp` (GPU target): the code-object op now declares a `parallel_finalize` attribute. This is its contract that its `finalize()` writes only its own instance and does not touch the shared context, so many instances may be finalized concurrently. 
- `src/module.cpp` (core): `module::finalize` queries the generic `parallel_finalize` attribute (the same `attributes()` mechanism existing passes use for `pointwise`, `reduce`, etc.) - it does **not** reference any GPU op by name. When `MIGRAPHX_FINALIZE_PARALLEL` is set, ops that declare the attribute (and have no sub-modules) are finalized first via `par_for` across up to N worker threads, capped by the number of such ops; the remaining ops are then finalized serially. 
- **Default off is byte-identical to current behavior:** when `MIGRAPHX_FINALIZE_PARALLEL` is unset (or `0`), `module::finalize` takes the original serial loop unchanged. Tracing (`MIGRAPHX_FINALIZE_PARALLEL`) also forces the serial path so trace output ordering is preserved. 

Correctness rests on the opt-in attribute contract: only ops whose `finalize()` is free of shared-state writes set `parallel_finalize`. The GPU code-object op satisfies this (it ignores its `context` argument and writes only its own instance). Ops with sub-modules are excluded from the parallel pass.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [x] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
