### PR TITLE
Fix nonzero for non-standard input layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Full documentation for MIGraphX is available at
 
 ### Resolved issues
 
+* Fixed the reference `nonzero` operator to handle non-standard input layouts such as transposed or broadcasted tensors.
 * Restored support for the documented flat {min,max,optimals} JSON format in migraphx-driver's --default-dyn-dim and --dyn-input-dim flags (#4926).
 * Fixed ONNX `Where` parsing for dynamic-shape inputs that require broadcasting (including mixed static and dynamic inputs), which previously threw `same_dims: where: Dimensions do not match` (#4925).
 * Fixed a regression in `simplify_algebra` where `find_conv_broadcast_input` could trigger `Dimensions do not match` for padded broadcast-convolution rewrites in no-interior spatial cases (#4738).

--- a/src/include/migraphx/op/nonzero.hpp
+++ b/src/include/migraphx/op/nonzero.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/op/nonzero.hpp
+++ b/src/include/migraphx/op/nonzero.hpp
@@ -48,8 +48,6 @@ struct nonzero
         auto dim_num                      = inputs[0].lens().size();
         std::vector<std::size_t> out_lens = {dim_num, elem_num};
 
-        if(inputs[0].ndim() == out_lens.size())
-            return inputs[0].with_lens(shape::int64_type, out_lens);
         return {shape::int64_type, out_lens};
     }
 

--- a/src/include/migraphx/op/nonzero.hpp
+++ b/src/include/migraphx/op/nonzero.hpp
@@ -31,6 +31,7 @@
 #include <migraphx/par_for.hpp>
 #include <migraphx/argument.hpp>
 #include <cmath>
+#include <cstdint>
 #include <utility>
 
 namespace migraphx {
@@ -55,17 +56,16 @@ struct nonzero
     {
         auto s = args.front().get_shape();
         argument result{output_shape};
-        result.visit([&](auto output) {
-            std::fill(output.begin(), output.end(), 0);
-            args.front().visit([&](auto v) {
-                std::size_t nonzero_idx = 0;
-                shape_for_each(s, [&](const auto& idx_v) {
-                    if(not float_equal(v[idx_v], 0))
-                    {
-                        auto out_idx = nonzero_idx++;
-                        par_for(idx_v.size(), [&](auto j) { output(j, out_idx) = idx_v[j]; });
-                    }
-                });
+        auto output = result.get<std::int64_t>();
+        std::fill(output.begin(), output.end(), 0);
+        args.front().visit([&](auto v) {
+            std::size_t nonzero_idx = 0;
+            shape_for_each(s, [&](const auto& idx_v) {
+                if(not float_equal(v[idx_v], 0))
+                {
+                    auto out_idx = nonzero_idx++;
+                    par_for(idx_v.size(), [&](auto i) { output(i, out_idx) = idx_v[i]; });
+                }
             });
         });
 

--- a/src/include/migraphx/op/nonzero.hpp
+++ b/src/include/migraphx/op/nonzero.hpp
@@ -48,6 +48,8 @@ struct nonzero
         auto dim_num                      = inputs[0].lens().size();
         std::vector<std::size_t> out_lens = {dim_num, elem_num};
 
+        if(inputs[0].ndim() == out_lens.size())
+            return inputs[0].with_lens(shape::int64_type, out_lens);
         return {shape::int64_type, out_lens};
     }
 
@@ -70,7 +72,7 @@ struct nonzero
             par_for(vec_idx.size(), [&](auto i) {
                 for(std::size_t j = 0; j < vec_idx.front().size(); ++j)
                 {
-                    output[output_shape.index({j, i})] = vec_idx[i][j];
+                    output(j, i) = vec_idx[i][j];
                 }
             });
         });

--- a/src/include/migraphx/op/nonzero.hpp
+++ b/src/include/migraphx/op/nonzero.hpp
@@ -43,7 +43,7 @@ struct nonzero
 
     shape compute_shape(std::vector<shape> inputs) const
     {
-        check_shapes{inputs, *this}.has(1).standard();
+        check_shapes{inputs, *this}.has(1);
         auto elem_num                     = inputs[0].elements();
         auto dim_num                      = inputs[0].lens().size();
         std::vector<std::size_t> out_lens = {dim_num, elem_num};
@@ -56,8 +56,8 @@ struct nonzero
         std::vector<std::vector<std::size_t>> vec_idx;
         auto s = args.front().get_shape();
         args.front().visit([&](auto v) {
-            shape_for_each(s, [&](const auto& idx_v, size_t idx) {
-                if(not float_equal(v[idx], 0))
+            shape_for_each(s, [&](const auto& idx_v) {
+                if(not float_equal(v[idx_v], 0))
                 {
                     vec_idx.push_back(idx_v);
                 }

--- a/src/include/migraphx/op/nonzero.hpp
+++ b/src/include/migraphx/op/nonzero.hpp
@@ -53,25 +53,19 @@ struct nonzero
 
     argument compute(const shape& output_shape, std::vector<argument> args) const
     {
-        std::vector<std::vector<std::size_t>> vec_idx;
         auto s = args.front().get_shape();
-        args.front().visit([&](auto v) {
-            shape_for_each(s, [&](const auto& idx_v) {
-                if(not float_equal(v[idx_v], 0))
-                {
-                    vec_idx.push_back(idx_v);
-                }
-            });
-        });
-
         argument result{output_shape};
         result.visit([&](auto output) {
             std::fill(output.begin(), output.end(), 0);
-            par_for(vec_idx.size(), [&](auto i) {
-                for(std::size_t j = 0; j < vec_idx.front().size(); ++j)
-                {
-                    output(j, i) = vec_idx[i][j];
-                }
+            args.front().visit([&](auto v) {
+                std::size_t nonzero_idx = 0;
+                shape_for_each(s, [&](const auto& idx_v) {
+                    if(not float_equal(v[idx_v], 0))
+                    {
+                        auto out_idx = nonzero_idx++;
+                        par_for(idx_v.size(), [&](auto j) { output(j, out_idx) = idx_v[j]; });
+                    }
+                });
             });
         });
 

--- a/test/ref/nonzero.cpp
+++ b/test/ref/nonzero.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/ref/nonzero.cpp
+++ b/test/ref/nonzero.cpp
@@ -48,3 +48,39 @@ TEST_CASE(nonzero_test)
                                  1, 1, 0, 0, 0, 0, 0, 1, 0, 2, 0, 2, 0, 2, 0, 0, 0, 0};
     EXPECT(migraphx::verify::verify_rms_range(result_vector, gold));
 }
+
+TEST_CASE(nonzero_transposed_input)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape s{migraphx::shape::float_type, {2, 3}};
+    std::vector<float> data = {1.0f, 0.0f, 2.0f, 0.0f, 3.0f, 4.0f};
+    auto input              = mm->add_literal(migraphx::literal(s, data));
+    auto transposed =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), input);
+    auto ret = mm->add_instruction(migraphx::make_op("nonzero"), transposed);
+    mm->add_return({ret});
+    p.compile(migraphx::make_target("ref"));
+    auto result = p.eval({}).back();
+    std::vector<int64_t> result_vector;
+    result.visit([&](auto output) { result_vector.assign(output.begin(), output.end()); });
+    std::vector<int64_t> gold = {0, 1, 2, 2, 0, 0, 0, 1, 0, 1, 0, 0};
+    EXPECT(migraphx::verify::verify_rms_range(result_vector, gold));
+}
+
+TEST_CASE(nonzero_broadcasted_input)
+{
+    migraphx::program p;
+    auto* mm   = p.get_main_module();
+    auto input = mm->add_literal(migraphx::literal{migraphx::shape::float_type, {1.0f}});
+    auto broadcasted =
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 3}}}), input);
+    auto ret = mm->add_instruction(migraphx::make_op("nonzero"), broadcasted);
+    mm->add_return({ret});
+    p.compile(migraphx::make_target("ref"));
+    auto result = p.eval({}).back();
+    std::vector<int64_t> result_vector;
+    result.visit([&](auto output) { result_vector.assign(output.begin(), output.end()); });
+    std::vector<int64_t> gold = {0, 0, 0, 1, 1, 1, 0, 1, 2, 0, 1, 2};
+    EXPECT(migraphx::verify::verify_rms_range(result_vector, gold));
+}

--- a/test/ref/nonzero.cpp
+++ b/test/ref/nonzero.cpp
@@ -64,6 +64,7 @@ TEST_CASE(nonzero_transposed_input)
     auto result = p.eval({}).back();
     std::vector<int64_t> result_vector;
     result.visit([&](auto output) { result_vector.assign(output.begin(), output.end()); });
+    // np.nonzero(data.reshape(2, 3).T), padded to nonzero output shape {2, 6}.
     std::vector<int64_t> gold = {0, 1, 2, 2, 0, 0, 0, 1, 0, 1, 0, 0};
     EXPECT(migraphx::verify::verify_rms_range(result_vector, gold));
 }

--- a/test/verify/test_nonzero.cpp
+++ b/test/verify/test_nonzero.cpp
@@ -51,3 +51,24 @@ template struct test_nonzero<migraphx::shape::fp8e4m3fnuz_type>;
 template struct test_nonzero<migraphx::shape::fp8e5m2fnuz_type>;
 template struct test_nonzero<migraphx::shape::fp8e4m3fn_type>;
 template struct test_nonzero<migraphx::shape::fp8e5m2_type>;
+
+template <migraphx::shape::type_t DType>
+struct test_nonzero_transpose : verify_program<test_nonzero_transpose<DType>>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        migraphx::shape s{DType, {2, 3}};
+        auto x = mm->add_parameter("data", s);
+        auto transposed =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), x);
+        auto r = mm->add_instruction(migraphx::make_op("nonzero"), transposed);
+        mm->add_return({r});
+
+        return p;
+    }
+};
+
+template struct test_nonzero_transpose<migraphx::shape::bool_type>;
+template struct test_nonzero_transpose<migraphx::shape::float_type>;


### PR DESCRIPTION
## Motivation
Fix the reference `nonzero` operator so it accepts and correctly reads non-standard input layouts such as transposed and broadcasted tensors.

## Technical Details
Removed the standard-layout requirement from `nonzero` shape checking and changed compute-time element access to use the logical index from `shape_for_each`. Added reference and verify tests for transposed inputs, plus reference coverage for broadcasted inputs.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.