### PR TITLE
Handle benchmark MXR dump as successful compile

### DIFF
--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -1260,8 +1260,9 @@ int main(int argc, const char* argv[], const char* envp[])
         {
             m.at(cmd)(ap, {args.begin() + 1, args.end()});
         }
-        catch(const migraphx::benchmark_mxr_dumped&)
+        catch(const migraphx::benchmark_mxr_dumped& e)
         {
+            (void)e;
         }
 
         // Dump all the MIGraphX (consumed) Environment Variables:

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -47,6 +47,7 @@
 #include <migraphx/version.h>
 #include <migraphx/env.hpp>
 #include <migraphx/logger.hpp>
+#include <migraphx/errors.hpp>
 
 #include <migraphx/dead_code_elimination.hpp>
 #include <migraphx/eliminate_identity.hpp>
@@ -1255,7 +1256,13 @@ int main(int argc, const char* argv[], const char* envp[])
 
         auto start_time = std::chrono::system_clock::now();
 
-        m.at(cmd)(ap, {args.begin() + 1, args.end()});
+        try
+        {
+            m.at(cmd)(ap, {args.begin() + 1, args.end()});
+        }
+        catch(const migraphx::benchmark_mxr_dumped&)
+        {
+        }
 
         // Dump all the MIGraphX (consumed) Environment Variables:
         const auto mgx_env_map = migraphx::get_all_envs();

--- a/src/include/migraphx/errors.hpp
+++ b/src/include/migraphx/errors.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,11 @@ struct exception : std::runtime_error
     }
 };
 
+struct benchmark_mxr_dumped : exception
+{
+    benchmark_mxr_dumped(unsigned int e = 0, const std::string& msg = "") : exception(e, msg) {}
+};
+
 /**
  * @brief Create an exception object
  *
@@ -55,6 +60,19 @@ inline exception make_exception(const std::string& context, const std::string& m
 
 inline exception
 make_exception(const std::string& context, unsigned int e, const std::string& message = "")
+{
+    return {e, context + ": " + message};
+}
+
+inline benchmark_mxr_dumped make_benchmark_mxr_dumped_exception(const std::string& context,
+                                                                const std::string& message = "")
+{
+    return {0, context + ": " + message};
+}
+
+inline benchmark_mxr_dumped make_benchmark_mxr_dumped_exception(const std::string& context,
+                                                                unsigned int e,
+                                                                const std::string& message = "")
 {
     return {e, context + ": " + message};
 }
@@ -79,6 +97,8 @@ inline std::string make_source_context(const std::string& file, int line, const 
  * @brief Throw an exception with context information
  */
 #define MIGRAPHX_THROW(...) throw migraphx::make_exception(MIGRAPHX_MAKE_SOURCE_CTX(), __VA_ARGS__)
+#define MIGRAPHX_THROW_BENCHMARK_MXR_DUMPED(...) \
+    throw migraphx::make_benchmark_mxr_dumped_exception(MIGRAPHX_MAKE_SOURCE_CTX(), __VA_ARGS__)
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/pass_manager.cpp
+++ b/src/pass_manager.cpp
@@ -33,6 +33,7 @@
 #include <migraphx/filesystem.hpp>
 #include <migraphx/load_save.hpp>
 #include <migraphx/logger.hpp>
+#include <migraphx/errors.hpp>
 #include <iostream>
 #include <sstream>
 #include <algorithm>
@@ -179,6 +180,11 @@ struct module_pm : module_pass_manager
         try
         {
             f();
+        }
+        catch(const benchmark_mxr_dumped& e)
+        {
+            log::info() << "Benchmark MXR dump " << p.name() << ": " << e.what();
+            throw;
         }
         catch(const std::exception& e)
         {

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -34,6 +34,7 @@
 #include <migraphx/dead_code_elimination.hpp>
 #include <migraphx/memory_coloring.hpp>
 #include <migraphx/logger.hpp>
+#include <migraphx/errors.hpp>
 #include <migraphx/op/identity.hpp>
 #include <migraphx/builtin.hpp>
 #include <migraphx/load_save.hpp>
@@ -586,7 +587,7 @@ struct compile_manager
         // root module has had a chance to dump its benchmark MXR files.
         if(dump_mxr and is_root)
         {
-            MIGRAPHX_THROW(
+            MIGRAPHX_THROW_BENCHMARK_MXR_DUMPED(
                 "Benchmark MXR files dumped to " + mxr_path +
                 ". Run the MXR files to create a problem cache, then recompile with the cache.");
         }


### PR DESCRIPTION
## Motivation
Avoid error logs and nonzero driver execution for the expected `migraphx-driver compile` path that dumps benchmark MXR files via `MIGRAPHX_GPU_DUMP_BENCHMARK_MXR`.
## Technical Details
Added a dedicated `migraphx::benchmark_mxr_dumped` exception and throw macro, used it for the benchmark MXR dump completion path, logged it as info in the pass manager, and swallowed it at driver command dispatch so the dump-only mode completes successfully.
## Changelog Category
Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.