### PR TITLE
if miopen/hipblas/rocblas are not enabled, send gemms to rocmlir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Full documentation for MIGraphX is available at
 * Updated netron output to create an ONNX-like protobuff. Now also includes debug symbols if enabled. (#4701)
 * Updated python API to allow getting and adding debug symbols from instructions. (#4803)
 * Allow for 1 arg slicing over a dynamic dimension. (#5015)
+* Route convolutions and dot operations through rocMLIR when MIOpen or GEMM libraries are disabled at build time (#5059).
 
 ### Resolved issues
 

--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -1512,11 +1512,11 @@ void fuse_mlir::apply(module_pass_manager& mpm) const
         if(is_navi)
             return mlir_mode::all;
 #if !MIGRAPHX_USE_MIOPEN
-        if(option.find("conv") != std::string_view::npos)
+        if(contains(option, "conv"))
             return mlir_mode::all;
 #endif
 #if !MIGRAPHX_USE_ROCBLAS and !MIGRAPHX_USE_HIPBLASLT
-        if(option == "dot" or option == "fused_dot")
+        if(contains(option, "dot") or contains(option, "fused_dot"))
             return mlir_mode::all;
 #endif
         return std::max(m1, m2);

--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -1511,6 +1511,14 @@ void fuse_mlir::apply(module_pass_manager& mpm) const
             return mlir_mode::all;
         if(is_navi)
             return mlir_mode::all;
+#if !MIGRAPHX_USE_MIOPEN
+        if(option.find("conv") != std::string_view::npos)
+            return mlir_mode::all;
+#endif
+#if !MIGRAPHX_USE_ROCBLAS and !MIGRAPHX_USE_HIPBLASLT
+        if(option == "dot" or option == "fused_dot")
+            return mlir_mode::all;
+#endif
         return std::max(m1, m2);
     };
 


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When external libraries are not enabled, gemm ops need to be sent to rocmlir so they are lowered properly.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
Just adds a check for the libraries. If not enabled, then send relevant ops to rocmlir

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
