### PR TITLE
Prevent propagate_precision from removing fp8 converts

### DIFF
--- a/src/propagate_precision.cpp
+++ b/src/propagate_precision.cpp
@@ -31,6 +31,7 @@
 #include <migraphx/functional.hpp>
 #include <migraphx/ranges.hpp>
 #include <migraphx/eliminate_convert.hpp>
+#include <migraphx/fp8_types.hpp>
 #include <unordered_set>
 #include <unordered_map>
 
@@ -42,6 +43,27 @@ namespace {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 #endif
+// Precision must not be propagated across a type-category boundary. fp8 is a
+// low-precision floating storage type used for quantization, so it forms its
+// own category distinct from wider (non-quantized) floating-point types;
+// crossing that boundary would undo the quantization.
+enum class type_category
+{
+    integral,
+    fp8,
+    non_quantized_floating,
+};
+
+static type_category get_type_category(shape::type_t t)
+{
+    static const std::set<shape::type_t> fp8 = fp8_types{}.get();
+    if(contains(fp8, t))
+        return type_category::fp8;
+    if(shape::is_integral(t))
+        return type_category::integral;
+    return type_category::non_quantized_floating;
+}
+
 // Class wrappper so we can compare precision using comparison operators
 struct precision
 {
@@ -81,10 +103,12 @@ struct precision
     {
         return (xp > yp) or (xp == yp);
     }
-    // Check if two precisions are in the same category (both integral or both floating-point)
+    // Two precisions share a category only if both integral, both fp8, or both
+    // non-quantized floating-point. fp8 is isolated so precision is not
+    // propagated across a quantization boundary.
     friend bool same_category(const precision& xp, const precision& yp)
     {
-        return shape::is_integral(xp.type) == shape::is_integral(yp.type);
+        return get_type_category(xp.type) == get_type_category(yp.type);
     }
 };
 #ifdef __clang__
@@ -134,7 +158,7 @@ static std::unordered_set<instruction_ref> find_adjacent_inputs(instruction_ref 
             return;
         if(contains(result, ins))
             return;
-        // Stop at div when crossing type category boundary (e.g., int to float)
+        // Stop when crossing a type category boundary (e.g., int or fp8 to float)
         if(not same_category(precision{ins->get_shape().type()}, target))
             return;
         auto next = get_next_input(ins);
@@ -160,7 +184,7 @@ static std::unordered_set<instruction_ref> find_adjacent_outputs(instruction_ref
                 continue;
             if(contains(result, output))
                 continue;
-            // Stop at div when crossing type category boundary (e.g., int to float)
+            // Stop when crossing a type category boundary (e.g., int or fp8 to float)
             if(not same_category(precision{output->get_shape().type()}, target))
                 continue;
             auto next = get_next_input(output);

--- a/src/propagate_precision.cpp
+++ b/src/propagate_precision.cpp
@@ -43,10 +43,10 @@ namespace {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 #endif
-// Precision must not be propagated across a type-category boundary. fp8 is a
-// low-precision floating storage type used for quantization, so it forms its
-// own category distinct from wider (non-quantized) floating-point types;
-// crossing that boundary would undo the quantization.
+
+// Precision must not be propagated across a type-category boundary.
+// fp8 is a quantization type, so it forms its own category.
+// Crossing that boundary would undo the quantization.
 enum class type_category
 {
     integral,
@@ -103,9 +103,6 @@ struct precision
     {
         return (xp > yp) or (xp == yp);
     }
-    // Two precisions share a category only if both integral, both fp8, or both
-    // non-quantized floating-point. fp8 is isolated so precision is not
-    // propagated across a quantization boundary.
     friend bool same_category(const precision& xp, const precision& yp)
     {
         return get_type_category(xp.type) == get_type_category(yp.type);

--- a/src/propagate_precision.cpp
+++ b/src/propagate_precision.cpp
@@ -51,7 +51,7 @@ enum class type_category
 {
     integral,
     fp8,
-    non_quantized_floating,
+    standard_float,
 };
 
 type_category get_type_category(shape::type_t t)
@@ -61,7 +61,7 @@ type_category get_type_category(shape::type_t t)
         return type_category::fp8;
     if(shape::is_integral(t))
         return type_category::integral;
-    return type_category::non_quantized_floating;
+    return type_category::standard_float;
 }
 
 // Class wrappper so we can compare precision using comparison operators

--- a/src/propagate_precision.cpp
+++ b/src/propagate_precision.cpp
@@ -54,7 +54,7 @@ enum class type_category
     non_quantized_floating,
 };
 
-static type_category get_type_category(shape::type_t t)
+type_category get_type_category(shape::type_t t)
 {
     static const std::set<shape::type_t> fp8 = fp8_types{}.get();
     if(contains(fp8, t))

--- a/test/propagate_precision.cpp
+++ b/test/propagate_precision.cpp
@@ -270,4 +270,43 @@ TEST_CASE(propagate_no_crossover_through_bool_int_chain)
     EXPECT(m1.sort() == m2.sort());
 }
 
+// fp8 is a quantization storage type; precision must not be propagated across
+// an fp8 <-> floating-point convert (doing so would undo the quantization).
+// Input direction: convert(fp8 -> float) with an upstream fp8 pointwise op.
+TEST_CASE(propagate_no_crossover_fp8_boundary_input)
+{
+    migraphx::shape s1{migraphx::shape::fp8e4m3fnuz_type, {2, 3}};
+    migraphx::shape s2{migraphx::shape::float_type, {2, 3}};
+    migraphx::module m1;
+    {
+        auto x        = m1.add_parameter("x", s1);
+        auto y        = m1.add_parameter("y", s2);
+        auto absx     = m1.add_instruction(migraphx::make_op("abs"), x);
+        auto convert1 = m1.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), absx);
+        auto mul = m1.add_instruction(migraphx::make_op("mul"), convert1, y);
+        m1.add_return({mul});
+    }
+    migraphx::module m2 = m1;
+    run_pass(m1);
+    EXPECT(m1.sort() == m2.sort());
+}
+
+// Output direction: convert(float -> fp8) with a downstream fp8 pointwise op.
+TEST_CASE(propagate_no_crossover_fp8_boundary_output)
+{
+    migraphx::shape s1{migraphx::shape::float_type, {2, 3}};
+    migraphx::module m1;
+    {
+        auto x        = m1.add_parameter("x", s1);
+        auto convert1 = m1.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::fp8e4m3fnuz_type}}), x);
+        auto absx = m1.add_instruction(migraphx::make_op("abs"), convert1);
+        m1.add_return({absx});
+    }
+    migraphx::module m2 = m1;
+    run_pass(m1);
+    EXPECT(m1.sort() == m2.sort());
+}
+
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
* Was hitting error when rocMLIR disabled and running fp8_ocp_to_fnuz tests on MI300

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
* `fp8_ocp_to_fnuz` does bit conversions around `dequantizelinear` to convert fpocp to fnuz.
* With rocMLIR disabled the `rewrite_quantization` pass runs. The pass replaces `dequantizelinear` instructions into primitive instructions including `convert`.
* `propagate_precision` sees the `convert` between fp8 and float and tries to upgrade the type. This leads to an issue later with `bit_cast` and the type sizes no longer matching correctly.
* Fix the bug by introducing a new category to propagate_precision to prevent conversions between float <-> fp8.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.
