### PR TITLE
Allow benchmark MXR dumps during cross-compile

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -351,8 +351,10 @@ struct compile_plan
                 if(solutions.empty())
                     MIGRAPHX_THROW("No solutions provided for " + preop.name() + " with " +
                                    problem_string() + "\n\n" + print_modules());
-                if(enabled(MIGRAPHX_SKIP_BENCHMARKING{}) or ctx->is_cross_compile() or
-                   solutions.size() == 1)
+                const bool dump_mxr =
+                    not string_value_of(MIGRAPHX_GPU_DUMP_BENCHMARK_MXR{}).empty();
+                if(enabled(MIGRAPHX_SKIP_BENCHMARKING{}) or
+                   (ctx->is_cross_compile() and not dump_mxr) or solutions.size() == 1)
                 {
                     ctx->get_problem_cache().insert(preop.name(), problem, solutions.front());
                     results.resize(1);


### PR DESCRIPTION
## Motivation
Allow `MIGRAPHX_GPU_DUMP_BENCHMARK_MXR` to dump benchmark MXR files during cross-compile flows.

## Technical Details
Updated `src/targets/gpu/compile_ops.cpp` so cross-compile mode skips benchmarking only when `MIGRAPHX_GPU_DUMP_BENCHMARK_MXR` is not set. This preserves the normal cross-compile skip path while allowing benchmark candidates to run when MXR dumping is requested.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.