### PR TITLE
Add from_string/to_string enum macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,9 @@ rocm_enable_cppcheck(
         arithOperationsOnVoidPointer
         definePrefix:*test/include/test.hpp
         definePrefix:*src/targets/gpu/kernels/include/migraphx/kernels/test.hpp
+        # test/pp.cpp exercises the MIGRAPHX_PP_* metaprogramming macros directly, which
+        # cppcheck's preprocessor cannot expand.
+        unknownMacro:*test/pp.cpp
         UseNamedLogicOperator:*src/targets/gpu/kernels/include/migraphx/kernels/debug.hpp
         ctuOneDefinitionRuleViolation:*test/*
         useSmartPointer:*src/api/api.cpp

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -25,12 +25,13 @@
 #define MIGRAPHX_GUARD_MIGRAPHX_ENUM_HPP
 
 #include <algorithm>
-#include <initializer_list>
+#include <array>
 #include <iterator>
 #include <string>
-#include <utility>
-#include <vector>
 #include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <migraphx/array.hpp>
 #include <migraphx/config.hpp>
 #include <migraphx/errors.hpp>
 #include <migraphx/pp.hpp>
@@ -70,59 +71,51 @@ struct enum_capturer
     }
 };
 
-// Zip the stringized enumerator names (split on commas, dropping any `= value` suffix) with
-// their captured values into a lookup table.
+// Looks up the name of an enumerator. The entries array (from migraphx_enum_entries) holds only
+// the values, so the name is the correspondingly-positioned token from the stringized enumerator
+// list, with any `= value` suffix stripped.
 template <class Enum>
-std::vector<std::pair<std::string, Enum>> make_enum_entries(const std::string& names,
-                                                            std::initializer_list<Enum> values)
+std::string enum_to_string(const std::string& names, Enum value)
 {
-    auto parts = split_string(names, ',');
-    if(parts.size() != values.size())
-        MIGRAPHX_THROW("MIGRAPHX_ENUM: number of names does not match number of values");
-    std::vector<std::pair<std::string, Enum>> entries;
-    entries.reserve(values.size());
-    std::transform(parts.begin(),
-                   parts.end(),
-                   values.begin(),
-                   std::back_inserter(entries),
-                   [](const std::string& part, Enum value) {
-                       auto pos  = part.find('=');
-                       auto text = pos == std::string::npos ? part : part.substr(0, pos);
-                       return std::make_pair(trim(text), value);
-                   });
-    return entries;
-}
-
-template <class Enum>
-std::string enum_to_string(Enum value)
-{
-    const auto& entries = migraphx_enum_entries(value);
-    auto it             = std::find_if(
-        entries.begin(), entries.end(), [&](const auto& p) { return p.second == value; });
+    const auto entries = migraphx_enum_entries(value);
+    auto parts         = split_string(names, ',');
+    if(parts.size() != entries.size())
+        MIGRAPHX_THROW("MIGRAPHX_ENUM: too many enumerators for " + get_type_name<Enum>());
+    const auto* it = std::find(entries.begin(), entries.end(), value);
     if(it == entries.end())
         MIGRAPHX_THROW("Invalid value for enum " + get_type_name<Enum>());
-    return it->first;
+    const auto& part = parts[it - entries.begin()];
+    auto pos         = part.find('=');
+    return trim(pos == std::string::npos ? part : part.substr(0, pos));
 }
 
 } // namespace detail
 
-// Returns the name/value table for an enum declared with MIGRAPHX_ENUM.
+// Returns the array of enumerator values for an enum declared with MIGRAPHX_ENUM.
 template <class Enum>
-const std::vector<std::pair<std::string, Enum>>& enum_entries()
+auto enum_entries()
 {
     static_assert(std::is_enum<Enum>{}, "enum_entries<Enum> requires an enum type");
     return migraphx_enum_entries(Enum{});
 }
 
-// Converts the name of an enumerator back into its value, throwing when the name is unknown.
+// Converts the name of an enumerator back into its value, throwing when the name is unknown. The
+// name -> value table is built once per enum from migraphx_enum_entries so lookups are O(1).
 template <class Enum>
 Enum from_string(const std::string& name)
 {
     static_assert(std::is_enum<Enum>{}, "from_string<Enum> requires an enum type");
-    const auto& entries = migraphx_enum_entries(Enum{});
-    auto it             = std::find_if(
-        entries.begin(), entries.end(), [&](const auto& p) { return p.first == name; });
-    if(it == entries.end())
+    static const auto lookup = [] {
+        const auto entries = migraphx_enum_entries(Enum{});
+        std::unordered_map<std::string, Enum> result;
+        std::transform(entries.begin(),
+                       entries.end(),
+                       std::inserter(result, result.end()),
+                       [](Enum value) { return std::make_pair(to_string(value), value); });
+        return result;
+    }();
+    auto it = lookup.find(name);
+    if(it == lookup.end())
         MIGRAPHX_THROW("Invalid name '" + name + "' for enum " + get_type_name<Enum>());
     return it->second;
 }
@@ -145,22 +138,25 @@ Enum from_string(const std::string& name)
 //     std::string s = to_string(green);                     // "green"
 //     color c       = migraphx::from_string<color>("blue"); // blue
 //
+// migraphx_enum_entries returns just the array of enumerator values; the names are recovered on
+// demand from the stringized enumerator list by to_string.
+//
 // Supports explicit enumerator values and up to 63 enumerators. When used in a .cpp rather than a
 // header, place it in an anonymous namespace so the generated helpers get internal linkage.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define MIGRAPHX_ENUM(name, ...)                                                        \
-    enum name                                                                           \
-    {                                                                                   \
-        __VA_ARGS__                                                                     \
-    };                                                                                  \
-    inline const std::vector<std::pair<std::string, name>>& migraphx_enum_entries(name) \
-    {                                                                                   \
-        static const std::vector<std::pair<std::string, name>> entries =                \
-            migraphx::detail::make_enum_entries<name>(                                  \
-                #__VA_ARGS__,                                                           \
-                {MIGRAPHX_PP_TRANSFORM_ARGS(MIGRAPHX_ENUM_PP_CAPTURE, __VA_ARGS__)});   \
-        return entries;                                                                 \
-    }                                                                                   \
-    inline std::string to_string(name value) { return migraphx::detail::enum_to_string(value); }
+#define MIGRAPHX_ENUM(name, ...)                                                \
+    enum name                                                                   \
+    {                                                                           \
+        __VA_ARGS__                                                             \
+    };                                                                          \
+    inline auto migraphx_enum_entries(name)                                     \
+    {                                                                           \
+        return migraphx::make_array<name>(                                      \
+            MIGRAPHX_PP_TRANSFORM_ARGS(MIGRAPHX_ENUM_PP_CAPTURE, __VA_ARGS__)); \
+    }                                                                           \
+    inline std::string to_string(name value)                                    \
+    {                                                                           \
+        return migraphx::detail::enum_to_string(#__VA_ARGS__, value);           \
+    }
 
 #endif // MIGRAPHX_GUARD_MIGRAPHX_ENUM_HPP

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -33,6 +33,7 @@
 #include <type_traits>
 #include <migraphx/config.hpp>
 #include <migraphx/errors.hpp>
+#include <migraphx/pp.hpp>
 #include <migraphx/stringutils.hpp>
 #include <migraphx/type_name.hpp>
 
@@ -42,10 +43,10 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace detail {
 
 // enum_capture and enum_capturer implement the value capturing used by MIGRAPHX_ENUM. Each
-// enumerator `e` in the list is rewritten to `enum_capturer{}->*name::e`. Since operator->*
-// binds more tightly than assignment, `enum_capturer{}->*name::e = 42` parses as
-// `(enum_capturer{}->*name::e) = 42`: operator->* captures the real value of the enumerator
-// (which already accounts for the `= 42`), and operator= simply swallows the initializer.
+// enumerator `e` in the list is rewritten to `enum_capturer{}->*e`. Since operator->* binds
+// more tightly than assignment, `enum_capturer{}->*e = 42` parses as
+// `(enum_capturer{}->*e) = 42`: operator->* captures the real value of the enumerator (which
+// already accounts for the `= 42`), and operator= simply swallows the initializer.
 template <class T>
 struct enum_capture
 {
@@ -129,122 +130,9 @@ Enum from_string(const std::string& name)
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
 
-// Preprocessor machinery: apply a macro to each enumerator in the list. The names use the
-// `_PP_` infix so they are recognized as pure preprocessor helpers by clang-tidy.
-
-#define MIGRAPHX_ENUM_PP_ARG_N(_1,  \
-                               _2,  \
-                               _3,  \
-                               _4,  \
-                               _5,  \
-                               _6,  \
-                               _7,  \
-                               _8,  \
-                               _9,  \
-                               _10, \
-                               _11, \
-                               _12, \
-                               _13, \
-                               _14, \
-                               _15, \
-                               _16, \
-                               _17, \
-                               _18, \
-                               _19, \
-                               _20, \
-                               _21, \
-                               _22, \
-                               _23, \
-                               _24, \
-                               _25, \
-                               _26, \
-                               _27, \
-                               _28, \
-                               _29, \
-                               _30, \
-                               _31, \
-                               _32, \
-                               N,   \
-                               ...) \
-    N
-#define MIGRAPHX_ENUM_PP_RSEQ()                                                                    \
-    32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, \
-        8, 7, 6, 5, 4, 3, 2, 1, 0
-#define MIGRAPHX_ENUM_PP_NARG(...) MIGRAPHX_ENUM_PP_NARG_IMPL(__VA_ARGS__, MIGRAPHX_ENUM_PP_RSEQ())
-#define MIGRAPHX_ENUM_PP_NARG_IMPL(...) MIGRAPHX_ENUM_PP_ARG_N(__VA_ARGS__)
-
-#define MIGRAPHX_ENUM_PP_CONCAT(a, b) MIGRAPHX_ENUM_PP_CONCAT_IMPL(a, b)
-#define MIGRAPHX_ENUM_PP_CONCAT_IMPL(a, b) a##b
-
-#define MIGRAPHX_ENUM_PP_CAPTURE(name, x) (migraphx::detail::enum_capturer{}->*name::x)
-
-#define MIGRAPHX_ENUM_PP_EACH(m, name, ...)                                             \
-    MIGRAPHX_ENUM_PP_CONCAT(MIGRAPHX_ENUM_PP_EACH_, MIGRAPHX_ENUM_PP_NARG(__VA_ARGS__)) \
-    (m, name, __VA_ARGS__)
-
-#define MIGRAPHX_ENUM_PP_EACH_1(m, name, x) m(name, x)
-#define MIGRAPHX_ENUM_PP_EACH_2(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_1(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_3(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_2(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_4(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_3(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_5(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_4(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_6(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_5(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_7(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_6(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_8(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_7(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_9(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_8(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_10(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_9(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_11(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_10(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_12(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_11(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_13(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_12(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_14(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_13(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_15(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_14(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_16(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_15(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_17(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_16(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_18(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_17(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_19(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_18(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_20(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_19(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_21(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_20(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_22(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_21(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_23(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_22(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_24(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_23(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_25(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_24(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_26(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_25(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_27(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_26(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_28(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_27(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_29(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_28(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_30(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_29(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_31(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_30(m, name, __VA_ARGS__)
-#define MIGRAPHX_ENUM_PP_EACH_32(m, name, x, ...) \
-    m(name, x), MIGRAPHX_ENUM_PP_EACH_31(m, name, __VA_ARGS__)
+// Rewrites a single enumerator `x` (which may include an `= value`) so that operator->* captures
+// its value. See the note on enum_capture above for why operator->* is used here.
+#define MIGRAPHX_ENUM_PP_CAPTURE(x) (migraphx::detail::enum_capturer{}->*x)
 
 // Declares an unscoped enum together with `to_string(name)` and `migraphx::from_string<name>`
 // helpers for converting the enumerators to and from their names. Use it at namespace scope:
@@ -254,10 +142,11 @@ Enum from_string(const std::string& name)
 //         green = 5,
 //         blue)
 //
-//     std::string s = to_string(green);              // "green"
+//     std::string s = to_string(green);                     // "green"
 //     color c       = migraphx::from_string<color>("blue"); // blue
 //
-// Supports explicit enumerator values and up to 32 enumerators.
+// Supports explicit enumerator values and up to 16 enumerators. When used in a .cpp rather than a
+// header, place it in an anonymous namespace so the generated helpers get internal linkage.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define MIGRAPHX_ENUM(name, ...)                                                        \
     enum name                                                                           \
@@ -269,7 +158,7 @@ Enum from_string(const std::string& name)
         static const std::vector<std::pair<std::string, name>> entries =                \
             migraphx::detail::make_enum_entries<name>(                                  \
                 #__VA_ARGS__,                                                           \
-                {MIGRAPHX_ENUM_PP_EACH(MIGRAPHX_ENUM_PP_CAPTURE, name, __VA_ARGS__)});  \
+                {MIGRAPHX_PP_TRANSFORM_ARGS(MIGRAPHX_ENUM_PP_CAPTURE, __VA_ARGS__)});   \
         return entries;                                                                 \
     }                                                                                   \
     inline std::string to_string(name value) { return migraphx::detail::enum_to_string(value); }

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -35,6 +35,7 @@
 #include <migraphx/config.hpp>
 #include <migraphx/errors.hpp>
 #include <migraphx/pp.hpp>
+#include <migraphx/requires.hpp>
 #include <migraphx/stringutils.hpp>
 #include <migraphx/type_name.hpp>
 
@@ -91,20 +92,31 @@ std::string enum_to_string(const std::string& names, Enum value)
 
 } // namespace detail
 
+// Detects enums declared with the MIGRAPHX_ENUM family: those provide a migraphx_enum_entries hook
+// and therefore support to_string and migraphx::from_string.
+template <class T, class = void>
+struct is_named_enum : std::false_type
+{
+};
+
+template <class T>
+struct is_named_enum<T, std::void_t<decltype(migraphx_enum_entries(std::declval<T>()))>>
+    : std::true_type
+{
+};
+
 // Returns the array of enumerator values for an enum declared with MIGRAPHX_ENUM.
-template <class Enum>
+template <class Enum, MIGRAPHX_REQUIRES(is_named_enum<Enum>{})>
 auto enum_entries()
 {
-    static_assert(std::is_enum<Enum>{}, "enum_entries<Enum> requires an enum type");
     return migraphx_enum_entries(Enum{});
 }
 
 // Converts the name of an enumerator back into its value, throwing when the name is unknown. The
 // name -> value table is built once per enum from migraphx_enum_entries so lookups are O(1).
-template <class Enum>
+template <class Enum, MIGRAPHX_REQUIRES(is_named_enum<Enum>{})>
 Enum from_string(const std::string& name)
 {
-    static_assert(std::is_enum<Enum>{}, "from_string<Enum> requires an enum type");
     static const auto lookup = [] {
         const auto entries = migraphx_enum_entries(Enum{});
         std::unordered_map<std::string, Enum> result;

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -34,6 +34,7 @@
 #include <migraphx/array.hpp>
 #include <migraphx/config.hpp>
 #include <migraphx/errors.hpp>
+#include <migraphx/functional.hpp>
 #include <migraphx/pp.hpp>
 #include <migraphx/requires.hpp>
 #include <migraphx/stringutils.hpp>
@@ -72,22 +73,56 @@ struct enum_capturer
     }
 };
 
-// Looks up the name of an enumerator. The entries array (from migraphx_enum_entries) holds only
-// the values, so the name is the correspondingly-positioned token from the stringized enumerator
-// list, with any `= value` suffix stripped.
-template <class Enum>
-std::string enum_to_string(const std::string& names, Enum value)
+// Wraps an enumerator as a type so that get_type_name renders it as its name: the compiler spells
+// a named enumerator as its own identifier, e.g. get_type_name<enum_value<color, green>>() is
+// "...enum_value<color, green>".
+template <class T, T X>
+struct enum_value
 {
-    const auto entries = migraphx_enum_entries(value);
-    auto parts         = split_string(names, ',');
-    if(parts.size() != entries.size())
-        MIGRAPHX_THROW("MIGRAPHX_ENUM: too many enumerators for " + get_type_name<Enum>());
-    const auto* it = std::find(entries.begin(), entries.end(), value);
-    if(it == entries.end())
+};
+
+// Recovers the enumerator name from that type name, e.g. "green" from "...enum_value<color, green>"
+// or "on" from "...enum_value<mode, mode::on>" (scoped and nested enumerators are qualified).
+template <class T, T X>
+std::string enum_value_name()
+{
+    const std::string& full = get_type_name<enum_value<T, X>>();
+    auto begin              = full.find(',', full.find('<')) + 1;
+    auto name               = trim(full.substr(begin, full.rfind('>') - begin));
+    auto scope              = name.rfind("::");
+    return scope == std::string::npos ? name : name.substr(scope + 2);
+}
+
+template <class Enum, std::size_t N>
+auto enum_value_names()
+{
+    return sequence_c<N>([](auto... is) {
+        constexpr auto entries = migraphx_enum_entries(Enum{});
+        return make_array<std::string>(enum_value_name<Enum, entries[is]>()...);
+    });
+}
+
+// Maps an enumerator value to its name. The value set comes from migraphx_enum_entries, but the
+// names are derived from the values through get_type_name rather than from any stored strings. The
+// value -> name table is built once per enum so lookups are O(1).
+template <class Enum>
+std::string enum_to_string(Enum value)
+{
+    static const auto lookup = [] {
+        constexpr auto entries = migraphx_enum_entries(Enum{});
+        const auto names       = enum_value_names<Enum, entries.size()>();
+        std::unordered_map<Enum, std::string> result;
+        std::transform(entries.begin(),
+                       entries.end(),
+                       names.begin(),
+                       std::inserter(result, result.end()),
+                       [](Enum v, const std::string& n) { return std::make_pair(v, n); });
+        return result;
+    }();
+    auto it = lookup.find(value);
+    if(it == lookup.end())
         MIGRAPHX_THROW("Invalid value for enum " + get_type_name<Enum>());
-    const auto& part = parts[it - entries.begin()];
-    auto pos         = part.find('=');
-    return trim(pos == std::string::npos ? part : part.substr(0, pos));
+    return it->second;
 }
 
 } // namespace detail
@@ -148,18 +183,14 @@ Enum from_string(const std::string& name)
 // `linkage` is `inline` for a namespace-scope enum or `friend` for a class-scope (nested) enum;
 // `capture` is the per-enumerator capture macro; `prologue` runs before the capture list and is
 // used by the scoped variants to declare the enum_scope alias. migraphx_enum_entries returns just
-// the array of enumerator values; the names are recovered on demand from the stringized enumerator
-// list by to_string.
+// the array of enumerator values; to_string recovers the names from those values via get_type_name.
 #define MIGRAPHX_DETAIL_ENUM_HELPERS(linkage, name, capture, prologue, ...) \
-    linkage auto migraphx_enum_entries(name)                                \
+    linkage constexpr auto migraphx_enum_entries(name)                      \
     {                                                                       \
         prologue return migraphx::make_array<name>(                         \
             MIGRAPHX_PP_TRANSFORM_ARGS(capture, __VA_ARGS__));              \
     }                                                                       \
-    linkage std::string to_string(name value)                               \
-    {                                                                       \
-        return migraphx::detail::enum_to_string(#__VA_ARGS__, value);       \
-    }
+    linkage std::string to_string(name value) { return migraphx::detail::enum_to_string(value); }
 
 // Declares an unscoped enum and generates `to_string` and `migraphx::from_string` helpers that
 // convert its enumerators to and from their names. Use it at namespace scope:

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -132,6 +132,23 @@ Enum from_string(const std::string& name)
 // visible unqualified).
 #define MIGRAPHX_ENUM_CLASS_PP_CAPTURE(x) (migraphx::detail::enum_capturer{}->*enum_scope::x)
 
+// Generates the ADL hooks (migraphx_enum_entries + to_string) shared by the MIGRAPHX_ENUM family.
+// `linkage` is `inline` for a namespace-scope enum or `friend` for a class-scope (nested) enum;
+// `capture` is the per-enumerator capture macro; `prologue` runs before the capture list and is
+// used by the scoped variants to declare the enum_scope alias. migraphx_enum_entries returns just
+// the array of enumerator values; the names are recovered on demand from the stringized enumerator
+// list by to_string.
+#define MIGRAPHX_ENUM_DEFINE_HELPERS(linkage, name, capture, prologue, ...) \
+    linkage auto migraphx_enum_entries(name)                                \
+    {                                                                       \
+        prologue return migraphx::make_array<name>(                         \
+            MIGRAPHX_PP_TRANSFORM_ARGS(capture, __VA_ARGS__));              \
+    }                                                                       \
+    linkage std::string to_string(name value)                               \
+    {                                                                       \
+        return migraphx::detail::enum_to_string(#__VA_ARGS__, value);       \
+    }
+
 // Declares an unscoped enum together with `to_string(name)` and `migraphx::from_string<name>`
 // helpers for converting the enumerators to and from their names. Use it at namespace scope:
 //
@@ -143,30 +160,20 @@ Enum from_string(const std::string& name)
 //     std::string s = to_string(green);                     // "green"
 //     color c       = migraphx::from_string<color>("blue"); // blue
 //
-// migraphx_enum_entries returns just the array of enumerator values; the names are recovered on
-// demand from the stringized enumerator list by to_string.
-//
 // Supports explicit enumerator values and up to 63 enumerators. When used in a .cpp rather than a
 // header, place it in an anonymous namespace so the generated helpers get internal linkage.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define MIGRAPHX_ENUM(name, ...)                                                \
-    enum name                                                                   \
-    {                                                                           \
-        __VA_ARGS__                                                             \
-    };                                                                          \
-    inline auto migraphx_enum_entries(name)                                     \
-    {                                                                           \
-        return migraphx::make_array<name>(                                      \
-            MIGRAPHX_PP_TRANSFORM_ARGS(MIGRAPHX_ENUM_PP_CAPTURE, __VA_ARGS__)); \
-    }                                                                           \
-    inline std::string to_string(name value)                                    \
-    {                                                                           \
-        return migraphx::detail::enum_to_string(#__VA_ARGS__, value);           \
-    }
+#define MIGRAPHX_ENUM(name, ...) \
+    enum name                    \
+    {                            \
+        __VA_ARGS__              \
+    };                           \
+    MIGRAPHX_ENUM_DEFINE_HELPERS(inline, name, MIGRAPHX_ENUM_PP_CAPTURE, , __VA_ARGS__)
 
-// Like MIGRAPHX_ENUM, but declares a scoped enum (enum class). The enumerators are captured
-// through a local `enum_scope` alias since they are not visible unqualified. to_string and
-// migraphx::from_string work the same way:
+// Like MIGRAPHX_ENUM, but declares a scoped enum (enum class). The enumerators are captured through
+// a local `enum_scope` alias since they are not visible unqualified. Explicit enumerator values
+// must be self-contained (literals or expressions that do not reference other enumerators, which
+// are not visible unqualified in a scoped enum):
 //
 //     MIGRAPHX_ENUM_CLASS(color,
 //         red,
@@ -176,25 +183,44 @@ Enum from_string(const std::string& name)
 //     std::string s = to_string(color::green);              // "green"
 //     color c       = migraphx::from_string<color>("blue"); // color::blue
 //
-// Explicit enumerator values must be self-contained (literals or expressions that do not reference
-// other enumerators, which are not visible unqualified in a scoped enum). Supports up to 63
-// enumerators. When used in a .cpp rather than a header, place it in an anonymous namespace so the
-// generated helpers get internal linkage.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define MIGRAPHX_ENUM_CLASS(name, ...)                                                \
-    enum class name                                                                   \
-    {                                                                                 \
-        __VA_ARGS__                                                                   \
-    };                                                                                \
-    inline auto migraphx_enum_entries(name)                                           \
-    {                                                                                 \
-        using enum_scope = name;                                                      \
-        return migraphx::make_array<name>(                                            \
-            MIGRAPHX_PP_TRANSFORM_ARGS(MIGRAPHX_ENUM_CLASS_PP_CAPTURE, __VA_ARGS__)); \
-    }                                                                                 \
-    inline std::string to_string(name value)                                          \
-    {                                                                                 \
-        return migraphx::detail::enum_to_string(#__VA_ARGS__, value);                 \
-    }
+#define MIGRAPHX_ENUM_CLASS(name, ...) \
+    enum class name                    \
+    {                                  \
+        __VA_ARGS__                    \
+    };                                 \
+    MIGRAPHX_ENUM_DEFINE_HELPERS(      \
+        inline, name, MIGRAPHX_ENUM_CLASS_PP_CAPTURE, using enum_scope = name;, __VA_ARGS__)
+
+// Like MIGRAPHX_ENUM, but for an enum declared inside a class or struct. The helpers are declared
+// as hidden friends instead of free functions so that argument-dependent lookup still finds them
+// for the nested enum type. Must be used inside a class/struct body:
+//
+//     struct widget
+//     {
+//         MIGRAPHX_NESTED_ENUM(mode, off, on = 3, standby)
+//     };
+//
+//     std::string s = to_string(widget::on);                  // "on"
+//     widget::mode m = migraphx::from_string<widget::mode>("off");
+//
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define MIGRAPHX_NESTED_ENUM(name, ...) \
+    enum name                           \
+    {                                   \
+        __VA_ARGS__                     \
+    };                                  \
+    MIGRAPHX_ENUM_DEFINE_HELPERS(friend, name, MIGRAPHX_ENUM_PP_CAPTURE, , __VA_ARGS__)
+
+// Like MIGRAPHX_ENUM_CLASS, but for a scoped enum declared inside a class or struct (see
+// MIGRAPHX_NESTED_ENUM). Must be used inside a class/struct body.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define MIGRAPHX_NESTED_ENUM_CLASS(name, ...) \
+    enum class name                           \
+    {                                         \
+        __VA_ARGS__                           \
+    };                                        \
+    MIGRAPHX_ENUM_DEFINE_HELPERS(             \
+        friend, name, MIGRAPHX_ENUM_CLASS_PP_CAPTURE, using enum_scope = name;, __VA_ARGS__)
 
 #endif // MIGRAPHX_GUARD_MIGRAPHX_ENUM_HPP

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -110,7 +110,8 @@ std::string enum_to_string(Enum value)
 {
     static const auto lookup = [] {
         constexpr auto entries = migraphx_enum_entries(Enum{});
-        const auto names       = enum_value_names<Enum, entries.size()>();
+        constexpr auto n       = entries.size();
+        const auto names       = enum_value_names<Enum, n>();
         std::unordered_map<Enum, std::string> result;
         std::transform(entries.begin(),
                        entries.end(),
@@ -184,6 +185,16 @@ Enum from_string(const std::string& name)
 // `capture` is the per-enumerator capture macro; `prologue` runs before the capture list and is
 // used by the scoped variants to declare the enum_scope alias. migraphx_enum_entries returns just
 // the array of enumerator values; to_string recovers the names from those values via get_type_name.
+#ifdef CPPCHECK
+// cppcheck's preprocessor cannot expand the recursive MIGRAPHX_PP_TRANSFORM_ARGS, so generate the
+// hooks without it; the captured values are irrelevant to static analysis.
+#define MIGRAPHX_DETAIL_ENUM_HELPERS(linkage, name, capture, prologue, ...) \
+    linkage constexpr auto migraphx_enum_entries(name)                      \
+    {                                                                       \
+        return migraphx::make_array<name>(name{});                          \
+    }                                                                       \
+    linkage std::string to_string(name value) { return migraphx::detail::enum_to_string(value); }
+#else
 #define MIGRAPHX_DETAIL_ENUM_HELPERS(linkage, name, capture, prologue, ...) \
     linkage constexpr auto migraphx_enum_entries(name)                      \
     {                                                                       \
@@ -191,6 +202,7 @@ Enum from_string(const std::string& name)
             MIGRAPHX_PP_TRANSFORM_ARGS(capture, __VA_ARGS__));              \
     }                                                                       \
     linkage std::string to_string(name value) { return migraphx::detail::enum_to_string(value); }
+#endif
 
 // Declares an unscoped enum and generates `to_string` and `migraphx::from_string` helpers that
 // convert its enumerators to and from their names. Use it at namespace scope:

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -161,8 +161,8 @@ Enum from_string(const std::string& name)
         return migraphx::detail::enum_to_string(#__VA_ARGS__, value);       \
     }
 
-// Declares an unscoped enum together with `to_string(name)` and `migraphx::from_string<name>`
-// helpers for converting the enumerators to and from their names. Use it at namespace scope:
+// Declares an unscoped enum and generates `to_string` and `migraphx::from_string` helpers that
+// convert its enumerators to and from their names. Use it at namespace scope:
 //
 //     MIGRAPHX_ENUM(color,
 //         red,
@@ -172,8 +172,8 @@ Enum from_string(const std::string& name)
 //     std::string s = to_string(green);                     // "green"
 //     color c       = migraphx::from_string<color>("blue"); // blue
 //
-// Supports explicit enumerator values and up to 63 enumerators. When used in a .cpp rather than a
-// header, place it in an anonymous namespace so the generated helpers get internal linkage.
+// Enumerators may take explicit values, and up to 63 are supported. When used in a .cpp instead of
+// a header, place it in an anonymous namespace so the generated helpers get internal linkage.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define MIGRAPHX_ENUM(name, ...) \
     enum name                    \
@@ -182,10 +182,7 @@ Enum from_string(const std::string& name)
     };                           \
     MIGRAPHX_DETAIL_ENUM_HELPERS(inline, name, MIGRAPHX_DETAIL_ENUM_CAPTURE, , __VA_ARGS__)
 
-// Like MIGRAPHX_ENUM, but declares a scoped enum (enum class). The enumerators are captured through
-// a local `enum_scope` alias since they are not visible unqualified. Explicit enumerator values
-// must be self-contained (literals or expressions that do not reference other enumerators, which
-// are not visible unqualified in a scoped enum):
+// Like MIGRAPHX_ENUM, but declares a scoped enum (enum class):
 //
 //     MIGRAPHX_ENUM_CLASS(color,
 //         red,
@@ -195,6 +192,8 @@ Enum from_string(const std::string& name)
 //     std::string s = to_string(color::green);              // "green"
 //     color c       = migraphx::from_string<color>("blue"); // color::blue
 //
+// An explicit enumerator value must be self-contained: it cannot reference another enumerator,
+// which is not visible unqualified in a scoped enum.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define MIGRAPHX_ENUM_CLASS(name, ...) \
     enum class name                    \
@@ -204,18 +203,17 @@ Enum from_string(const std::string& name)
     MIGRAPHX_DETAIL_ENUM_HELPERS(      \
         inline, name, MIGRAPHX_DETAIL_ENUM_CLASS_CAPTURE, using enum_scope = name;, __VA_ARGS__)
 
-// Like MIGRAPHX_ENUM, but for an enum declared inside a class or struct. The helpers are declared
-// as hidden friends instead of free functions so that argument-dependent lookup still finds them
-// for the nested enum type. Must be used inside a class/struct body:
+// Like MIGRAPHX_ENUM, but for an enum declared inside a class or struct. The helpers are generated
+// as hidden friends instead of free functions so that argument-dependent lookup still finds them.
+// Use it inside the class/struct body:
 //
 //     struct widget
 //     {
 //         MIGRAPHX_NESTED_ENUM(mode, off, on = 3, standby)
 //     };
 //
-//     std::string s = to_string(widget::on);                  // "on"
-//     widget::mode m = migraphx::from_string<widget::mode>("off");
-//
+//     std::string s  = to_string(widget::on);                      // "on"
+//     widget::mode m = migraphx::from_string<widget::mode>("off"); // widget::off
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define MIGRAPHX_NESTED_ENUM(name, ...) \
     enum name                           \
@@ -224,8 +222,17 @@ Enum from_string(const std::string& name)
     };                                  \
     MIGRAPHX_DETAIL_ENUM_HELPERS(friend, name, MIGRAPHX_DETAIL_ENUM_CAPTURE, , __VA_ARGS__)
 
-// Like MIGRAPHX_ENUM_CLASS, but for a scoped enum declared inside a class or struct (see
-// MIGRAPHX_NESTED_ENUM). Must be used inside a class/struct body.
+// Like MIGRAPHX_NESTED_ENUM, but declares a scoped enum (enum class); it relates to
+// MIGRAPHX_NESTED_ENUM as MIGRAPHX_ENUM_CLASS does to MIGRAPHX_ENUM, including the same restriction
+// on explicit enumerator values. Use it inside the class/struct body:
+//
+//     struct widget
+//     {
+//         MIGRAPHX_NESTED_ENUM_CLASS(unit, mm, cm = 10, m)
+//     };
+//
+//     std::string s  = to_string(widget::unit::cm);               // "cm"
+//     widget::unit u = migraphx::from_string<widget::unit>("mm"); // widget::unit::mm
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define MIGRAPHX_NESTED_ENUM_CLASS(name, ...) \
     enum class name                           \

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -145,7 +145,7 @@ Enum from_string(const std::string& name)
 //     std::string s = to_string(green);                     // "green"
 //     color c       = migraphx::from_string<color>("blue"); // blue
 //
-// Supports explicit enumerator values and up to 16 enumerators. When used in a .cpp rather than a
+// Supports explicit enumerator values and up to 63 enumerators. When used in a .cpp rather than a
 // header, place it in an anonymous namespace so the generated helpers get internal linkage.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define MIGRAPHX_ENUM(name, ...)                                                        \

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -125,12 +125,12 @@ Enum from_string(const std::string& name)
 
 // Rewrites a single enumerator `x` (which may include an `= value`) so that operator->* captures
 // its value. See the note on enum_capture above for why operator->* is used here.
-#define MIGRAPHX_ENUM_PP_CAPTURE(x) (migraphx::detail::enum_capturer{}->*x)
+#define MIGRAPHX_DETAIL_ENUM_CAPTURE(x) (migraphx::detail::enum_capturer{}->*x)
 
 // The scoped-enum variant qualifies the enumerator with `enum_scope`, a local alias for the enum
 // type that MIGRAPHX_ENUM_CLASS declares in the entries function (scoped enumerators are not
 // visible unqualified).
-#define MIGRAPHX_ENUM_CLASS_PP_CAPTURE(x) (migraphx::detail::enum_capturer{}->*enum_scope::x)
+#define MIGRAPHX_DETAIL_ENUM_CLASS_CAPTURE(x) (migraphx::detail::enum_capturer{}->*enum_scope::x)
 
 // Generates the ADL hooks (migraphx_enum_entries + to_string) shared by the MIGRAPHX_ENUM family.
 // `linkage` is `inline` for a namespace-scope enum or `friend` for a class-scope (nested) enum;
@@ -138,7 +138,7 @@ Enum from_string(const std::string& name)
 // used by the scoped variants to declare the enum_scope alias. migraphx_enum_entries returns just
 // the array of enumerator values; the names are recovered on demand from the stringized enumerator
 // list by to_string.
-#define MIGRAPHX_ENUM_DEFINE_HELPERS(linkage, name, capture, prologue, ...) \
+#define MIGRAPHX_DETAIL_ENUM_HELPERS(linkage, name, capture, prologue, ...) \
     linkage auto migraphx_enum_entries(name)                                \
     {                                                                       \
         prologue return migraphx::make_array<name>(                         \
@@ -168,7 +168,7 @@ Enum from_string(const std::string& name)
     {                            \
         __VA_ARGS__              \
     };                           \
-    MIGRAPHX_ENUM_DEFINE_HELPERS(inline, name, MIGRAPHX_ENUM_PP_CAPTURE, , __VA_ARGS__)
+    MIGRAPHX_DETAIL_ENUM_HELPERS(inline, name, MIGRAPHX_DETAIL_ENUM_CAPTURE, , __VA_ARGS__)
 
 // Like MIGRAPHX_ENUM, but declares a scoped enum (enum class). The enumerators are captured through
 // a local `enum_scope` alias since they are not visible unqualified. Explicit enumerator values
@@ -189,8 +189,8 @@ Enum from_string(const std::string& name)
     {                                  \
         __VA_ARGS__                    \
     };                                 \
-    MIGRAPHX_ENUM_DEFINE_HELPERS(      \
-        inline, name, MIGRAPHX_ENUM_CLASS_PP_CAPTURE, using enum_scope = name;, __VA_ARGS__)
+    MIGRAPHX_DETAIL_ENUM_HELPERS(      \
+        inline, name, MIGRAPHX_DETAIL_ENUM_CLASS_CAPTURE, using enum_scope = name;, __VA_ARGS__)
 
 // Like MIGRAPHX_ENUM, but for an enum declared inside a class or struct. The helpers are declared
 // as hidden friends instead of free functions so that argument-dependent lookup still finds them
@@ -210,7 +210,7 @@ Enum from_string(const std::string& name)
     {                                   \
         __VA_ARGS__                     \
     };                                  \
-    MIGRAPHX_ENUM_DEFINE_HELPERS(friend, name, MIGRAPHX_ENUM_PP_CAPTURE, , __VA_ARGS__)
+    MIGRAPHX_DETAIL_ENUM_HELPERS(friend, name, MIGRAPHX_DETAIL_ENUM_CAPTURE, , __VA_ARGS__)
 
 // Like MIGRAPHX_ENUM_CLASS, but for a scoped enum declared inside a class or struct (see
 // MIGRAPHX_NESTED_ENUM). Must be used inside a class/struct body.
@@ -220,7 +220,7 @@ Enum from_string(const std::string& name)
     {                                         \
         __VA_ARGS__                           \
     };                                        \
-    MIGRAPHX_ENUM_DEFINE_HELPERS(             \
-        friend, name, MIGRAPHX_ENUM_CLASS_PP_CAPTURE, using enum_scope = name;, __VA_ARGS__)
+    MIGRAPHX_DETAIL_ENUM_HELPERS(             \
+        friend, name, MIGRAPHX_DETAIL_ENUM_CLASS_CAPTURE, using enum_scope = name;, __VA_ARGS__)
 
 #endif // MIGRAPHX_GUARD_MIGRAPHX_ENUM_HPP

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -1,0 +1,277 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MIGRAPHX_GUARD_MIGRAPHX_ENUM_HPP
+#define MIGRAPHX_GUARD_MIGRAPHX_ENUM_HPP
+
+#include <algorithm>
+#include <initializer_list>
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+#include <type_traits>
+#include <migraphx/config.hpp>
+#include <migraphx/errors.hpp>
+#include <migraphx/stringutils.hpp>
+#include <migraphx/type_name.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+
+namespace detail {
+
+// enum_capture and enum_capturer implement the value capturing used by MIGRAPHX_ENUM. Each
+// enumerator `e` in the list is rewritten to `enum_capturer{}->*name::e`. Since operator->*
+// binds more tightly than assignment, `enum_capturer{}->*name::e = 42` parses as
+// `(enum_capturer{}->*name::e) = 42`: operator->* captures the real value of the enumerator
+// (which already accounts for the `= 42`), and operator= simply swallows the initializer.
+template <class T>
+struct enum_capture
+{
+    T value;
+
+    template <class U>
+    constexpr enum_capture& operator=(U)
+    {
+        return *this;
+    }
+
+    constexpr operator T() const { return value; }
+};
+
+struct enum_capturer
+{
+    template <class T>
+    constexpr enum_capture<T> operator->*(T value) const
+    {
+        return {value};
+    }
+};
+
+// Zip the stringized enumerator names (split on commas, dropping any `= value` suffix) with
+// their captured values into a lookup table.
+template <class Enum>
+std::vector<std::pair<std::string, Enum>> make_enum_entries(const std::string& names,
+                                                            std::initializer_list<Enum> values)
+{
+    auto parts = split_string(names, ',');
+    if(parts.size() != values.size())
+        MIGRAPHX_THROW("MIGRAPHX_ENUM: number of names does not match number of values");
+    std::vector<std::pair<std::string, Enum>> entries;
+    entries.reserve(values.size());
+    std::transform(parts.begin(),
+                   parts.end(),
+                   values.begin(),
+                   std::back_inserter(entries),
+                   [](const std::string& part, Enum value) {
+                       auto pos  = part.find('=');
+                       auto text = pos == std::string::npos ? part : part.substr(0, pos);
+                       return std::make_pair(trim(text), value);
+                   });
+    return entries;
+}
+
+template <class Enum>
+std::string enum_to_string(Enum value)
+{
+    const auto& entries = migraphx_enum_entries(value);
+    auto it             = std::find_if(
+        entries.begin(), entries.end(), [&](const auto& p) { return p.second == value; });
+    if(it == entries.end())
+        MIGRAPHX_THROW("Invalid value for enum " + get_type_name<Enum>());
+    return it->first;
+}
+
+} // namespace detail
+
+// Returns the name/value table for an enum declared with MIGRAPHX_ENUM.
+template <class Enum>
+const std::vector<std::pair<std::string, Enum>>& enum_entries()
+{
+    static_assert(std::is_enum<Enum>{}, "enum_entries<Enum> requires an enum type");
+    return migraphx_enum_entries(Enum{});
+}
+
+// Converts the name of an enumerator back into its value, throwing when the name is unknown.
+template <class Enum>
+Enum from_string(const std::string& name)
+{
+    static_assert(std::is_enum<Enum>{}, "from_string<Enum> requires an enum type");
+    const auto& entries = migraphx_enum_entries(Enum{});
+    auto it             = std::find_if(
+        entries.begin(), entries.end(), [&](const auto& p) { return p.first == name; });
+    if(it == entries.end())
+        MIGRAPHX_THROW("Invalid name '" + name + "' for enum " + get_type_name<Enum>());
+    return it->second;
+}
+
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+
+// Preprocessor machinery: apply a macro to each enumerator in the list. The names use the
+// `_PP_` infix so they are recognized as pure preprocessor helpers by clang-tidy.
+
+#define MIGRAPHX_ENUM_PP_ARG_N(_1,  \
+                               _2,  \
+                               _3,  \
+                               _4,  \
+                               _5,  \
+                               _6,  \
+                               _7,  \
+                               _8,  \
+                               _9,  \
+                               _10, \
+                               _11, \
+                               _12, \
+                               _13, \
+                               _14, \
+                               _15, \
+                               _16, \
+                               _17, \
+                               _18, \
+                               _19, \
+                               _20, \
+                               _21, \
+                               _22, \
+                               _23, \
+                               _24, \
+                               _25, \
+                               _26, \
+                               _27, \
+                               _28, \
+                               _29, \
+                               _30, \
+                               _31, \
+                               _32, \
+                               N,   \
+                               ...) \
+    N
+#define MIGRAPHX_ENUM_PP_RSEQ()                                                                    \
+    32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, \
+        8, 7, 6, 5, 4, 3, 2, 1, 0
+#define MIGRAPHX_ENUM_PP_NARG(...) MIGRAPHX_ENUM_PP_NARG_IMPL(__VA_ARGS__, MIGRAPHX_ENUM_PP_RSEQ())
+#define MIGRAPHX_ENUM_PP_NARG_IMPL(...) MIGRAPHX_ENUM_PP_ARG_N(__VA_ARGS__)
+
+#define MIGRAPHX_ENUM_PP_CONCAT(a, b) MIGRAPHX_ENUM_PP_CONCAT_IMPL(a, b)
+#define MIGRAPHX_ENUM_PP_CONCAT_IMPL(a, b) a##b
+
+#define MIGRAPHX_ENUM_PP_CAPTURE(name, x) (migraphx::detail::enum_capturer{}->*name::x)
+
+#define MIGRAPHX_ENUM_PP_EACH(m, name, ...)                                             \
+    MIGRAPHX_ENUM_PP_CONCAT(MIGRAPHX_ENUM_PP_EACH_, MIGRAPHX_ENUM_PP_NARG(__VA_ARGS__)) \
+    (m, name, __VA_ARGS__)
+
+#define MIGRAPHX_ENUM_PP_EACH_1(m, name, x) m(name, x)
+#define MIGRAPHX_ENUM_PP_EACH_2(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_1(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_3(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_2(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_4(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_3(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_5(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_4(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_6(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_5(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_7(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_6(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_8(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_7(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_9(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_8(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_10(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_9(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_11(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_10(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_12(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_11(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_13(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_12(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_14(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_13(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_15(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_14(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_16(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_15(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_17(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_16(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_18(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_17(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_19(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_18(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_20(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_19(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_21(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_20(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_22(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_21(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_23(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_22(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_24(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_23(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_25(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_24(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_26(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_25(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_27(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_26(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_28(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_27(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_29(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_28(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_30(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_29(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_31(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_30(m, name, __VA_ARGS__)
+#define MIGRAPHX_ENUM_PP_EACH_32(m, name, x, ...) \
+    m(name, x), MIGRAPHX_ENUM_PP_EACH_31(m, name, __VA_ARGS__)
+
+// Declares an unscoped enum together with `to_string(name)` and `migraphx::from_string<name>`
+// helpers for converting the enumerators to and from their names. Use it at namespace scope:
+//
+//     MIGRAPHX_ENUM(color,
+//         red,
+//         green = 5,
+//         blue)
+//
+//     std::string s = to_string(green);              // "green"
+//     color c       = migraphx::from_string<color>("blue"); // blue
+//
+// Supports explicit enumerator values and up to 32 enumerators.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define MIGRAPHX_ENUM(name, ...)                                                        \
+    enum name                                                                           \
+    {                                                                                   \
+        __VA_ARGS__                                                                     \
+    };                                                                                  \
+    inline const std::vector<std::pair<std::string, name>>& migraphx_enum_entries(name) \
+    {                                                                                   \
+        static const std::vector<std::pair<std::string, name>> entries =                \
+            migraphx::detail::make_enum_entries<name>(                                  \
+                #__VA_ARGS__,                                                           \
+                {MIGRAPHX_ENUM_PP_EACH(MIGRAPHX_ENUM_PP_CAPTURE, name, __VA_ARGS__)});  \
+        return entries;                                                                 \
+    }                                                                                   \
+    inline std::string to_string(name value) { return migraphx::detail::enum_to_string(value); }
+
+#endif // MIGRAPHX_GUARD_MIGRAPHX_ENUM_HPP

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -127,6 +127,11 @@ Enum from_string(const std::string& name)
 // its value. See the note on enum_capture above for why operator->* is used here.
 #define MIGRAPHX_ENUM_PP_CAPTURE(x) (migraphx::detail::enum_capturer{}->*x)
 
+// The scoped-enum variant qualifies the enumerator with `enum_scope`, a local alias for the enum
+// type that MIGRAPHX_ENUM_CLASS declares in the entries function (scoped enumerators are not
+// visible unqualified).
+#define MIGRAPHX_ENUM_CLASS_PP_CAPTURE(x) (migraphx::detail::enum_capturer{}->*enum_scope::x)
+
 // Declares an unscoped enum together with `to_string(name)` and `migraphx::from_string<name>`
 // helpers for converting the enumerators to and from their names. Use it at namespace scope:
 //
@@ -157,6 +162,39 @@ Enum from_string(const std::string& name)
     inline std::string to_string(name value)                                    \
     {                                                                           \
         return migraphx::detail::enum_to_string(#__VA_ARGS__, value);           \
+    }
+
+// Like MIGRAPHX_ENUM, but declares a scoped enum (enum class). The enumerators are captured
+// through a local `enum_scope` alias since they are not visible unqualified. to_string and
+// migraphx::from_string work the same way:
+//
+//     MIGRAPHX_ENUM_CLASS(color,
+//         red,
+//         green = 5,
+//         blue)
+//
+//     std::string s = to_string(color::green);              // "green"
+//     color c       = migraphx::from_string<color>("blue"); // color::blue
+//
+// Explicit enumerator values must be self-contained (literals or expressions that do not reference
+// other enumerators, which are not visible unqualified in a scoped enum). Supports up to 63
+// enumerators. When used in a .cpp rather than a header, place it in an anonymous namespace so the
+// generated helpers get internal linkage.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define MIGRAPHX_ENUM_CLASS(name, ...)                                                \
+    enum class name                                                                   \
+    {                                                                                 \
+        __VA_ARGS__                                                                   \
+    };                                                                                \
+    inline auto migraphx_enum_entries(name)                                           \
+    {                                                                                 \
+        using enum_scope = name;                                                      \
+        return migraphx::make_array<name>(                                            \
+            MIGRAPHX_PP_TRANSFORM_ARGS(MIGRAPHX_ENUM_CLASS_PP_CAPTURE, __VA_ARGS__)); \
+    }                                                                                 \
+    inline std::string to_string(name value)                                          \
+    {                                                                                 \
+        return migraphx::detail::enum_to_string(#__VA_ARGS__, value);                 \
     }
 
 #endif // MIGRAPHX_GUARD_MIGRAPHX_ENUM_HPP

--- a/src/include/migraphx/pp.hpp
+++ b/src/include/migraphx/pp.hpp
@@ -75,43 +75,208 @@
 #define MIGRAPHX_PP_REPEAT(n, m, ...) \
     MIGRAPHX_PP_PRIMITIVE_CAT(MIGRAPHX_PP_REPEAT, n)(m, __VA_ARGS__)
 
-#define MIGRAPHX_PP_RES_ARGS() , , , , , , , , , , , , , , ,
+// MIGRAPHX_PP_TRANSFORM_ARGS / MIGRAPHX_PP_EACH_ARGS support up to 63 elements. RES_ARGS pads the
+// argument list with 62 empty entries so that even a single-element call fills all 63 x-slots of
+// _IMPL. The worst case (63 elements) expands _IMPL with 2 + 63 + 62 = 127 arguments, which is the
+// most a macro invocation is guaranteed to support, so this cannot be raised further.
+#define MIGRAPHX_PP_RES_ARGS()                                                                    \
+    , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , \
+        , , , , , , , , , , , , , ,
 
 #define MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARGS(...) \
     MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARGS_IMPL(__VA_ARGS__)
 
-#define MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARGS_IMPL(                                       \
-    m, delim, x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, ...) \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x0)                                           \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x1)                                       \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x1)                                           \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x2)                                       \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x2)                                           \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x3)                                       \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x3)                                           \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x4)                                       \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x4)                                           \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x5)                                       \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x5)                                           \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x6)                                       \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x6)                                           \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x7)                                       \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x7)                                           \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x8)                                       \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x8)                                           \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x9)                                       \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x9)                                           \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x10)                                      \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x10)                                          \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x11)                                      \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x11)                                          \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x12)                                      \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x12)                                          \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x13)                                      \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x13)                                          \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x14)                                      \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x14)                                          \
-    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x15) MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x15)
+#define MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARGS_IMPL(m,     \
+                                                  delim, \
+                                                  x0,    \
+                                                  x1,    \
+                                                  x2,    \
+                                                  x3,    \
+                                                  x4,    \
+                                                  x5,    \
+                                                  x6,    \
+                                                  x7,    \
+                                                  x8,    \
+                                                  x9,    \
+                                                  x10,   \
+                                                  x11,   \
+                                                  x12,   \
+                                                  x13,   \
+                                                  x14,   \
+                                                  x15,   \
+                                                  x16,   \
+                                                  x17,   \
+                                                  x18,   \
+                                                  x19,   \
+                                                  x20,   \
+                                                  x21,   \
+                                                  x22,   \
+                                                  x23,   \
+                                                  x24,   \
+                                                  x25,   \
+                                                  x26,   \
+                                                  x27,   \
+                                                  x28,   \
+                                                  x29,   \
+                                                  x30,   \
+                                                  x31,   \
+                                                  x32,   \
+                                                  x33,   \
+                                                  x34,   \
+                                                  x35,   \
+                                                  x36,   \
+                                                  x37,   \
+                                                  x38,   \
+                                                  x39,   \
+                                                  x40,   \
+                                                  x41,   \
+                                                  x42,   \
+                                                  x43,   \
+                                                  x44,   \
+                                                  x45,   \
+                                                  x46,   \
+                                                  x47,   \
+                                                  x48,   \
+                                                  x49,   \
+                                                  x50,   \
+                                                  x51,   \
+                                                  x52,   \
+                                                  x53,   \
+                                                  x54,   \
+                                                  x55,   \
+                                                  x56,   \
+                                                  x57,   \
+                                                  x58,   \
+                                                  x59,   \
+                                                  x60,   \
+                                                  x61,   \
+                                                  x62,   \
+                                                  ...)   \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x0)           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x1)       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x1)           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x2)       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x2)           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x3)       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x3)           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x4)       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x4)           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x5)       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x5)           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x6)       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x6)           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x7)       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x7)           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x8)       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x8)           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x9)       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x9)           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x10)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x10)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x11)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x11)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x12)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x12)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x13)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x13)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x14)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x14)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x15)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x15)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x16)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x16)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x17)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x17)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x18)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x18)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x19)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x19)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x20)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x20)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x21)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x21)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x22)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x22)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x23)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x23)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x24)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x24)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x25)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x25)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x26)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x26)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x27)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x27)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x28)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x28)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x29)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x29)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x30)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x30)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x31)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x31)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x32)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x32)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x33)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x33)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x34)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x34)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x35)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x35)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x36)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x36)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x37)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x37)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x38)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x38)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x39)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x39)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x40)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x40)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x41)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x41)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x42)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x42)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x43)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x43)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x44)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x44)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x45)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x45)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x46)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x46)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x47)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x47)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x48)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x48)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x49)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x49)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x50)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x50)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x51)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x51)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x52)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x52)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x53)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x53)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x54)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x54)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x55)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x55)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x56)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x56)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x57)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x57)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x58)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x58)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x59)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x59)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x60)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x60)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x61)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x61)          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x62)      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x62)
 
 #define MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x) \
     MIGRAPHX_PP_IIF(MIGRAPHX_PP_IS_EMPTY_ARG(x))(MIGRAPHX_PP_EAT, m)(x)

--- a/src/include/migraphx/pp.hpp
+++ b/src/include/migraphx/pp.hpp
@@ -1,0 +1,129 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MIGRAPHX_GUARD_MIGRAPHX_PP_HPP
+#define MIGRAPHX_GUARD_MIGRAPHX_PP_HPP
+
+// NOLINTBEGIN(*-macro-to-enum)
+
+#define MIGRAPHX_PP_PRIMITIVE_CAT(x, y) x##y
+#define MIGRAPHX_PP_CAT(x, y) MIGRAPHX_PP_PRIMITIVE_CAT(x, y)
+
+#define MIGRAPHX_PP_EAT(...)
+#define MIGRAPHX_PP_EXPAND(...) __VA_ARGS__
+#define MIGRAPHX_PP_COMMA(...) ,
+
+#define MIGRAPHX_PP_IIF(c) MIGRAPHX_PP_PRIMITIVE_CAT(MIGRAPHX_PP_IIF_, c)
+#define MIGRAPHX_PP_IIF_0(t, ...) __VA_ARGS__
+#define MIGRAPHX_PP_IIF_1(t, ...) t
+
+#define MIGRAPHX_PP_COMPL(b) MIGRAPHX_PP_PRIMITIVE_CAT(MIGRAPHX_PP_COMPL_, b)
+#define MIGRAPHX_PP_COMPL_0 1
+#define MIGRAPHX_PP_COMPL_1 0
+
+#define MIGRAPHX_PP_BITAND(x) MIGRAPHX_PP_PRIMITIVE_CAT(MIGRAPHX_PP_BITAND_, x)
+#define MIGRAPHX_PP_BITAND_0(y) 0
+#define MIGRAPHX_PP_BITAND_1(y) y
+
+#define MIGRAPHX_PP_CHECK(...) MIGRAPHX_PP_CHECK_N(__VA_ARGS__, 0, )
+#define MIGRAPHX_PP_CHECK_N(x, n, ...) n
+#define MIGRAPHX_PP_PROBE(x) x, 1,
+
+#define MIGRAPHX_PP_IS_PAREN(x) MIGRAPHX_PP_CHECK(MIGRAPHX_PP_IS_PAREN_PROBE x)
+#define MIGRAPHX_PP_IS_PAREN_PROBE(...) MIGRAPHX_PP_PROBE(~)
+
+#define MIGRAPHX_PP_PRIMITIVE_IS_EMPTY(x) \
+    MIGRAPHX_PP_CHECK(MIGRAPHX_PP_PRIMITIVE_IS_EMPTY_PROBE x())
+#define MIGRAPHX_PP_PRIMITIVE_IS_EMPTY_PROBE(...) MIGRAPHX_PP_PROBE(~)
+
+#define MIGRAPHX_PP_IS_EMPTY_ARG(x)                                \
+    MIGRAPHX_PP_BITAND(MIGRAPHX_PP_COMPL(MIGRAPHX_PP_IS_PAREN(x))) \
+    (MIGRAPHX_PP_PRIMITIVE_IS_EMPTY(x))
+
+#define MIGRAPHX_PP_REPEAT0(m, ...) m(0, __VA_ARGS__)
+#define MIGRAPHX_PP_REPEAT1(m, ...) MIGRAPHX_PP_REPEAT0(m, __VA_ARGS__) m(1, __VA_ARGS__)
+#define MIGRAPHX_PP_REPEAT2(m, ...) MIGRAPHX_PP_REPEAT1(m, __VA_ARGS__) m(2, __VA_ARGS__)
+#define MIGRAPHX_PP_REPEAT3(m, ...) MIGRAPHX_PP_REPEAT2(m, __VA_ARGS__) m(3, __VA_ARGS__)
+#define MIGRAPHX_PP_REPEAT4(m, ...) MIGRAPHX_PP_REPEAT3(m, __VA_ARGS__) m(4, __VA_ARGS__)
+#define MIGRAPHX_PP_REPEAT5(m, ...) MIGRAPHX_PP_REPEAT4(m, __VA_ARGS__) m(5, __VA_ARGS__)
+#define MIGRAPHX_PP_REPEAT6(m, ...) MIGRAPHX_PP_REPEAT5(m, __VA_ARGS__) m(6, __VA_ARGS__)
+#define MIGRAPHX_PP_REPEAT7(m, ...) MIGRAPHX_PP_REPEAT6(m, __VA_ARGS__) m(7, __VA_ARGS__)
+#define MIGRAPHX_PP_REPEAT8(m, ...) MIGRAPHX_PP_REPEAT7(m, __VA_ARGS__) m(8, __VA_ARGS__)
+#define MIGRAPHX_PP_REPEAT9(m, ...) MIGRAPHX_PP_REPEAT8(m, __VA_ARGS__) m(9, __VA_ARGS__)
+#define MIGRAPHX_PP_REPEAT10(m, ...) MIGRAPHX_PP_REPEAT9(m, __VA_ARGS__) m(10, __VA_ARGS__)
+
+#define MIGRAPHX_PP_REPEAT(n, m, ...) \
+    MIGRAPHX_PP_PRIMITIVE_CAT(MIGRAPHX_PP_REPEAT, n)(m, __VA_ARGS__)
+
+#define MIGRAPHX_PP_RES_ARGS() , , , , , , , , , , , , , , ,
+
+#define MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARGS(...) \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARGS_IMPL(__VA_ARGS__)
+
+#define MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARGS_IMPL(                                       \
+    m, delim, x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, ...) \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x0)                                           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x1)                                       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x1)                                           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x2)                                       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x2)                                           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x3)                                       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x3)                                           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x4)                                       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x4)                                           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x5)                                       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x5)                                           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x6)                                       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x6)                                           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x7)                                       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x7)                                           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x8)                                       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x8)                                           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x9)                                       \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x9)                                           \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x10)                                      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x10)                                          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x11)                                      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x11)                                          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x12)                                      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x12)                                          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x13)                                      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x13)                                          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x14)                                      \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x14)                                          \
+    MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(delim, x15) MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x15)
+
+#define MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARG(m, x) \
+    MIGRAPHX_PP_IIF(MIGRAPHX_PP_IS_EMPTY_ARG(x))(MIGRAPHX_PP_EAT, m)(x)
+
+#define MIGRAPHX_PP_EACH_ARGS(m, ...)                        \
+    MIGRAPHX_PP_EXPAND(MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARGS( \
+        m, MIGRAPHX_PP_EAT, __VA_ARGS__, MIGRAPHX_PP_RES_ARGS()))
+
+#define MIGRAPHX_PP_TRANSFORM_ARGS(m, ...)                   \
+    MIGRAPHX_PP_EXPAND(MIGRAPHX_PP_PRIMITIVE_TRANSFORM_ARGS( \
+        m, MIGRAPHX_PP_COMMA, __VA_ARGS__, MIGRAPHX_PP_RES_ARGS()))
+
+// NOLINTEND(*-macro-to-enum)
+
+#endif // MIGRAPHX_GUARD_MIGRAPHX_PP_HPP

--- a/src/include/migraphx/value.hpp
+++ b/src/include/migraphx/value.hpp
@@ -25,6 +25,7 @@
 #define MIGRAPHX_GUARD_RTGLIB_VALUE_HPP
 
 #include <migraphx/config.hpp>
+#include <migraphx/enum.hpp>
 #include <migraphx/errors.hpp>
 #include <migraphx/requires.hpp>
 #include <migraphx/type_name.hpp>
@@ -68,8 +69,23 @@ struct value_converter
 };
 
 template <class To>
-struct value_converter<To, MIGRAPHX_CLASS_REQUIRES(std::is_enum<To>{})>
+struct value_converter<To, MIGRAPHX_CLASS_REQUIRES(std::is_enum<To>{} and not is_named_enum<To>{})>
 {
+    template <class From>
+    static auto apply(const From& x)
+        -> decltype(static_cast<To>(value_converter<std::underlying_type_t<To>>::apply(x)))
+    {
+        return static_cast<To>(value_converter<std::underlying_type_t<To>>::apply(x));
+    }
+};
+
+// A named enum (declared with MIGRAPHX_ENUM) is retrieved from its name when the value holds a
+// string, and from its integer value otherwise.
+template <class To>
+struct value_converter<To, MIGRAPHX_CLASS_REQUIRES(is_named_enum<To>{})>
+{
+    static To apply(const std::string& x) { return from_string<To>(x); }
+
     template <class From>
     static auto apply(const From& x)
         -> decltype(static_cast<To>(value_converter<std::underlying_type_t<To>>::apply(x)))
@@ -143,7 +159,7 @@ To try_convert_value(const From& x)
 
 struct MIGRAPHX_EXPORT value
 {
-// clang-format off
+    // clang-format off
 #define MIGRAPHX_VISIT_VALUE_TYPES(m) \
     m(int64, std::int64_t) \
     m(uint64, std::uint64_t) \
@@ -239,8 +255,8 @@ struct MIGRAPHX_EXPORT value
                                                           std::enable_if<true, T>>::type>;
 
     template <class T>
-    using is_pickable =
-        bool_c<((std::is_arithmetic<T>{} or std::is_enum<T>{}) and not std::is_pointer<T>{})>;
+    using is_pickable = bool_c<((std::is_arithmetic<T>{} or std::is_enum<T>{}) and
+                                not std::is_pointer<T>{} and not is_named_enum<T>{})>;
 
     template <class T>
     using range_value = std::decay_t<decltype(std::declval<T>().end(), *std::declval<T>().begin())>;
@@ -268,6 +284,15 @@ struct MIGRAPHX_EXPORT value
     value(const std::string& pkey, T i) : value(pkey, static_cast<pick<T>>(i))
     {
     }
+    // A named enum (declared with MIGRAPHX_ENUM) is stored as its name.
+    template <class T, MIGRAPHX_REQUIRES(is_named_enum<T>{})>
+    value(T e) : value(to_string(e))
+    {
+    }
+    template <class T, MIGRAPHX_REQUIRES(is_named_enum<T>{})>
+    value(const std::string& pkey, T e) : value(pkey, to_string(e))
+    {
+    }
     template <class T, class U, class = decltype(value(T{}, U{}))>
     value(const std::pair<T, U>& p) : value(p.first, p.second)
     {
@@ -277,8 +302,13 @@ struct MIGRAPHX_EXPORT value
     {
         return *this = static_cast<pick<T>>(rhs); // NOLINT
     }
+    template <class T, MIGRAPHX_REQUIRES(is_named_enum<T>{})>
+    value& operator=(T rhs)
+    {
+        return *this = to_string(rhs); // NOLINT
+    }
     template <class T, MIGRAPHX_REQUIRES(is_generic_range<T>{})>
-    value& operator=(const T& rhs)
+    value& operator=(const T & rhs)
     {
         return *this = from_values(std::move(rhs)); // NOLINT
     }

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -224,7 +224,9 @@ TEST_CASE(from_string_unknown_throws)
 
 TEST_CASE(to_string_unknown_throws)
 {
-    EXPECT(test::throws([] { to_string(static_cast<color>(999)); }));
+    // 4 is within color's representable range [0, 7] but is not a named enumerator, so it is an
+    // unknown value without the undefined behavior of casting an out-of-range integer to the enum.
+    EXPECT(test::throws([] { to_string(static_cast<color>(4)); }));
 }
 
 TEST_CASE(namespace_scoped_enum)

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -23,6 +23,7 @@
  */
 #include <migraphx/enum.hpp>
 #include <algorithm>
+#include <string>
 #include <type_traits>
 #include "test.hpp"
 
@@ -48,6 +49,13 @@ struct gadget
 {
     MIGRAPHX_NESTED_ENUM(mode, off, on = 3, standby)
     MIGRAPHX_NESTED_ENUM_CLASS(unit, mm, cm = 10, m)
+};
+
+// A plain enum declared without the macro, for the negative is_named_enum case.
+enum plain_enum
+{
+    plain_a,
+    plain_b
 };
 
 // Sixty-three enumerators, the maximum supported by the underlying pp.hpp transform.
@@ -264,6 +272,19 @@ TEST_CASE(nested_enum_class)
     EXPECT(to_string(gadget::unit::cm) == "cm");
     EXPECT(migraphx::from_string<gadget::unit>("m") == gadget::unit::m);
     EXPECT(test::throws([] { migraphx::from_string<gadget::unit>("km"); }));
+}
+
+TEST_CASE(is_named_enum_trait)
+{
+    // True for every MIGRAPHX_ENUM variant, including nested ones.
+    EXPECT(migraphx::is_named_enum<color>{});
+    EXPECT(migraphx::is_named_enum<scoped_color>{});
+    EXPECT(migraphx::is_named_enum<gadget::mode>{});
+    EXPECT(migraphx::is_named_enum<gadget::unit>{});
+    // False for plain enums and non-enum types.
+    EXPECT(not migraphx::is_named_enum<plain_enum>{});
+    EXPECT(not migraphx::is_named_enum<int>{});
+    EXPECT(not migraphx::is_named_enum<std::string>{});
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -1,0 +1,120 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/enum.hpp>
+#include <algorithm>
+#include "test.hpp"
+
+MIGRAPHX_ENUM(color, red, green = 5, blue)
+
+// The example from the feature request: an explicit value on the last enumerator.
+MIGRAPHX_ENUM(my_enum, first, last = 10)
+
+// Single enumerator, exercises the base case of the value-capturing expansion.
+MIGRAPHX_ENUM(solo, only_one)
+
+// Expression-valued enumerators, including one that references a previous enumerator.
+MIGRAPHX_ENUM(flags, none = 0, bit0 = 1 << 0, bit1 = 1 << 1, both = bit0 + bit1)
+
+namespace migraphx {
+// Declared inside the migraphx namespace to make sure the generated to_string(status) does not
+// become ambiguous with the generic migraphx::to_string(const T&).
+MIGRAPHX_ENUM(status, ok, busy = 4, done)
+} // namespace migraphx
+
+TEST_CASE(underlying_values)
+{
+    EXPECT(static_cast<int>(red) == 0);
+    EXPECT(static_cast<int>(green) == 5);
+    // Value continues incrementing after an explicit enumerator.
+    EXPECT(static_cast<int>(blue) == 6);
+}
+
+TEST_CASE(to_string_names)
+{
+    EXPECT(to_string(red) == "red");
+    EXPECT(to_string(green) == "green");
+    EXPECT(to_string(blue) == "blue");
+    EXPECT(to_string(only_one) == "only_one");
+}
+
+TEST_CASE(from_string_values)
+{
+    EXPECT(migraphx::from_string<color>("red") == red);
+    EXPECT(migraphx::from_string<color>("green") == green);
+    EXPECT(migraphx::from_string<color>("blue") == blue);
+}
+
+TEST_CASE(explicit_last_value)
+{
+    EXPECT(static_cast<int>(first) == 0);
+    EXPECT(static_cast<int>(last) == 10);
+    EXPECT(to_string(first) == "first");
+    EXPECT(to_string(last) == "last");
+    EXPECT(migraphx::from_string<my_enum>("last") == last);
+}
+
+TEST_CASE(expression_values)
+{
+    EXPECT(static_cast<int>(both) == 3);
+    EXPECT(to_string(both) == "both");
+    EXPECT(migraphx::from_string<flags>("bit1") == bit1);
+}
+
+TEST_CASE(entries_table)
+{
+    auto entries = migraphx::enum_entries<color>();
+    EXPECT(entries.size() == 3);
+    EXPECT(entries[0] == std::make_pair(std::string("red"), red));
+    EXPECT(entries[1] == std::make_pair(std::string("green"), green));
+    EXPECT(entries[2] == std::make_pair(std::string("blue"), blue));
+}
+
+TEST_CASE(round_trip)
+{
+    auto entries = migraphx::enum_entries<color>();
+    EXPECT(std::all_of(entries.begin(), entries.end(), [](const auto& p) {
+        return migraphx::from_string<color>(p.first) == p.second and to_string(p.second) == p.first;
+    }));
+}
+
+TEST_CASE(from_string_unknown_throws)
+{
+    EXPECT(test::throws([] { migraphx::from_string<color>("purple"); }));
+}
+
+TEST_CASE(to_string_unknown_throws)
+{
+    EXPECT(test::throws([] { to_string(static_cast<color>(999)); }));
+}
+
+TEST_CASE(namespace_scoped_enum)
+{
+    // Both the ADL-found overload and the qualified call resolve to the generated overload.
+    EXPECT(to_string(migraphx::ok) == "ok");
+    EXPECT(migraphx::to_string(migraphx::busy) == "busy");
+    EXPECT(static_cast<int>(migraphx::done) == 5);
+    EXPECT(migraphx::from_string<migraphx::status>("done") == migraphx::done);
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  */
 #include <migraphx/enum.hpp>
+#include <migraphx/value.hpp>
 #include <algorithm>
 #include <string>
 #include <type_traits>
@@ -285,6 +286,50 @@ TEST_CASE(is_named_enum_trait)
     EXPECT(not migraphx::is_named_enum<plain_enum>{});
     EXPECT(not migraphx::is_named_enum<int>{});
     EXPECT(not migraphx::is_named_enum<std::string>{});
+}
+
+TEST_CASE(value_stores_named_enum_as_string)
+{
+    migraphx::value v = green;
+    EXPECT(v.is_string());
+    EXPECT(v.get_string() == "green");
+    EXPECT(v.to<color>() == green);
+}
+
+TEST_CASE(value_retrieves_named_enum_from_string)
+{
+    migraphx::value v = "blue";
+    EXPECT(v.to<color>() == blue);
+}
+
+TEST_CASE(value_retrieves_named_enum_from_int)
+{
+    migraphx::value v = 5;
+    EXPECT(v.to<color>() == green);
+}
+
+TEST_CASE(value_assign_named_enum)
+{
+    migraphx::value v;
+    v = green;
+    EXPECT(v.is_string() and v.get_string() == "green");
+}
+
+TEST_CASE(value_keyed_named_enum)
+{
+    migraphx::value v("c", blue);
+    EXPECT(v.get_key() == "c");
+    EXPECT(v.is_string() and v.get_string() == "blue");
+    EXPECT(v.to<color>() == blue);
+}
+
+TEST_CASE(value_scoped_named_enum_round_trip)
+{
+    migraphx::value v = scoped_color::magenta;
+    EXPECT(v.is_string() and v.get_string() == "magenta");
+    EXPECT(v.to<scoped_color>() == scoped_color::magenta);
+    migraphx::value vi = 7;
+    EXPECT(vi.to<scoped_color>() == scoped_color::magenta);
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -156,16 +156,16 @@ TEST_CASE(entries_table)
 {
     auto entries = migraphx::enum_entries<color>();
     EXPECT(entries.size() == 3);
-    EXPECT(entries[0] == std::make_pair(std::string("red"), red));
-    EXPECT(entries[1] == std::make_pair(std::string("green"), green));
-    EXPECT(entries[2] == std::make_pair(std::string("blue"), blue));
+    EXPECT(entries[0] == red);
+    EXPECT(entries[1] == green);
+    EXPECT(entries[2] == blue);
 }
 
 TEST_CASE(round_trip)
 {
     auto entries = migraphx::enum_entries<color>();
-    EXPECT(std::all_of(entries.begin(), entries.end(), [](const auto& p) {
-        return migraphx::from_string<color>(p.first) == p.second and to_string(p.second) == p.first;
+    EXPECT(std::all_of(entries.begin(), entries.end(), [](color value) {
+        return migraphx::from_string<color>(to_string(value)) == value;
     }));
 }
 
@@ -173,8 +173,8 @@ TEST_CASE(max_enumerators)
 {
     auto entries = migraphx::enum_entries<many>();
     EXPECT(entries.size() == 63);
-    EXPECT(entries.front() == std::make_pair(std::string("m0"), m0));
-    EXPECT(entries.back() == std::make_pair(std::string("m62"), m62));
+    EXPECT(entries.front() == m0);
+    EXPECT(entries.back() == m62);
     EXPECT(static_cast<int>(m62) == 62);
     EXPECT(to_string(m32) == "m32");
     EXPECT(migraphx::from_string<many>("m47") == m47);

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -25,6 +25,9 @@
 #include <algorithm>
 #include "test.hpp"
 
+// These enums are test-local fixtures; the anonymous namespace gives the macro-generated helper
+// functions internal linkage.
+namespace {
 MIGRAPHX_ENUM(color, red, green = 5, blue)
 
 // The example from the feature request: an explicit value on the last enumerator.
@@ -34,11 +37,16 @@ MIGRAPHX_ENUM(my_enum, first, last = 10)
 MIGRAPHX_ENUM(solo, only_one)
 
 // Expression-valued enumerators, including one that references a previous enumerator.
-MIGRAPHX_ENUM(flags, none = 0, bit0 = 1 << 0, bit1 = 1 << 1, both = bit0 + bit1)
+MIGRAPHX_ENUM(flags, none = 0, bit0 = 1, bit1 = 2, both = bit0 + bit1)
+
+// Sixteen enumerators, the maximum supported by the underlying pp.hpp transform.
+MIGRAPHX_ENUM(sixteen, s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15)
+} // namespace
 
 namespace migraphx {
-// Declared inside the migraphx namespace to make sure the generated to_string(status) does not
-// become ambiguous with the generic migraphx::to_string(const T&).
+// Declared with external linkage inside the migraphx namespace (as a real header would) so we can
+// check that the generated to_string(status) is not ambiguous with migraphx::to_string(const T&).
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 MIGRAPHX_ENUM(status, ok, busy = 4, done)
 } // namespace migraphx
 
@@ -96,6 +104,17 @@ TEST_CASE(round_trip)
     EXPECT(std::all_of(entries.begin(), entries.end(), [](const auto& p) {
         return migraphx::from_string<color>(p.first) == p.second and to_string(p.second) == p.first;
     }));
+}
+
+TEST_CASE(max_enumerators)
+{
+    auto entries = migraphx::enum_entries<sixteen>();
+    EXPECT(entries.size() == 16);
+    EXPECT(entries.front() == std::make_pair(std::string("s0"), s0));
+    EXPECT(entries.back() == std::make_pair(std::string("s15"), s15));
+    EXPECT(static_cast<int>(s15) == 15);
+    EXPECT(to_string(s7) == "s7");
+    EXPECT(migraphx::from_string<sixteen>("s11") == s11);
 }
 
 TEST_CASE(from_string_unknown_throws)

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -43,6 +43,13 @@ MIGRAPHX_ENUM(flags, none = 0, bit0 = 1, bit1 = 2, both = bit0 + bit1)
 // Scoped enum (enum class) with an explicit value.
 MIGRAPHX_ENUM_CLASS(scoped_color, cyan, magenta = 7, yellow)
 
+// Enums nested in a struct, exercising the friend-based (MIGRAPHX_NESTED_*) variants.
+struct gadget
+{
+    MIGRAPHX_NESTED_ENUM(mode, off, on = 3, standby)
+    MIGRAPHX_NESTED_ENUM_CLASS(unit, mm, cm = 10, m)
+};
+
 // Sixty-three enumerators, the maximum supported by the underlying pp.hpp transform.
 MIGRAPHX_ENUM(many,
               m0,
@@ -233,6 +240,30 @@ TEST_CASE(enum_class_unknown_throws)
 {
     EXPECT(test::throws([] { migraphx::from_string<scoped_color>("black"); }));
     EXPECT(test::throws([] { to_string(static_cast<scoped_color>(999)); }));
+}
+
+TEST_CASE(nested_enum)
+{
+    EXPECT(static_cast<int>(gadget::off) == 0);
+    EXPECT(static_cast<int>(gadget::on) == 3);
+    EXPECT(static_cast<int>(gadget::standby) == 4);
+    EXPECT(to_string(gadget::on) == "on");
+    EXPECT(migraphx::from_string<gadget::mode>("standby") == gadget::standby);
+    auto entries = migraphx::enum_entries<gadget::mode>();
+    EXPECT(entries.size() == 3);
+    EXPECT(entries[0] == gadget::off);
+    EXPECT(entries[2] == gadget::standby);
+}
+
+TEST_CASE(nested_enum_class)
+{
+    EXPECT(not std::is_convertible<gadget::unit, int>{});
+    EXPECT(static_cast<int>(gadget::unit::mm) == 0);
+    EXPECT(static_cast<int>(gadget::unit::cm) == 10);
+    EXPECT(static_cast<int>(gadget::unit::m) == 11);
+    EXPECT(to_string(gadget::unit::cm) == "cm");
+    EXPECT(migraphx::from_string<gadget::unit>("m") == gadget::unit::m);
+    EXPECT(test::throws([] { migraphx::from_string<gadget::unit>("km"); }));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -23,6 +23,7 @@
  */
 #include <migraphx/enum.hpp>
 #include <migraphx/value.hpp>
+#include <migraphx/serialize.hpp>
 #include <algorithm>
 #include <string>
 #include <type_traits>
@@ -57,6 +58,22 @@ enum plain_enum
 {
     plain_a,
     plain_b
+};
+
+// A reflectable struct with named-enum fields, for the serialize round-trip.
+struct config
+{
+    MIGRAPHX_NESTED_ENUM(mode, off, on = 3, standby)
+    MIGRAPHX_NESTED_ENUM_CLASS(unit, mm, cm = 10, m)
+    mode active_mode = on;
+    unit length_unit = unit::cm;
+
+    template <class Self, class F>
+    static auto reflect(Self& self, F f)
+    {
+        return migraphx::pack(f(self.active_mode, "active_mode"),
+                              f(self.length_unit, "length_unit"));
+    }
 };
 
 // Sixty-three enumerators, the maximum supported by the underlying pp.hpp transform.
@@ -330,6 +347,36 @@ TEST_CASE(value_scoped_named_enum_round_trip)
     EXPECT(v.to<scoped_color>() == scoped_color::magenta);
     migraphx::value vi = 7;
     EXPECT(vi.to<scoped_color>() == scoped_color::magenta);
+}
+
+TEST_CASE(serialize_standalone_named_enum)
+{
+    // to_value stores the enum as its name.
+    EXPECT(migraphx::to_value(green).is_string());
+    EXPECT(migraphx::to_value(green).get_string() == "green");
+    // from_value recovers it from the name string...
+    EXPECT(migraphx::from_value<color>(migraphx::to_value(green)) == green);
+    // ...and from an integer value.
+    migraphx::value vi = 5;
+    EXPECT(migraphx::from_value<color>(vi) == green);
+}
+
+TEST_CASE(serialize_named_enum_field)
+{
+    config c;
+    c.active_mode = config::standby;
+    c.length_unit = config::unit::m;
+
+    migraphx::value v = migraphx::to_value(c);
+    // The named-enum fields are serialized as their names.
+    EXPECT(v.at("active_mode").is_string());
+    EXPECT(v.at("active_mode").get_string() == "standby");
+    EXPECT(v.at("length_unit").get_string() == "m");
+
+    // And they round-trip back.
+    auto c2 = migraphx::from_value<config>(v);
+    EXPECT(c2.active_mode == config::standby);
+    EXPECT(c2.length_unit == config::unit::m);
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -39,8 +39,71 @@ MIGRAPHX_ENUM(solo, only_one)
 // Expression-valued enumerators, including one that references a previous enumerator.
 MIGRAPHX_ENUM(flags, none = 0, bit0 = 1, bit1 = 2, both = bit0 + bit1)
 
-// Sixteen enumerators, the maximum supported by the underlying pp.hpp transform.
-MIGRAPHX_ENUM(sixteen, s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15)
+// Sixty-three enumerators, the maximum supported by the underlying pp.hpp transform.
+MIGRAPHX_ENUM(many,
+              m0,
+              m1,
+              m2,
+              m3,
+              m4,
+              m5,
+              m6,
+              m7,
+              m8,
+              m9,
+              m10,
+              m11,
+              m12,
+              m13,
+              m14,
+              m15,
+              m16,
+              m17,
+              m18,
+              m19,
+              m20,
+              m21,
+              m22,
+              m23,
+              m24,
+              m25,
+              m26,
+              m27,
+              m28,
+              m29,
+              m30,
+              m31,
+              m32,
+              m33,
+              m34,
+              m35,
+              m36,
+              m37,
+              m38,
+              m39,
+              m40,
+              m41,
+              m42,
+              m43,
+              m44,
+              m45,
+              m46,
+              m47,
+              m48,
+              m49,
+              m50,
+              m51,
+              m52,
+              m53,
+              m54,
+              m55,
+              m56,
+              m57,
+              m58,
+              m59,
+              m60,
+              m61,
+              m62)
 } // namespace
 
 namespace migraphx {
@@ -108,13 +171,13 @@ TEST_CASE(round_trip)
 
 TEST_CASE(max_enumerators)
 {
-    auto entries = migraphx::enum_entries<sixteen>();
-    EXPECT(entries.size() == 16);
-    EXPECT(entries.front() == std::make_pair(std::string("s0"), s0));
-    EXPECT(entries.back() == std::make_pair(std::string("s15"), s15));
-    EXPECT(static_cast<int>(s15) == 15);
-    EXPECT(to_string(s7) == "s7");
-    EXPECT(migraphx::from_string<sixteen>("s11") == s11);
+    auto entries = migraphx::enum_entries<many>();
+    EXPECT(entries.size() == 63);
+    EXPECT(entries.front() == std::make_pair(std::string("m0"), m0));
+    EXPECT(entries.back() == std::make_pair(std::string("m62"), m62));
+    EXPECT(static_cast<int>(m62) == 62);
+    EXPECT(to_string(m32) == "m32");
+    EXPECT(migraphx::from_string<many>("m47") == m47);
 }
 
 TEST_CASE(from_string_unknown_throws)

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -23,6 +23,7 @@
  */
 #include <migraphx/enum.hpp>
 #include <algorithm>
+#include <type_traits>
 #include "test.hpp"
 
 // These enums are test-local fixtures; the anonymous namespace gives the macro-generated helper
@@ -38,6 +39,9 @@ MIGRAPHX_ENUM(solo, only_one)
 
 // Expression-valued enumerators, including one that references a previous enumerator.
 MIGRAPHX_ENUM(flags, none = 0, bit0 = 1, bit1 = 2, both = bit0 + bit1)
+
+// Scoped enum (enum class) with an explicit value.
+MIGRAPHX_ENUM_CLASS(scoped_color, cyan, magenta = 7, yellow)
 
 // Sixty-three enumerators, the maximum supported by the underlying pp.hpp transform.
 MIGRAPHX_ENUM(many,
@@ -197,6 +201,38 @@ TEST_CASE(namespace_scoped_enum)
     EXPECT(migraphx::to_string(migraphx::busy) == "busy");
     EXPECT(static_cast<int>(migraphx::done) == 5);
     EXPECT(migraphx::from_string<migraphx::status>("done") == migraphx::done);
+}
+
+TEST_CASE(enum_class_values_and_strings)
+{
+    EXPECT(static_cast<int>(scoped_color::cyan) == 0);
+    EXPECT(static_cast<int>(scoped_color::magenta) == 7);
+    // Value continues incrementing after an explicit enumerator.
+    EXPECT(static_cast<int>(scoped_color::yellow) == 8);
+    EXPECT(to_string(scoped_color::cyan) == "cyan");
+    EXPECT(to_string(scoped_color::magenta) == "magenta");
+    EXPECT(migraphx::from_string<scoped_color>("yellow") == scoped_color::yellow);
+}
+
+TEST_CASE(enum_class_entries)
+{
+    auto entries = migraphx::enum_entries<scoped_color>();
+    EXPECT(entries.size() == 3);
+    EXPECT(entries[0] == scoped_color::cyan);
+    EXPECT(entries[1] == scoped_color::magenta);
+    EXPECT(entries[2] == scoped_color::yellow);
+}
+
+TEST_CASE(enum_class_is_scoped)
+{
+    // A real scoped enum is not implicitly convertible to its underlying type.
+    EXPECT(not std::is_convertible<scoped_color, int>{});
+}
+
+TEST_CASE(enum_class_unknown_throws)
+{
+    EXPECT(test::throws([] { migraphx::from_string<scoped_color>("black"); }));
+    EXPECT(test::throws([] { to_string(static_cast<scoped_color>(999)); }));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/pp.cpp
+++ b/test/pp.cpp
@@ -1,0 +1,140 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/pp.hpp>
+#include <string>
+#include "test.hpp"
+
+// Helper macros for the tests below. They use the `_PP_` infix so clang-tidy recognizes them as
+// preprocessor helpers.
+#define MIGRAPHX_TEST_PP_IDENT(x) x
+#define MIGRAPHX_TEST_PP_QUOTE(x) #x
+#define MIGRAPHX_TEST_PP_PLUS(x) +(x)
+#define MIGRAPHX_TEST_PP_ADD_ONE(z, ...) +1
+#define MIGRAPHX_TEST_PP_ADD_INDEX(z, ...) +(z)
+
+TEST_CASE(cat)
+{
+    EXPECT(MIGRAPHX_PP_CAT(12, 34) == 1234);
+    // Concatenation forms a new identifier.
+    int MIGRAPHX_PP_CAT(foo, bar) = 99;
+    EXPECT(foobar == 99);
+}
+
+TEST_CASE(expand_eat_comma)
+{
+    EXPECT(MIGRAPHX_PP_EXPAND(1 + 2) == 3);
+    // EAT discards its arguments entirely.
+    int n = 5 MIGRAPHX_PP_EAT(+100);
+    EXPECT(n == 5);
+    // COMMA always expands to a single comma, ignoring its arguments.
+    int arr[] = {1 MIGRAPHX_PP_COMMA(z) 2};
+    EXPECT(arr[0] == 1);
+    EXPECT(arr[1] == 2);
+}
+
+TEST_CASE(iif)
+{
+    EXPECT(MIGRAPHX_PP_IIF(1)(10, 20) == 10);
+    EXPECT(MIGRAPHX_PP_IIF(0)(10, 20) == 20);
+}
+
+TEST_CASE(complement)
+{
+    EXPECT(MIGRAPHX_PP_COMPL(0) == 1);
+    EXPECT(MIGRAPHX_PP_COMPL(1) == 0);
+}
+
+TEST_CASE(bit_and)
+{
+    EXPECT(MIGRAPHX_PP_BITAND(1)(5) == 5);
+    EXPECT(MIGRAPHX_PP_BITAND(0)(5) == 0);
+}
+
+TEST_CASE(is_paren)
+{
+    EXPECT(MIGRAPHX_PP_IS_PAREN((7)) == 1);
+    EXPECT(MIGRAPHX_PP_IS_PAREN(7) == 0);
+}
+
+TEST_CASE(is_empty_arg)
+{
+    EXPECT(MIGRAPHX_PP_IS_EMPTY_ARG() == 1);
+    EXPECT(MIGRAPHX_PP_IS_EMPTY_ARG(7) == 0);
+}
+
+TEST_CASE(repeat)
+{
+    // REPEAT(n, m, ...) invokes m for the indices 0..n inclusive.
+    int count = 0 MIGRAPHX_PP_REPEAT(4, MIGRAPHX_TEST_PP_ADD_ONE, ~);
+    EXPECT(count == 5);
+    int index_sum = 0 MIGRAPHX_PP_REPEAT(3, MIGRAPHX_TEST_PP_ADD_INDEX, ~);
+    EXPECT(index_sum == 6); // 0 + 1 + 2 + 3
+}
+
+TEST_CASE(each_args)
+{
+    // EACH_ARGS applies the macro to each argument with no separator.
+    int sum = 0 MIGRAPHX_PP_EACH_ARGS(MIGRAPHX_TEST_PP_PLUS, 1, 2, 3, 4);
+    EXPECT(sum == 10);
+    int one = 0 MIGRAPHX_PP_EACH_ARGS(MIGRAPHX_TEST_PP_PLUS, 9);
+    EXPECT(one == 9);
+}
+
+TEST_CASE(transform_args_values)
+{
+    // TRANSFORM_ARGS applies the macro to each argument separated by commas.
+    int arr[] = {MIGRAPHX_PP_TRANSFORM_ARGS(MIGRAPHX_TEST_PP_IDENT, 3, 5, 7)};
+    EXPECT(sizeof(arr) == 3 * sizeof(int));
+    EXPECT(arr[0] == 3);
+    EXPECT(arr[1] == 5);
+    EXPECT(arr[2] == 7);
+}
+
+TEST_CASE(transform_args_single)
+{
+    // A single argument produces no trailing comma.
+    int arr[] = {MIGRAPHX_PP_TRANSFORM_ARGS(MIGRAPHX_TEST_PP_IDENT, 42)};
+    EXPECT(sizeof(arr) == sizeof(int));
+    EXPECT(arr[0] == 42);
+}
+
+TEST_CASE(transform_args_strings)
+{
+    std::string names[] = {MIGRAPHX_PP_TRANSFORM_ARGS(MIGRAPHX_TEST_PP_QUOTE, red, green, blue)};
+    EXPECT(names[0] == "red");
+    EXPECT(names[1] == "green");
+    EXPECT(names[2] == "blue");
+}
+
+TEST_CASE(transform_args_max)
+{
+    // Sixteen arguments is the maximum supported by the transform.
+    int arr[] = {MIGRAPHX_PP_TRANSFORM_ARGS(
+        MIGRAPHX_TEST_PP_IDENT, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)};
+    EXPECT(sizeof(arr) == 16 * sizeof(int));
+    EXPECT(arr[0] == 0);
+    EXPECT(arr[15] == 15);
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/pp.cpp
+++ b/test/pp.cpp
@@ -127,14 +127,85 @@ TEST_CASE(transform_args_strings)
     EXPECT(names[2] == "blue");
 }
 
+TEST_CASE(transform_args_beyond_sixteen)
+{
+    // The transform used to cap at 16 arguments; verify it now handles more.
+    int arr[] = {MIGRAPHX_PP_TRANSFORM_ARGS(
+        MIGRAPHX_TEST_PP_IDENT, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)};
+    EXPECT(sizeof(arr) == 17 * sizeof(int));
+    EXPECT(arr[16] == 16);
+}
+
 TEST_CASE(transform_args_max)
 {
-    // Sixteen arguments is the maximum supported by the transform.
-    int arr[] = {MIGRAPHX_PP_TRANSFORM_ARGS(
-        MIGRAPHX_TEST_PP_IDENT, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)};
-    EXPECT(sizeof(arr) == 16 * sizeof(int));
+    // Sixty-three arguments is the maximum supported by the transform.
+    int arr[] = {MIGRAPHX_PP_TRANSFORM_ARGS(MIGRAPHX_TEST_PP_IDENT,
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22,
+                                            23,
+                                            24,
+                                            25,
+                                            26,
+                                            27,
+                                            28,
+                                            29,
+                                            30,
+                                            31,
+                                            32,
+                                            33,
+                                            34,
+                                            35,
+                                            36,
+                                            37,
+                                            38,
+                                            39,
+                                            40,
+                                            41,
+                                            42,
+                                            43,
+                                            44,
+                                            45,
+                                            46,
+                                            47,
+                                            48,
+                                            49,
+                                            50,
+                                            51,
+                                            52,
+                                            53,
+                                            54,
+                                            55,
+                                            56,
+                                            57,
+                                            58,
+                                            59,
+                                            60,
+                                            61,
+                                            62)};
+    EXPECT(sizeof(arr) == 63 * sizeof(int));
     EXPECT(arr[0] == 0);
-    EXPECT(arr[15] == 15);
+    EXPECT(arr[62] == 62);
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation
This enables us to support in a generic way enums that can convert to and from strings. For storing in the `value` object this makes the API simpler to set as the user can just set it to the string of an enum. The value class has been updated to support this. No enums has been rewritten to use this yet.

## Technical Details
This creates a macro which defines the enum and it adds an additional function to return an array of the entries. From there the to_string/from_string can use this to create a lookup to do the conversion.

To allow setting values normally like `some_value = 10` in the macro, there is a little trick used to capture the enum and swallow the assignment. It overloads the `->*` operator(similar to how it captures expression in test.hpp) and the object there has an assignment operator that does nothing. 

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.
