### PR TITLE
Don't throw an exception when using MIGRAPHX_GPU_DUMP_BENCHMARK_MXR

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -44,6 +44,7 @@
 #include <migraphx/gpu/context.hpp>
 #include <migraphx/gpu/time_op.hpp>
 #include <algorithm>
+#include <cstdlib>
 #include <functional>
 
 namespace migraphx {
@@ -588,9 +589,10 @@ struct compile_manager
         // root module has had a chance to dump its benchmark MXR files.
         if(dump_mxr and is_root)
         {
-            MIGRAPHX_THROW(
-                "Benchmark MXR files dumped to " + mxr_path +
-                ". Run the MXR files to create a problem cache, then recompile with the cache.");
+            log::info() << "Benchmark MXR files dumped to " << mxr_path
+                        << ". Run the MXR files to create a problem cache, then recompile with the "
+                           "cache.";
+            std::exit(0);
         }
 
         // Remove compile_plan already executed


### PR DESCRIPTION
## Motivation
We were throwing an exception when dumping benchmark-mxr files,
with MIGRAPHX_GPU_DUMP_BENCHMARK_MXR. This can be confusing
for the users. With this change, we print the message and exit without
throwing an exception.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
