### PR TITLE
Fuse_pointwise fuse dynamic even if scalar

### DIFF
--- a/src/fuse_pointwise.cpp
+++ b/src/fuse_pointwise.cpp
@@ -109,7 +109,8 @@ static void create_pointwise_modules(module_pass_manager& mpm)
             if(contains(param_map, input))
                 continue;
             auto scalar = get_scalar(input);
-            if(scalar.empty())
+            // Have dynamic shapes always get put into a pointwise module even if scalar input
+            if(scalar.empty() or input->get_shape().dynamic())
             {
                 pointwise_inputs.push_back(input);
                 param_map[input] =

--- a/test/fuse_pointwise.cpp
+++ b/test/fuse_pointwise.cpp
@@ -96,6 +96,34 @@ TEST_CASE(single_dyn)
     EXPECT(p1 == p2);
 }
 
+// A scalar literal broadcast to a dynamic shape must become a pointwise-module
+// parameter instead of being folded into a literal inside the submodule.
+TEST_CASE(scalar_broadcast_dyn)
+{
+    migraphx::shape s{migraphx::shape::float_type, {{2, 4}, {3, 3}}};
+    migraphx::shape lit_shape{migraphx::shape::float_type, {1, 1}};
+    migraphx::program p1;
+    {
+        auto* mm  = p1.get_main_module();
+        auto x    = mm->add_parameter("x", s);
+        auto one  = mm->add_literal(migraphx::literal{lit_shape, {1.0f}});
+        auto mb   = mm->add_instruction(migraphx::make_op("multibroadcast"), one, x);
+        auto add1 = mm->add_instruction(migraphx::make_op("add"), x, mb);
+        mm->add_return({add1});
+    }
+    run_pass(p1);
+    migraphx::program p2;
+    {
+        auto* mm  = p2.get_main_module();
+        auto x    = mm->add_parameter("x", s);
+        auto one  = mm->add_literal(migraphx::literal{lit_shape, {1.0f}});
+        auto mb   = mm->add_instruction(migraphx::make_op("multibroadcast"), one, x);
+        auto add1 = add_pointwise(p2, "main:pointwise0", {x, mb}, single_pointwise("add"));
+        mm->add_return({add1});
+    }
+    EXPECT(p1 == p2);
+}
+
 TEST_CASE(double_add)
 {
     migraphx::shape s{migraphx::shape::float_type, {2, 3}};


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
* Was hitting an error running with `dyn_code_object` of a bare `convert` instruction being left over because it was converting a dynamic `multibroadcast` of a scalar.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
