### PR TITLE
update before installing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -549,6 +549,7 @@ pipeline {
                                     apt install half
                                     #ls -lR
                                     md5sum ./build/*.deb
+                                    apt update
                                     apt install -y --allow-unauthenticated ./build/*.deb
                                     env
                                     cd /onnxruntime && ./build_and_test_onnxrt.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -546,11 +546,11 @@ pipeline {
                         script {
                             rocmtest(setup: setuppackage, docker_args: '-u root', image: DOCKER_IMAGE_ORT, imageTag: env.IMAGE_TAG_ORT) {
                                 sh '''
-                                    apt install half
+                                    apt-get update
+                                    apt-get install -y half
                                     #ls -lR
                                     md5sum ./build/*.deb
-                                    apt update
-                                    apt install -y --allow-unauthenticated ./build/*.deb
+                                    apt-get install -y --allow-unauthenticated ./build/*.deb
                                     env
                                     cd /onnxruntime && ./build_and_test_onnxrt.sh
                                 '''


### PR DESCRIPTION
## Motivation
Jenkins failures can occur when the `apt install` is not predicated with an `apt update`  
