### PR TITLE
Sanitize benchmark mxr file name to use `_` instead of invalid Windows characters

### DIFF
--- a/src/fileutils.cpp
+++ b/src/fileutils.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,9 @@
  */
 
 #include <migraphx/fileutils.hpp>
+#include <algorithm>
+#include <string>
+#include <string_view>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -64,6 +67,14 @@ fs::path make_static_library_filename(std::string_view name)
 fs::path append_extension(const fs::path& path, std::string_view ext)
 {
     return fs::path{path}.replace_extension(path.extension().string().append(ext));
+}
+
+std::string sanitize_filename(std::string s)
+{
+    static constexpr std::string_view invalid = "<>:\"/\\|?*";
+    std::replace_if(
+        s.begin(), s.end(), [](char c) { return invalid.find(c) != std::string_view::npos; }, '_');
+    return s;
 }
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/include/migraphx/filesystem.hpp
+++ b/src/include/migraphx/filesystem.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,9 +25,6 @@
 #define MIGRAPHX_GUARD_RTGLIB_FILESYSTEM_HPP
 
 #include <migraphx/config.hpp>
-#include <algorithm>
-#include <string>
-#include <string_view>
 
 #if defined(CPPCHECK)
 #define MIGRAPHX_HAS_FILESYSTEM 1
@@ -75,15 +72,6 @@ namespace fs = ::std::filesystem;
 #elif MIGRAPHX_HAS_FILESYSTEM_TS
 namespace fs = ::std::experimental::filesystem;
 #endif
-
-// Replace invalid characters for Windows with '_'.
-inline std::string sanitize_filename(std::string s)
-{
-    static constexpr std::string_view invalid = "<>:\"/\\|?*";
-    std::replace_if(
-        s.begin(), s.end(), [](char c) { return invalid.find(c) != std::string_view::npos; }, '_');
-    return s;
-}
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/include/migraphx/filesystem.hpp
+++ b/src/include/migraphx/filesystem.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,9 @@
 #define MIGRAPHX_GUARD_RTGLIB_FILESYSTEM_HPP
 
 #include <migraphx/config.hpp>
+#include <algorithm>
+#include <string>
+#include <string_view>
 
 #if defined(CPPCHECK)
 #define MIGRAPHX_HAS_FILESYSTEM 1
@@ -72,6 +75,15 @@ namespace fs = ::std::filesystem;
 #elif MIGRAPHX_HAS_FILESYSTEM_TS
 namespace fs = ::std::experimental::filesystem;
 #endif
+
+// Replace invalid characters for Windows with '_'.
+inline std::string sanitize_filename(std::string s)
+{
+    static constexpr std::string_view invalid = "<>:\"/\\|?*";
+    std::replace_if(
+        s.begin(), s.end(), [](char c) { return invalid.find(c) != std::string_view::npos; }, '_');
+    return s;
+}
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/include/migraphx/fileutils.hpp
+++ b/src/include/migraphx/fileutils.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,7 @@
 #include <migraphx/filesystem.hpp>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {

--- a/src/include/migraphx/fileutils.hpp
+++ b/src/include/migraphx/fileutils.hpp
@@ -26,6 +26,7 @@
 #define MIGRAPHX_GUARD_MIGRAPHLIB_FILEUTILS_HPP
 
 #include <migraphx/filesystem.hpp>
+#include <string>
 #include <string_view>
 
 namespace migraphx {

--- a/src/include/migraphx/fileutils.hpp
+++ b/src/include/migraphx/fileutils.hpp
@@ -36,6 +36,7 @@ MIGRAPHX_EXPORT fs::path make_shared_object_filename(std::string_view name);
 MIGRAPHX_EXPORT fs::path make_object_file_filename(std::string_view name);
 MIGRAPHX_EXPORT fs::path make_static_library_filename(std::string_view name);
 MIGRAPHX_EXPORT fs::path append_extension(const fs::path& path, std::string_view ext);
+MIGRAPHX_EXPORT std::string sanitize_filename(std::string s);
 
 inline std::string operator+(std::string l, const fs::path& r) { return std::move(l) + r.string(); }
 

--- a/src/pass_manager.cpp
+++ b/src/pass_manager.cpp
@@ -35,10 +35,8 @@
 #include <migraphx/logger.hpp>
 #include <iostream>
 #include <sstream>
-#include <algorithm>
 #include <utility>
 #include <string>
-#include <string_view>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -159,14 +157,6 @@ struct module_pm : module_pass_manager
         validate_pass(*mod, p, *t);
     }
 
-    static void sanitize(std::string& s)
-    {
-        static constexpr std::string_view invalid = "<>:\"/\\|?*";
-
-        std::replace_if(
-            s.begin(), s.end(), [](char c) { return invalid.find(c) != std::string::npos; }, '_');
-    }
-
     template <class F>
     void try_and_dump_on_error(const pass& p, F f) const
     {
@@ -189,7 +179,7 @@ struct module_pm : module_pass_manager
             std::string base = p.name() + std::to_string(clk) + ".mxr";
 #if defined(_WIN32)
             // On Windows, some pass names may contain invalid characters for filenames
-            sanitize(base);
+            base = sanitize_filename(base);
 #endif
             fs::path fname = dirname / base;
             log::error() << "Dump: " << fname;

--- a/src/pass_manager.cpp
+++ b/src/pass_manager.cpp
@@ -180,7 +180,7 @@ struct module_pm : module_pass_manager
             std::string base = p.name() + std::to_string(clk) + ".mxr";
 #if defined(_WIN32)
             // On Windows, some pass names may contain invalid characters for filenames
-            base = sanitize_filename(base);
+            base = sanitize_filename(std::move(base));
 #endif
             fs::path fname = dirname / base;
             log::error() << "Dump: " << fname;

--- a/src/pass_manager.cpp
+++ b/src/pass_manager.cpp
@@ -31,6 +31,7 @@
 #include <migraphx/time.hpp>
 #include <migraphx/iterator_for.hpp>
 #include <migraphx/filesystem.hpp>
+#include <migraphx/fileutils.hpp>
 #include <migraphx/load_save.hpp>
 #include <migraphx/logger.hpp>
 #include <iostream>

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -38,6 +38,7 @@
 #include <migraphx/builtin.hpp>
 #include <migraphx/load_save.hpp>
 #include <migraphx/filesystem.hpp>
+#include <migraphx/fileutils.hpp>
 #include <migraphx/json.hpp>
 #include <migraphx/gpu/compiler.hpp>
 #include <migraphx/gpu/compile_ops.hpp>

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -516,9 +516,8 @@ struct compile_plan
 
             mm->add_instruction(builtin::comment{comment_text}, {});
             auto problem_hash = std::hash<std::string>{}(to_string(config->problem));
-            // Sanitize the op name for use in a filename. Replace "::" with "__".
-            auto op_filename = replace_string(preop.name(), "::", "__");
-            auto mxr_file = mxr_dir / (op_filename + "_" + std::to_string(i) + "_" +
+            auto op_filename  = sanitize_filename(preop.name());
+            auto mxr_file     = mxr_dir / (op_filename + "_" + std::to_string(i) + "_" +
                                        std::to_string(problem_hash) + ".mxr");
             log::info() << "Saving benchmark binary: " << mxr_file;
             save(bench_prog, mxr_file.string());

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -516,7 +516,9 @@ struct compile_plan
 
             mm->add_instruction(builtin::comment{comment_text}, {});
             auto problem_hash = std::hash<std::string>{}(to_string(config->problem));
-            auto mxr_file     = mxr_dir / (preop.name() + "_" + std::to_string(i) + "_" +
+            // Sanitize the op name for use in a filename. Replace "::" with "__".
+            auto op_filename = replace_string(preop.name(), "::", "__");
+            auto mxr_file = mxr_dir / (op_filename + "_" + std::to_string(i) + "_" +
                                        std::to_string(problem_hash) + ".mxr");
             log::info() << "Saving benchmark binary: " << mxr_file;
             save(bench_prog, mxr_file.string());

--- a/test/fileutils.cpp
+++ b/test/fileutils.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -88,6 +88,30 @@ TEST_CASE(append_file_extension)
     auto name    = fs::path{baze_name}.replace_extension(txt);
     auto updated = migraphx::MIGRAPHX_INLINE_NS::append_extension(name, bz2);
     EXPECT(updated == std::string{baze_name}.append(txt).append(bz2));
+}
+
+TEST_CASE(sanitize_filename_replaces_invalid_chars)
+{
+    // Each Windows-invalid character maps to a single '_'.
+    EXPECT(migraphx::sanitize_filename("a:b") == "a_b");
+    EXPECT(migraphx::sanitize_filename("a*b") == "a_b");
+    EXPECT(migraphx::sanitize_filename("a?b") == "a_b");
+    EXPECT(migraphx::sanitize_filename("a\\b") == "a_b");
+    EXPECT(migraphx::sanitize_filename("a/b") == "a_b");
+    EXPECT(migraphx::sanitize_filename("a<b>c|d\"e") == "a_b_c_d_e");
+}
+
+TEST_CASE(sanitize_filename_double_colon)
+{
+    // "::" in op names (e.g. "gpu::mlir_op") becomes "__".
+    EXPECT(migraphx::sanitize_filename("gpu::mlir_op") == "gpu__mlir_op");
+}
+
+TEST_CASE(sanitize_filename_no_invalid_chars)
+{
+    // Valid names are returned unchanged.
+    EXPECT(migraphx::sanitize_filename("gpu_mlir_op_8_123.mxr") == "gpu_mlir_op_8_123.mxr");
+    EXPECT(migraphx::sanitize_filename("") == "");
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation
Windows has issues with filenames containing `::`.
This changes mxr file names to use `__` instead of `::`.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
