### PR TITLE
Add mlss_use_specific_ops as a GPU backend option

### DIFF
--- a/src/include/migraphx/compile_options.hpp
+++ b/src/include/migraphx/compile_options.hpp
@@ -65,6 +65,21 @@ inline void set_backend_options(compile_options& options, const value& v)
         options.backend_options[opt.get_key()] = opt.without_key();
 }
 
+/**
+ * Read a backend option by name, converting it to `To`. Returns `default_value`
+ * when the option is not present.
+ */
+template <class To>
+To get_backend_option(const compile_options& options,
+                      const std::string& name,
+                      const To& default_value)
+{
+    auto it = options.backend_options.find(name);
+    if(it == options.backend_options.end())
+        return default_value;
+    return it->second.to<To>();
+}
+
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
 

--- a/src/include/migraphx/compile_options.hpp
+++ b/src/include/migraphx/compile_options.hpp
@@ -65,21 +65,6 @@ inline void set_backend_options(compile_options& options, const value& v)
         options.backend_options[opt.get_key()] = opt.without_key();
 }
 
-/**
- * Read a backend option by name, converting it to `To`. Returns `default_value`
- * when the option is not present.
- */
-template <class To>
-To get_backend_option(const compile_options& options,
-                      const std::string& name,
-                      const To& default_value)
-{
-    auto it = options.backend_options.find(name);
-    if(it == options.backend_options.end())
-        return default_value;
-    return it->second.to<To>();
-}
-
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
 

--- a/src/targets/gpu/fuse_mlss.cpp
+++ b/src/targets/gpu/fuse_mlss.cpp
@@ -54,12 +54,17 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_MLSS_USE_SPECIFIC_OPS);
 
 #ifdef MIGRAPHX_USE_AMDMLSS
 
-static bool mlss_specific_op(std::string_view op_name)
+static bool op_in_list(const std::string& list, std::string_view op_name)
 {
-    static const auto options =
-        split_string(string_value_of(MIGRAPHX_MLSS_USE_SPECIFIC_OPS{}, ""), ',');
+    const auto options = split_string(list, ',');
     return std::any_of(
         options.begin(), options.end(), [&](const auto& opt) { return opt == op_name; });
+}
+
+static bool mlss_specific_op(std::string_view op_name)
+{
+    static const std::string env = string_value_of(MIGRAPHX_MLSS_USE_SPECIFIC_OPS{}, "");
+    return op_in_list(env, op_name);
 }
 
 // ---------------------------------------------------------------------------
@@ -382,7 +387,7 @@ struct find_mlss_conv_bias_leaky_relu
 void fuse_mlss::apply(module_pass_manager& mpm) const
 {
 #ifdef MIGRAPHX_USE_AMDMLSS
-    if(enable_conv or mlss_specific_op("conv"))
+    if(op_in_list(use_specific_ops, "conv") or mlss_specific_op("conv"))
     {
         // Match most-specific patterns first to avoid partial consumption.
         match::find_matches(mpm, find_mlss_conv_bias_relu{ctx});

--- a/src/targets/gpu/fuse_mlss.cpp
+++ b/src/targets/gpu/fuse_mlss.cpp
@@ -54,16 +54,16 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_MLSS_USE_SPECIFIC_OPS);
 
 #ifdef MIGRAPHX_USE_AMDMLSS
 
-static bool op_in_list(const std::string& list, std::string_view op_name)
+static bool op_in_list(const std::vector<std::string>& list, std::string_view op_name)
 {
-    const auto options = split_string(list, ',');
     return std::any_of(
-        options.begin(), options.end(), [&](const auto& opt) { return opt == op_name; });
+        list.begin(), list.end(), [&](const auto& opt) { return opt == op_name; });
 }
 
 static bool mlss_specific_op(std::string_view op_name)
 {
-    static const std::string env = string_value_of(MIGRAPHX_MLSS_USE_SPECIFIC_OPS{}, "");
+    static const auto env =
+        split_string(string_value_of(MIGRAPHX_MLSS_USE_SPECIFIC_OPS{}, ""), ',');
     return op_in_list(env, op_name);
 }
 

--- a/src/targets/gpu/fuse_mlss.cpp
+++ b/src/targets/gpu/fuse_mlss.cpp
@@ -26,6 +26,7 @@
 #include <migraphx/instruction.hpp>
 #include <migraphx/instruction_ref.hpp>
 #include <migraphx/env.hpp>
+#include <migraphx/ranges.hpp>
 #include <migraphx/stringutils.hpp>
 #include <migraphx/matcher.hpp>
 #include <migraphx/make_op.hpp>
@@ -54,16 +55,11 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_MLSS_USE_SPECIFIC_OPS);
 
 #ifdef MIGRAPHX_USE_AMDMLSS
 
-static bool op_in_list(const std::vector<std::string>& list, std::string_view op_name)
-{
-    return std::any_of(list.begin(), list.end(), [&](const auto& opt) { return opt == op_name; });
-}
-
 static bool mlss_specific_op(std::string_view op_name)
 {
     static const auto env =
         split_string(string_value_of(MIGRAPHX_MLSS_USE_SPECIFIC_OPS{}, ""), ',');
-    return op_in_list(env, op_name);
+    return contains(env, op_name);
 }
 
 // ---------------------------------------------------------------------------
@@ -386,7 +382,7 @@ struct find_mlss_conv_bias_leaky_relu
 void fuse_mlss::apply(module_pass_manager& mpm) const
 {
 #ifdef MIGRAPHX_USE_AMDMLSS
-    if(op_in_list(use_specific_ops, "conv") or mlss_specific_op("conv"))
+    if(contains(use_specific_ops, "conv") or mlss_specific_op("conv"))
     {
         // Match most-specific patterns first to avoid partial consumption.
         match::find_matches(mpm, find_mlss_conv_bias_relu{ctx});

--- a/src/targets/gpu/fuse_mlss.cpp
+++ b/src/targets/gpu/fuse_mlss.cpp
@@ -56,8 +56,7 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_MLSS_USE_SPECIFIC_OPS);
 
 static bool op_in_list(const std::vector<std::string>& list, std::string_view op_name)
 {
-    return std::any_of(
-        list.begin(), list.end(), [&](const auto& opt) { return opt == op_name; });
+    return std::any_of(list.begin(), list.end(), [&](const auto& opt) { return opt == op_name; });
 }
 
 static bool mlss_specific_op(std::string_view op_name)

--- a/src/targets/gpu/include/migraphx/gpu/fuse_mlss.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/fuse_mlss.hpp
@@ -24,6 +24,7 @@
 #ifndef MIGRAPHX_GUARD_GPU_FUSE_MLSS_HPP
 #define MIGRAPHX_GUARD_GPU_FUSE_MLSS_HPP
 
+#include <string>
 #include <migraphx/config.hpp>
 #include <migraphx/gpu/context.hpp>
 
@@ -37,9 +38,9 @@ namespace gpu {
 struct MIGRAPHX_GPU_EXPORT fuse_mlss
 {
     context* ctx = nullptr;
-    // Force-enable conv fusion regardless of env-var configuration; used by tests
-    // so they don't have to mutate the process environment.
-    bool enable_conv = false;
+    // Comma-separated list of ops to force onto AMDMLSS (e.g. "conv"), supplied via
+    // compile_options. Takes effect in addition to MIGRAPHX_MLSS_USE_SPECIFIC_OPS.
+    std::string use_specific_ops = "";
     std::string name() const { return "gpu::fuse_mlss"; }
     void apply(module_pass_manager& mpm) const;
 };

--- a/src/targets/gpu/include/migraphx/gpu/fuse_mlss.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/fuse_mlss.hpp
@@ -25,6 +25,7 @@
 #define MIGRAPHX_GUARD_GPU_FUSE_MLSS_HPP
 
 #include <string>
+#include <vector>
 #include <migraphx/config.hpp>
 #include <migraphx/gpu/context.hpp>
 
@@ -38,9 +39,9 @@ namespace gpu {
 struct MIGRAPHX_GPU_EXPORT fuse_mlss
 {
     context* ctx = nullptr;
-    // Comma-separated list of ops to force onto AMDMLSS (e.g. "conv"), supplied via
-    // compile_options. Takes effect in addition to MIGRAPHX_MLSS_USE_SPECIFIC_OPS.
-    std::string use_specific_ops = "";
+    // List of ops to force onto AMDMLSS (e.g. "conv"), supplied via compile_options.
+    // Takes effect in addition to MIGRAPHX_MLSS_USE_SPECIFIC_OPS.
+    std::vector<std::string> use_specific_ops = {};
     std::string name() const { return "gpu::fuse_mlss"; }
     void apply(module_pass_manager& mpm) const;
 };

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -184,7 +184,9 @@ struct pipeline_factory
                                        .flash_decoding_enabled = mlir_flash_decoding_enabled()}),
             dead_code_elimination{},
             optimize_module{},
-            fuse_mlss{get_context()},
+            fuse_mlss{.ctx = get_context(),
+                      .use_specific_ops =
+                          get_backend_option(options, "mlss_use_specific_ops", std::string{})},
             fuse_pointwise_reduce{},
             dead_code_elimination{},
 #ifndef _WIN32

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -45,6 +45,7 @@
 #include <migraphx/preallocate_param.hpp>
 #include <migraphx/promote_literals.hpp>
 #include <migraphx/propagate_precision.hpp>
+#include <migraphx/reflect.hpp>
 #include <migraphx/register_target.hpp>
 #include <migraphx/replace_allocate.hpp>
 #include <migraphx/rewrite_dot.hpp>
@@ -57,6 +58,7 @@
 #include <migraphx/rewrite_rnn.hpp>
 #include <migraphx/rewrite_topk.hpp>
 #include <migraphx/schedule.hpp>
+#include <migraphx/serialize.hpp>
 #include <migraphx/simplify_dyn_ops.hpp>
 #include <migraphx/simplify_qdq.hpp>
 #include <migraphx/simplify_reshapes.hpp>
@@ -97,10 +99,24 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_SET_GEMM_PROVIDER)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_FULL_DYNAMIC)
 
 namespace {
+// Backend options recognized by the GPU target, supplied via
+// compile_options::backend_options.
+struct backend_options
+{
+    std::vector<std::string> mlss_use_specific_ops = {};
+
+    template <class Self, class F>
+    static auto reflect(Self& self, F f)
+    {
+        return pack(f(self.mlss_use_specific_ops, "mlss_use_specific_ops"));
+    }
+};
+
 struct pipeline_factory
 {
     migraphx::context* gctx_ptr = nullptr;
     compile_options options;
+    backend_options backend_opts = {};
 
     migraphx::context* get_generic_context() const { return gctx_ptr; }
 
@@ -185,8 +201,7 @@ struct pipeline_factory
             dead_code_elimination{},
             optimize_module{},
             fuse_mlss{.ctx = get_context(),
-                      .use_specific_ops =
-                          get_backend_option(options, "mlss_use_specific_ops", std::string{})},
+                      .use_specific_ops = backend_opts.mlss_use_specific_ops},
             fuse_pointwise_reduce{},
             dead_code_elimination{},
 #ifndef _WIN32
@@ -257,7 +272,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
     ctx.set_exhaustive_tune_flag(options.exhaustive_tune);
     ctx.load_problem_cache(); // TODO: update load_problem_cache to include gpu arch
 
-    pipeline_factory p{&gctx, options};
+    pipeline_factory p{&gctx, options, from_value<backend_options>(value(options.backend_options))};
 
     std::vector<std::vector<pass>> pipelines = {
         p.dynamic_shapes_pipeline(),

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -200,8 +200,7 @@ struct pipeline_factory
                                        .flash_decoding_enabled = mlir_flash_decoding_enabled()}),
             dead_code_elimination{},
             optimize_module{},
-            fuse_mlss{.ctx = get_context(),
-                      .use_specific_ops = backend_opts.mlss_use_specific_ops},
+            fuse_mlss{.ctx = get_context(), .use_specific_ops = backend_opts.mlss_use_specific_ops},
             fuse_pointwise_reduce{},
             dead_code_elimination{},
 #ifndef _WIN32

--- a/test/gpu/fuse_mlss.cpp
+++ b/test/gpu/fuse_mlss.cpp
@@ -44,7 +44,7 @@ static void run_pass(migraphx::program& p)
 {
     migraphx::run_passes(
         p,
-        {migraphx::gpu::fuse_mlss{.ctx = &get_context(), .use_specific_ops = "conv"},
+        {migraphx::gpu::fuse_mlss{.ctx = &get_context(), .use_specific_ops = {"conv"}},
          migraphx::dead_code_elimination{}});
 }
 

--- a/test/gpu/fuse_mlss.cpp
+++ b/test/gpu/fuse_mlss.cpp
@@ -42,9 +42,10 @@ static migraphx::gpu::context& get_context()
 
 static void run_pass(migraphx::program& p)
 {
-    migraphx::run_passes(p,
-                         {migraphx::gpu::fuse_mlss{&get_context(), /*enable_conv=*/true},
-                          migraphx::dead_code_elimination{}});
+    migraphx::run_passes(
+        p,
+        {migraphx::gpu::fuse_mlss{.ctx = &get_context(), .use_specific_ops = "conv"},
+         migraphx::dead_code_elimination{}});
 }
 
 // Build the pre-pass program for conv+bias+relu:


### PR DESCRIPTION
- compile_options.hpp: add get_backend_option() read helper
- fuse_mlss: replace bool enable_conv with std::string use_specific_ops;
    extract op_in_list() so the compile option and MIGRAPHX_MLSS_USE_SPECIFIC_OPS
    env var both enable conv fusion
- target.cpp: read "mlss_use_specific_ops" from backend_options
- test: update run_pass to the new field

Usage: options.set_advance_backend_option("mlss_use_specific_ops", "conv");
