### PR TITLE
Enable hipBLASLt GEMM for gfx115x

### DIFF
--- a/src/targets/gpu/device_name.cpp
+++ b/src/targets/gpu/device_name.cpp
@@ -141,7 +141,8 @@ static bool hipblaslt_supported_impl(const std::string& gfx_name)
 {
     return (gfx_name == "gfx90a" or (starts_with(gfx_name, "gfx94") and gfx_name >= "gfx942") or
             (starts_with(gfx_name, "gfx95") and gfx_name >= "gfx950") or
-            starts_with(gfx_name, "gfx110") or starts_with(gfx_name, "gfx120"));
+            starts_with(gfx_name, "gfx110") or starts_with(gfx_name, "gfx115") or
+            starts_with(gfx_name, "gfx120"));
 }
 #endif
 


### PR DESCRIPTION
## Summary
Adds `gfx115` to `hipblaslt_supported_impl()` so gfx1150/1151/1152/1153 (Strix Halo/Point, RDNA3.5) use the hipBLASLt GEMM path.

Previously `hipblaslt_supported_impl()` gated hipBLASLt on gfx110x and gfx120x but not gfx115x, so on these parts the lowering pass fell back to rocBLAS for every GEMM. rocBLAS lacks BF16/INT8 Tensile solutions for these parts, so quantized dot ops returned `rocblas_status_not_implemented` at runtime while FP16/FP32 worked. hipBLASLt ships tuned BF16/INT8 kernels for the gfx115 family, so this allows it to use the hipBLASLt path.

## Change
- `src/targets/gpu/device_name.cpp`: add `starts_with(gfx_name, "gfx115")` to the hipBLASLt-supported predicate.

## Test plan
- [ ] Build with `MIGRAPHX_USE_HIPBLASLT` enabled and run quantized (BF16/INT8) dot ops on a gfx115x device; confirm they no longer fall back to rocBLAS / return `rocblas_status_not_implemented`.
- [ ] Confirm FP16/FP32 GEMM behavior unchanged on gfx115x.

Made with [Cursor](https://cursor.com)