### PR TITLE
Fix windows CI: Workaround files not being deleted

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -160,7 +160,21 @@ jobs:
         CXXFLAGS: "/std:c++17"
       # We disable the assembly files for BLAKE3 in rocmlir. An update to
       # rocmlirs cmake is needed.
+      #
+      # `rbuild prepare` is meant to skip rebuilding deps when the dependency
+      # hash is unchanged, but a Windows bug in that path leaves stale deps in
+      # place. Do the hash comparison ourselves against the hash cached in the
+      # cget directory and wipe cget on a mismatch (or when it is missing) so
+      # prepare rebuilds from a clean state.
       run: |
+        expected_hash=$(rbuild hash -s gh-win-gpu)
+        stored_hash=$(cat cget/hash 2>/dev/null || true)
+        if [ "$expected_hash" != "$stored_hash" ]; then
+          echo "Dependency hash mismatch (expected '$expected_hash', stored '$stored_hash'); clearing cget"
+          rm -rf cget
+        else
+          echo "Dependency hash matches ('$expected_hash'); reusing cached cget"
+        fi
         rbuild prepare -d cget -s gh-win-gpu -G Ninja -DCMAKE_BUILD_TYPE=Release \
           -DLLVM_DISABLE_ASSEMBLY_FILES=On \
           -DLLVM_ENABLE_DIA_SDK=Off


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
There is an issue where removing packages doesnt delete all the files. Instead of relying on `cget clean` to remove the packages this just does the hash check manually and then uses `rm -rf` to clear the directory when the hash doesnt match.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
