### PR TITLE
Add toggle for wavefront size to cross compilation options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ Full documentation for MIGraphX is available at
 * Added a fuse_horizontal pass which batches independent cross embedding gather instructions (#4599).
 * Added GPU JIT `Resize` kernel (#4553).
 * Added environment variable `MIGRAPHX_SKIP_BENCHMARKING` which when enabled, skips tuning of MIGraphX and rocMLIR kernels (#4628).
-* Added cross-compilation support for the GPU target, enabling compilation for a target architecture without a physical device present, with new API and `migraphx-driver` flag support, including a JSON object to specify device properties in the driver (#4795, #4981).
-* Added cross-compile wavefront size configuration via `gpu_wavefront_size` API field and `--gpu-wavefront-size` / `wavefront_size` in `--gpu-arch-params` for the GPU target.
+* Added cross-compilation support for the GPU target, enabling compilation for a target architecture without a physical device present, with new API and `migraphx-driver` flag support, including a JSON object to specify device properties in the driver (#4795, #4981, #5065).
 * Added Cubic resize jit kernel (#4652).
 * Added JIT compiler for `fill` operation (#4666).
 * Added trace callback function to allow inspection of instruction output buffers; see `examples/migraphx/cpp_trace_callback` for an example (#4780).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Full documentation for MIGraphX is available at
 * Added GPU JIT `Resize` kernel (#4553).
 * Added environment variable `MIGRAPHX_SKIP_BENCHMARKING` which when enabled, skips tuning of MIGraphX and rocMLIR kernels (#4628).
 * Added cross-compilation support for the GPU target, enabling compilation for a target architecture without a physical device present, with new API and `migraphx-driver` flag support, including a JSON object to specify device properties in the driver (#4795, #4981).
+* Added cross-compile wavefront size configuration via `gpu_wavefront_size` API field and `--gpu-wavefront-size` / `wavefront_size` in `--gpu-arch-params` for the GPU target.
 * Added Cubic resize jit kernel (#4652).
 * Added JIT compiler for `fill` operation (#4666).
 * Added trace callback function to allow inspection of instruction output buffers; see `examples/migraphx/cpp_trace_callback` for an example (#4780).

--- a/docs/dev/cross_compilation.rst
+++ b/docs/dev/cross_compilation.rst
@@ -30,13 +30,25 @@ without any advanced device configuration:
 
 For specific device configurations, use
 ``--gpu-arch-params``, a JSON object that is only used when ``--gpu-arch`` is set.
-It accepts ``num_cu``, ``num_chiplets``, ``max_threads_per_cu``, and
-``max_threads_per_block``. For example, to cross-compile for a ``gfx942`` with 304
-compute units and 8 chiplets:
+It accepts ``num_cu``, ``num_chiplets``, ``max_threads_per_cu``,
+``max_threads_per_block``, and ``wavefront_size``. For example, to cross-compile
+for a ``gfx942`` with 304 compute units and 8 chiplets:
 
 .. code-block:: bash
+
     migraphx-driver compile model.onnx --gpu-arch gfx942 \
         --gpu-arch-params "{num_cu:304, num_chiplets:8}" -o model_gfx942.mxr
+
+Set ``wavefront_size`` explicitly to override the inferred value. The default
+``0`` infers wavefront size from the architecture name (wave32 for RDNA
+``gfx10``/``gfx11``/``gfx12``, wave64 otherwise). Use ``--gpu-wavefront-size`` or
+``wavefront_size`` in ``--gpu-arch-params`` to override:
+
+.. code-block:: bash
+
+    migraphx-driver compile model.onnx --gpu-arch gfx942 \
+        --gpu-arch-params "{wavefront_size:32, num_cu:60}" -o model_gfx942.mxr
+
 The produced ``.mxr`` is loaded on the target machine like any other compiled
 program:
 
@@ -61,8 +73,15 @@ usual:
 
 The recognized fields (with defaults) are ``gpu_arch`` (empty), ``gpu_num_cu``
 (``120``), ``gpu_num_chiplets`` (``1``), ``gpu_max_threads_per_cu`` (``2048``),
-and ``gpu_max_threads_per_block`` (``1024``). A non-empty ``gpu_arch`` is what
-puts the target into cross-compile mode.
+``gpu_max_threads_per_block`` (``1024``), and ``gpu_wavefront_size`` (``0``).
+A value of ``0`` for ``gpu_wavefront_size`` infers wavefront size from the
+architecture; set ``32`` or ``64`` explicitly to override.
+A non-empty ``gpu_arch`` is what puts the target into cross-compile mode.
+
+.. code-block:: cpp
+
+    migraphx::target t = migraphx::make_target(
+        "gpu", migraphx::value{{"gpu_arch", "gfx942"}, {"gpu_wavefront_size", 32}});
 
 How it works
 ------------
@@ -82,8 +101,10 @@ In cross-compile mode, ``target::get_context()`` builds a context backed by a
 synthetic ``hipDeviceProp_t`` instead of querying a real device. The synthetic
 properties are filled in by ``make_cross_compile_device_props``
 (``src/targets/gpu/cross_compile_device.cpp``), which sets the arch name, compute
-unit count, chiplet count, max threads, and the wavefront size implied by the
-architecture (wave32 for RDNA ``gfx10``/``gfx11``/``gfx12``, wave64 otherwise).
+unit count, chiplet count, max threads, and wavefront size. When
+``gpu_wavefront_size`` is ``0``, wavefront size is inferred from the architecture
+(wave32 for RDNA ``gfx10``/``gfx11``/``gfx12``, wave64 otherwise); otherwise the
+explicit ``32`` or ``64`` override is used.
 
 A cross-compile context cannot touch a device. The target's ``copy_to``,
 ``copy_from``, and ``allocate`` all throw in this mode, and the context's

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -697,10 +697,11 @@ struct compiler_target
     // GPU cross-compile options. When gpu_arch is non-empty, the GPU target is
     // configured for cross-compilation against the given architecture without
     // requiring a physical device.
-    std::string gpu_arch         = {};
-    std::size_t gpu_num_cu       = 120;
-    std::size_t gpu_num_chiplets = 1;
-    std::string gpu_arch_params  = {};
+    std::string gpu_arch           = {};
+    std::size_t gpu_num_cu         = 120;
+    std::size_t gpu_num_chiplets   = 1;
+    std::size_t gpu_wavefront_size = 0;
+    std::string gpu_arch_params    = {};
 
     void parse(argument_parser& ap)
     {
@@ -722,12 +723,17 @@ struct compiler_target
            {"--gpu-num-chiplets"},
            ap.help("Number of chiplets (XCCs) to assume for cross-compilation. "
                    "Only used when --gpu-arch is set."));
+        ap(gpu_wavefront_size,
+           {"--gpu-wavefront-size"},
+           ap.help("Wavefront size to assume for cross-compilation (32 or 64; 0 = infer "
+                   "from architecture). Only used when --gpu-arch is set."));
         ap(gpu_arch_params,
            {"--gpu-arch-params"},
            ap.help("Device properties to assume for cross-compilation, as a JSON object "
                    "(format: \"{arch:gfx942, num_cu:120, num_chiplets:1, "
-                   "max_threads_per_cu:2048, max_threads_per_block:1024}\"). Overrides "
-                   "--gpu-arch, --gpu-num-cus and --gpu-num-chiplets for any keys present."));
+                   "max_threads_per_cu:2048, max_threads_per_block:1024, wavefront_size:32}\"). "
+                   "Overrides --gpu-arch, --gpu-num-cus, --gpu-num-chiplets and "
+                   "--gpu-wavefront-size for any keys present."));
     }
 
     static const std::unordered_map<std::string, std::string>& gpu_arch_param_keys()
@@ -737,7 +743,8 @@ struct compiler_target
             {"num_cu", "gpu_num_cu"},
             {"num_chiplets", "gpu_num_chiplets"},
             {"max_threads_per_cu", "gpu_max_threads_per_cu"},
-            {"max_threads_per_block", "gpu_max_threads_per_block"}};
+            {"max_threads_per_block", "gpu_max_threads_per_block"},
+            {"wavefront_size", "gpu_wavefront_size"}};
         return key_map;
     }
 
@@ -747,7 +754,8 @@ struct compiler_target
         {
             migraphx::value opts = {{"gpu_arch", gpu_arch},
                                     {"gpu_num_cu", gpu_num_cu},
-                                    {"gpu_num_chiplets", gpu_num_chiplets}};
+                                    {"gpu_num_chiplets", gpu_num_chiplets},
+                                    {"gpu_wavefront_size", gpu_wavefront_size}};
             if(not gpu_arch_params.empty())
             {
                 const auto& key_map = gpu_arch_param_keys();

--- a/src/targets/gpu/cross_compile_device.cpp
+++ b/src/targets/gpu/cross_compile_device.cpp
@@ -53,7 +53,7 @@ hipDeviceProp_t make_cross_compile_device_props(const std::string& arch_name,
     auto n = std::min(arch_name.size(), sizeof(props.gcnArchName) - 1);
     std::copy_n(arch_name.begin(), n, props.gcnArchName);
     props.gcnArchName[n] = '\0';
-    props.warpSize       = wavefront_size != 0 ? wavefront_size : arch_wavefront_size(arch_name);
+    props.warpSize       = wavefront_size == 0 ? arch_wavefront_size(arch_name) : wavefront_size;
     props.maxThreadsPerMultiProcessor = std::max<std::size_t>(max_threads_per_cu, 1);
     props.maxThreadsPerBlock          = std::max<std::size_t>(max_threads_per_block, 1);
     props.multiProcessorCount         = std::max<std::size_t>(cu_count, 1);

--- a/src/targets/gpu/cross_compile_device.cpp
+++ b/src/targets/gpu/cross_compile_device.cpp
@@ -23,6 +23,7 @@
  */
 #include <migraphx/gpu/cross_compile_device.hpp>
 #include <migraphx/gpu/device_name.hpp>
+#include <migraphx/errors.hpp>
 #include <migraphx/stringutils.hpp>
 #include <algorithm>
 
@@ -42,13 +43,17 @@ static int arch_wavefront_size(const std::string& arch_name)
 hipDeviceProp_t make_cross_compile_device_props(const std::string& arch_name,
                                                 std::size_t cu_count,
                                                 std::size_t max_threads_per_cu,
-                                                std::size_t max_threads_per_block)
+                                                std::size_t max_threads_per_block,
+                                                std::size_t wavefront_size)
 {
+    if(wavefront_size != 0 and wavefront_size != 32 and wavefront_size != 64)
+        MIGRAPHX_THROW("Invalid cross-compile wavefront_size: expected 0 (auto), 32, or 64");
+
     hipDeviceProp_t props{};
     auto n = std::min(arch_name.size(), sizeof(props.gcnArchName) - 1);
     std::copy_n(arch_name.begin(), n, props.gcnArchName);
     props.gcnArchName[n] = '\0';
-    props.warpSize       = arch_wavefront_size(arch_name);
+    props.warpSize = wavefront_size != 0 ? wavefront_size : arch_wavefront_size(arch_name);
     props.maxThreadsPerMultiProcessor = std::max<std::size_t>(max_threads_per_cu, 1);
     props.maxThreadsPerBlock          = std::max<std::size_t>(max_threads_per_block, 1);
     props.multiProcessorCount         = std::max<std::size_t>(cu_count, 1);

--- a/src/targets/gpu/cross_compile_device.cpp
+++ b/src/targets/gpu/cross_compile_device.cpp
@@ -53,7 +53,7 @@ hipDeviceProp_t make_cross_compile_device_props(const std::string& arch_name,
     auto n = std::min(arch_name.size(), sizeof(props.gcnArchName) - 1);
     std::copy_n(arch_name.begin(), n, props.gcnArchName);
     props.gcnArchName[n] = '\0';
-    props.warpSize = wavefront_size != 0 ? wavefront_size : arch_wavefront_size(arch_name);
+    props.warpSize       = wavefront_size != 0 ? wavefront_size : arch_wavefront_size(arch_name);
     props.maxThreadsPerMultiProcessor = std::max<std::size_t>(max_threads_per_cu, 1);
     props.maxThreadsPerBlock          = std::max<std::size_t>(max_threads_per_block, 1);
     props.multiProcessorCount         = std::max<std::size_t>(cu_count, 1);

--- a/src/targets/gpu/include/migraphx/gpu/context.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/context.hpp
@@ -75,11 +75,12 @@ struct hip_device
                std::size_t cu_count,
                std::size_t chiplets,
                std::size_t max_threads_per_cu    = 2048,
-               std::size_t max_threads_per_block = 1024)
+               std::size_t max_threads_per_block = 1024,
+               std::size_t wavefront_size        = 0)
         : cross_compile_mode(true),
           chiplet_count_override(std::max<std::size_t>(chiplets, 1)),
           device_props(make_cross_compile_device_props(
-              arch_name, cu_count, max_threads_per_cu, max_threads_per_block))
+              arch_name, cu_count, max_threads_per_cu, max_threads_per_block, wavefront_size))
     {
         add_stream();
     }
@@ -315,9 +316,14 @@ struct context
             std::size_t cu_count,
             std::size_t chiplets,
             std::size_t max_threads_per_cu    = 2048,
-            std::size_t max_threads_per_block = 1024)
-        : current_device(std::make_shared<hip_device>(
-              arch_name, cu_count, chiplets, max_threads_per_cu, max_threads_per_block)),
+            std::size_t max_threads_per_block = 1024,
+            std::size_t wavefront_size        = 0)
+        : current_device(std::make_shared<hip_device>(arch_name,
+                                                      cu_count,
+                                                      chiplets,
+                                                      max_threads_per_cu,
+                                                      max_threads_per_block,
+                                                      wavefront_size)),
           pc(std::make_shared<auto_save_problem_cache>())
     {
     }

--- a/src/targets/gpu/include/migraphx/gpu/cross_compile_device.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/cross_compile_device.hpp
@@ -39,7 +39,8 @@ MIGRAPHX_GPU_EXPORT hipDeviceProp_t
 make_cross_compile_device_props(const std::string& arch_name,
                                 std::size_t cu_count,
                                 std::size_t max_threads_per_cu    = 2048,
-                                std::size_t max_threads_per_block = 1024);
+                                std::size_t max_threads_per_block = 1024,
+                                std::size_t wavefront_size        = 0);
 
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/targets/gpu/include/migraphx/gpu/target.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/target.hpp
@@ -43,6 +43,7 @@ struct MIGRAPHX_GPU_EXPORT target
     std::size_t gpu_num_chiplets          = 1;
     std::size_t gpu_max_threads_per_cu    = 2048;
     std::size_t gpu_max_threads_per_block = 1024;
+    std::size_t gpu_wavefront_size        = 0;
 
     template <class Self, class F>
     static auto reflect(Self& self, F f)
@@ -51,7 +52,8 @@ struct MIGRAPHX_GPU_EXPORT target
                     f(self.gpu_num_cu, "gpu_num_cu"),
                     f(self.gpu_num_chiplets, "gpu_num_chiplets"),
                     f(self.gpu_max_threads_per_cu, "gpu_max_threads_per_cu"),
-                    f(self.gpu_max_threads_per_block, "gpu_max_threads_per_block"));
+                    f(self.gpu_max_threads_per_block, "gpu_max_threads_per_block"),
+                    f(self.gpu_wavefront_size, "gpu_wavefront_size"));
     }
 
     bool is_cross_compile() const { return not gpu_arch.empty(); }

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -298,7 +298,8 @@ migraphx::context target::get_context() const
                        gpu_num_cu,
                        gpu_num_chiplets,
                        gpu_max_threads_per_cu,
-                       gpu_max_threads_per_block);
+                       gpu_max_threads_per_block,
+                       gpu_wavefront_size);
     return context(gpu::get_device_id());
 }
 

--- a/test/gpu/jit.cpp
+++ b/test/gpu/jit.cpp
@@ -247,6 +247,11 @@ TEST_CASE(cross_compile_wavefront_size)
 {
     EXPECT(migraphx::gpu::make_cross_compile_device_props("gfx1101", 1).warpSize == 32);
     EXPECT(migraphx::gpu::make_cross_compile_device_props("gfx942", 1).warpSize == 64);
+    EXPECT(migraphx::gpu::make_cross_compile_device_props("gfx942", 1, 2048, 1024, 32).warpSize ==
+           32);
+    EXPECT(migraphx::gpu::make_cross_compile_device_props("gfx12xx", 1).warpSize == 32);
+    EXPECT(migraphx::gpu::make_cross_compile_device_props("gfx12xx", 1, 2048, 1024, 64).warpSize ==
+           64);
 }
 
 TEST_CASE(compile_errors)

--- a/test/gpu/target_serialize.cpp
+++ b/test/gpu/target_serialize.cpp
@@ -56,9 +56,8 @@ TEST_CASE(gpu_target_to_value_with_max_threads)
 
 TEST_CASE(gpu_target_to_value_with_wavefront_size)
 {
-    auto t = migraphx::make_target("gpu",
-                                   migraphx::value{{"gpu_arch", "gfx1200"},
-                                                   {"gpu_wavefront_size", 32}});
+    auto t = migraphx::make_target(
+        "gpu", migraphx::value{{"gpu_arch", "gfx1200"}, {"gpu_wavefront_size", 32}});
     auto v = t.to_value();
     CHECK(v.at("gpu_wavefront_size").without_key().to<std::size_t>() == 32);
 

--- a/test/gpu/target_serialize.cpp
+++ b/test/gpu/target_serialize.cpp
@@ -54,4 +54,17 @@ TEST_CASE(gpu_target_to_value_with_max_threads)
     CHECK(v.at("gpu_max_threads_per_block").without_key().to<std::size_t>() == 256);
 }
 
+TEST_CASE(gpu_target_to_value_with_wavefront_size)
+{
+    auto t = migraphx::make_target("gpu",
+                                   migraphx::value{{"gpu_arch", "gfx1200"},
+                                                   {"gpu_wavefront_size", 32}});
+    auto v = t.to_value();
+    CHECK(v.at("gpu_wavefront_size").without_key().to<std::size_t>() == 32);
+
+    auto t2 = migraphx::make_target("gpu");
+    t2.from_value(v);
+    CHECK(t2.to_value() == v);
+}
+
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
For cross compiling, we want to be able to toggle the wavefront size for architectures instead of just letting the decision be made strictly on whether or not the arch is `gfx11` or `gfx12`.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
This PR adds wavefront size as a toggle, which can be directly set via JSON object with the driver `--gpu-arch-params` option, or directly with a CLI flag `--gpu-wavefront-size`, or the various language APIs:

1. `--gpu-arch-params` JSON (primary, matches other toggles)
```
migraphx-driver compile model.onnx --gpu-arch gfx1200 \
  --gpu-arch-params "{wavefront_size:64, num_cu:60}"
```

2. Dedicated CLI flag
```
migraphx-driver compile model.onnx --gpu-arch gfx1200 --gpu-wavefront-size 64
```
Same as `--gpu-num-cus` style. `--gpu-arch-params` overrides this if both are set (same precedence pattern as the other params).

3. C++ target API
```
auto t = migraphx::make_target("gpu", migraphx::value{
    {"gpu_arch", "gfx1200"},
    {"gpu_wavefront_size", 64},
});
p.compile(t);
```

4. C API
```
migraphx::target t("gpu", "{gpu_arch: gfx1200, gpu_wavefront_size: 64
```

5.  Python API
```
t = migraphx.get_target("gpu", gpu_arch="gfx1200", gpu_wavefront_size=64)
p.compile(t)
```
Works automatically via `reflect()` on `gpu::target`

List was generated by cursor.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
