### PR TITLE
Refactor slice op for symbolic bounds and explicit input mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Full documentation for MIGraphX is available at
 * Updated python API to allow getting and adding debug symbols from instructions. (#4803)
 * Allow for 1 arg slicing over a dynamic dimension. (#5015)
 * Route convolutions and dot operations through rocMLIR when MIOpen or GEMM libraries are disabled at build time (#5059).
+* Refactored `slice` operator to handle symbolics and data-dependent shape functions (#5088).
 
 ### Resolved issues
 

--- a/src/include/migraphx/dim_like.hpp
+++ b/src/include/migraphx/dim_like.hpp
@@ -24,14 +24,17 @@
 #ifndef MIGRAPHX_GUARD_MIGRAPHLIB_DIM_LIKE_HPP
 #define MIGRAPHX_GUARD_MIGRAPHLIB_DIM_LIKE_HPP
 
+#include <algorithm>
 #include <cstdint>
 #include <ostream>
 #include <type_traits>
+#include <vector>
 
 #include <migraphx/config.hpp>
 #include <migraphx/picked_variant.hpp>
 #include <migraphx/requires.hpp>
 #include <migraphx/shape.hpp>
+#include <migraphx/sym.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -57,6 +60,36 @@ inline std::ostream& operator<<(std::ostream& os, const dim_like& d)
 {
     visit([&](const auto& x) { os << x; }, d);
     return os;
+}
+
+// Extracts the concrete int64_t from each entry; throws (via std::get) if any
+// entry holds a symbolic dynamic_dimension.
+inline std::vector<int64_t> to_ints(const std::vector<dim_like>& dims)
+{
+    std::vector<int64_t> result(dims.size());
+    std::transform(dims.begin(), dims.end(), result.begin(), [](const dim_like& d) {
+        return std::get<int64_t>(d);
+    });
+    return result;
+}
+
+inline std::vector<sym::expr> to_sym_exprs(const std::vector<dim_like>& dims)
+{
+    std::vector<sym::expr> result(dims.size());
+    std::transform(dims.begin(), dims.end(), result.begin(), [](const dim_like& d) -> sym::expr {
+        if(std::holds_alternative<shape::dynamic_dimension>(d))
+            return std::get<shape::dynamic_dimension>(d).sym_expr;
+        return sym::lit(std::get<int64_t>(d));
+    });
+    return result;
+}
+
+// Check if any of the dim_like are a shape::dynamic_dimension.
+inline bool any_sym(const std::vector<dim_like>& dims)
+{
+    return std::any_of(dims.begin(), dims.end(), [](const dim_like& d) {
+        return std::holds_alternative<shape::dynamic_dimension>(d);
+    });
 }
 
 MIGRAPHX_EXPORT void migraphx_to_value(value& v, const dim_like& d);

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -26,7 +26,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cstdint>
 #include <iterator>
 #include <string>
 #include <type_traits>
@@ -141,80 +140,6 @@ struct is_named_enum<T, std::void_t<decltype(migraphx_enum_entries(std::declval<
     : std::true_type
 {
 };
-
-// Detects enums declared with MIGRAPHX_BIT_FLAG_ENUM: those provide a migraphx_is_bit_flag hook and
-// therefore support the type-safe bitwise operators below.
-template <class T, class = void>
-struct is_bit_flag : std::false_type
-{
-};
-
-template <class T>
-struct is_bit_flag<T, std::void_t<decltype(migraphx_is_bit_flag(std::declval<T>()))>>
-    : std::true_type
-{
-};
-
-// Type-safe bitwise operators for enums declared with MIGRAPHX_BIT_FLAG_ENUM. They operate on the
-// enum's underlying integer and return the enum type, so combining values never leaks to a raw
-// integer and different flag enums cannot be mixed.
-template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
-constexpr E operator|(E lhs, E rhs)
-{
-    using U = std::underlying_type_t<E>;
-    return static_cast<E>(static_cast<U>(lhs) | static_cast<U>(rhs));
-}
-
-template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
-constexpr E operator&(E lhs, E rhs)
-{
-    using U = std::underlying_type_t<E>;
-    return static_cast<E>(static_cast<U>(lhs) & static_cast<U>(rhs));
-}
-
-template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
-constexpr E operator^(E lhs, E rhs)
-{
-    using U = std::underlying_type_t<E>;
-    return static_cast<E>(static_cast<U>(lhs) ^ static_cast<U>(rhs));
-}
-
-template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
-constexpr E operator~(E val)
-{
-    using U = std::underlying_type_t<E>;
-    return static_cast<E>(~static_cast<U>(val));
-}
-
-// clang-format misparses the `E&` reference parameter as a binary-and when the template
-// is constrained with MIGRAPHX_REQUIRES, so keep these declarations formatted by hand.
-// clang-format off
-template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
-constexpr E& operator|=(E& lhs, E rhs)
-{
-    return lhs = lhs | rhs;
-}
-
-template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
-constexpr E& operator&=(E& lhs, E rhs)
-{
-    return lhs = lhs & rhs;
-}
-
-template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
-constexpr E& operator^=(E& lhs, E rhs)
-{
-    return lhs = lhs ^ rhs;
-}
-// clang-format on
-
-// Returns true when every bit set in flag is also set in val.
-template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
-constexpr bool has_flag(E val, E flag)
-{
-    using U = std::underlying_type_t<E>;
-    return (static_cast<U>(val) & static_cast<U>(flag)) == static_cast<U>(flag);
-}
 
 // Returns the array of enumerator values for an enum declared with MIGRAPHX_ENUM.
 template <class Enum, MIGRAPHX_REQUIRES(is_named_enum<Enum>{})>
@@ -359,44 +284,5 @@ Enum from_string(const std::string& name)
     };                                        \
     MIGRAPHX_DETAIL_ENUM_HELPERS(             \
         friend, name, MIGRAPHX_DETAIL_ENUM_CLASS_CAPTURE, using enum_scope = name;, __VA_ARGS__)
-
-// Emits the ADL hook that marks an enum as a bit flag, which is_bit_flag detects to enable the
-// bitwise operators. `linkage` is `inline` at namespace scope or `friend` at class scope, mirroring
-// MIGRAPHX_DETAIL_ENUM_HELPERS.
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define MIGRAPHX_DETAIL_BIT_FLAG_ENUM(linkage, name) \
-    linkage constexpr bool migraphx_is_bit_flag(name) { return true; }
-
-// Declares a scoped enum (enum class) with the given underlying type and enables the type-safe
-// bitwise operators |, &, ^, ~, |=, &=, ^= and has_flag() on it. Use it at namespace scope:
-//
-//     MIGRAPHX_BIT_FLAG_ENUM(access, std::uint8_t,
-//         none  = 0,
-//         read  = 1 << 0,
-//         write = 1 << 1)
-//
-//     auto rw = access::read | access::write;
-//     if(has_flag(rw, access::read)) { /* ... */ }
-//
-// Unlike MIGRAPHX_ENUM_CLASS, no to_string/from_string helpers are generated, so enumerator values
-// should be self-contained bit masks.
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define MIGRAPHX_BIT_FLAG_ENUM(name, type, ...) \
-    enum class name : type                      \
-    {                                           \
-        __VA_ARGS__                             \
-    };                                          \
-    MIGRAPHX_DETAIL_BIT_FLAG_ENUM(inline, name)
-
-// Like MIGRAPHX_BIT_FLAG_ENUM, but for a scoped enum declared inside a class or struct; the hook is
-// generated as a hidden friend so argument-dependent lookup still finds it. Use it inside the
-// class/struct body.
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define MIGRAPHX_NESTED_BIT_FLAG_ENUM(name, type, ...) \
-    enum class name : type                             \
-    {                                                  \
-        __VA_ARGS__                                    \
-    };                                                 \
-    MIGRAPHX_DETAIL_BIT_FLAG_ENUM(friend, name)
 
 #endif // MIGRAPHX_GUARD_MIGRAPHX_ENUM_HPP

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <iterator>
 #include <string>
 #include <type_traits>
@@ -140,6 +141,76 @@ struct is_named_enum<T, std::void_t<decltype(migraphx_enum_entries(std::declval<
     : std::true_type
 {
 };
+
+// Detects enums declared with MIGRAPHX_BIT_FLAG_ENUM: those provide a migraphx_is_bit_flag hook and
+// therefore support the type-safe bitwise operators below.
+template <class T, class = void>
+struct is_bit_flag : std::false_type
+{
+};
+
+template <class T>
+struct is_bit_flag<T, std::void_t<decltype(migraphx_is_bit_flag(std::declval<T>()))>>
+    : std::true_type
+{
+};
+
+// Type-safe bitwise operators for enums declared with MIGRAPHX_BIT_FLAG_ENUM. They operate on the
+// enum's underlying integer and return the enum type, so combining values never leaks to a raw
+// integer and different flag enums cannot be mixed.
+template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
+constexpr E operator|(E lhs, E rhs)
+{
+    using U = std::underlying_type_t<E>;
+    return static_cast<E>(static_cast<U>(lhs) | static_cast<U>(rhs));
+}
+
+template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
+constexpr E operator&(E lhs, E rhs)
+{
+    using U = std::underlying_type_t<E>;
+    return static_cast<E>(static_cast<U>(lhs) & static_cast<U>(rhs));
+}
+
+template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
+constexpr E operator^(E lhs, E rhs)
+{
+    using U = std::underlying_type_t<E>;
+    return static_cast<E>(static_cast<U>(lhs) ^ static_cast<U>(rhs));
+}
+
+template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
+constexpr E operator~(E val)
+{
+    using U = std::underlying_type_t<E>;
+    return static_cast<E>(~static_cast<U>(val));
+}
+
+template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
+constexpr E& operator|=(E& lhs, E rhs)
+{
+    return lhs = lhs | rhs;
+}
+
+template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
+constexpr E& operator&=(E& lhs, E rhs)
+{
+    return lhs = lhs & rhs;
+}
+
+template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
+constexpr E& operator^=(E& lhs, E rhs)
+{
+    return lhs = lhs ^ rhs;
+}
+
+// Returns true when every bit set in flag is also set in val.
+template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
+constexpr bool has_flag(E val, E flag)
+{
+    using U = std::underlying_type_t<E>;
+    return (static_cast<U>(val) & static_cast<U>(flag)) == static_cast<U>(flag);
+}
 
 // Returns the array of enumerator values for an enum declared with MIGRAPHX_ENUM.
 template <class Enum, MIGRAPHX_REQUIRES(is_named_enum<Enum>{})>
@@ -284,5 +355,44 @@ Enum from_string(const std::string& name)
     };                                        \
     MIGRAPHX_DETAIL_ENUM_HELPERS(             \
         friend, name, MIGRAPHX_DETAIL_ENUM_CLASS_CAPTURE, using enum_scope = name;, __VA_ARGS__)
+
+// Emits the ADL hook that marks an enum as a bit flag, which is_bit_flag detects to enable the
+// bitwise operators. `linkage` is `inline` at namespace scope or `friend` at class scope, mirroring
+// MIGRAPHX_DETAIL_ENUM_HELPERS.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define MIGRAPHX_DETAIL_BIT_FLAG_ENUM(linkage, name) \
+    linkage constexpr bool migraphx_is_bit_flag(name) { return true; }
+
+// Declares a scoped enum (enum class) with the given underlying type and enables the type-safe
+// bitwise operators |, &, ^, ~, |=, &=, ^= and has_flag() on it. Use it at namespace scope:
+//
+//     MIGRAPHX_BIT_FLAG_ENUM(access, std::uint8_t,
+//         none  = 0,
+//         read  = 1 << 0,
+//         write = 1 << 1)
+//
+//     auto rw = access::read | access::write;
+//     if(has_flag(rw, access::read)) { /* ... */ }
+//
+// Unlike MIGRAPHX_ENUM_CLASS, no to_string/from_string helpers are generated, so enumerator values
+// should be self-contained bit masks.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define MIGRAPHX_BIT_FLAG_ENUM(name, type, ...) \
+    enum class name : type                      \
+    {                                           \
+        __VA_ARGS__                             \
+    };                                          \
+    MIGRAPHX_DETAIL_BIT_FLAG_ENUM(inline, name)
+
+// Like MIGRAPHX_BIT_FLAG_ENUM, but for a scoped enum declared inside a class or struct; the hook is
+// generated as a hidden friend so argument-dependent lookup still finds it. Use it inside the
+// class/struct body.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define MIGRAPHX_NESTED_BIT_FLAG_ENUM(name, type, ...) \
+    enum class name : type                             \
+    {                                                  \
+        __VA_ARGS__                                    \
+    };                                                 \
+    MIGRAPHX_DETAIL_BIT_FLAG_ENUM(friend, name)
 
 #endif // MIGRAPHX_GUARD_MIGRAPHX_ENUM_HPP

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <array>
 #include <iterator>
+#include <ostream>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
@@ -45,11 +46,9 @@ inline namespace MIGRAPHX_INLINE_NS {
 
 namespace detail {
 
-// enum_capture and enum_capturer implement the value capturing used by MIGRAPHX_ENUM. Each
-// enumerator `e` in the list is rewritten to `enum_capturer{}->*e`. Since operator->* binds
-// more tightly than assignment, `enum_capturer{}->*e = 42` parses as
-// `(enum_capturer{}->*e) = 42`: operator->* captures the real value of the enumerator (which
-// already accounts for the `= 42`), and operator= simply swallows the initializer.
+// Value capturing for MIGRAPHX_ENUM: each enumerator `e` becomes `enum_capturer{}->*e`. operator->*
+// binds tighter than assignment, so `enum_capturer{}->*e = 42` captures e's real value (which
+// already accounts for the `= 42`) and operator= swallows the initializer.
 template <class T>
 struct enum_capture
 {
@@ -73,16 +72,15 @@ struct enum_capturer
     }
 };
 
-// Wraps an enumerator as a type so that get_type_name renders it as its name: the compiler spells
-// a named enumerator as its own identifier, e.g. get_type_name<enum_value<color, green>>() is
-// "...enum_value<color, green>".
+// Wraps an enumerator as a type so get_type_name spells it by name, e.g.
+// get_type_name<enum_value<color, green>>() is "...enum_value<color, green>".
 template <class T, T X>
 struct enum_value
 {
 };
 
-// Recovers the enumerator name from that type name, e.g. "green" from "...enum_value<color, green>"
-// or "on" from "...enum_value<mode, mode::on>" (scoped and nested enumerators are qualified).
+// Recovers the enumerator name from that type name, stripping the qualification that scoped and
+// nested enumerators carry: "...enum_value<mode, mode::on>" gives "on".
 template <class T, T X>
 std::string enum_value_name()
 {
@@ -102,9 +100,9 @@ auto enum_value_names()
     });
 }
 
-// Maps an enumerator value to its name. The value set comes from migraphx_enum_entries, but the
-// names are derived from the values through get_type_name rather than from any stored strings. The
-// value -> name table is built once per enum so lookups are O(1).
+// Maps an enumerator value to its name. Values come from migraphx_enum_entries, names from
+// get_type_name rather than any stored strings. The table is built once per enum, so lookups are
+// O(1).
 template <class Enum>
 std::string enum_to_string(Enum value)
 {
@@ -128,8 +126,7 @@ std::string enum_to_string(Enum value)
 
 } // namespace detail
 
-// Detects enums declared with the MIGRAPHX_ENUM family: those provide a migraphx_enum_entries hook
-// and therefore support to_string and migraphx::from_string.
+// True for enums from the MIGRAPHX_ENUM family, which provide the migraphx_enum_entries hook.
 template <class T, class = void>
 struct is_named_enum : std::false_type
 {
@@ -148,8 +145,8 @@ auto enum_entries()
     return migraphx_enum_entries(Enum{});
 }
 
-// Converts the name of an enumerator back into its value, throwing when the name is unknown. The
-// name -> value table is built once per enum from migraphx_enum_entries so lookups are O(1).
+// Converts an enumerator name back into its value, throwing when the name is unknown. The table is
+// built once per enum, so lookups are O(1).
 template <class Enum, MIGRAPHX_REQUIRES(is_named_enum<Enum>{})>
 Enum from_string(const std::string& name)
 {
@@ -171,40 +168,51 @@ Enum from_string(const std::string& name)
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
 
-// Rewrites a single enumerator `x` (which may include an `= value`) so that operator->* captures
-// its value. See the note on enum_capture above for why operator->* is used here.
+// Rewrites one enumerator `x` (possibly `x = value`) so operator->* captures its value; see the
+// note on enum_capture above.
 #define MIGRAPHX_DETAIL_ENUM_CAPTURE(x) (migraphx::detail::enum_capturer{}->*x)
 
-// The scoped-enum variant qualifies the enumerator with `enum_scope`, a local alias for the enum
-// type that MIGRAPHX_ENUM_CLASS declares in the entries function (scoped enumerators are not
-// visible unqualified).
+// Scoped variant: qualifies with `enum_scope`, the alias the entries function declares, since
+// scoped enumerators are not visible unqualified.
 #define MIGRAPHX_DETAIL_ENUM_CLASS_CAPTURE(x) (migraphx::detail::enum_capturer{}->*enum_scope::x)
 
-// Generates the ADL hooks (migraphx_enum_entries + to_string) shared by the MIGRAPHX_ENUM family.
-// `linkage` is `inline` for a namespace-scope enum or `friend` for a class-scope (nested) enum;
-// `capture` is the per-enumerator capture macro; `prologue` runs before the capture list and is
-// used by the scoped variants to declare the enum_scope alias. migraphx_enum_entries returns just
-// the array of enumerator values; to_string recovers the names from those values via get_type_name.
+// Linkage for the namespace-scope variants. These enums belong in an anonymous namespace in a .cpp,
+// which gives the helpers internal linkage, so any the file never calls would trip
+// -Wunused-function. The nested variants generate hidden friends and need no marking.
+#define MIGRAPHX_DETAIL_ENUM_INLINE [[maybe_unused]] inline
+
+// Generates the ADL hooks (migraphx_enum_entries, to_string, operator<<) shared by the family.
+// `linkage` is MIGRAPHX_DETAIL_ENUM_INLINE at namespace scope or `friend` for a nested enum;
+// `capture` is the per-enumerator capture macro; `prologue` declares the enum_scope alias for the
+// scoped variants. operator<< comes after to_string so the friend variant reaches it by ADL.
 #ifdef CPPCHECK
-// cppcheck's preprocessor cannot expand the recursive MIGRAPHX_PP_TRANSFORM_ARGS, so generate the
-// hooks without it; the captured values are irrelevant to static analysis.
-#define MIGRAPHX_DETAIL_ENUM_HELPERS(linkage, name, capture, prologue, ...) \
-    linkage constexpr auto migraphx_enum_entries(name)                      \
-    {                                                                       \
-        return migraphx::make_array<name>(name{});                          \
-    }                                                                       \
-    linkage std::string to_string(name value) { return migraphx::detail::enum_to_string(value); }
+// cppcheck cannot expand the recursive MIGRAPHX_PP_TRANSFORM_ARGS; the captured values do not
+// matter to static analysis.
+#define MIGRAPHX_DETAIL_ENUM_HELPERS(linkage, name, capture, prologue, ...)                       \
+    linkage constexpr auto migraphx_enum_entries(name)                                            \
+    {                                                                                             \
+        return migraphx::make_array<name>(name{});                                                \
+    }                                                                                             \
+    linkage std::string to_string(name value) { return migraphx::detail::enum_to_string(value); } \
+    linkage std::ostream& operator<<(std::ostream& os, name value)                                \
+    {                                                                                             \
+        return os << to_string(value);                                                            \
+    }
 #else
-#define MIGRAPHX_DETAIL_ENUM_HELPERS(linkage, name, capture, prologue, ...) \
-    linkage constexpr auto migraphx_enum_entries(name)                      \
-    {                                                                       \
-        prologue return migraphx::make_array<name>(                         \
-            MIGRAPHX_PP_TRANSFORM_ARGS(capture, __VA_ARGS__));              \
-    }                                                                       \
-    linkage std::string to_string(name value) { return migraphx::detail::enum_to_string(value); }
+#define MIGRAPHX_DETAIL_ENUM_HELPERS(linkage, name, capture, prologue, ...)                       \
+    linkage constexpr auto migraphx_enum_entries(name)                                            \
+    {                                                                                             \
+        prologue return migraphx::make_array<name>(                                               \
+            MIGRAPHX_PP_TRANSFORM_ARGS(capture, __VA_ARGS__));                                    \
+    }                                                                                             \
+    linkage std::string to_string(name value) { return migraphx::detail::enum_to_string(value); } \
+    linkage std::ostream& operator<<(std::ostream& os, name value)                                \
+    {                                                                                             \
+        return os << to_string(value);                                                            \
+    }
 #endif
 
-// Declares an unscoped enum and generates `to_string` and `migraphx::from_string` helpers that
+// Declares an unscoped enum plus `to_string`, `migraphx::from_string`, and `operator<<`, which
 // convert its enumerators to and from their names. Use it at namespace scope:
 //
 //     MIGRAPHX_ENUM(color,
@@ -214,18 +222,21 @@ Enum from_string(const std::string& name)
 //
 //     std::string s = to_string(green);                     // "green"
 //     color c       = migraphx::from_string<color>("blue"); // blue
+//     std::cout << green;                                   // prints "green"
 //
-// Enumerators may take explicit values, and up to 63 are supported. When used in a .cpp instead of
-// a header, place it in an anonymous namespace so the generated helpers get internal linkage.
+// operator<< is an exact match, so it beats the conversion to the underlying type: the enum streams
+// as its name, not its number. Up to 63 enumerators, which may take explicit values. In a .cpp,
+// declare it in an anonymous namespace so the helpers get internal linkage.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define MIGRAPHX_ENUM(name, ...) \
-    enum name                    \
-    {                            \
-        __VA_ARGS__              \
-    };                           \
-    MIGRAPHX_DETAIL_ENUM_HELPERS(inline, name, MIGRAPHX_DETAIL_ENUM_CAPTURE, , __VA_ARGS__)
+#define MIGRAPHX_ENUM(name, ...)  \
+    enum name                     \
+    {                             \
+        __VA_ARGS__               \
+    };                            \
+    MIGRAPHX_DETAIL_ENUM_HELPERS( \
+        MIGRAPHX_DETAIL_ENUM_INLINE, name, MIGRAPHX_DETAIL_ENUM_CAPTURE, , __VA_ARGS__)
 
-// Like MIGRAPHX_ENUM, but declares a scoped enum (enum class):
+// Like MIGRAPHX_ENUM, but a scoped enum (enum class):
 //
 //     MIGRAPHX_ENUM_CLASS(color,
 //         red,
@@ -234,21 +245,24 @@ Enum from_string(const std::string& name)
 //
 //     std::string s = to_string(color::green);              // "green"
 //     color c       = migraphx::from_string<color>("blue"); // color::blue
+//     std::cout << color::green;                            // prints "green"
 //
-// An explicit enumerator value must be self-contained: it cannot reference another enumerator,
-// which is not visible unqualified in a scoped enum.
+// An explicit value must be self-contained: it cannot reference another enumerator, which is not
+// visible unqualified in a scoped enum.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define MIGRAPHX_ENUM_CLASS(name, ...) \
-    enum class name                    \
-    {                                  \
-        __VA_ARGS__                    \
-    };                                 \
-    MIGRAPHX_DETAIL_ENUM_HELPERS(      \
-        inline, name, MIGRAPHX_DETAIL_ENUM_CLASS_CAPTURE, using enum_scope = name;, __VA_ARGS__)
+#define MIGRAPHX_ENUM_CLASS(name, ...)                               \
+    enum class name                                                  \
+    {                                                                \
+        __VA_ARGS__                                                  \
+    };                                                               \
+    MIGRAPHX_DETAIL_ENUM_HELPERS(MIGRAPHX_DETAIL_ENUM_INLINE,        \
+                                 name,                               \
+                                 MIGRAPHX_DETAIL_ENUM_CLASS_CAPTURE, \
+                                 using enum_scope = name;            \
+                                 , __VA_ARGS__)
 
-// Like MIGRAPHX_ENUM, but for an enum declared inside a class or struct. The helpers are generated
-// as hidden friends instead of free functions so that argument-dependent lookup still finds them.
-// Use it inside the class/struct body:
+// Like MIGRAPHX_ENUM, but for an enum inside a class or struct: the helpers become hidden friends
+// rather than free functions, so ADL still finds them. Use it in the class body:
 //
 //     struct widget
 //     {
@@ -257,6 +271,7 @@ Enum from_string(const std::string& name)
 //
 //     std::string s  = to_string(widget::on);                      // "on"
 //     widget::mode m = migraphx::from_string<widget::mode>("off"); // widget::off
+//     std::cout << widget::on;                                     // prints "on"
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define MIGRAPHX_NESTED_ENUM(name, ...) \
     enum name                           \
@@ -265,9 +280,8 @@ Enum from_string(const std::string& name)
     };                                  \
     MIGRAPHX_DETAIL_ENUM_HELPERS(friend, name, MIGRAPHX_DETAIL_ENUM_CAPTURE, , __VA_ARGS__)
 
-// Like MIGRAPHX_NESTED_ENUM, but declares a scoped enum (enum class); it relates to
-// MIGRAPHX_NESTED_ENUM as MIGRAPHX_ENUM_CLASS does to MIGRAPHX_ENUM, including the same restriction
-// on explicit enumerator values. Use it inside the class/struct body:
+// Like MIGRAPHX_NESTED_ENUM, but a scoped enum, with the same restriction on explicit values as
+// MIGRAPHX_ENUM_CLASS. Use it in the class body:
 //
 //     struct widget
 //     {
@@ -276,6 +290,7 @@ Enum from_string(const std::string& name)
 //
 //     std::string s  = to_string(widget::unit::cm);               // "cm"
 //     widget::unit u = migraphx::from_string<widget::unit>("mm"); // widget::unit::mm
+//     std::cout << widget::unit::cm;                              // prints "cm"
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define MIGRAPHX_NESTED_ENUM_CLASS(name, ...) \
     enum class name                           \

--- a/src/include/migraphx/enum.hpp
+++ b/src/include/migraphx/enum.hpp
@@ -186,6 +186,9 @@ constexpr E operator~(E val)
     return static_cast<E>(~static_cast<U>(val));
 }
 
+// clang-format misparses the `E&` reference parameter as a binary-and when the template
+// is constrained with MIGRAPHX_REQUIRES, so keep these declarations formatted by hand.
+// clang-format off
 template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>
 constexpr E& operator|=(E& lhs, E rhs)
 {
@@ -203,6 +206,7 @@ constexpr E& operator^=(E& lhs, E rhs)
 {
     return lhs = lhs ^ rhs;
 }
+// clang-format on
 
 // Returns true when every bit set in flag is also set in val.
 template <class E, MIGRAPHX_REQUIRES(is_bit_flag<E>{})>

--- a/src/include/migraphx/op/slice.hpp
+++ b/src/include/migraphx/op/slice.hpp
@@ -314,9 +314,9 @@ struct slice
     /// because shapes with dynamic rank are not supported.
     std::unordered_map<std::string, std::vector<int64_t>>
     normalize_starts_ends_axes(shape input_shape,
-                               std::vector<int64_t>& starts_vec,
-                               std::vector<int64_t>& ends_vec,
-                               std::vector<int64_t>& axes_vec) const
+                               const std::vector<int64_t>& starts_vec,
+                               const std::vector<int64_t>& ends_vec,
+                               const std::vector<int64_t>& axes_vec) const
     {
         assert(not input_shape.dynamic());
         auto axes_attrs = this->attributes().at("normalize_axes");
@@ -337,8 +337,8 @@ struct slice
 
     argument compute(const dyn_output& dyn_out, std::vector<argument> args) const
     {
-        auto input       = args[0];
-        auto input_shape = input.get_shape();
+        const auto& input = args[0];
+        auto input_shape  = input.get_shape();
         if(args.size() == 1)
         {
             std::size_t offset = compute_offset(input_shape);

--- a/src/include/migraphx/op/slice.hpp
+++ b/src/include/migraphx/op/slice.hpp
@@ -40,22 +40,25 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace op {
 
 /// Slice operator that accepts variable axes, starts and ends.
-/// All of `starts`, `ends`, and `axes` attributes must be supplied.
 ///
-/// `mode` specifies what the inputs to slice are:
-/// one_input: slice(input);
-/// starts_input: slice(input, starts);
-/// ends_input: slice(input, ends);
-/// axes_input: slice(input, axes);
-/// starts_ends_input: slice(input, starts, ends);
-/// starts_axes_input: slice(input, starts, axes);
-/// ends_axes_input: slice(input, ends, axes);
-/// starts_ends_axes_input: slice(input, start, ends, axes);
+/// `mode` lists which of `starts`, `ends`, and `axes` are supplied as variable inputs.
+/// Each entry corresponds to one of the trailing inputs (after `data`).
+/// Inputs are always given in the canonical order `starts` before `ends` before `axes`. Valid
+/// modes:
+///   {}: slice(input);
+///   {starts}: slice(input, starts);
+///   {ends}: slice(input, ends);
+///   {axes}: slice(input, axes);
+///   {starts, ends}: slice(input, starts, ends);
+///   {starts, axes}: slice(input, starts, axes);
+///   {ends, axes}: slice(input, ends, axes);
+///   {starts, ends, axes}: slice(input, starts, ends, axes);
 ///
 /// Attributes:
 /// axes: axes to slice over
 /// starts: slice starting indices
 /// ends: slice ending indices
+/// mode: what inputs[1:4] of slice mean
 ///
 /// Parameters:
 /// data: the input tensor to slice (dynamic or static shape)
@@ -64,22 +67,14 @@ namespace op {
 /// axes_input: axes to slice over (optional, static shape)
 struct slice
 {
-    MIGRAPHX_NESTED_ENUM_CLASS(slice_mode,
-                               one_input,
-                               starts_input,
-                               ends_input,
-                               axes_input,
-                               starts_ends_input,
-                               starts_axes_input,
-                               ends_axes_input,
-                               starts_ends_axes_input);
+    MIGRAPHX_NESTED_ENUM_CLASS(slice_mode, starts, ends, axes);
 
     friend std::ostream& operator<<(std::ostream& os, slice_mode v) { return os << to_string(v); }
 
     std::vector<int64_t> axes{};
     std::vector<dim_like> starts{};
     std::vector<dim_like> ends{};
-    slice_mode mode = slice_mode::one_input;
+    std::vector<slice_mode> mode{};
 
     template <class Self, class F>
     static auto reflect(Self& self, F f)
@@ -133,7 +128,6 @@ struct slice
     /// Check that the inputs, attributes, and mode are valid.
     void check_inputs_and_attributes(std::vector<shape> inputs) const
     {
-        auto input_shape = inputs[0];
         // All set (non-empty) bound attributes must agree on the number of sliced axes.
         // A variable (input-provided) bound leaves its attribute empty, so empty attrs are skipped.
         std::size_t attr_size = 0;
@@ -151,10 +145,15 @@ struct slice
             if(any_sym(starts) or any_sym(ends))
                 MIGRAPHX_THROW(
                     "SLICE: Invalid attributes: symbolic in attribute for 1 input slice");
-            if(mode != slice_mode::one_input)
+            if(not mode.empty())
                 MIGRAPHX_THROW("SLICE: Invalid mode for 1 input");
             return;
         }
+        // There is one mode entry per variable input (the trailing inputs after `data`).
+        if(mode.size() != inputs.size() - 1)
+            MIGRAPHX_THROW("SLICE: number of mode entries (" + migraphx::to_string(mode.size()) +
+                           ") must match number of variable inputs (" +
+                           migraphx::to_string(inputs.size() - 1) + ")");
         // Check that inputs [1, end) are all 1D, have the same dimension, and are static shape.
         check_shapes{inputs.begin() + 1,
                      inputs.end(),
@@ -162,92 +161,30 @@ struct slice
                      false}
             .only_dims(1)
             .same_dims();
-        if(inputs.size() == 2)
-        {
-            std::vector<slice_mode> two_input_modes_not_axes = {slice_mode::starts_input,
-                                                                slice_mode::ends_input};
-            if(contains(two_input_modes_not_axes, mode))
-            {
-                if(inputs[1].lens()[0] != axes.size())
-                    MIGRAPHX_THROW("SLICE: input length (" +
-                                   migraphx::to_string(inputs[1].lens()[0]) +
-                                   ") does not match attribute length (" +
-                                   migraphx::to_string(axes.size()) + ")");
-            }
-            else if(mode == slice_mode::axes_input)
-            {
-                if(inputs[1].lens()[0] != starts.size())
-                    MIGRAPHX_THROW("SLICE: input length (" +
-                                   migraphx::to_string(inputs[1].lens()[0]) +
-                                   ") does not match attribute length (" +
-                                   migraphx::to_string(starts.size()) + ")");
-            }
-            else
-            {
-                MIGRAPHX_THROW("SLICE: Invalid mode for 2 inputs");
-            }
-        }
-        else if(inputs.size() == 3)
-        {
-            if(mode == slice_mode::starts_ends_input)
-            {
-                if(inputs[1].lens()[0] != axes.size())
-                    MIGRAPHX_THROW("SLICE: input length (" +
-                                   migraphx::to_string(inputs[1].lens()[0]) +
-                                   ") does not match attribute length (" +
-                                   migraphx::to_string(axes.size()) + ")");
-            }
-            else if(mode == slice_mode::starts_axes_input)
-            {
-                if(inputs[1].lens()[0] != ends.size())
-                    MIGRAPHX_THROW("SLICE: input length (" +
-                                   migraphx::to_string(inputs[1].lens()[0]) +
-                                   ") does not match attribute length (" +
-                                   migraphx::to_string(ends.size()) + ")");
-            }
-            else if(mode == slice_mode::ends_axes_input)
-            {
-                if(inputs[1].lens()[0] != starts.size())
-                    MIGRAPHX_THROW("SLICE: input length (" +
-                                   migraphx::to_string(inputs[1].lens()[0]) +
-                                   ") does not match attribute length (" +
-                                   migraphx::to_string(starts.size()) + ")");
-            }
-            else
-            {
-                MIGRAPHX_THROW("SLICE: Invalid mode for 3 inputs");
-            }
-        }
-        else
-        {
-            if(mode != slice_mode::starts_ends_axes_input)
-            {
-                MIGRAPHX_THROW("SLICE: Invalid mode for 4 inputs");
-            }
-        }
-        return;
+        // Every set attribute shares `attr_size` and defines the number of sliced axes, so each
+        // variable input must match it.
+        if(attr_size != 0 and inputs[1].lens()[0] != attr_size)
+            MIGRAPHX_THROW("SLICE: input length (" + migraphx::to_string(inputs[1].lens()[0]) +
+                           ") does not match attribute length (" + migraphx::to_string(attr_size) +
+                           ")");
     }
 
+    // Range-based fallback applies when every variable input leaves its associated attribute
+    // unset. A symbolic attribute alongside an input takes the symbolic path instead.
     // TODO: remove this once range-based dynamic shapes are deprecated
     bool use_range_based_logic() const
     {
-        if(mode == slice_mode::starts_input and starts.empty())
-            return true;
-        else if(mode == slice_mode::ends_input and ends.empty())
-            return true;
-        else if(mode == slice_mode::axes_input and axes.empty())
-            return true;
-        else if(mode == slice_mode::starts_ends_input and starts.empty() and ends.empty())
-            return true;
-        else if(mode == slice_mode::starts_axes_input and starts.empty() and axes.empty())
-            return true;
-        else if(mode == slice_mode::ends_axes_input and ends.empty() and axes.empty())
-            return true;
-        else if(mode == slice_mode::starts_ends_axes_input and starts.empty() and ends.empty() and
-                axes.empty())
-            return true;
-        else
+        if(mode.empty())
             return false;
+        return std::all_of(mode.begin(), mode.end(), [&](slice_mode m) {
+            switch(m)
+            {
+            case slice_mode::starts: return starts.empty();
+            case slice_mode::ends: return ends.empty();
+            case slice_mode::axes: return axes.empty();
+            }
+            return false;
+        });
     }
 
     // For when there is a variable input and the associated attribute is not set.
@@ -255,12 +192,8 @@ struct slice
     // TODO: remove this once range-based dynamic shapes are deprecated
     shape range_based_compute_shape_for_two_or_more(shape input_shape) const
     {
-        auto dds                                      = input_shape.to_dynamic().dyn_dims();
-        static std::vector<slice_mode> has_axes_input = {slice_mode::axes_input,
-                                                         slice_mode::starts_axes_input,
-                                                         slice_mode::ends_axes_input,
-                                                         slice_mode::starts_ends_axes_input};
-        if(contains(has_axes_input, mode))
+        auto dds = input_shape.to_dynamic().dyn_dims();
+        if(contains(mode, slice_mode::axes))
         {
             std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
                 return shape::dynamic_dimension{0, dd.get_interval().max};
@@ -376,62 +309,29 @@ struct slice
     }
 
     /// Used to normalize starts/ends/axes at runtime.
-    /// If given, normalize the starts/ends/axes inputs. Otherwise get from operator attributes.
-    /// If starts_input or ends_input is not given, assuming starts/ends attributes are only
-    /// integers. If starts/ends have symbolics, they should go through the starts_input and
+    /// If starts/ends have symbolics, they should go through the starts_input and
     /// ends_input instead. `axes` attribute should always be correctly normalized at compile-time
     /// because shapes with dynamic rank are not supported.
-    ///
-    /// input_shape: static shape of the input
-    /// starts_input: optional
-    /// ends_input: optional
-    /// axes_input: optional
     std::unordered_map<std::string, std::vector<int64_t>>
     normalize_starts_ends_axes(shape input_shape,
-                               const optional<std::vector<int64_t>>& starts_input,
-                               const optional<std::vector<int64_t>>& ends_input,
-                               const optional<std::vector<int64_t>>& axes_input) const
+                               std::vector<int64_t>& starts_vec,
+                               std::vector<int64_t>& ends_vec,
+                               std::vector<int64_t>& axes_vec) const
     {
         assert(not input_shape.dynamic());
         auto axes_attrs = this->attributes().at("normalize_axes");
         std::vector<int64_t> norm_starts;
         std::vector<int64_t> norm_ends;
         std::vector<int64_t> norm_axes;
-        if(axes_input)
-        {
-            norm_axes = normalize_axes(axes_input.value(),
-                                       input_shape,
-                                       axes_attrs.at("axes"),
-                                       "Slice variable axes_input");
-        }
-        else
-        {
-            norm_axes = this->axes;
-        }
-        if(starts_input)
-        {
-            norm_starts = normalize_indices(starts_input.value(),
-                                            norm_axes,
-                                            input_shape,
-                                            axes_attrs.at("starts"),
-                                            "Slice variable starts_input");
-        }
-        else
-        {
-            norm_starts = to_ints(this->starts);
-        }
-        if(ends_input)
-        {
-            norm_ends = normalize_indices(ends_input.value(),
-                                          norm_axes,
-                                          input_shape,
-                                          axes_attrs.at("ends"),
-                                          "Slice variable input ends");
-        }
-        else
-        {
-            norm_ends = to_ints(this->ends);
-        }
+        norm_axes = normalize_axes(
+            axes_vec, input_shape, axes_attrs.at("axes"), "Slice variable axes_input");
+        norm_starts = normalize_indices(starts_vec,
+                                        norm_axes,
+                                        input_shape,
+                                        axes_attrs.at("starts"),
+                                        "Slice variable starts_input");
+        norm_ends   = normalize_indices(
+            ends_vec, norm_axes, input_shape, axes_attrs.at("ends"), "Slice variable input ends");
         return {{"norm_starts", norm_starts}, {"norm_ends", norm_ends}, {"norm_axes", norm_axes}};
     }
 
@@ -446,82 +346,29 @@ struct slice
         }
         else
         {
-            std::unordered_map<std::string, std::vector<int64_t>> norm_inputs;
-            // Attribute-provided dims are passed as their concrete int values (via to_ints) so they
-            // are re-normalized/clamped against the runtime input shape, just like the runtime
-            // inputs. Symbolic bounds only ever appear on the input-provided dims.
-            if(mode == slice_mode::starts_input)
+            std::vector<int64_t> starts_vec;
+            std::vector<int64_t> ends_vec;
+            std::vector<int64_t> axes_vec;
+            for(std::size_t i = 0; i < mode.size(); ++i)
             {
-                args[1].visit([&](auto starts_input) {
-                    norm_inputs =
-                        normalize_starts_ends_axes(input_shape,
-                                                   starts_input.template to_vector<int64_t>(),
-                                                   to_ints(this->ends),
-                                                   this->axes);
+                args[i + 1].visit([&](auto input_view) {
+                    auto vec = input_view.template to_vector<int64_t>();
+                    switch(mode[i])
+                    {
+                    case slice_mode::starts: starts_vec = vec; break;
+                    case slice_mode::ends: ends_vec = vec; break;
+                    case slice_mode::axes: axes_vec = vec; break;
+                    }
                 });
             }
-            else if(mode == slice_mode::ends_input)
-            {
-                args[1].visit([&](auto ends_input) {
-                    norm_inputs =
-                        normalize_starts_ends_axes(input_shape,
-                                                   to_ints(this->starts),
-                                                   ends_input.template to_vector<int64_t>(),
-                                                   this->axes);
-                });
-            }
-            else if(mode == slice_mode::axes_input)
-            {
-                args[1].visit([&](auto axes_input) {
-                    norm_inputs =
-                        normalize_starts_ends_axes(input_shape,
-                                                   to_ints(this->starts),
-                                                   to_ints(this->ends),
-                                                   axes_input.template to_vector<int64_t>());
-                });
-            }
-            else if(mode == slice_mode::starts_ends_input)
-            {
-                // attr axes set; inputs are (data, starts_input, ends_input)
-                visit_all(args[1], args[2])([&](auto starts_input, auto ends_input) {
-                    norm_inputs =
-                        normalize_starts_ends_axes(input_shape,
-                                                   starts_input.template to_vector<int64_t>(),
-                                                   ends_input.template to_vector<int64_t>(),
-                                                   this->axes);
-                });
-            }
-            else if(mode == slice_mode::starts_axes_input)
-            {
-                visit_all(args[1], args[2])([&](auto starts_input, auto axes_input) {
-                    norm_inputs =
-                        normalize_starts_ends_axes(input_shape,
-                                                   starts_input.template to_vector<int64_t>(),
-                                                   to_ints(this->ends),
-                                                   axes_input.template to_vector<int64_t>());
-                });
-            }
-            else if(mode == slice_mode::ends_axes_input)
-            {
-                visit_all(args[1], args[2])([&](auto ends_input, auto axes_input) {
-                    norm_inputs =
-                        normalize_starts_ends_axes(input_shape,
-                                                   to_ints(this->starts),
-                                                   ends_input.template to_vector<int64_t>(),
-                                                   axes_input.template to_vector<int64_t>());
-                });
-            }
-            else // mode == slice_mode::starts_ends_axes_input
-            {
-                visit_all(args[1], args[2], args[3])(
-                    [&](auto starts_input, auto ends_input, auto axes_input) {
-                        norm_inputs =
-                            normalize_starts_ends_axes(input_shape,
-                                                       starts_input.template to_vector<int64_t>(),
-                                                       ends_input.template to_vector<int64_t>(),
-                                                       axes_input.template to_vector<int64_t>());
-                    });
-            }
+            if(starts_vec.empty())
+                starts_vec = to_ints(this->starts);
+            if(ends_vec.empty())
+                ends_vec = to_ints(this->ends);
+            if(axes_vec.empty())
+                axes_vec = this->axes;
+            auto norm_inputs =
+                normalize_starts_ends_axes(input_shape, starts_vec, ends_vec, axes_vec);
             auto offset = compute_offset(
                 input_shape, norm_inputs.at("norm_starts"), norm_inputs.at("norm_axes"));
             shape calc_shape = shape{input_shape.type(),

--- a/src/include/migraphx/op/slice.hpp
+++ b/src/include/migraphx/op/slice.hpp
@@ -129,7 +129,7 @@ struct slice
     void check_inputs_and_attributes(const std::vector<shape>& inputs) const
     {
         // All set (non-empty) bound attributes must agree on the number of sliced axes.
-        // A variable (input-provided) bound leaves its attribute empty, so empty attrs are skipped.
+        // A variable (input-provided) bound can leave its attribute empty, so empty attrs are skipped.
         std::size_t attr_size = 0;
         for(auto s : {axes.size(), starts.size(), ends.size()})
         {

--- a/src/include/migraphx/op/slice.hpp
+++ b/src/include/migraphx/op/slice.hpp
@@ -27,72 +27,73 @@
 #include <migraphx/check_shapes.hpp>
 #include <migraphx/argument.hpp>
 #include <migraphx/config.hpp>
+#include <migraphx/dim_like.hpp>
 #include <migraphx/value.hpp>
 #include <migraphx/dyn_output.hpp>
 #include <migraphx/op/normalize_attribute.hpp>
 #include <migraphx/normalize_attributes.hpp>
+#include <migraphx/enum.hpp>
 #include <array>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace op {
 
-/**
- * Slice operator that accepts variable axes, starts and ends.
- * All of `starts`, `ends`, and `axes` must be supplied by either
- * their attribute or an input (but not both).
- *
- * Valid calls:
- * slice(input); axes, starts, ends set
- * slice(input, starts); axes, ends set
- * slice(input, ends); starts, axes set
- * slice(input, axes); starts, ends set
- * slice(input, starts, ends); axes set
- * slice(input, starts, axes); ends set
- * slice(input, ends, axes); starts set
- * slice(input, start, ends, axes); none set
- *
- * Attributes:
- * axes: constant axes to slice over (optional)
- * starts: constant slice starting indices (optional)
- * ends: constant slice ending indices (optional)
- *
- * Parameters:
- * data: the input tensor to slice (dynamic or static shape)
- * input_starts: starting indices of slice (optional, static shape)
- * input_ends: ending indices of slice (optional, static shape)
- * input_axes: axes to slice over (optional, static shape)
- */
+/// Slice operator that accepts variable axes, starts and ends.
+/// All of `starts`, `ends`, and `axes` attributes must be supplied.
+///
+/// `mode` specifies what the inputs to slice are:
+/// one_input: slice(input);
+/// starts_input: slice(input, starts);
+/// ends_input: slice(input, ends);
+/// axes_input: slice(input, axes);
+/// starts_ends_input: slice(input, starts, ends);
+/// starts_axes_input: slice(input, starts, axes);
+/// ends_axes_input: slice(input, ends, axes);
+/// starts_ends_axes_input: slice(input, start, ends, axes);
+///
+/// Attributes:
+/// axes: axes to slice over
+/// starts: slice starting indices
+/// ends: slice ending indices
+///
+/// Parameters:
+/// data: the input tensor to slice (dynamic or static shape)
+/// starts_input: starting indices of slice (optional, static shape)
+/// ends_input: ending indices of slice (optional, static shape)
+/// axes_input: axes to slice over (optional, static shape)
 struct slice
 {
-    std::vector<int64_t> axes{};
-    std::vector<int64_t> starts{};
-    std::vector<int64_t> ends{};
+    MIGRAPHX_NESTED_ENUM_CLASS(slice_mode,
+                               one_input,
+                               starts_input,
+                               ends_input,
+                               axes_input,
+                               starts_ends_input,
+                               starts_axes_input,
+                               ends_axes_input,
+                               starts_ends_axes_input);
 
-    /**
-     * Named arrays for the set attribute possibilities.
-     */
-    static constexpr std::array<bool, 3> all_set     = {true, true, true};
-    static constexpr std::array<bool, 3> ends_axes   = {false, true, true};
-    static constexpr std::array<bool, 3> starts_axes = {true, false, true};
-    static constexpr std::array<bool, 3> starts_ends = {true, true, false};
-    static constexpr std::array<bool, 3> axes_only   = {false, false, true};
-    static constexpr std::array<bool, 3> ends_only   = {false, true, false};
-    static constexpr std::array<bool, 3> starts_only = {true, false, false};
-    static constexpr std::array<bool, 3> none_set    = {false, false, false};
+    friend std::ostream& operator<<(std::ostream& os, slice_mode v) { return os << to_string(v); }
+
+    std::vector<int64_t> axes{};
+    std::vector<dim_like> starts{};
+    std::vector<dim_like> ends{};
+    slice_mode mode = slice_mode::one_input;
 
     template <class Self, class F>
     static auto reflect(Self& self, F f)
     {
-        return pack(f(self.axes, "axes"), f(self.starts, "starts"), f(self.ends, "ends"));
+        return pack(f(self.axes, "axes"),
+                    f(self.starts, "starts"),
+                    f(self.ends, "ends"),
+                    f(self.mode, "mode"));
     }
 
-    /**
-     * Ensure that attribute axes is within limits.
-     * Will attempt to normalize starts and ends; but will use the dynamic_dimension.max
-     * values for dynamic shapes. This makes it so you have to renormalize for
-     * non-fixed dynamic_dimensions.
-     */
+    /// Ensure that attribute axes is within limits.
+    /// Will attempt to normalize starts and ends; but will use the dynamic_dimension.max
+    /// values for dynamic shapes. This makes it so you have to renormalize for
+    /// non-fixed dynamic_dimensions.
     value attributes() const
     {
         value normalize_axes     = value::object{};
@@ -112,12 +113,10 @@ struct slice
 
     std::string name() const { return "slice"; }
 
-    /**
-     * Computes the slice output shape dimensions for given starts, ends,and axes.
-     * Templated to also handle tensor views.
-     * Possibly different type between [in_starts, in_ends] and [in_axes] if in_axes is this
-     * object's axes attribute. Assumes in_starts and in_ends are normalized; in_axes are valid.
-     */
+    /// Computes the slice output shape dimensions for given starts, ends,and axes.
+    /// Templated to also handle tensor views.
+    /// Possibly different type between [in_starts, in_ends] and [in_axes] if in_axes is this
+    /// object's axes attribute. Assumes in_starts and in_ends are normalized; in_axes are valid.
     template <class A, class B>
     std::vector<std::size_t>
     lens_calc(const std::vector<std::size_t>& lengths, A in_starts, A in_ends, B in_axes) const
@@ -131,192 +130,195 @@ struct slice
         return new_lens;
     }
 
-    /// Get the attributes that are non-empty
-    std::array<bool, 3> get_set_attributes() const
+    /// Check that the inputs, attributes, and mode are valid.
+    void check_inputs_and_attributes(std::vector<shape> inputs) const
     {
-        std::array<std::vector<int64_t>, 3> attrs = {this->starts, this->ends, this->axes};
-        std::array<bool, 3> bool_vec;
-        std::transform(attrs.cbegin(), attrs.cend(), bool_vec.begin(), [](const auto& a) {
-            return not a.empty();
-        });
-        return bool_vec;
-    }
-
-    /// Helper function for normalize_compute_shape()
-    shape compute_two_or_more(std::vector<shape> inputs) const
-    {
-        auto input_shape    = inputs[0];
-        auto set_attributes = get_set_attributes();
-        // check that inputs [1, end) are all 1D, have the same
-        // dimension, and are static
+        auto input_shape = inputs[0];
+        // All set (non-empty) bound attributes must agree on the number of sliced axes.
+        // A variable (input-provided) bound leaves its attribute empty, so empty attrs are skipped.
+        std::size_t attr_size = 0;
+        for(auto s : {axes.size(), starts.size(), ends.size()})
+        {
+            if(s == 0)
+                continue;
+            if(attr_size == 0)
+                attr_size = s;
+            else if(s != attr_size)
+                MIGRAPHX_THROW("SLICE: set starts/ends/axes attributes must have the same length");
+        }
+        if(inputs.size() == 1)
+        {
+            if(any_sym(starts) or any_sym(ends))
+                MIGRAPHX_THROW("SLICE: Invalid attributes: symbolic in attribute for 1 input slice");
+            if(mode != slice_mode::one_input)
+                MIGRAPHX_THROW("SLICE: Invalid mode for 1 input");
+            return;
+        }
+        // Check that inputs [1, end) are all 1D, have the same dimension, and are static shape.
         check_shapes{inputs.begin() + 1,
                      inputs.end(),
-                     std::string("SLICE: inputs (starts, ends, and input_axes)"),
+                     std::string("SLICE: inputs (starts_input, ends_input, axes_input)"),
                      false}
             .only_dims(1)
             .same_dims();
-        auto dds = input_shape.to_dynamic().dyn_dims();
         if(inputs.size() == 2)
         {
-            if(set_attributes == ends_axes)
+            std::vector<slice_mode> two_input_modes_not_axes = {slice_mode::starts_input, slice_mode::ends_input};
+            if(contains(two_input_modes_not_axes, mode))
             {
-                // attr ends and axes set; inputs are (data, input_starts)
-                if(inputs[1].lens().at(0) != axes.size())
-                {
-                    MIGRAPHX_THROW("SLICE: 2 input and attributes mismatch: input_starts length (" +
-                                   to_string(inputs[1].lens().at(0)) + ") != number of axes (" +
-                                   to_string(axes.size()) + ")");
-                }
-                std::for_each(axes.cbegin(), axes.cend(), [&](const auto& axis) {
-                    dds.at(axis) = {0, dds.at(axis).get_interval().max};
-                });
+                if(inputs[1].lens()[0] != axes.size())
+                    MIGRAPHX_THROW("SLICE: input length (" + migraphx::to_string(inputs[1].lens()[0]) + ") does not match attribute length (" + migraphx::to_string(axes.size()) + ")");
             }
-            else if(set_attributes == starts_axes)
+            else if(mode == slice_mode::axes_input)
             {
-                // attr starts and axes set; inputs are (data, input_ends)
-                if(inputs[1].lens().at(0) != axes.size())
-                {
-                    MIGRAPHX_THROW("SLICE: 2 input and attributes mismatch: input_ends length (" +
-                                   to_string(inputs[1].lens().at(0)) + ") != number of axes (" +
-                                   to_string(axes.size()) + ")");
-                }
-                std::for_each(axes.cbegin(), axes.cend(), [&](const auto& axis) {
-                    dds.at(axis) = {0, dds.at(axis).get_interval().max};
-                });
-            }
-            else if(set_attributes == starts_ends)
-            {
-                // attr starts and ends set; inputs are (data, input_axes)
-                if(inputs[1].lens().at(0) != starts.size())
-                {
-                    MIGRAPHX_THROW("SLICE: 2 input and attributes mismatch: input_axes length (" +
-                                   to_string(inputs[1].lens().at(0)) + ") != number of starts (" +
-                                   to_string(starts.size()) + ")");
-                }
-                std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
-                    return shape::dynamic_dimension{0, dd.get_interval().max};
-                });
+                if(inputs[1].lens()[0] != starts.size())
+                    MIGRAPHX_THROW("SLICE: input length (" + migraphx::to_string(inputs[1].lens()[0]) + ") does not match attribute length (" + migraphx::to_string(starts.size()) + ")");
             }
             else
             {
-                MIGRAPHX_THROW("SLICE: Invalid 2 input and attributes configuration");
+                MIGRAPHX_THROW("SLICE: Invalid mode for 2 inputs");
             }
         }
         else if(inputs.size() == 3)
         {
-            if(set_attributes == axes_only)
+            if(mode == slice_mode::starts_ends_input)
             {
-                // attr axes set; inputs are (data, input_starts, input_ends)
-                if(inputs[1].lens().at(0) != axes.size())
-                {
-                    MIGRAPHX_THROW("SLICE: 3 input and attributes mismatch: input_starts length (" +
-                                   to_string(inputs[1].lens().at(0)) + ") != number of axes (" +
-                                   to_string(axes.size()) + ")");
-                }
-                std::for_each(axes.cbegin(), axes.cend(), [&](const auto& axis) {
-                    dds.at(axis) = {0, dds.at(axis).get_interval().max};
-                });
+                if(inputs[1].lens()[0] != axes.size())
+                    MIGRAPHX_THROW("SLICE: input length (" + migraphx::to_string(inputs[1].lens()[0]) + ") does not match attribute length (" + migraphx::to_string(axes.size()) + ")");
             }
-            else if(set_attributes == ends_only)
+            else if(mode == slice_mode::starts_axes_input)
             {
-                // attr ends set; inputs are (data, input_starts, input_axes)
-                if(inputs[1].lens().at(0) != ends.size())
-                {
-                    MIGRAPHX_THROW("SLICE: 3 input and attributes mismatch: input_starts length (" +
-                                   to_string(inputs[1].lens().at(0)) + ") != number of ends (" +
-                                   to_string(ends.size()) + ")");
-                }
-                std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
-                    return shape::dynamic_dimension{0, dd.get_interval().max};
-                });
+                if(inputs[1].lens()[0] != ends.size())
+                    MIGRAPHX_THROW("SLICE: input length (" + migraphx::to_string(inputs[1].lens()[0]) + ") does not match attribute length (" + migraphx::to_string(ends.size()) + ")");
             }
-            else if(set_attributes == starts_only)
-
+            else if(mode == slice_mode::ends_axes_input)
             {
-                // attr starts set; inputs are (data, input_ends, input_axes)
-                if(inputs[1].lens().at(0) != starts.size())
-                {
-                    MIGRAPHX_THROW("SLICE: 3 input and attributes mismatch: input_ends length (" +
-                                   to_string(inputs[1].lens().at(0)) + ") != number of starts (" +
-                                   to_string(starts.size()) + ")");
-                }
-                std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
-                    return shape::dynamic_dimension{0, dd.get_interval().max};
-                });
+                if(inputs[1].lens()[0] != starts.size())
+                    MIGRAPHX_THROW("SLICE: input length (" + migraphx::to_string(inputs[1].lens()[0]) + ") does not match attribute length (" + migraphx::to_string(starts.size()) + ")");
             }
             else
             {
-                MIGRAPHX_THROW("Invalid 3 input and attributes configuration");
+                MIGRAPHX_THROW("SLICE: Invalid mode for 3 inputs");
             }
         }
         else
         {
-            // all 4 inputs (data, inputs_starts, input_ends, input_axes)
+            if(mode != slice_mode::starts_ends_axes_input)
+            {
+                MIGRAPHX_THROW("SLICE: Invalid mode for 4 inputs");
+            }
+        }
+        return;
+    }
+
+    // TODO: remove this once range-based dynamic shapes are deprecated
+    bool use_range_based_logic() const
+    {
+        if(mode == slice_mode::starts_input and starts.empty())
+            return true;
+        else if(mode == slice_mode::ends_input and ends.empty())
+            return true;
+        else if(mode == slice_mode::axes_input and axes.empty())
+            return true;
+        else if(mode == slice_mode::starts_ends_input and starts.empty() and ends.empty())
+            return true;
+        else if(mode == slice_mode::starts_axes_input and starts.empty() and axes.empty())
+            return true;
+        else if(mode == slice_mode::ends_axes_input and ends.empty() and axes.empty())
+            return true;
+        else if(mode == slice_mode::starts_ends_axes_input and starts.empty() and ends.empty() and axes.empty())
+            return true;
+        else
+            return false;
+    }
+
+    // For when there is a variable input and the associated attribute is not set.
+    // ex: slice(data, starts) starts = {}, ends = {2, 3}, axes = {0, 1}
+    // TODO: remove this once range-based dynamic shapes are deprecated
+    shape range_based_compute_shape_for_two_or_more(shape input_shape) const
+    {
+        auto dds = input_shape.to_dynamic().dyn_dims();
+        static std::vector<slice_mode> has_axes_input = {
+            slice_mode::axes_input,
+            slice_mode::starts_axes_input,
+            slice_mode::ends_axes_input,
+            slice_mode::starts_ends_axes_input
+        };
+        if(contains(has_axes_input, mode))
+        {
             std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
                 return shape::dynamic_dimension{0, dd.get_interval().max};
             });
         }
+
+        std::for_each(axes.cbegin(), axes.cend(), [&](const auto& axis) {
+                dds.at(axis) = {0, dds.at(axis).get_interval().max};
+        });
         return shape{input_shape.type(), dds};
+    }
+
+
+    // Static and symbolic inputs share this path; the result is demoted back to
+    // static when fully fixed (slice is a view).
+    shape symbolic_compute_shape(const shape& s) const
+    {
+        if(starts.size() != axes.size() or ends.size() != axes.size())
+            MIGRAPHX_THROW("SLICE: Attribute sizes do not match for symbolic_compute_shape()");
+        auto sym_in      = s.to_symbolic();
+        auto dds         = sym_in.dyn_dims();
+        auto start_exprs = to_sym_exprs(starts);
+        auto end_exprs   = to_sym_exprs(ends);
+        for(std::size_t i = 0; i < axes.size(); ++i)
+            dds[axes[i]] = shape::dynamic_dimension{end_exprs[i] - start_exprs[i]};
+        shape result{s.type(), std::move(dds), sym_in.dyn_strides()};
+        if(not s.symbolic() and result.is_fixed())
+            return result.to_static();
+        return result;
     }
 
     // uses the normalize_axes flag to normalize axes, starts, and ends
     shape normalize_compute_shape(std::vector<shape> inputs) const
     {
         check_shapes{inputs, *this, true}.has(1, 2, 3, 4);
-        if(inputs.size() != 1)
-            return compute_two_or_more(inputs);
-
+        check_inputs_and_attributes(inputs);
         auto input_shape    = inputs[0];
-        auto set_attributes = get_set_attributes();
-        if(set_attributes != all_set)
-            MIGRAPHX_THROW("SLICE 1_arg: Invalid 1 input and attributes configuration");
-
-        // TODO: support slicing non-fixed symbolic dims (output dim would be
-        // a sym::expr derived from starts/ends and the symbolic axis bound).
-        if(input_shape.dynamic() and std::any_of(axes.begin(), axes.end(), [&](auto axis) {
-               return not input_shape.dyn_dims()[axis].is_fixed();
-           }))
+        if(inputs.size() == 1 and input_shape.dynamic() and not input_shape.symbolic())
         {
-            if(input_shape.symbolic())
+            // Fallback for range-based dynamic shapes.
+            // Non-fixed sliced axis: bounds aren't normalized (can be negative or
+            // out-of-bounds), so use a relaxed [0, max] bound. (#5015)
+            // TODO: remove this once range-based dynamic shapes are deprecated
+            if(std::any_of(axes.begin(), axes.end(), [&](auto axis) {
+                   return not input_shape.dyn_dims()[axis].is_fixed();
+               }))
             {
-                MIGRAPHX_THROW(
-                    "SLICE 1_arg: slicing is not allowed on non-fixed symbolic input axis ");
+                auto dds = input_shape.dyn_dims();
+                for(auto axis : axes)
+                    dds[axis] = {0, dds[axis].get_interval().max};
+                return shape{input_shape.type(), dds};
             }
-            // Attributes are not normalized for this case, so they can be negative or
-            // out-of-bounds. Using a relaxed dimension bound for now instead of calculating the
-            // tightest possible bound.
-            auto dds = input_shape.dyn_dims();
-            for(auto axis : this->axes)
-            {
-                dds[axis] = {0, dds[axis].get_interval().max};
-            }
+
+            auto new_lens = lens_calc(input_shape.max_lens(), to_ints(starts), to_ints(ends), axes);
+            auto dds      = input_shape.dyn_dims();
+            for(auto axis : axes)
+                dds[axis] = shape::dynamic_dimension{new_lens[axis], new_lens[axis]};
             return shape{input_shape.type(), dds};
         }
-
-        auto new_lens = lens_calc(input_shape.max_lens(), this->starts, this->ends, this->axes);
-
-        if(not input_shape.dynamic())
-            return shape{input_shape.type(), new_lens, input_shape.strides()};
-
-        auto dds = input_shape.dyn_dims();
-        for(auto axis : this->axes)
+        else if(inputs.size() > 1 and use_range_based_logic())
         {
-            dds[axis] = input_shape.symbolic()
-                            ? shape::dynamic_dimension{sym::lit(new_lens[axis])}
-                            : shape::dynamic_dimension{new_lens[axis], new_lens[axis]};
+            // TODO: remove this once range-based dynamic shapes are deprecated
+            return range_based_compute_shape_for_two_or_more(input_shape);
         }
-
-        if(input_shape.symbolic())
-            return shape{input_shape.type(), dds, input_shape.dyn_strides()};
-        return shape{input_shape.type(), dds};
+        else
+        {
+            return symbolic_compute_shape(input_shape);
+        }
     }
 
-    /**
-     * Calculates the starting offset for the sliced tensor.
-     * Used in compute when only data input and all other information are in the attributes.
-     *
-     * \param s static input shape
-     */
+    /// Calculates the starting offset for the sliced tensor.
+    /// Used in compute when only data input and all other information are in the attributes.
+    ///
+    /// s: static input shape
     auto compute_offset(const shape& s) const
     {
         const std::vector<std::size_t>& lens    = s.lens();
@@ -327,85 +329,85 @@ struct slice
             for(std::size_t i = 0; i < axes.size(); i++)
             {
                 auto axis = axes[i];
-                offset += starts[i] * strides[axis];
+                offset += std::get<int64_t>(starts[i]) * strides[axis];
             }
         }
         else
         {
             for(std::size_t axis = 0; axis < lens.size(); axis++)
             {
-                offset += starts[axis] * strides[axis];
+                offset += std::get<int64_t>(starts[axis]) * strides[axis];
             }
         }
         return offset * s.type_size();
     }
 
-    /**
-     * Calculates the starting offset for the sliced tensor (for aliasing).
-     * Used for 2-4 inputs to `slice.
-     *
-     * \param s static input shape
-     * \param input_starts starting indices of slice
-     * \param ax_vec axes to slice on
-     */
+    /// Calculates the starting offset for the sliced tensor (for aliasing).
+    /// Used for 2-4 inputs to `slice.
+    ///
+    /// s: static input shape
+    /// starts_input: starting indices of slice
+    /// ax_vec: axes to slice on
     template <class T>
-    auto compute_offset(const shape& s, const T& input_starts, const T& ax_vec) const
+    auto compute_offset(const shape& s, const T& starts_input, const T& ax_vec) const
     {
         auto ret = 0;
         for(std::size_t i = 0; i < ax_vec.size(); ++i)
         {
             auto axis = ax_vec[i];
-            ret += input_starts[i] * s.strides().at(axis);
+            ret += starts_input[i] * s.strides().at(axis);
         }
         return ret * s.type_size();
     }
 
-    /**
-     * If given, normalize the inputs. Otherwise get from operator attributes.
-     * Return the values in a map.
-     *
-     * Parameters
-     * input_shape: static shape of the input
-     * input_starts: optional
-     * input_ends: optional
-     * input_ends: optional
-     */
+    /// Used to normalize starts/ends/axes at runtime.
+    /// If given, normalize the starts/ends/axes inputs. Otherwise get from operator attributes.
+    /// If starts_input or ends_input is not given, assuming starts/ends attributes are only
+    /// integers. If starts/ends have symbolics, they should go through the starts_input and
+    /// ends_input instead. `axes` attribute should always be correctly normalized at compile-time
+    /// because shapes with dynamic rank are not supported.
+    ///
+    /// input_shape: static shape of the input
+    /// starts_input: optional
+    /// ends_input: optional
+    /// axes_input: optional
     std::unordered_map<std::string, std::vector<int64_t>>
     normalize_starts_ends_axes(shape input_shape,
-                               const optional<std::vector<int64_t>>& input_starts,
-                               const optional<std::vector<int64_t>>& input_ends,
-                               const optional<std::vector<int64_t>>& input_axes) const
+                               const optional<std::vector<int64_t>>& starts_input,
+                               const optional<std::vector<int64_t>>& ends_input,
+                               const optional<std::vector<int64_t>>& axes_input) const
     {
+        assert(not input_shape.dynamic());
         auto axes_attrs = this->attributes().at("normalize_axes");
         std::vector<int64_t> norm_starts;
         std::vector<int64_t> norm_ends;
         std::vector<int64_t> norm_axes;
-        if(input_axes)
+        if(axes_input)
         {
-            norm_axes = normalize_axes(input_axes.value(),
+            norm_axes = normalize_axes(axes_input.value(),
                                        input_shape,
                                        axes_attrs.at("axes"),
-                                       "Slice variable input_axes");
+                                       "Slice variable axes_input");
         }
         else
         {
             norm_axes = this->axes;
         }
-        if(input_starts)
+        if(starts_input)
         {
-            norm_starts = normalize_indices(input_starts.value(),
+            norm_starts = normalize_indices(starts_input.value(),
                                             norm_axes,
                                             input_shape,
                                             axes_attrs.at("starts"),
-                                            "Slice variable input_starts");
+                                            "Slice variable starts_input");
         }
         else
         {
-            norm_starts = this->starts;
+            norm_starts = to_ints(this->starts);
         }
-        if(input_ends)
+        if(ends_input)
         {
-            norm_ends = normalize_indices(input_ends.value(),
+            norm_ends = normalize_indices(ends_input.value(),
                                           norm_axes,
                                           input_shape,
                                           axes_attrs.at("ends"),
@@ -413,7 +415,7 @@ struct slice
         }
         else
         {
-            norm_ends = this->ends;
+            norm_ends = to_ints(this->ends);
         }
         return {{"norm_starts", norm_starts}, {"norm_ends", norm_ends}, {"norm_axes", norm_axes}};
     }
@@ -429,87 +431,80 @@ struct slice
         }
         else
         {
-            // Note that we re-normalize both the attributes and inputs because of the non-fixed
-            // dynamic input shape case. It's possible to only re-normalize if slicing over
-            // non-fixed dynamic_dimensions.
-            auto set_attributes = get_set_attributes();
             std::unordered_map<std::string, std::vector<int64_t>> norm_inputs;
-            if(set_attributes == ends_axes)
+            // Attribute-provided dims are passed as their concrete int values (via to_ints) so they
+            // are re-normalized/clamped against the runtime input shape, just like the runtime
+            // inputs. Symbolic bounds only ever appear on the input-provided dims.
+            if(mode == slice_mode::starts_input)
             {
-                // attr ends and axes set; inputs are (data, input_starts)
-                args[1].visit([&](auto input_starts) {
+                args[1].visit([&](auto starts_input) {
                     norm_inputs =
                         normalize_starts_ends_axes(input_shape,
-                                                   input_starts.template to_vector<int64_t>(),
-                                                   this->ends,
+                                                   starts_input.template to_vector<int64_t>(),
+                                                   to_ints(this->ends),
                                                    this->axes);
                 });
             }
-            else if(set_attributes == starts_axes)
+            else if(mode == slice_mode::ends_input)
             {
-                // attr starts and axes set; inputs are (data, input_ends)
-                args[1].visit([&](auto input_ends) {
+                args[1].visit([&](auto ends_input) {
                     norm_inputs =
                         normalize_starts_ends_axes(input_shape,
-                                                   this->starts,
-                                                   input_ends.template to_vector<int64_t>(),
+                                                   to_ints(this->starts),
+                                                   ends_input.template to_vector<int64_t>(),
                                                    this->axes);
                 });
             }
-            else if(set_attributes == starts_ends)
+            else if(mode == slice_mode::axes_input)
             {
-                // attr starts and ends set; inputs are (data, input_axes)
-                args[1].visit([&](auto input_axes) {
+                args[1].visit([&](auto axes_input) {
                     norm_inputs =
                         normalize_starts_ends_axes(input_shape,
-                                                   this->starts,
-                                                   this->ends,
-                                                   input_axes.template to_vector<int64_t>());
+                                                   to_ints(this->starts),
+                                                   to_ints(this->ends),
+                                                   axes_input.template to_vector<int64_t>());
                 });
             }
-            else if(set_attributes == axes_only)
+            else if(mode == slice_mode::starts_ends_input)
             {
-                // attr axes set; inputs are (data, input_starts, input_ends)
-                visit_all(args[1], args[2])([&](auto input_starts, auto input_ends) {
+                // attr axes set; inputs are (data, starts_input, ends_input)
+                visit_all(args[1], args[2])([&](auto starts_input, auto ends_input) {
                     norm_inputs =
                         normalize_starts_ends_axes(input_shape,
-                                                   input_starts.template to_vector<int64_t>(),
-                                                   input_ends.template to_vector<int64_t>(),
+                                                   starts_input.template to_vector<int64_t>(),
+                                                   ends_input.template to_vector<int64_t>(),
                                                    this->axes);
                 });
             }
-            else if(set_attributes == ends_only)
+            else if(mode == slice_mode::starts_axes_input)
             {
-                // attr ends set; inputs are (data, input_starts, input_axes)
-                visit_all(args[1], args[2])([&](auto input_starts, auto input_axes) {
+                visit_all(args[1], args[2])([&](auto starts_input, auto axes_input) {
                     norm_inputs =
                         normalize_starts_ends_axes(input_shape,
-                                                   input_starts.template to_vector<int64_t>(),
-                                                   this->ends,
-                                                   input_axes.template to_vector<int64_t>());
+                                                   starts_input.template to_vector<int64_t>(),
+                                                   to_ints(this->ends),
+                                                   axes_input.template to_vector<int64_t>());
                 });
             }
-            else if(set_attributes == starts_only)
+            else if(mode == slice_mode::ends_axes_input)
             {
-                // attr starts set; inputs are (data, input_ends, input_axes)
-                visit_all(args[1], args[2])([&](auto input_ends, auto input_axes) {
+                visit_all(args[1], args[2])([&](auto ends_input, auto axes_input) {
                     norm_inputs =
                         normalize_starts_ends_axes(input_shape,
-                                                   this->starts,
-                                                   input_ends.template to_vector<int64_t>(),
-                                                   input_axes.template to_vector<int64_t>());
+                                                   to_ints(this->starts),
+                                                   ends_input.template to_vector<int64_t>(),
+                                                   axes_input.template to_vector<int64_t>());
                 });
             }
-            else
+            else // mode == slice_mode::starts_ends_axes_input
             {
-                // no attr set, all inputs
                 visit_all(args[1], args[2], args[3])(
-                    [&](auto input_starts, auto input_ends, auto input_axes) {
+                    [&](auto starts_input, auto ends_input, auto axes_input) {
                         norm_inputs =
                             normalize_starts_ends_axes(input_shape,
-                                                       input_starts.template to_vector<int64_t>(),
-                                                       input_ends.template to_vector<int64_t>(),
-                                                       input_axes.template to_vector<int64_t>());
+                                                       starts_input.template to_vector<int64_t>(),
+                                                       ends_input.template to_vector<int64_t>(),
+                                                       axes_input.template to_vector<int64_t>());
                     });
             }
             auto offset = compute_offset(

--- a/src/include/migraphx/op/slice.hpp
+++ b/src/include/migraphx/op/slice.hpp
@@ -58,7 +58,7 @@ namespace op {
 /// axes: axes to slice over
 /// starts: slice starting indices
 /// ends: slice ending indices
-/// mode: what inputs[1:4] of slice mean
+/// mode: the role (starts/ends/axes) of each variable input after `data`
 ///
 /// Parameters:
 /// data: the input tensor to slice (dynamic or static shape)
@@ -126,7 +126,7 @@ struct slice
     }
 
     /// Check that the inputs, attributes, and mode are valid.
-    void check_inputs_and_attributes(std::vector<shape> inputs) const
+    void check_inputs_and_attributes(const std::vector<shape>& inputs) const
     {
         // All set (non-empty) bound attributes must agree on the number of sliced axes.
         // A variable (input-provided) bound leaves its attribute empty, so empty attrs are skipped.
@@ -190,7 +190,7 @@ struct slice
     // For when there is a variable input and the associated attribute is not set.
     // ex: slice(data, starts) starts = {}, ends = {2, 3}, axes = {0, 1}
     // TODO: remove this once range-based dynamic shapes are deprecated
-    shape range_based_compute_shape_for_two_or_more(shape input_shape) const
+    shape range_based_compute_shape_for_two_or_more(const shape& input_shape) const
     {
         auto dds = input_shape.to_dynamic().dyn_dims();
         if(contains(mode, slice_mode::axes))
@@ -291,7 +291,7 @@ struct slice
     }
 
     /// Calculates the starting offset for the sliced tensor (for aliasing).
-    /// Used for 2-4 inputs to `slice.
+    /// Used for 2-4 inputs to `slice`.
     ///
     /// s: static input shape
     /// starts_input: starting indices of slice
@@ -320,19 +320,41 @@ struct slice
     {
         assert(not input_shape.dynamic());
         auto axes_attrs = this->attributes().at("normalize_axes");
-        std::vector<int64_t> norm_starts;
-        std::vector<int64_t> norm_ends;
-        std::vector<int64_t> norm_axes;
-        norm_axes = normalize_axes(
+        auto norm_axes  = normalize_axes(
             axes_vec, input_shape, axes_attrs.at("axes"), "Slice variable axes_input");
-        norm_starts = normalize_indices(starts_vec,
-                                        norm_axes,
-                                        input_shape,
-                                        axes_attrs.at("starts"),
-                                        "Slice variable starts_input");
-        norm_ends   = normalize_indices(
+        auto norm_starts = normalize_indices(starts_vec,
+                                             norm_axes,
+                                             input_shape,
+                                             axes_attrs.at("starts"),
+                                             "Slice variable starts_input");
+        auto norm_ends   = normalize_indices(
             ends_vec, norm_axes, input_shape, axes_attrs.at("ends"), "Slice variable input ends");
         return {{"norm_starts", norm_starts}, {"norm_ends", norm_ends}, {"norm_axes", norm_axes}};
+    }
+
+    /// Resolves the concrete starts/ends/axes for a variable-input slice using the modes and inputs.
+    /// `read_input` is a function that returns a std::vector<int64_t> of the input at i.
+    template <class F>
+    std::array<std::vector<int64_t>, 3> resolve_bounds(F read_input) const
+    {
+
+        std::array<std::vector<int64_t>, 3> result{};
+        for(std::size_t i = 0; i < mode.size(); ++i)
+        {
+            switch(mode[i])
+            {
+            case slice_mode::starts: result[0] = read_input(i); break;
+            case slice_mode::ends: result[1] = read_input(i); break;
+            case slice_mode::axes: result[2] = read_input(i); break;
+            }
+        }
+        if(result[0].empty())
+            result[0] = to_ints(this->starts);
+        if(result[1].empty())
+            result[1] = to_ints(this->ends);
+        if(result[2].empty())
+            result[2] = this->axes;
+        return result;
     }
 
     argument compute(const dyn_output& dyn_out, std::vector<argument> args) const
@@ -346,27 +368,12 @@ struct slice
         }
         else
         {
-            std::vector<int64_t> starts_vec;
-            std::vector<int64_t> ends_vec;
-            std::vector<int64_t> axes_vec;
-            for(std::size_t i = 0; i < mode.size(); ++i)
-            {
-                args[i + 1].visit([&](auto input_view) {
-                    auto vec = input_view.template to_vector<int64_t>();
-                    switch(mode[i])
-                    {
-                    case slice_mode::starts: starts_vec = vec; break;
-                    case slice_mode::ends: ends_vec = vec; break;
-                    case slice_mode::axes: axes_vec = vec; break;
-                    }
-                });
-            }
-            if(starts_vec.empty())
-                starts_vec = to_ints(this->starts);
-            if(ends_vec.empty())
-                ends_vec = to_ints(this->ends);
-            if(axes_vec.empty())
-                axes_vec = this->axes;
+            auto [starts_vec, ends_vec, axes_vec] = resolve_bounds([&](std::size_t i) {
+                std::vector<int64_t> vec;
+                args[i + 1].visit(
+                    [&](auto input_view) { vec = input_view.template to_vector<int64_t>(); });
+                return vec;
+            });
             auto norm_inputs =
                 normalize_starts_ends_axes(input_shape, starts_vec, ends_vec, axes_vec);
             auto offset = compute_offset(

--- a/src/include/migraphx/op/slice.hpp
+++ b/src/include/migraphx/op/slice.hpp
@@ -69,8 +69,6 @@ struct slice
 {
     MIGRAPHX_NESTED_ENUM_CLASS(slice_mode, starts, ends, axes);
 
-    friend std::ostream& operator<<(std::ostream& os, slice_mode v) { return os << to_string(v); }
-
     std::vector<int64_t> axes{};
     std::vector<dim_like> starts{};
     std::vector<dim_like> ends{};
@@ -129,7 +127,8 @@ struct slice
     void check_inputs_and_attributes(const std::vector<shape>& inputs) const
     {
         // All set (non-empty) bound attributes must agree on the number of sliced axes.
-        // A variable (input-provided) bound can leave its attribute empty, so empty attrs are skipped.
+        // A variable (input-provided) bound can leave its attribute empty, so empty attrs are
+        // skipped.
         std::size_t attr_size = 0;
         for(auto s : {axes.size(), starts.size(), ends.size()})
         {
@@ -229,7 +228,7 @@ struct slice
     {
         check_shapes{inputs, *this, true}.has(1, 2, 3, 4);
         check_inputs_and_attributes(inputs);
-        auto input_shape    = inputs[0];
+        auto input_shape = inputs[0];
         if(inputs.size() == 1 and input_shape.dynamic() and not input_shape.symbolic())
         {
             // Fallback for range-based dynamic shapes.

--- a/src/include/migraphx/op/slice.hpp
+++ b/src/include/migraphx/op/slice.hpp
@@ -332,8 +332,8 @@ struct slice
         return {{"norm_starts", norm_starts}, {"norm_ends", norm_ends}, {"norm_axes", norm_axes}};
     }
 
-    /// Resolves the concrete starts/ends/axes for a variable-input slice using the modes and inputs.
-    /// `read_input` is a function that returns a std::vector<int64_t> of the input at i.
+    /// Resolves the concrete starts/ends/axes for a variable-input slice using the modes and
+    /// inputs. `read_input` is a function that returns a std::vector<int64_t> of the input at i.
     template <class F>
     std::array<std::vector<int64_t>, 3> resolve_bounds(F read_input) const
     {

--- a/src/include/migraphx/op/slice.hpp
+++ b/src/include/migraphx/op/slice.hpp
@@ -149,7 +149,8 @@ struct slice
         if(inputs.size() == 1)
         {
             if(any_sym(starts) or any_sym(ends))
-                MIGRAPHX_THROW("SLICE: Invalid attributes: symbolic in attribute for 1 input slice");
+                MIGRAPHX_THROW(
+                    "SLICE: Invalid attributes: symbolic in attribute for 1 input slice");
             if(mode != slice_mode::one_input)
                 MIGRAPHX_THROW("SLICE: Invalid mode for 1 input");
             return;
@@ -163,16 +164,23 @@ struct slice
             .same_dims();
         if(inputs.size() == 2)
         {
-            std::vector<slice_mode> two_input_modes_not_axes = {slice_mode::starts_input, slice_mode::ends_input};
+            std::vector<slice_mode> two_input_modes_not_axes = {slice_mode::starts_input,
+                                                                slice_mode::ends_input};
             if(contains(two_input_modes_not_axes, mode))
             {
                 if(inputs[1].lens()[0] != axes.size())
-                    MIGRAPHX_THROW("SLICE: input length (" + migraphx::to_string(inputs[1].lens()[0]) + ") does not match attribute length (" + migraphx::to_string(axes.size()) + ")");
+                    MIGRAPHX_THROW("SLICE: input length (" +
+                                   migraphx::to_string(inputs[1].lens()[0]) +
+                                   ") does not match attribute length (" +
+                                   migraphx::to_string(axes.size()) + ")");
             }
             else if(mode == slice_mode::axes_input)
             {
                 if(inputs[1].lens()[0] != starts.size())
-                    MIGRAPHX_THROW("SLICE: input length (" + migraphx::to_string(inputs[1].lens()[0]) + ") does not match attribute length (" + migraphx::to_string(starts.size()) + ")");
+                    MIGRAPHX_THROW("SLICE: input length (" +
+                                   migraphx::to_string(inputs[1].lens()[0]) +
+                                   ") does not match attribute length (" +
+                                   migraphx::to_string(starts.size()) + ")");
             }
             else
             {
@@ -184,17 +192,26 @@ struct slice
             if(mode == slice_mode::starts_ends_input)
             {
                 if(inputs[1].lens()[0] != axes.size())
-                    MIGRAPHX_THROW("SLICE: input length (" + migraphx::to_string(inputs[1].lens()[0]) + ") does not match attribute length (" + migraphx::to_string(axes.size()) + ")");
+                    MIGRAPHX_THROW("SLICE: input length (" +
+                                   migraphx::to_string(inputs[1].lens()[0]) +
+                                   ") does not match attribute length (" +
+                                   migraphx::to_string(axes.size()) + ")");
             }
             else if(mode == slice_mode::starts_axes_input)
             {
                 if(inputs[1].lens()[0] != ends.size())
-                    MIGRAPHX_THROW("SLICE: input length (" + migraphx::to_string(inputs[1].lens()[0]) + ") does not match attribute length (" + migraphx::to_string(ends.size()) + ")");
+                    MIGRAPHX_THROW("SLICE: input length (" +
+                                   migraphx::to_string(inputs[1].lens()[0]) +
+                                   ") does not match attribute length (" +
+                                   migraphx::to_string(ends.size()) + ")");
             }
             else if(mode == slice_mode::ends_axes_input)
             {
                 if(inputs[1].lens()[0] != starts.size())
-                    MIGRAPHX_THROW("SLICE: input length (" + migraphx::to_string(inputs[1].lens()[0]) + ") does not match attribute length (" + migraphx::to_string(starts.size()) + ")");
+                    MIGRAPHX_THROW("SLICE: input length (" +
+                                   migraphx::to_string(inputs[1].lens()[0]) +
+                                   ") does not match attribute length (" +
+                                   migraphx::to_string(starts.size()) + ")");
             }
             else
             {
@@ -226,7 +243,8 @@ struct slice
             return true;
         else if(mode == slice_mode::ends_axes_input and ends.empty() and axes.empty())
             return true;
-        else if(mode == slice_mode::starts_ends_axes_input and starts.empty() and ends.empty() and axes.empty())
+        else if(mode == slice_mode::starts_ends_axes_input and starts.empty() and ends.empty() and
+                axes.empty())
             return true;
         else
             return false;
@@ -237,13 +255,11 @@ struct slice
     // TODO: remove this once range-based dynamic shapes are deprecated
     shape range_based_compute_shape_for_two_or_more(shape input_shape) const
     {
-        auto dds = input_shape.to_dynamic().dyn_dims();
-        static std::vector<slice_mode> has_axes_input = {
-            slice_mode::axes_input,
-            slice_mode::starts_axes_input,
-            slice_mode::ends_axes_input,
-            slice_mode::starts_ends_axes_input
-        };
+        auto dds                                      = input_shape.to_dynamic().dyn_dims();
+        static std::vector<slice_mode> has_axes_input = {slice_mode::axes_input,
+                                                         slice_mode::starts_axes_input,
+                                                         slice_mode::ends_axes_input,
+                                                         slice_mode::starts_ends_axes_input};
         if(contains(has_axes_input, mode))
         {
             std::transform(dds.begin(), dds.end(), dds.begin(), [](const auto& dd) {
@@ -252,11 +268,10 @@ struct slice
         }
 
         std::for_each(axes.cbegin(), axes.cend(), [&](const auto& axis) {
-                dds.at(axis) = {0, dds.at(axis).get_interval().max};
+            dds.at(axis) = {0, dds.at(axis).get_interval().max};
         });
         return shape{input_shape.type(), dds};
     }
-
 
     // Static and symbolic inputs share this path; the result is demoted back to
     // static when fully fixed (slice is a view).

--- a/src/normalize_attributes.cpp
+++ b/src/normalize_attributes.cpp
@@ -69,8 +69,8 @@ static dim_like to_dim_like(const sym::expr& e)
     return shape::dynamic_dimension{e};
 }
 
-// Symbolic analog of tune_attribute for dim_like bounds (clip_min/clip_max +
-// use_len). Applies the ONNX clamp norm(v) = clamp(v < 0 ? v + D : v, 0, D)
+// Symbolic analog of tune_attribute for dim_like bounds. Requires use_len normalization
+// (throws otherwise) and applies the ONNX clamp norm(v) = clamp(v < 0 ? v + D : v, 0, D)
 // symbolically, folding against the interval bounds where provable.
 template <class Message>
 static value tune_attribute_sym(const std::vector<dim_like>& dims,

--- a/src/normalize_attributes.cpp
+++ b/src/normalize_attributes.cpp
@@ -25,10 +25,78 @@
 #include <migraphx/ranges.hpp>
 #include <migraphx/normalize_attributes.hpp>
 #include <migraphx/stringutils.hpp>
+#include <migraphx/dim_like.hpp>
+#include <migraphx/sym.hpp>
+#include <migraphx/value.hpp>
 #include <migraphx/op/normalize_attribute.hpp>
 #include <migraphx/op/common.hpp>
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
+
+// min/max that fold to one operand when the ordering is provable via intervals,
+// and only fall back to a symbolic min/max node when it is indeterminate.
+static sym::expr fold_min(const sym::expr& a, const sym::expr& b)
+{
+    auto lt = sym::strict_less(a, b);
+    if(lt.has_value())
+        return *lt ? a : b;
+    return sym::min(a, b);
+}
+static sym::expr fold_max(const sym::expr& a, const sym::expr& b)
+{
+    auto lt = sym::strict_less(a, b);
+    if(lt.has_value())
+        return *lt ? b : a;
+    return sym::max(a, b);
+}
+
+static sym::expr axis_len_expr(const shape& s, int64_t axis)
+{
+    if(not s.dynamic())
+        return sym::lit(static_cast<int64_t>(s.lens().at(axis)));
+    const auto& dd = s.dyn_dims().at(axis);
+    if(dd.is_symbolic())
+        return dd.sym_expr;
+    if(dd.is_fixed())
+        return sym::lit(static_cast<int64_t>(dd.get_interval().max));
+    MIGRAPHX_THROW("normalize_attributes: cannot normalize a symbolic bound on a non-fixed axis");
+}
+
+static dim_like to_dim_like(const sym::expr& e)
+{
+    if(e.name() == "literal")
+        return sym::to<int64_t>(e.eval({}));
+    return shape::dynamic_dimension{e};
+}
+
+// Symbolic analog of tune_attribute for dim_like bounds (clip_min/clip_max +
+// use_len). Applies the ONNX clamp norm(v) = clamp(v < 0 ? v + D : v, 0, D)
+// symbolically, folding against the interval bounds where provable.
+template <class Message>
+static value tune_attribute_sym(const std::vector<dim_like>& dims,
+                                const std::vector<int64_t>& axes,
+                                const std::vector<op::normalize_attribute>& attrs,
+                                const shape& input_shape,
+                                Message m)
+{
+    if(not contains(attrs, op::normalize_attribute::use_len))
+        MIGRAPHX_THROW(m() + "symbolic bounds are only supported with use_len normalization");
+    if(axes.size() != dims.size())
+        MIGRAPHX_THROW(m() + "symbolic bounds require one axis per bound");
+    auto zero  = sym::lit(std::int64_t{0});
+    auto exprs = to_sym_exprs(dims);
+    std::vector<dim_like> result(dims.size());
+    std::transform(
+        exprs.begin(), exprs.end(), axes.begin(), result.begin(), [&](const auto& v, auto axis) {
+            auto len = axis_len_expr(input_shape, axis);
+            auto neg = sym::strict_less(v, zero); // from-the-end (negative) index?
+            if(not neg.has_value())
+                MIGRAPHX_THROW(m() + "symbolic bound of indeterminate sign cannot be normalized");
+            auto abs_v = *neg ? v + len : v;
+            return to_dim_like(fold_min(fold_max(abs_v, zero), len));
+        });
+    return migraphx::to_value(result);
+}
 
 /**
  * Parameters:
@@ -234,6 +302,22 @@ bool normalize_attributes(operation& op, const shape& input_shape)
                 if(val.contains("axes"))
                 {
                     axes = val.at("axes").without_key().to_vector<int64_t>();
+                }
+                // Symbolic (dim_like) bounds serialize as objects; clamp them
+                // symbolically rather than against a compile-time length.
+                if(std::any_of(vv.begin(), vv.end(), [](const auto& e) { return e.is_object(); }))
+                {
+                    auto dims = migraphx::from_value<std::vector<dim_like>>(vv);
+                    val[key] =
+                        tune_attribute_sym(dims,
+                                           axes,
+                                           rv.without_key().to_vector<op::normalize_attribute>(),
+                                           input_shape,
+                                           message);
+                    op.from_value(val);
+                    val   = op.to_value();
+                    tuned = true;
+                    continue;
                 }
                 auto vec    = vv.to_vector<int64_t>();
                 auto result = tune_attribute(vec, axes, rv.without_key(), input_shape, message);

--- a/src/normalize_attributes.cpp
+++ b/src/normalize_attributes.cpp
@@ -33,20 +33,10 @@
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
-// Re-clamping against a bound the expression already clamps to would only nest a redundant
-// node, since min(min(x, b), b) == min(x, b) and max(max(x, b), b) == max(x, b). Attributes are
-// normalized again on every shape computation, so without this the nesting grows without bound.
-static bool already_clamped(const sym::expr& e, std::string_view op_name, const sym::expr& bound)
-{
-    return e.name() == op_name and contains(e.children(), bound);
-}
-
-// min/max that fold to one operand when the ordering is provable via intervals,
-// and only fall back to a symbolic min/max node when it is indeterminate.
+// `min/max` that fold to one operand when the ordering is provable via intervals.
+// Fall back to a symbolic min/max node when it is indeterminate.
 static sym::expr fold_min(const sym::expr& a, const sym::expr& b)
 {
-    if(already_clamped(a, "min", b))
-        return a;
     auto lt = sym::strict_less(a, b);
     if(lt.has_value())
         return *lt ? a : b;
@@ -54,8 +44,6 @@ static sym::expr fold_min(const sym::expr& a, const sym::expr& b)
 }
 static sym::expr fold_max(const sym::expr& a, const sym::expr& b)
 {
-    if(already_clamped(a, "max", b))
-        return a;
     auto lt = sym::strict_less(a, b);
     if(lt.has_value())
         return *lt ? b : a;

--- a/src/normalize_attributes.cpp
+++ b/src/normalize_attributes.cpp
@@ -33,10 +33,20 @@
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
+// Re-clamping against a bound the expression already clamps to would only nest a redundant
+// node, since min(min(x, b), b) == min(x, b) and max(max(x, b), b) == max(x, b). Attributes are
+// normalized again on every shape computation, so without this the nesting grows without bound.
+static bool already_clamped(const sym::expr& e, std::string_view op_name, const sym::expr& bound)
+{
+    return e.name() == op_name and contains(e.children(), bound);
+}
+
 // min/max that fold to one operand when the ordering is provable via intervals,
 // and only fall back to a symbolic min/max node when it is indeterminate.
 static sym::expr fold_min(const sym::expr& a, const sym::expr& b)
 {
+    if(already_clamped(a, "min", b))
+        return a;
     auto lt = sym::strict_less(a, b);
     if(lt.has_value())
         return *lt ? a : b;
@@ -44,6 +54,8 @@ static sym::expr fold_min(const sym::expr& a, const sym::expr& b)
 }
 static sym::expr fold_max(const sym::expr& a, const sym::expr& b)
 {
+    if(already_clamped(a, "max", b))
+        return a;
     auto lt = sym::strict_less(a, b);
     if(lt.has_value())
         return *lt ? b : a;
@@ -53,12 +65,12 @@ static sym::expr fold_max(const sym::expr& a, const sym::expr& b)
 static sym::expr axis_len_expr(const shape& s, int64_t axis)
 {
     if(not s.dynamic())
-        return sym::lit(static_cast<int64_t>(s.lens().at(axis)));
+        return sym::lit(s.lens().at(axis));
     const auto& dd = s.dyn_dims().at(axis);
     if(dd.is_symbolic())
         return dd.sym_expr;
     if(dd.is_fixed())
-        return sym::lit(static_cast<int64_t>(dd.get_interval().max));
+        return sym::lit(dd.get_interval().max);
     MIGRAPHX_THROW("normalize_attributes: cannot normalize a symbolic bound on a non-fixed axis");
 }
 

--- a/src/onnx/parse_nonmaxsuppression.cpp
+++ b/src/onnx/parse_nonmaxsuppression.cpp
@@ -51,7 +51,8 @@ struct parse_nonmaxsuppression : op_parser<parse_nonmaxsuppression>
             auto num_selected =
                 info.add_instruction(make_op("get_tuple_elem", {{"index", 1}}), nms_ins);
             return info.add_instruction(
-                make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"mode", "ends_input"}}),
+                make_op("slice",
+                        {{"axes", {0}}, {"starts", {0}}, {"mode", migraphx::value::array{"ends"}}}),
                 indices,
                 num_selected);
         }

--- a/src/onnx/parse_nonmaxsuppression.cpp
+++ b/src/onnx/parse_nonmaxsuppression.cpp
@@ -51,7 +51,9 @@ struct parse_nonmaxsuppression : op_parser<parse_nonmaxsuppression>
             auto num_selected =
                 info.add_instruction(make_op("get_tuple_elem", {{"index", 1}}), nms_ins);
             return info.add_instruction(
-                make_op("slice", {{"axes", {0}}, {"starts", {0}}}), indices, num_selected);
+                make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"mode", "ends_input"}}),
+                indices,
+                num_selected);
         }
         else
         {

--- a/src/onnx/parse_slice.cpp
+++ b/src/onnx/parse_slice.cpp
@@ -95,12 +95,9 @@ struct parse_slice : op_parser<parse_slice>
             return ins;
     }
 
-    slice_desc construct_slice_desc(const onnx_parser& parser,
-                                    onnx_parser::node_info info,
-                                    std::vector<instruction_ref> args) const
+    slice_desc handle_sd_inputs(const onnx_parser& parser, onnx_parser::node_info info, std::vector<instruction_ref> args) const
     {
         slice_desc sd;
-
         // ONNX Slice can have up to 5 inputs, we first check the 5th one
         // to decide whether MIGX can handle this slice.
         if(args.size() == 5)
@@ -109,27 +106,25 @@ struct parse_slice : op_parser<parse_slice>
             check_arg_empty(step_arg, "PARSE_SLICE: cannot handle variable steps for slice");
             step_arg.visit([&](auto s) { sd.steps.assign(s.begin(), s.end()); });
         }
-
         if(args.size() >= 4)
         {
-            auto _axes = sd.try_insert(args.at(3));
-            if(_axes.empty())
+            auto tmp_axes = sd.try_insert(args.at(3));
+            if(tmp_axes.empty())
                 sd.mode.insert(sd.mode.begin(), op::slice::slice_mode::axes);
-            sd.axes = _axes;
+            sd.axes = tmp_axes;
         }
         else if(contains(info.attributes, "axes"))
         {
             literal s = parser.parse_value(info.attributes.at("axes"));
             s.visit([&](auto v) { copy(v, std::back_inserter(sd.axes)); });
         }
-
         // NOTE: goes through range-based dynamic shapes pathway only
         if(args.size() >= 3)
         {
-            auto _ends = sd.try_insert(args.at(2));
-            if(_ends.empty())
+            auto tmp_ends = sd.try_insert(args.at(2));
+            if(tmp_ends.empty())
                 sd.mode.insert(sd.mode.begin(), op::slice::slice_mode::ends);
-            sd.ends.assign(_ends.begin(), _ends.end());
+            sd.ends.assign(tmp_ends.begin(), tmp_ends.end());
         }
         else if(contains(info.attributes, "ends"))
         {
@@ -140,13 +135,12 @@ struct parse_slice : op_parser<parse_slice>
                 });
             });
         }
-
         if(args.size() >= 2)
         {
-            auto _starts = sd.try_insert(args.at(1));
-            if(_starts.empty())
+            auto tmp_starts = sd.try_insert(args.at(1));
+            if(tmp_starts.empty())
                 sd.mode.insert(sd.mode.begin(), op::slice::slice_mode::starts);
-            sd.starts.assign(_starts.begin(), _starts.end());
+            sd.starts.assign(tmp_starts.begin(), tmp_starts.end());
         }
         else if(contains(info.attributes, "starts"))
         {
@@ -157,10 +151,16 @@ struct parse_slice : op_parser<parse_slice>
                 });
             });
         }
-
         // data input argument
         sd.always_insert(args.at(0));
+        return sd;
+    }
 
+    slice_desc construct_slice_desc(const onnx_parser& parser,
+                                    onnx_parser::node_info info,
+                                    std::vector<instruction_ref> args) const
+    {
+        slice_desc sd = handle_sd_inputs(parser, info, args);
         // If axes arg is not given, the default is all of them.
         if(sd.axes.empty() and sd.op_args.size() <= 3)
         {

--- a/src/onnx/parse_slice.cpp
+++ b/src/onnx/parse_slice.cpp
@@ -95,7 +95,9 @@ struct parse_slice : op_parser<parse_slice>
             return ins;
     }
 
-    slice_desc handle_sd_inputs(const onnx_parser& parser, onnx_parser::node_info info, std::vector<instruction_ref> args) const
+    slice_desc handle_sd_inputs(const onnx_parser& parser,
+                                onnx_parser::node_info info,
+                                std::vector<instruction_ref> args) const
     {
         slice_desc sd;
         // ONNX Slice can have up to 5 inputs, we first check the 5th one

--- a/src/onnx/parse_slice.cpp
+++ b/src/onnx/parse_slice.cpp
@@ -99,7 +99,7 @@ struct parse_slice : op_parser<parse_slice>
     {
         slice_desc sd;
         // ONNX Slice can have up to 5 inputs, we first check the 5th one
-        // to decide whether MIGX can handle this slice.
+        // to decide whether MIGraphX can handle this slice.
         if(args.size() == 5)
         {
             migraphx::argument step_arg = args.back()->eval();
@@ -118,7 +118,6 @@ struct parse_slice : op_parser<parse_slice>
             literal s = parser.parse_value(info.attributes.at("axes"));
             s.visit([&](auto v) { copy(v, std::back_inserter(sd.axes)); });
         }
-        // NOTE: goes through range-based dynamic shapes pathway only
         if(args.size() >= 3)
         {
             auto tmp_ends = sd.try_insert(args.at(2));
@@ -160,7 +159,7 @@ struct parse_slice : op_parser<parse_slice>
                                     onnx_parser::node_info info,
                                     std::vector<instruction_ref> args) const
     {
-        slice_desc sd = handle_sd_inputs(parser, info, args);
+        slice_desc sd = handle_sd_inputs(parser, std::move(info), args);
         // If axes arg is not given, the default is all of them.
         if(sd.axes.empty() and sd.op_args.size() <= 3)
         {

--- a/src/onnx/parse_slice.cpp
+++ b/src/onnx/parse_slice.cpp
@@ -27,19 +27,11 @@
 #include <migraphx/ranges.hpp>
 #include <migraphx/instruction.hpp>
 #include <migraphx/make_op.hpp>
-#include <migraphx/enum.hpp>
 #include <migraphx/dim_like.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace onnx {
-
-MIGRAPHX_BIT_FLAG_ENUM(slice_input_flags,
-                       std::uint8_t,
-                       none         = 0,
-                       starts_input = 1 << 0,
-                       ends_input   = 1 << 1,
-                       axes_input   = 1 << 2)
 
 struct parse_slice : op_parser<parse_slice>
 {
@@ -54,7 +46,7 @@ struct parse_slice : op_parser<parse_slice>
         std::vector<dim_like> ends;
         std::vector<int64_t> steps;
         std::vector<int64_t> raxes;
-        slice_input_flags flags = slice_input_flags::none;
+        std::vector<op::slice::slice_mode> mode{};
 
         void always_insert(instruction_ref arg) { op_args.insert(op_args.begin(), arg); }
 
@@ -74,36 +66,7 @@ struct parse_slice : op_parser<parse_slice>
             return result;
         }
 
-        op::slice::slice_mode get_slice_mode(slice_input_flags slice_flags)
-        {
-            switch(slice_flags)
-            {
-            case slice_input_flags::none: return op::slice::slice_mode::one_input;
-            case slice_input_flags::starts_input: return op::slice::slice_mode::starts_input;
-            case slice_input_flags::ends_input: return op::slice::slice_mode::ends_input;
-            case slice_input_flags::axes_input: return op::slice::slice_mode::axes_input;
-            case(slice_input_flags::starts_input | slice_input_flags::ends_input):
-                return op::slice::slice_mode::starts_ends_input;
-            case(slice_input_flags::starts_input | slice_input_flags::axes_input):
-                return op::slice::slice_mode::starts_axes_input;
-            case(slice_input_flags::ends_input | slice_input_flags::axes_input):
-                return op::slice::slice_mode::ends_axes_input;
-            case(slice_input_flags::starts_input | slice_input_flags::ends_input |
-                 slice_input_flags::axes_input):
-                return op::slice::slice_mode::starts_ends_axes_input;
-            default: MIGRAPHX_THROW("PARSE_SLICE: invalid slice_mode");
-            }
-        }
-
-        op::slice create_slice_operator()
-        {
-            op::slice slice_op;
-            slice_op.axes   = axes;
-            slice_op.starts = starts;
-            slice_op.ends   = ends;
-            slice_op.mode   = get_slice_mode(flags);
-            return slice_op;
-        }
+        op::slice create_slice_operator() { return op::slice{axes, starts, ends, mode}; }
     };
 
     instruction_ref parse(const op_desc& /*opd*/,
@@ -151,7 +114,7 @@ struct parse_slice : op_parser<parse_slice>
         {
             auto _axes = sd.try_insert(args.at(3));
             if(_axes.empty())
-                sd.flags |= slice_input_flags::axes_input;
+                sd.mode.insert(sd.mode.begin(), op::slice::slice_mode::axes);
             sd.axes = _axes;
         }
         else if(contains(info.attributes, "axes"))
@@ -165,7 +128,7 @@ struct parse_slice : op_parser<parse_slice>
         {
             auto _ends = sd.try_insert(args.at(2));
             if(_ends.empty())
-                sd.flags |= slice_input_flags::ends_input;
+                sd.mode.insert(sd.mode.begin(), op::slice::slice_mode::ends);
             sd.ends.assign(_ends.begin(), _ends.end());
         }
         else if(contains(info.attributes, "ends"))
@@ -182,7 +145,7 @@ struct parse_slice : op_parser<parse_slice>
         {
             auto _starts = sd.try_insert(args.at(1));
             if(_starts.empty())
-                sd.flags |= slice_input_flags::starts_input;
+                sd.mode.insert(sd.mode.begin(), op::slice::slice_mode::starts);
             sd.starts.assign(_starts.begin(), _starts.end());
         }
         else if(contains(info.attributes, "starts"))

--- a/src/onnx/parse_slice.cpp
+++ b/src/onnx/parse_slice.cpp
@@ -76,36 +76,32 @@ struct parse_slice : op_parser<parse_slice>
 
         op::slice::slice_mode get_slice_mode(slice_input_flags slice_flags)
         {
-            switch (slice_flags)
+            switch(slice_flags)
             {
-                case slice_input_flags::none:
-                    return op::slice::slice_mode::one_input;
-                case slice_input_flags::starts_input:
-                    return op::slice::slice_mode::starts_input;
-                case slice_input_flags::ends_input:
-                    return op::slice::slice_mode::ends_input;
-                case slice_input_flags::axes_input:
-                    return op::slice::slice_mode::axes_input;
-                case (slice_input_flags::starts_input | slice_input_flags::ends_input):
-                    return op::slice::slice_mode::starts_ends_input;
-                case (slice_input_flags::starts_input | slice_input_flags::axes_input):
-                    return op::slice::slice_mode::starts_axes_input;
-                case (slice_input_flags::ends_input | slice_input_flags::axes_input):
-                    return op::slice::slice_mode::ends_axes_input;
-                case (slice_input_flags::starts_input | slice_input_flags::ends_input | slice_input_flags::axes_input):
-                    return op::slice::slice_mode::starts_ends_axes_input;
-                default:
-                    MIGRAPHX_THROW("PARSE_SLICE: invalid slice_mode");
+            case slice_input_flags::none: return op::slice::slice_mode::one_input;
+            case slice_input_flags::starts_input: return op::slice::slice_mode::starts_input;
+            case slice_input_flags::ends_input: return op::slice::slice_mode::ends_input;
+            case slice_input_flags::axes_input: return op::slice::slice_mode::axes_input;
+            case(slice_input_flags::starts_input | slice_input_flags::ends_input):
+                return op::slice::slice_mode::starts_ends_input;
+            case(slice_input_flags::starts_input | slice_input_flags::axes_input):
+                return op::slice::slice_mode::starts_axes_input;
+            case(slice_input_flags::ends_input | slice_input_flags::axes_input):
+                return op::slice::slice_mode::ends_axes_input;
+            case(slice_input_flags::starts_input | slice_input_flags::ends_input |
+                 slice_input_flags::axes_input):
+                return op::slice::slice_mode::starts_ends_axes_input;
+            default: MIGRAPHX_THROW("PARSE_SLICE: invalid slice_mode");
             }
         }
 
         op::slice create_slice_operator()
         {
             op::slice slice_op;
-            slice_op.axes = axes;
+            slice_op.axes   = axes;
             slice_op.starts = starts;
-            slice_op.ends = ends;
-            slice_op.mode = get_slice_mode(flags);
+            slice_op.ends   = ends;
+            slice_op.mode   = get_slice_mode(flags);
             return slice_op;
         }
     };

--- a/src/onnx/parse_slice.cpp
+++ b/src/onnx/parse_slice.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,10 +27,19 @@
 #include <migraphx/ranges.hpp>
 #include <migraphx/instruction.hpp>
 #include <migraphx/make_op.hpp>
+#include <migraphx/enum.hpp>
+#include <migraphx/dim_like.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace onnx {
+
+MIGRAPHX_BIT_FLAG_ENUM(slice_input_flags,
+                       std::uint8_t,
+                       none         = 0,
+                       starts_input = 1 << 0,
+                       ends_input   = 1 << 1,
+                       axes_input   = 1 << 2)
 
 struct parse_slice : op_parser<parse_slice>
 {
@@ -39,17 +48,18 @@ struct parse_slice : op_parser<parse_slice>
 
     struct slice_desc
     {
-        op::slice op;
         std::vector<instruction_ref> op_args;
+        std::vector<int64_t> axes;
+        std::vector<dim_like> starts;
+        std::vector<dim_like> ends;
         std::vector<int64_t> steps;
         std::vector<int64_t> raxes;
+        slice_input_flags flags = slice_input_flags::none;
 
         void always_insert(instruction_ref arg) { op_args.insert(op_args.begin(), arg); }
 
-        /**
-         * Either insert argument into `this->op_args` or return the constant value of the argument
-         */
-        std::vector<int64_t> insert(instruction_ref arg)
+        // Either insert argument into `this->op_args` or return the constant value of the argument
+        std::vector<int64_t> try_insert(instruction_ref arg)
         {
             std::vector<int64_t> result;
             migraphx::argument arg_value = arg->eval();
@@ -63,6 +73,41 @@ struct parse_slice : op_parser<parse_slice>
             }
             return result;
         }
+
+        op::slice::slice_mode get_slice_mode(slice_input_flags slice_flags)
+        {
+            switch (slice_flags)
+            {
+                case slice_input_flags::none:
+                    return op::slice::slice_mode::one_input;
+                case slice_input_flags::starts_input:
+                    return op::slice::slice_mode::starts_input;
+                case slice_input_flags::ends_input:
+                    return op::slice::slice_mode::ends_input;
+                case slice_input_flags::axes_input:
+                    return op::slice::slice_mode::axes_input;
+                case (slice_input_flags::starts_input | slice_input_flags::ends_input):
+                    return op::slice::slice_mode::starts_ends_input;
+                case (slice_input_flags::starts_input | slice_input_flags::axes_input):
+                    return op::slice::slice_mode::starts_axes_input;
+                case (slice_input_flags::ends_input | slice_input_flags::axes_input):
+                    return op::slice::slice_mode::ends_axes_input;
+                case (slice_input_flags::starts_input | slice_input_flags::ends_input | slice_input_flags::axes_input):
+                    return op::slice::slice_mode::starts_ends_axes_input;
+                default:
+                    MIGRAPHX_THROW("PARSE_SLICE: invalid slice_mode");
+            }
+        }
+
+        op::slice create_slice_operator()
+        {
+            op::slice slice_op;
+            slice_op.axes = axes;
+            slice_op.starts = starts;
+            slice_op.ends = ends;
+            slice_op.mode = get_slice_mode(flags);
+            return slice_op;
+        }
     };
 
     instruction_ref parse(const op_desc& /*opd*/,
@@ -71,7 +116,7 @@ struct parse_slice : op_parser<parse_slice>
                           const std::vector<instruction_ref>& args) const
     {
         auto sd  = construct_slice_desc(parser, info, args);
-        auto ins = info.add_instruction(sd.op, sd.op_args);
+        auto ins = info.add_instruction(sd.create_slice_operator(), sd.op_args);
         if(not sd.raxes.empty())
         {
             ins = info.add_instruction(make_op("reverse", {{"axes", sd.raxes}}), ins);
@@ -85,7 +130,7 @@ struct parse_slice : op_parser<parse_slice>
                            std::back_inserter(nsteps),
                            [](auto s) { return std::abs(s); });
             return ins = info.add_instruction(
-                       make_op("step", {{"axes", sd.op.axes}, {"steps", nsteps}}), ins);
+                       make_op("step", {{"axes", sd.axes}, {"steps", nsteps}}), ins);
         }
         else
             return ins;
@@ -97,8 +142,8 @@ struct parse_slice : op_parser<parse_slice>
     {
         slice_desc sd;
 
-        // slice can have up to 5 inputs, we first check the 5th one
-        // to decide whether MIGRAPHX can handle this slice.
+        // ONNX Slice can have up to 5 inputs, we first check the 5th one
+        // to decide whether MIGX can handle this slice.
         if(args.size() == 5)
         {
             migraphx::argument step_arg = args.back()->eval();
@@ -108,51 +153,69 @@ struct parse_slice : op_parser<parse_slice>
 
         if(args.size() >= 4)
         {
-            sd.op.axes = sd.insert(args.at(3));
+            auto _axes = sd.try_insert(args.at(3));
+            if(_axes.empty())
+                sd.flags |= slice_input_flags::axes_input;
+            sd.axes = _axes;
         }
         else if(contains(info.attributes, "axes"))
         {
             literal s = parser.parse_value(info.attributes.at("axes"));
-            s.visit([&](auto v) { copy(v, std::back_inserter(sd.op.axes)); });
+            s.visit([&](auto v) { copy(v, std::back_inserter(sd.axes)); });
         }
 
+        // NOTE: goes through range-based dynamic shapes pathway only
         if(args.size() >= 3)
         {
-            sd.op.ends = sd.insert(args.at(2));
+            auto _ends = sd.try_insert(args.at(2));
+            if(_ends.empty())
+                sd.flags |= slice_input_flags::ends_input;
+            sd.ends.assign(_ends.begin(), _ends.end());
         }
         else if(contains(info.attributes, "ends"))
         {
             literal s = parser.parse_value(info.attributes.at("ends"));
-            s.visit([&](auto v) { copy(v, std::back_inserter(sd.op.ends)); });
+            s.visit([&](auto v) {
+                std::transform(v.begin(), v.end(), std::back_inserter(sd.ends), [](auto e) {
+                    return static_cast<int64_t>(e);
+                });
+            });
         }
 
         if(args.size() >= 2)
         {
-            sd.op.starts = sd.insert(args.at(1));
+            auto _starts = sd.try_insert(args.at(1));
+            if(_starts.empty())
+                sd.flags |= slice_input_flags::starts_input;
+            sd.starts.assign(_starts.begin(), _starts.end());
         }
         else if(contains(info.attributes, "starts"))
         {
             literal s = parser.parse_value(info.attributes.at("starts"));
-            s.visit([&](auto v) { copy(v, std::back_inserter(sd.op.starts)); });
+            s.visit([&](auto v) {
+                std::transform(v.begin(), v.end(), std::back_inserter(sd.starts), [](auto e) {
+                    return static_cast<int64_t>(e);
+                });
+            });
         }
 
         // data input argument
         sd.always_insert(args.at(0));
 
         // If axes arg is not given, the default is all of them.
-        if(sd.op.axes.empty() and sd.op_args.size() <= 3)
+        if(sd.axes.empty() and sd.op_args.size() <= 3)
         {
             std::vector<int64_t> axes(args[0]->get_shape().ndim());
             std::iota(axes.begin(), axes.end(), int64_t{0});
-            sd.op.axes = axes;
+            sd.axes = axes;
         }
 
         if(std::any_of(sd.steps.begin(), sd.steps.end(), [](auto s) { return s != 1; }))
         {
-            if(sd.op.starts.empty() or sd.op.ends.empty())
+            if(sd.starts.empty() or sd.ends.empty())
                 MIGRAPHX_THROW(
                     "PARSE_SLICE: steps and variable starts and/or ends is not supported");
-            if(sd.op.axes.empty())
+            if(sd.axes.empty())
                 MIGRAPHX_THROW("PARSE_SLICE: steps and variable axes is not supported");
         }
 
@@ -161,12 +224,13 @@ struct parse_slice : op_parser<parse_slice>
         {
             if(sd.steps[i] >= 0)
                 continue;
-            sd.op.starts[i] += 1;
-            if(sd.op.starts[i] == 0)
-                sd.op.starts[i] = INT_MAX;
-            sd.op.ends[i] += 1;
-            sd.raxes.push_back(sd.op.axes[i]);
-            std::swap(sd.op.starts[i], sd.op.ends[i]);
+            auto start = std::get<int64_t>(sd.starts[i]) + 1;
+            if(start == 0)
+                start = INT_MAX;
+            sd.starts[i] = start;
+            sd.ends[i]   = std::get<int64_t>(sd.ends[i]) + 1;
+            sd.raxes.push_back(sd.axes[i]);
+            std::swap(sd.starts[i], sd.ends[i]);
         }
         return sd;
     }

--- a/src/onnx/parse_split.cpp
+++ b/src/onnx/parse_split.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/onnx/parse_split.cpp
+++ b/src/onnx/parse_split.cpp
@@ -68,7 +68,7 @@ static auto parse_dyn_split(const onnx_parser::node_info& info,
         // slice(input, starts = {n * chunk_size}, ends = {(n+1) * chunk_size}); axes =
         // {tuned_axis}
         ret_ins.at(n) = info.add_instruction(
-            make_op("slice", {{"axes", {tuned_axis}}}),
+            make_op("slice", {{"axes", {tuned_axis}}, {"mode", "starts_ends_input"}}),
             args[0],
             info.add_instruction(
                 make_op("mul"), chunk_size, info.add_literal(literal{int64_scalar_shape, {n}})),
@@ -79,7 +79,10 @@ static auto parse_dyn_split(const onnx_parser::node_info& info,
     // last slice: slice(input, starts = {n * chunk_size}); ends = max_int, axes =
     // {tuned_axis}
     ret_ins.at(num_outputs - 1) = info.add_instruction(
-        make_op("slice", {{"axes", {tuned_axis}}, {"ends", {std::numeric_limits<int64_t>::max()}}}),
+        make_op("slice",
+                {{"axes", {tuned_axis}},
+                 {"ends", {std::numeric_limits<int64_t>::max()}},
+                 {"mode", "starts_input"}}),
         args[0],
         info.add_instruction(make_op("mul"),
                              chunk_size,

--- a/src/onnx/parse_split.cpp
+++ b/src/onnx/parse_split.cpp
@@ -68,7 +68,8 @@ static auto parse_dyn_split(const onnx_parser::node_info& info,
         // slice(input, starts = {n * chunk_size}, ends = {(n+1) * chunk_size}); axes =
         // {tuned_axis}
         ret_ins.at(n) = info.add_instruction(
-            make_op("slice", {{"axes", {tuned_axis}}, {"mode", "starts_ends_input"}}),
+            make_op("slice",
+                    {{"axes", {tuned_axis}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
             args[0],
             info.add_instruction(
                 make_op("mul"), chunk_size, info.add_literal(literal{int64_scalar_shape, {n}})),
@@ -82,7 +83,7 @@ static auto parse_dyn_split(const onnx_parser::node_info& info,
         make_op("slice",
                 {{"axes", {tuned_axis}},
                  {"ends", {std::numeric_limits<int64_t>::max()}},
-                 {"mode", "starts_input"}}),
+                 {"mode", migraphx::value::array{"starts"}}}),
         args[0],
         info.add_instruction(make_op("mul"),
                              chunk_size,

--- a/src/onnx/parse_topk.cpp
+++ b/src/onnx/parse_topk.cpp
@@ -90,11 +90,15 @@ struct parse_topk : op_parser<parse_topk>
         {
             // dynamic slice on outputs of `topk`
             ret_val = info.add_instruction(
-                make_op("slice", {{"starts", {0}}, {"axes", {axis}}, {"mode", "ends_input"}}),
+                make_op(
+                    "slice",
+                    {{"starts", {0}}, {"axes", {axis}}, {"mode", migraphx::value::array{"ends"}}}),
                 ret_val,
                 args.at(1));
             ret_ind = info.add_instruction(
-                make_op("slice", {{"starts", {0}}, {"axes", {axis}}, {"mode", "ends_input"}}),
+                make_op(
+                    "slice",
+                    {{"starts", {0}}, {"axes", {axis}}, {"mode", migraphx::value::array{"ends"}}}),
                 ret_ind,
                 args.at(1));
         }

--- a/src/onnx/parse_topk.cpp
+++ b/src/onnx/parse_topk.cpp
@@ -90,9 +90,13 @@ struct parse_topk : op_parser<parse_topk>
         {
             // dynamic slice on outputs of `topk`
             ret_val = info.add_instruction(
-                make_op("slice", {{"starts", {0}}, {"axes", {axis}}}), ret_val, args.at(1));
+                make_op("slice", {{"starts", {0}}, {"axes", {axis}}, {"mode", "ends_input"}}),
+                ret_val,
+                args.at(1));
             ret_ind = info.add_instruction(
-                make_op("slice", {{"starts", {0}}, {"axes", {axis}}}), ret_ind, args.at(1));
+                make_op("slice", {{"starts", {0}}, {"axes", {axis}}, {"mode", "ends_input"}}),
+                ret_ind,
+                args.at(1));
         }
 
         return {ret_val, ret_ind};

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -205,8 +205,10 @@ struct find_mul_slice_conv
                auto sop = any_cast<op::slice>(i->get_operator());
                if(sop.axes != slice_op.axes)
                    return true;
-               if(std::max(std::get<int64_t>(sop.starts.front()), std::get<int64_t>(slice_op.starts.front())) <
-                  std::min(std::get<int64_t>(sop.ends.front()), std::get<int64_t>(slice_op.ends.front())))
+               if(std::max(std::get<int64_t>(sop.starts.front()),
+                           std::get<int64_t>(slice_op.starts.front())) <
+                  std::min(std::get<int64_t>(sop.ends.front()),
+                           std::get<int64_t>(slice_op.ends.front())))
                    return true;
                return false;
            }))

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -1788,11 +1788,7 @@ struct find_split_concat
         if(not std::is_sorted(it, it + splits.size(), [](instruction_ref x, instruction_ref y) {
                auto xop = any_cast<op::slice>(x->get_operator());
                auto yop = any_cast<op::slice>(y->get_operator());
-               auto xs  = to_ints(xop.starts);
-               auto xe  = to_ints(xop.ends);
-               auto ys  = to_ints(yop.starts);
-               auto ye  = to_ints(yop.ends);
-               return std::tie(xs, xe) < std::tie(ys, ye);
+               return std::tuple(to_ints(xop.starts), to_ints(xop.ends)) < std::tuple(to_ints(yop.starts), to_ints(yop.ends));
            }))
             return;
 

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -205,10 +205,8 @@ struct find_mul_slice_conv
                auto sop = any_cast<op::slice>(i->get_operator());
                if(sop.axes != slice_op.axes)
                    return true;
-               if(std::max(std::get<int64_t>(sop.starts.front()),
-                           std::get<int64_t>(slice_op.starts.front())) <
-                  std::min(std::get<int64_t>(sop.ends.front()),
-                           std::get<int64_t>(slice_op.ends.front())))
+               if(std::max(std::get<int64_t>(sop.starts.front()), std::get<int64_t>(slice_op.starts.front())) <
+                  std::min(std::get<int64_t>(sop.ends.front()), std::get<int64_t>(slice_op.ends.front())))
                    return true;
                return false;
            }))
@@ -1393,7 +1391,12 @@ static std::vector<instruction_ref> get_splits(instruction_ref ins)
 
     // Sort the "slice" instructions in order of starts
     std::sort(result.begin(), result.end(), [&](auto x, auto y) {
-        return to_ints(get_start(x)) < to_ints(get_start(y));
+        const auto& xs = get_start(x);
+        const auto& ys = get_start(y);
+        return std::lexicographical_compare(
+            xs.begin(), xs.end(), ys.begin(), ys.end(), [](const dim_like& l, const dim_like& r) {
+                return std::get<int64_t>(l) < std::get<int64_t>(r);
+            });
     });
     if(std::any_of(get_start(result.front()).begin(),
                    get_start(result.front()).end(),

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -205,8 +205,10 @@ struct find_mul_slice_conv
                auto sop = any_cast<op::slice>(i->get_operator());
                if(sop.axes != slice_op.axes)
                    return true;
-               if(std::max(sop.starts.front(), slice_op.starts.front()) <
-                  std::min(sop.ends.front(), slice_op.ends.front()))
+               if(std::max(std::get<int64_t>(sop.starts.front()),
+                           std::get<int64_t>(slice_op.starts.front())) <
+                  std::min(std::get<int64_t>(sop.ends.front()),
+                           std::get<int64_t>(slice_op.ends.front())))
                    return true;
                return false;
            }))
@@ -223,17 +225,19 @@ struct find_mul_slice_conv
         auto new_mul = m.insert_instruction(ins, make_op("mul"), new_a, slice_w_ins);
 
         std::vector<instruction_ref> sliced_weights;
-        if(slice_op.starts.front() != 0)
+        if(std::get<int64_t>(slice_op.starts.front()) != 0)
             sliced_weights.push_back(m.insert_instruction(
                 ins,
-                make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", slice_op.starts}}),
+                make_op("slice",
+                        {{"axes", {0}}, {"starts", {0}}, {"ends", to_ints(slice_op.starts)}}),
                 w_ins));
         sliced_weights.push_back(new_mul);
         int64_t end_axis = w_ins->get_shape().lens().at(0);
-        if(slice_op.ends.front() != end_axis)
+        if(std::get<int64_t>(slice_op.ends.front()) != end_axis)
             sliced_weights.push_back(m.insert_instruction(
                 ins,
-                make_op("slice", {{"axes", {0}}, {"starts", slice_op.ends}, {"ends", {end_axis}}}),
+                make_op("slice",
+                        {{"axes", {0}}, {"starts", to_ints(slice_op.ends)}, {"ends", {end_axis}}}),
                 w_ins));
 
         auto new_weights =
@@ -1388,11 +1392,12 @@ static std::vector<instruction_ref> get_splits(instruction_ref ins)
     auto get_end   = [&](auto& i) -> auto& { return get_slice(i).ends; };
 
     // Sort the "slice" instructions in order of starts
-    std::sort(
-        result.begin(), result.end(), [&](auto x, auto y) { return get_start(x) < get_start(y); });
-    if(std::any_of(get_start(result.front()).begin(), get_start(result.front()).end(), [&](auto i) {
-           return i != 0;
-       }))
+    std::sort(result.begin(), result.end(), [&](auto x, auto y) {
+        return to_ints(get_start(x)) < to_ints(get_start(y));
+    });
+    if(std::any_of(get_start(result.front()).begin(),
+                   get_start(result.front()).end(),
+                   [&](const auto& i) { return std::get<int64_t>(i) != 0; }))
         return {};
 
     // one slice must "start" where the last slice "end"
@@ -1403,7 +1408,7 @@ static std::vector<instruction_ref> get_splits(instruction_ref ins)
     for(std::size_t i = 0; i < axes.size(); i++)
     {
         auto axis = axes[i];
-        if(ins->get_shape().lens()[axis] != get_slice(result.back()).ends[i])
+        if(ins->get_shape().lens()[axis] != std::get<int64_t>(get_slice(result.back()).ends[i]))
             return {};
     }
     return result;
@@ -1778,7 +1783,11 @@ struct find_split_concat
         if(not std::is_sorted(it, it + splits.size(), [](instruction_ref x, instruction_ref y) {
                auto xop = any_cast<op::slice>(x->get_operator());
                auto yop = any_cast<op::slice>(y->get_operator());
-               return std::tie(xop.starts, xop.ends) < std::tie(yop.starts, yop.ends);
+               auto xs  = to_ints(xop.starts);
+               auto xe  = to_ints(xop.ends);
+               auto ys  = to_ints(yop.starts);
+               auto ye  = to_ints(yop.ends);
+               return std::tie(xs, xe) < std::tie(ys, ye);
            }))
             return;
 
@@ -2496,8 +2505,8 @@ struct find_split_transpose
         for(auto in : split_outputs)
         {
             auto oper    = any_cast<op::slice>(in->get_operator());
-            auto starts  = oper.starts;
-            auto ends    = oper.ends;
+            auto starts  = to_ints(oper.starts);
+            auto ends    = to_ints(oper.ends);
             auto tr_orig = in->outputs().front();
             m.replace_instruction(
                 tr_orig,

--- a/src/simplify_dyn_ops.cpp
+++ b/src/simplify_dyn_ops.cpp
@@ -166,6 +166,34 @@ MIGRAPHX_PRED_MATCHER(slice_concrete_bounds, instruction_ref ins)
            std::all_of(slice_op.ends.begin(), slice_op.ends.end(), is_int);
 }
 
+// Fold a slice whose variable bounds are all constant into an attribute-only (1 input) slice.
+// Each variable input is read into the starts/ends/axes slot named by its mode entry, and the
+// remaining slots keep the operator's (concrete) attribute values.
+static void fold_const_input_slice(module& m, instruction_ref ins)
+{
+    auto inputs                     = ins->inputs();
+    auto slice_op                   = any_cast<op::slice>(ins->get_operator());
+    std::vector<int64_t> starts_vec = to_ints(slice_op.starts);
+    std::vector<int64_t> ends_vec   = to_ints(slice_op.ends);
+    std::vector<int64_t> axes_vec   = slice_op.axes;
+    for(std::size_t i = 0; i < slice_op.mode.size(); ++i)
+    {
+        inputs.at(i + 1)->eval().visit([&](auto output) {
+            std::vector<int64_t> vec(output.begin(), output.end());
+            switch(slice_op.mode[i])
+            {
+            case op::slice::slice_mode::starts: starts_vec = vec; break;
+            case op::slice::slice_mode::ends: ends_vec = vec; break;
+            case op::slice::slice_mode::axes: axes_vec = vec; break;
+            }
+        });
+    }
+    m.replace_instruction(
+        ins,
+        make_op("slice", {{"starts", starts_vec}, {"ends", ends_vec}, {"axes", axes_vec}}),
+        inputs.at(0));
+}
+
 /**
  * Simplify slice with 2 inputs to the 1 input version if inputs[1] is constant.
  * From:
@@ -183,40 +211,7 @@ struct find_const_2in_slice : match::supports_dynamic_shapes
 
     void apply(module& m, const match::matcher_result& mr) const
     {
-        auto ins      = mr.result;
-        auto inputs   = ins->inputs();
-        auto slice_op = any_cast<op::slice>(ins->get_operator());
-        std::vector<int64_t> starts_vec;
-        std::vector<int64_t> ends_vec;
-        std::vector<int64_t> axes_vec;
-        if(slice_op.mode == op::slice::slice_mode::starts_input)
-        {
-            // slice(data, starts)
-            inputs.at(1)->eval().visit(
-                [&](auto output) { starts_vec.assign(output.begin(), output.end()); });
-            ends_vec = to_ints(slice_op.ends);
-            axes_vec = slice_op.axes;
-        }
-        else if(slice_op.mode == op::slice::slice_mode::ends_input)
-        {
-            // slice(data, ends)
-            inputs.at(1)->eval().visit(
-                [&](auto output) { ends_vec.assign(output.begin(), output.end()); });
-            starts_vec = to_ints(slice_op.starts);
-            axes_vec   = slice_op.axes;
-        }
-        else
-        {
-            // slice(data, axes)
-            inputs.at(1)->eval().visit(
-                [&](auto output) { axes_vec.assign(output.begin(), output.end()); });
-            starts_vec = to_ints(slice_op.starts);
-            ends_vec   = to_ints(slice_op.ends);
-        }
-        m.replace_instruction(
-            ins,
-            make_op("slice", {{"starts", starts_vec}, {"ends", ends_vec}, {"axes", axes_vec}}),
-            inputs.at(0));
+        fold_const_input_slice(m, mr.result);
     }
 };
 
@@ -239,43 +234,7 @@ struct find_const_3in_slice : match::supports_dynamic_shapes
 
     void apply(module& m, const match::matcher_result& mr) const
     {
-        auto ins      = mr.result;
-        auto inputs   = ins->inputs();
-        auto slice_op = any_cast<op::slice>(ins->get_operator());
-        std::vector<int64_t> starts_vec;
-        std::vector<int64_t> ends_vec;
-        std::vector<int64_t> axes_vec;
-        if(slice_op.mode == op::slice::slice_mode::starts_ends_input)
-        {
-            // slice(data, starts, ends)
-            inputs.at(1)->eval().visit(
-                [&](auto output) { starts_vec.assign(output.begin(), output.end()); });
-            inputs.at(2)->eval().visit(
-                [&](auto output) { ends_vec.assign(output.begin(), output.end()); });
-            axes_vec = slice_op.axes;
-        }
-        else if(slice_op.mode == op::slice::slice_mode::starts_axes_input)
-        {
-            // slice(data, starts, axes)
-            inputs.at(1)->eval().visit(
-                [&](auto output) { starts_vec.assign(output.begin(), output.end()); });
-            inputs.at(2)->eval().visit(
-                [&](auto output) { axes_vec.assign(output.begin(), output.end()); });
-            ends_vec = to_ints(slice_op.ends);
-        }
-        else
-        {
-            // slice(data, ends, axes)
-            inputs.at(1)->eval().visit(
-                [&](auto output) { ends_vec.assign(output.begin(), output.end()); });
-            inputs.at(2)->eval().visit(
-                [&](auto output) { axes_vec.assign(output.begin(), output.end()); });
-            starts_vec = to_ints(slice_op.starts);
-        }
-        m.replace_instruction(
-            ins,
-            make_op("slice", {{"starts", starts_vec}, {"ends", ends_vec}, {"axes", axes_vec}}),
-            inputs.at(0));
+        fold_const_input_slice(m, mr.result);
     }
 };
 

--- a/src/simplify_dyn_ops.cpp
+++ b/src/simplify_dyn_ops.cpp
@@ -154,6 +154,18 @@ struct find_static_2in_broadcasts : match::supports_dynamic_shapes
     }
 };
 
+// Matches a slice whose set starts/ends bounds are all concrete ints (no
+// symbolic dim_like bounds), so the const-input rewrites can read them as ints.
+MIGRAPHX_PRED_MATCHER(slice_concrete_bounds, instruction_ref ins)
+{
+    if(ins->name() != "slice")
+        return false;
+    auto slice_op = any_cast<op::slice>(ins->get_operator());
+    auto is_int   = [](const dim_like& d) { return std::holds_alternative<int64_t>(d); };
+    return std::all_of(slice_op.starts.begin(), slice_op.starts.end(), is_int) and
+           std::all_of(slice_op.ends.begin(), slice_op.ends.end(), is_int);
+}
+
 /**
  * Simplify slice with 2 inputs to the 1 input version if inputs[1] is constant.
  * From:
@@ -165,32 +177,32 @@ struct find_const_2in_slice : match::supports_dynamic_shapes
 {
     auto matcher() const
     {
-        return match::name("slice")(match::nargs(2), match::arg(1)(match::is_constant()));
+        return match::name("slice")(
+            match::nargs(2), match::arg(1)(match::is_constant()), slice_concrete_bounds());
     }
 
     void apply(module& m, const match::matcher_result& mr) const
     {
-        auto ins       = mr.result;
-        auto inputs    = ins->inputs();
-        auto slice_op  = any_cast<op::slice>(ins->get_operator());
-        auto set_attrs = slice_op.get_set_attributes();
+        auto ins      = mr.result;
+        auto inputs   = ins->inputs();
+        auto slice_op = any_cast<op::slice>(ins->get_operator());
         std::vector<int64_t> starts_vec;
         std::vector<int64_t> ends_vec;
         std::vector<int64_t> axes_vec;
-        if(set_attrs == op::slice::ends_axes)
+        if(slice_op.mode == op::slice::slice_mode::starts_input)
         {
             // slice(data, starts)
             inputs.at(1)->eval().visit(
                 [&](auto output) { starts_vec.assign(output.begin(), output.end()); });
-            ends_vec = slice_op.ends;
+            ends_vec = to_ints(slice_op.ends);
             axes_vec = slice_op.axes;
         }
-        else if(set_attrs == op::slice::starts_axes)
+        else if(slice_op.mode == op::slice::slice_mode::ends_input)
         {
             // slice(data, ends)
             inputs.at(1)->eval().visit(
                 [&](auto output) { ends_vec.assign(output.begin(), output.end()); });
-            starts_vec = slice_op.starts;
+            starts_vec = to_ints(slice_op.starts);
             axes_vec   = slice_op.axes;
         }
         else
@@ -198,8 +210,8 @@ struct find_const_2in_slice : match::supports_dynamic_shapes
             // slice(data, axes)
             inputs.at(1)->eval().visit(
                 [&](auto output) { axes_vec.assign(output.begin(), output.end()); });
-            starts_vec = slice_op.starts;
-            ends_vec   = slice_op.ends;
+            starts_vec = to_ints(slice_op.starts);
+            ends_vec   = to_ints(slice_op.ends);
         }
         m.replace_instruction(
             ins,
@@ -221,19 +233,19 @@ struct find_const_3in_slice : match::supports_dynamic_shapes
     {
         return match::name("slice")(match::nargs(3),
                                     match::arg(1)(match::is_constant()),
-                                    match::arg(2)(match::is_constant()));
+                                    match::arg(2)(match::is_constant()),
+                                    slice_concrete_bounds());
     }
 
     void apply(module& m, const match::matcher_result& mr) const
     {
-        auto ins       = mr.result;
-        auto inputs    = ins->inputs();
-        auto slice_op  = any_cast<op::slice>(ins->get_operator());
-        auto set_attrs = slice_op.get_set_attributes();
+        auto ins      = mr.result;
+        auto inputs   = ins->inputs();
+        auto slice_op = any_cast<op::slice>(ins->get_operator());
         std::vector<int64_t> starts_vec;
         std::vector<int64_t> ends_vec;
         std::vector<int64_t> axes_vec;
-        if(set_attrs == op::slice::axes_only)
+        if(slice_op.mode == op::slice::slice_mode::starts_ends_input)
         {
             // slice(data, starts, ends)
             inputs.at(1)->eval().visit(
@@ -242,14 +254,14 @@ struct find_const_3in_slice : match::supports_dynamic_shapes
                 [&](auto output) { ends_vec.assign(output.begin(), output.end()); });
             axes_vec = slice_op.axes;
         }
-        else if(set_attrs == op::slice::ends_only)
+        else if(slice_op.mode == op::slice::slice_mode::starts_axes_input)
         {
             // slice(data, starts, axes)
             inputs.at(1)->eval().visit(
                 [&](auto output) { starts_vec.assign(output.begin(), output.end()); });
             inputs.at(2)->eval().visit(
                 [&](auto output) { axes_vec.assign(output.begin(), output.end()); });
-            ends_vec = slice_op.ends;
+            ends_vec = to_ints(slice_op.ends);
         }
         else
         {
@@ -258,7 +270,7 @@ struct find_const_3in_slice : match::supports_dynamic_shapes
                 [&](auto output) { ends_vec.assign(output.begin(), output.end()); });
             inputs.at(2)->eval().visit(
                 [&](auto output) { axes_vec.assign(output.begin(), output.end()); });
-            starts_vec = slice_op.starts;
+            starts_vec = to_ints(slice_op.starts);
         }
         m.replace_instruction(
             ins,

--- a/src/simplify_dyn_ops.cpp
+++ b/src/simplify_dyn_ops.cpp
@@ -155,15 +155,13 @@ struct find_static_2in_broadcasts : match::supports_dynamic_shapes
 };
 
 // Matches a slice whose set starts/ends bounds are all concrete ints (no
-// symbolic dim_like bounds), so the const-input rewrites can read them as ints.
+// symbolic dim_like bounds).
 MIGRAPHX_PRED_MATCHER(slice_concrete_bounds, instruction_ref ins)
 {
     if(ins->name() != "slice")
         return false;
     auto slice_op = any_cast<op::slice>(ins->get_operator());
-    auto is_int   = [](const dim_like& d) { return std::holds_alternative<int64_t>(d); };
-    return std::all_of(slice_op.starts.begin(), slice_op.starts.end(), is_int) and
-           std::all_of(slice_op.ends.begin(), slice_op.ends.end(), is_int);
+    return not any_sym(slice_op.starts) and not any_sym(slice_op.ends);
 }
 
 // Fold a slice whose variable bounds are all constant into an attribute-only (1 input) slice.
@@ -171,23 +169,14 @@ MIGRAPHX_PRED_MATCHER(slice_concrete_bounds, instruction_ref ins)
 // remaining slots keep the operator's (concrete) attribute values.
 static void fold_const_input_slice(module& m, instruction_ref ins)
 {
-    auto inputs                     = ins->inputs();
-    auto slice_op                   = any_cast<op::slice>(ins->get_operator());
-    std::vector<int64_t> starts_vec = to_ints(slice_op.starts);
-    std::vector<int64_t> ends_vec   = to_ints(slice_op.ends);
-    std::vector<int64_t> axes_vec   = slice_op.axes;
-    for(std::size_t i = 0; i < slice_op.mode.size(); ++i)
-    {
-        inputs.at(i + 1)->eval().visit([&](auto output) {
-            std::vector<int64_t> vec(output.begin(), output.end());
-            switch(slice_op.mode[i])
-            {
-            case op::slice::slice_mode::starts: starts_vec = vec; break;
-            case op::slice::slice_mode::ends: ends_vec = vec; break;
-            case op::slice::slice_mode::axes: axes_vec = vec; break;
-            }
-        });
-    }
+    auto inputs                           = ins->inputs();
+    auto slice_op                         = any_cast<op::slice>(ins->get_operator());
+    auto [starts_vec, ends_vec, axes_vec] = slice_op.resolve_bounds([&](std::size_t i) {
+        std::vector<int64_t> vec;
+        inputs.at(i + 1)->eval().visit(
+            [&](auto output) { vec.assign(output.begin(), output.end()); });
+        return vec;
+    });
     m.replace_instruction(
         ins,
         make_op("slice", {{"starts", starts_vec}, {"ends", ends_vec}, {"axes", axes_vec}}),

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -663,7 +663,8 @@ struct find_nested_slice
         auto op = any_cast<op::slice>(ins->get_operator());
         for(std::size_t i = 0; i < op.axes.size(); i++)
         {
-            result[op.axes[i]] = std::make_pair(op.starts[i], op.ends[i]);
+            result[op.axes[i]] =
+                std::make_pair(std::get<int64_t>(op.starts[i]), std::get<int64_t>(op.ends[i]));
         }
         return result;
     }
@@ -861,8 +862,8 @@ struct find_concat_slice
         for(const auto& sins : slice_candidates)
         {
             auto sop           = any_cast<op::slice>(sins->get_operator());
-            size_t slice_start = sop.starts.front();
-            size_t slice_len   = sop.ends.front() - slice_start;
+            size_t slice_start = std::get<int64_t>(sop.starts.front());
+            size_t slice_len   = std::get<int64_t>(sop.ends.front()) - slice_start;
             auto fii = std::find_if(prefix_scan.begin(), prefix_scan.end(), [&](const auto& j) {
                 return j == slice_start;
             });
@@ -1291,7 +1292,7 @@ struct find_gather
             return;
 
         const std::size_t axis_index = tune_axis(dlens.size(), gather_op.axis, gather_op.name());
-        const auto axis_len = dlens.at(axis_index);
+        const auto axis_len          = dlens.at(axis_index);
         if(axis_len == 0)
             return;
 
@@ -1820,8 +1821,13 @@ struct find_transpose_slice
     {
         assert(op.starts.size() == op.ends.size());
         std::vector<int64_t> result(op.starts.size());
-        std::transform(
-            op.ends.begin(), op.ends.end(), op.starts.begin(), result.begin(), std::minus<>{});
+        std::transform(op.ends.begin(),
+                       op.ends.end(),
+                       op.starts.begin(),
+                       result.begin(),
+                       [](const auto& e, const auto& s) {
+                           return std::get<int64_t>(e) - std::get<int64_t>(s);
+                       });
         return result;
     }
 
@@ -1846,14 +1852,15 @@ struct find_transpose_slice
                                       sdistance.begin(),
                                       0,
                                       std::plus<>{},
-                                      [&](auto x, auto d) -> uint64_t {
+                                      [&](const auto& x, auto d) -> uint64_t {
                                           if(d == 0)
                                               return 1;
                                           return f(x) % d;
                                       });
         };
+        auto get_int = [](const auto& x) { return std::get<int64_t>(x); };
         if(mod_by_distance(slice.axes, [&](auto x) { return ins->get_shape().lens()[x]; }) != 0 or
-           mod_by_distance(slice.starts, id{}) != 0 or mod_by_distance(slice.ends, id{}) != 0)
+           mod_by_distance(slice.starts, get_int) != 0 or mod_by_distance(slice.ends, get_int) != 0)
             return;
         // TODO: Handle multiple axes
         if(sdistance.size() != 1)
@@ -1891,8 +1898,8 @@ struct find_transpose_slice
         {
             auto op        = any_cast<op::slice>(s->get_operator());
             op.axes        = {0};
-            op.starts      = {op.starts.front() / sdistance.front()};
-            op.ends        = {op.ends.front() / sdistance.front()};
+            op.starts      = {std::get<int64_t>(op.starts.front()) / sdistance.front()};
+            op.ends        = {std::get<int64_t>(op.ends.front()) / sdistance.front()};
             auto slice_ins = m.insert_instruction(ins, op, transpose);
             auto squeeze =
                 m.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), slice_ins);

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -969,6 +969,14 @@ static const std::vector<rewrite_rule>& get_rewrite_rules()
             sqrt(_1 / _2) >> sqrt(_1) / sqrt(_2),
             log(exp(_1)) >> _1,
             exp(log(_1)) >> _1,
+            // Clamping against a bound the expression already clamps to only nests a
+            // redundant node, so repeated clamping (as attribute normalization does on
+            // every shape computation) keeps a single min/max instead of growing without
+            // bound. The inner node can hold the bound in either operand.
+            min(min(_1, _2), _2) >> min(_1, _2),
+            min(min(_2, _1), _2) >> min(_2, _1),
+            max(max(_1, _2), _2) >> max(_1, _2),
+            max(max(_2, _1), _2) >> max(_2, _1),
         };
     }();
     return rules;

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -699,6 +699,18 @@ struct mlir_program
         if(op.name() == "unpack_int4")
             v["axis"] = ins->get_shape().ndim() - 1;
 
+        // Drop slice's `mode` so the emitted IR matches what rocMLIR expects.
+        if(op.name() == "slice" and v.contains("mode"))
+        {
+            value filtered = value::object{};
+            for(const auto& attr : v)
+            {
+                if(attr.get_key() != "mode")
+                    filtered[attr.get_key()] = attr.without_key();
+            }
+            v = filtered;
+        }
+
         return v;
     }
 

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -24,9 +24,12 @@
 #include <migraphx/enum.hpp>
 #include <migraphx/value.hpp>
 #include <migraphx/serialize.hpp>
+#include <migraphx/streamutils.hpp>
 #include <algorithm>
+#include <sstream>
 #include <string>
 #include <type_traits>
+#include <vector>
 #include "test.hpp"
 
 // These enums are test-local fixtures; the anonymous namespace gives the macro-generated helper
@@ -39,6 +42,11 @@ MIGRAPHX_ENUM(my_enum, first, last = 10)
 
 // Single enumerator, exercises the base case of the value-capturing expansion.
 MIGRAPHX_ENUM(solo, only_one)
+
+// Declared and never used at all. Guards the [[maybe_unused]] on the generated namespace-scope
+// helpers: in an anonymous namespace they have internal linkage, so without it an enum whose
+// helpers this file never calls would warn under -Wunused-function.
+MIGRAPHX_ENUM(never_used, never_used_value)
 
 // Expression-valued enumerators, including one that references a previous enumerator.
 MIGRAPHX_ENUM(flags, none = 0, bit0 = 1, bit1 = 2, both = bit0 + bit1)
@@ -292,6 +300,63 @@ TEST_CASE(nested_enum_class)
     EXPECT(to_string(gadget::unit::cm) == "cm");
     EXPECT(migraphx::from_string<gadget::unit>("m") == gadget::unit::m);
     EXPECT(test::throws([] { migraphx::from_string<gadget::unit>("km"); }));
+}
+
+TEST_CASE(stream_unscoped_enum)
+{
+    std::ostringstream ss;
+    ss << red << ' ' << green << ' ' << blue;
+    // The generated overload is an exact match, so it wins over the conversion to int: green
+    // streams as its name and not as 5.
+    EXPECT(ss.str() == "red green blue");
+}
+
+TEST_CASE(stream_scoped_enum)
+{
+    std::ostringstream ss;
+    ss << scoped_color::magenta;
+    EXPECT(ss.str() == "magenta");
+}
+
+TEST_CASE(stream_nested_enum)
+{
+    std::ostringstream ss;
+    ss << gadget::on;
+    EXPECT(ss.str() == "on");
+}
+
+TEST_CASE(stream_nested_enum_class)
+{
+    std::ostringstream ss;
+    ss << gadget::unit::cm;
+    EXPECT(ss.str() == "cm");
+}
+
+TEST_CASE(stream_enum_in_migraphx_namespace)
+{
+    // The generated body calls to_string unqualified, which must not be ambiguous with the
+    // migraphx::to_string(const T&) template for an enum declared inside namespace migraphx.
+    std::ostringstream ss;
+    ss << migraphx::busy;
+    EXPECT(ss.str() == "busy");
+}
+
+TEST_CASE(stream_unknown_value_throws)
+{
+    EXPECT(test::throws([] {
+        std::ostringstream ss;
+        ss << static_cast<color>(4);
+    }));
+}
+
+TEST_CASE(stream_range_of_named_enums)
+{
+    // How a reflected vector-of-enum operator attribute reaches the printed IR: stream_range
+    // streams each element with a plain os << x.
+    std::vector<gadget::unit> units = {gadget::unit::mm, gadget::unit::m};
+    std::ostringstream ss;
+    ss << migraphx::stream_range(units);
+    EXPECT(ss.str() == "mm, m");
 }
 
 TEST_CASE(is_named_enum_trait)

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -148,6 +148,14 @@ namespace migraphx {
 // check that the generated to_string(status) is not ambiguous with migraphx::to_string(const T&).
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 MIGRAPHX_ENUM(status, ok, busy = 4, done)
+
+// Bit-flag enums. Declared in the migraphx namespace so that argument-dependent lookup finds the
+// operators (which also live in migraphx) from the global-scope test cases below. Two widths
+// exercise the selectable underlying type.
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+MIGRAPHX_BIT_FLAG_ENUM(access, std::uint8_t, none = 0, read = 1 << 0, write = 1 << 1, exec = 1 << 2)
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+MIGRAPHX_BIT_FLAG_ENUM(wide_flag, std::uint16_t, none = 0, lo = 1 << 0, hi = 1 << 15)
 } // namespace migraphx
 
 TEST_CASE(underlying_values)
@@ -305,6 +313,56 @@ TEST_CASE(is_named_enum_trait)
     EXPECT(not migraphx::is_named_enum<plain_enum>{});
     EXPECT(not migraphx::is_named_enum<int>{});
     EXPECT(not migraphx::is_named_enum<std::string>{});
+}
+
+TEST_CASE(bit_flag_operators)
+{
+    auto rw = migraphx::access::read | migraphx::access::write;
+    EXPECT(has_flag(rw, migraphx::access::read));
+    EXPECT(has_flag(rw, migraphx::access::write));
+    EXPECT(not has_flag(rw, migraphx::access::exec));
+
+    // & masks, and the result stays the enum type.
+    EXPECT((rw & migraphx::access::read) == migraphx::access::read);
+    EXPECT((rw & migraphx::access::exec) == migraphx::access::none);
+
+    rw |= migraphx::access::exec;
+    EXPECT(has_flag(rw, migraphx::access::exec));
+
+    // ~ and &= clear a bit.
+    rw &= ~migraphx::access::write;
+    EXPECT(not has_flag(rw, migraphx::access::write));
+    EXPECT(has_flag(rw, migraphx::access::read));
+
+    // ^ and ^= toggle a bit.
+    EXPECT((migraphx::access::read ^ migraphx::access::read) == migraphx::access::none);
+    auto toggled = migraphx::access::none;
+    toggled ^= migraphx::access::write;
+    EXPECT(toggled == migraphx::access::write);
+}
+
+TEST_CASE(bit_flag_width_and_scoped)
+{
+    // The underlying type is honored, so the storage width is selectable.
+    EXPECT(sizeof(migraphx::access) == 1);
+    EXPECT(sizeof(migraphx::wide_flag) == 2);
+    // A bit that only fits in the wider type round-trips through the underlying value.
+    EXPECT(static_cast<int>(migraphx::wide_flag::hi) == (1 << 15));
+    // It is still a real scoped enum: no implicit conversion to its underlying type.
+    EXPECT(not std::is_convertible<migraphx::access, int>{});
+}
+
+TEST_CASE(is_bit_flag_trait)
+{
+    EXPECT(migraphx::is_bit_flag<migraphx::access>{});
+    EXPECT(migraphx::is_bit_flag<migraphx::wide_flag>{});
+    // False for named enums, plain enums, and non-enum types: the operators do not leak to them.
+    EXPECT(not migraphx::is_bit_flag<color>{});
+    EXPECT(not migraphx::is_bit_flag<scoped_color>{});
+    EXPECT(not migraphx::is_bit_flag<plain_enum>{});
+    EXPECT(not migraphx::is_bit_flag<int>{});
+    // And a bit-flag enum does not get the named-enum string helpers.
+    EXPECT(not migraphx::is_named_enum<migraphx::access>{});
 }
 
 TEST_CASE(value_stores_named_enum_as_string)

--- a/test/enum.cpp
+++ b/test/enum.cpp
@@ -148,14 +148,6 @@ namespace migraphx {
 // check that the generated to_string(status) is not ambiguous with migraphx::to_string(const T&).
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 MIGRAPHX_ENUM(status, ok, busy = 4, done)
-
-// Bit-flag enums. Declared in the migraphx namespace so that argument-dependent lookup finds the
-// operators (which also live in migraphx) from the global-scope test cases below. Two widths
-// exercise the selectable underlying type.
-// NOLINTNEXTLINE(misc-use-internal-linkage)
-MIGRAPHX_BIT_FLAG_ENUM(access, std::uint8_t, none = 0, read = 1 << 0, write = 1 << 1, exec = 1 << 2)
-// NOLINTNEXTLINE(misc-use-internal-linkage)
-MIGRAPHX_BIT_FLAG_ENUM(wide_flag, std::uint16_t, none = 0, lo = 1 << 0, hi = 1 << 15)
 } // namespace migraphx
 
 TEST_CASE(underlying_values)
@@ -313,56 +305,6 @@ TEST_CASE(is_named_enum_trait)
     EXPECT(not migraphx::is_named_enum<plain_enum>{});
     EXPECT(not migraphx::is_named_enum<int>{});
     EXPECT(not migraphx::is_named_enum<std::string>{});
-}
-
-TEST_CASE(bit_flag_operators)
-{
-    auto rw = migraphx::access::read | migraphx::access::write;
-    EXPECT(has_flag(rw, migraphx::access::read));
-    EXPECT(has_flag(rw, migraphx::access::write));
-    EXPECT(not has_flag(rw, migraphx::access::exec));
-
-    // & masks, and the result stays the enum type.
-    EXPECT((rw & migraphx::access::read) == migraphx::access::read);
-    EXPECT((rw & migraphx::access::exec) == migraphx::access::none);
-
-    rw |= migraphx::access::exec;
-    EXPECT(has_flag(rw, migraphx::access::exec));
-
-    // ~ and &= clear a bit.
-    rw &= ~migraphx::access::write;
-    EXPECT(not has_flag(rw, migraphx::access::write));
-    EXPECT(has_flag(rw, migraphx::access::read));
-
-    // ^ and ^= toggle a bit.
-    EXPECT((migraphx::access::read ^ migraphx::access::read) == migraphx::access::none);
-    auto toggled = migraphx::access::none;
-    toggled ^= migraphx::access::write;
-    EXPECT(toggled == migraphx::access::write);
-}
-
-TEST_CASE(bit_flag_width_and_scoped)
-{
-    // The underlying type is honored, so the storage width is selectable.
-    EXPECT(sizeof(migraphx::access) == 1);
-    EXPECT(sizeof(migraphx::wide_flag) == 2);
-    // A bit that only fits in the wider type round-trips through the underlying value.
-    EXPECT(static_cast<int>(migraphx::wide_flag::hi) == (1 << 15));
-    // It is still a real scoped enum: no implicit conversion to its underlying type.
-    EXPECT(not std::is_convertible<migraphx::access, int>{});
-}
-
-TEST_CASE(is_bit_flag_trait)
-{
-    EXPECT(migraphx::is_bit_flag<migraphx::access>{});
-    EXPECT(migraphx::is_bit_flag<migraphx::wide_flag>{});
-    // False for named enums, plain enums, and non-enum types: the operators do not leak to them.
-    EXPECT(not migraphx::is_bit_flag<color>{});
-    EXPECT(not migraphx::is_bit_flag<scoped_color>{});
-    EXPECT(not migraphx::is_bit_flag<plain_enum>{});
-    EXPECT(not migraphx::is_bit_flag<int>{});
-    // And a bit-flag enum does not get the named-enum string helpers.
-    EXPECT(not migraphx::is_named_enum<migraphx::access>{});
 }
 
 TEST_CASE(value_stores_named_enum_as_string)

--- a/test/fuse_pointwise.cpp
+++ b/test/fuse_pointwise.cpp
@@ -1409,13 +1409,13 @@ TEST_CASE(split_pointwise_slices_dynamic)
         auto add1    = mm->add_instruction(migraphx::make_op("add"), x, y);
         auto s1      = mm->add_instruction(
             migraphx::make_op("slice",
-                                 {{"axes", {1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+                                   {{"axes", {1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
             add1,
             starts0,
             ends0);
         auto s2 = mm->add_instruction(
             migraphx::make_op("slice",
-                                 {{"axes", {1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+                              {{"axes", {1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
             add1,
             starts1,
             ends1);
@@ -1436,13 +1436,13 @@ TEST_CASE(split_pointwise_slices_dynamic)
         auto add1    = add_pointwise(p2, "main:pointwise0", {x, y}, single_pointwise("add"));
         auto s1      = mm->add_instruction(
             migraphx::make_op("slice",
-                                 {{"axes", {1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+                                   {{"axes", {1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
             add1,
             starts0,
             ends0);
         auto s2 = mm->add_instruction(
             migraphx::make_op("slice",
-                                 {{"axes", {1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+                              {{"axes", {1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
             add1,
             starts1,
             ends1);

--- a/test/fuse_pointwise.cpp
+++ b/test/fuse_pointwise.cpp
@@ -1407,10 +1407,18 @@ TEST_CASE(split_pointwise_slices_dynamic)
         auto starts1 = mm->add_parameter("starts1", si);
         auto ends1   = mm->add_parameter("ends1", si);
         auto add1    = mm->add_instruction(migraphx::make_op("add"), x, y);
-        auto s1 =
-            mm->add_instruction(migraphx::make_op("slice", {{"axes", {1}}}), add1, starts0, ends0);
-        auto s2 =
-            mm->add_instruction(migraphx::make_op("slice", {{"axes", {1}}}), add1, starts1, ends1);
+        auto s1      = mm->add_instruction(
+            migraphx::make_op("slice",
+                                 {{"axes", {1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+            add1,
+            starts0,
+            ends0);
+        auto s2 = mm->add_instruction(
+            migraphx::make_op("slice",
+                                 {{"axes", {1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+            add1,
+            starts1,
+            ends1);
         auto neg1 = mm->add_instruction(migraphx::make_op("neg"), s1);
         auto neg2 = mm->add_instruction(migraphx::make_op("neg"), s2);
         mm->add_return({neg1, neg2});
@@ -1426,10 +1434,18 @@ TEST_CASE(split_pointwise_slices_dynamic)
         auto starts1 = mm->add_parameter("starts1", si);
         auto ends1   = mm->add_parameter("ends1", si);
         auto add1    = add_pointwise(p2, "main:pointwise0", {x, y}, single_pointwise("add"));
-        auto s1 =
-            mm->add_instruction(migraphx::make_op("slice", {{"axes", {1}}}), add1, starts0, ends0);
-        auto s2 =
-            mm->add_instruction(migraphx::make_op("slice", {{"axes", {1}}}), add1, starts1, ends1);
+        auto s1      = mm->add_instruction(
+            migraphx::make_op("slice",
+                                 {{"axes", {1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+            add1,
+            starts0,
+            ends0);
+        auto s2 = mm->add_instruction(
+            migraphx::make_op("slice",
+                                 {{"axes", {1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+            add1,
+            starts1,
+            ends1);
         auto neg1 = add_pointwise(p2, "main:pointwise1", {s1}, single_pointwise("neg"));
         auto neg2 = add_pointwise(p2, "main:pointwise2", {s2}, single_pointwise("neg"));
         mm->add_return({neg1, neg2});

--- a/test/gpu/dyn_slice_lowering.cpp
+++ b/test/gpu/dyn_slice_lowering.cpp
@@ -49,7 +49,7 @@ TEST_CASE(dyn_slice_lowering_runtime_inputs)
         auto data   = m1.add_parameter("data", data_s);
         auto starts = m1.add_parameter("starts", idx_s);
         auto ends   = m1.add_parameter("ends", idx_s);
-        auto sl = m1.add_instruction(
+        auto sl     = m1.add_instruction(
             migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
             data,
             starts,

--- a/test/gpu/dyn_slice_lowering.cpp
+++ b/test/gpu/dyn_slice_lowering.cpp
@@ -50,7 +50,8 @@ TEST_CASE(dyn_slice_lowering_runtime_inputs)
         auto starts = m1.add_parameter("starts", idx_s);
         auto ends   = m1.add_parameter("ends", idx_s);
         auto sl     = m1.add_instruction(
-            migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
+            migraphx::make_op("slice",
+                                  {{"axes", {2}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
             data,
             starts,
             ends);
@@ -68,7 +69,8 @@ TEST_CASE(dyn_slice_lowering_runtime_inputs)
         auto sync =
             m2.add_instruction(migraphx::make_op("hip::sync_stream"), copy_starts, copy_ends);
         auto sl = m2.add_instruction(
-            migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
+            migraphx::make_op("slice",
+                              {{"axes", {2}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
             data,
             sync,
             copy_ends);

--- a/test/gpu/dyn_slice_lowering.cpp
+++ b/test/gpu/dyn_slice_lowering.cpp
@@ -49,8 +49,11 @@ TEST_CASE(dyn_slice_lowering_runtime_inputs)
         auto data   = m1.add_parameter("data", data_s);
         auto starts = m1.add_parameter("starts", idx_s);
         auto ends   = m1.add_parameter("ends", idx_s);
-        auto sl =
-            m1.add_instruction(migraphx::make_op("slice", {{"axes", {2}}}), data, starts, ends);
+        auto sl = m1.add_instruction(
+            migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
+            data,
+            starts,
+            ends);
         m1.add_return({sl});
     }
     run_lowering(m1);
@@ -64,8 +67,11 @@ TEST_CASE(dyn_slice_lowering_runtime_inputs)
         auto copy_ends   = m2.add_instruction(migraphx::make_op("hip::copy_from_gpu"), ends);
         auto sync =
             m2.add_instruction(migraphx::make_op("hip::sync_stream"), copy_starts, copy_ends);
-        auto sl =
-            m2.add_instruction(migraphx::make_op("slice", {{"axes", {2}}}), data, sync, copy_ends);
+        auto sl = m2.add_instruction(
+            migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
+            data,
+            sync,
+            copy_ends);
         m2.add_return({sl});
     }
     EXPECT(m1 == m2);

--- a/test/normalize_ops_test.cpp
+++ b/test/normalize_ops_test.cpp
@@ -23,12 +23,19 @@
  */
 #include <migraphx/normalize_ops.hpp>
 #include <migraphx/dead_code_elimination.hpp>
+#include <migraphx/dim_like.hpp>
 #include <migraphx/pass_manager.hpp>
 #include <migraphx/make_op.hpp>
 #include <migraphx/functional.hpp>
 #include <migraphx/op/normalize_attribute.hpp>
+#include <migraphx/serialize.hpp>
+#include <migraphx/sym.hpp>
 #include <basic_ops.hpp>
 #include <test.hpp>
+
+using dd = migraphx::shape::dynamic_dimension;
+using migraphx::sym::lit;
+using migraphx::sym::var;
 
 struct normalize_test_op
 {
@@ -177,6 +184,164 @@ TEST_CASE(slice_test_1)
     run_pass(m1);
 
     EXPECT(m1 == m2);
+}
+
+static migraphx::shape slice_sym_data_shape()
+{
+    return {migraphx::shape::float_type, {2, 3, 4, 5}};
+}
+
+// slice's starts/ends attributes are vectors of dim_like: each entry is either a plain integer
+// or a symbolic dynamic_dimension.
+static migraphx::value bounds(std::vector<migraphx::dim_like> v) { return migraphx::to_value(v); }
+
+// Builds slice(data, bound). `mode_key` names the bound that the variable input supplies at
+// runtime; that bound's attribute still carries the compile-time (possibly symbolic) value.
+// Symbolic bounds are only allowed with two or more inputs, hence the extra parameter.
+static migraphx::module create_slice_sym(const std::vector<int64_t>& axes,
+                                         const migraphx::value& starts,
+                                         const migraphx::value& ends,
+                                         const std::string& mode_key,
+                                         const migraphx::shape& data_shape = slice_sym_data_shape())
+{
+    migraphx::module m;
+    auto data = m.add_parameter("data", data_shape);
+    auto bound =
+        m.add_parameter(mode_key, migraphx::shape{migraphx::shape::int64_type, {axes.size()}});
+    auto r = m.add_instruction(migraphx::make_op("slice",
+                                                 {{"axes", axes},
+                                                  {"starts", starts},
+                                                  {"ends", ends},
+                                                  {"mode", migraphx::value::array{mode_key}}}),
+                               data,
+                               bound);
+    m.add_return({r});
+
+    return m;
+}
+
+TEST_CASE(slice_sym_ends_clamped_test)
+{
+    // n is not provably ordered against the axis length 5, so the bound clamps to min(n, 5).
+    auto n  = var("n", {1, 8});
+    auto m1 = create_slice_sym({3}, bounds({int64_t{0}}), bounds({dd{n}}), "ends");
+    auto m2 = create_slice_sym(
+        {3}, bounds({int64_t{0}}), bounds({dd{migraphx::sym::min(n, lit(5))}}), "ends");
+    run_pass(m1);
+
+    EXPECT(m1 == m2);
+}
+
+TEST_CASE(slice_sym_ends_below_len_test)
+{
+    // n < 5 is provable, so the bound keeps the bare symbol rather than gaining a min wrapper.
+    auto n  = var("n", {1, 4});
+    auto m1 = create_slice_sym({3}, bounds({int64_t{0}}), bounds({dd{n}}), "ends");
+    auto m2 = create_slice_sym({3}, bounds({int64_t{0}}), bounds({dd{n}}), "ends");
+    run_pass(m1);
+
+    EXPECT(m1 == m2);
+}
+
+TEST_CASE(slice_sym_ends_at_len_test)
+{
+    // n >= 5 is provable, so the bound collapses to the axis length and demotes to an integer.
+    auto n  = var("n", {6, 9});
+    auto m1 = create_slice_sym({3}, bounds({int64_t{0}}), bounds({dd{n}}), "ends");
+    auto m2 = create_slice_sym({3}, bounds({int64_t{0}}), bounds({int64_t{5}}), "ends");
+    run_pass(m1);
+
+    EXPECT(m1 == m2);
+}
+
+TEST_CASE(slice_sym_starts_clamped_test)
+{
+    // The starts attribute normalizes the same way. Axis 1 has length 3.
+    auto s  = var("s", {0, 5});
+    auto m1 = create_slice_sym({1}, bounds({dd{s}}), bounds({int64_t{3}}), "starts");
+    auto m2 = create_slice_sym(
+        {1}, bounds({dd{migraphx::sym::min(s, lit(3))}}), bounds({int64_t{3}}), "starts");
+    run_pass(m1);
+
+    EXPECT(m1 == m2);
+}
+
+TEST_CASE(slice_sym_mixed_bounds_test)
+{
+    // One symbolic entry routes the whole attribute through the symbolic path. Each entry is
+    // still clamped against its own axis length (3 for axis 1, 5 for axis 3), and the concrete
+    // entry stays concrete.
+    auto n  = var("n", {1, 8});
+    auto m1 = create_slice_sym(
+        {1, 3}, bounds({int64_t{0}, int64_t{0}}), bounds({dd{n}, int64_t{9}}), "ends");
+    auto m2 = create_slice_sym({1, 3},
+                               bounds({int64_t{0}, int64_t{0}}),
+                               bounds({dd{migraphx::sym::min(n, lit(3))}, int64_t{5}}),
+                               "ends");
+    run_pass(m1);
+
+    EXPECT(m1 == m2);
+}
+
+TEST_CASE(slice_sym_symbolic_axis_len_test)
+{
+    // When the sliced axis is itself symbolic, the clamp bound is that axis's symbol instead of
+    // a compile-time length.
+    auto k = var("k", {2, 6});
+    auto n = var("n", {1, 8});
+    migraphx::shape s{migraphx::shape::float_type, {dd{k}, dd{lit(4)}}};
+    auto m1 = create_slice_sym({0}, bounds({int64_t{0}}), bounds({dd{n}}), "ends", s);
+    auto m2 = create_slice_sym(
+        {0}, bounds({int64_t{0}}), bounds({dd{migraphx::sym::min(n, k)}}), "ends", s);
+    run_pass(m1);
+
+    EXPECT(m1 == m2);
+}
+
+TEST_CASE(slice_sym_normalize_idempotent_test)
+{
+    // Normalizing an already normalized symbolic bound must not nest a second clamp.
+    auto n  = var("n", {1, 8});
+    auto m1 = create_slice_sym({3}, bounds({int64_t{0}}), bounds({dd{n}}), "ends");
+    run_pass(m1);
+    auto once = m1;
+    run_pass(m1);
+
+    EXPECT(m1 == once);
+}
+
+TEST_CASE(slice_sym_missing_axes_throws)
+{
+    // The axes come from a variable input, leaving the axes attribute empty, so there is no
+    // axis to pair the symbolic bound with.
+    auto n = var("n", {1, 8});
+    EXPECT(test::throws<migraphx::exception>(
+        [&] {
+            migraphx::module m;
+            auto data = m.add_parameter("data", slice_sym_data_shape());
+            migraphx::shape sb{migraphx::shape::int64_type, {1}};
+            auto ends_in = m.add_parameter("ends", sb);
+            auto axes_in = m.add_parameter("axes", sb);
+            m.add_instruction(migraphx::make_op("slice",
+                                                {{"starts", bounds({int64_t{0}})},
+                                                 {"ends", bounds({dd{n}})},
+                                                 {"mode", migraphx::value::array{"ends", "axes"}}}),
+                              data,
+                              ends_in,
+                              axes_in);
+        },
+        "symbolic bounds require one axis per bound"));
+}
+
+TEST_CASE(slice_sym_nonfixed_axis_throws)
+{
+    // A range-based dynamic axis is neither symbolic nor fixed, so it has no length expression
+    // to clamp the symbolic bound against.
+    auto n = var("n", {1, 8});
+    migraphx::shape s{migraphx::shape::float_type, {{2, 4}, {3, 3}}};
+    EXPECT(test::throws<migraphx::exception>(
+        [&] { create_slice_sym({0}, bounds({int64_t{0}}), bounds({dd{n}}), "ends", s); },
+        "cannot normalize a symbolic bound on a non-fixed axis"));
 }
 
 static migraphx::module create_test_op(const std::vector<int64_t>& axes)

--- a/test/normalize_ops_test.cpp
+++ b/test/normalize_ops_test.cpp
@@ -23,7 +23,6 @@
  */
 #include <migraphx/normalize_ops.hpp>
 #include <migraphx/dead_code_elimination.hpp>
-#include <migraphx/dim_like.hpp>
 #include <migraphx/pass_manager.hpp>
 #include <migraphx/make_op.hpp>
 #include <migraphx/functional.hpp>
@@ -186,47 +185,44 @@ TEST_CASE(slice_test_1)
     EXPECT(m1 == m2);
 }
 
-static migraphx::shape slice_sym_data_shape()
-{
-    return {migraphx::shape::float_type, {2, 3, 4, 5}};
-}
-
-// slice's starts/ends attributes are vectors of dim_like: each entry is either a plain integer
-// or a symbolic dynamic_dimension.
-static migraphx::value bounds(std::vector<migraphx::dim_like> v) { return migraphx::to_value(v); }
-
-// Builds slice(data, bound). `mode_key` names the bound that the variable input supplies at
-// runtime; that bound's attribute still carries the compile-time (possibly symbolic) value.
-// Symbolic bounds are only allowed with two or more inputs, hence the extra parameter.
-static migraphx::module create_slice_sym(const std::vector<int64_t>& axes,
-                                         const migraphx::value& starts,
-                                         const migraphx::value& ends,
-                                         const std::string& mode_key,
-                                         const migraphx::shape& data_shape = slice_sym_data_shape())
-{
-    migraphx::module m;
-    auto data = m.add_parameter("data", data_shape);
-    auto bound =
-        m.add_parameter(mode_key, migraphx::shape{migraphx::shape::int64_type, {axes.size()}});
-    auto r = m.add_instruction(migraphx::make_op("slice",
-                                                 {{"axes", axes},
-                                                  {"starts", starts},
-                                                  {"ends", ends},
-                                                  {"mode", migraphx::value::array{mode_key}}}),
-                               data,
-                               bound);
-    m.add_return({r});
-
-    return m;
-}
-
 TEST_CASE(slice_sym_ends_clamped_test)
 {
     // n is not provably ordered against the axis length 5, so the bound clamps to min(n, 5).
-    auto n  = var("n", {1, 8});
-    auto m1 = create_slice_sym({3}, bounds({int64_t{0}}), bounds({dd{n}}), "ends");
-    auto m2 = create_slice_sym(
-        {3}, bounds({int64_t{0}}), bounds({dd{migraphx::sym::min(n, lit(5))}}), "ends");
+    auto n = var("n", {1, 8});
+    migraphx::shape s{migraphx::shape::float_type, {2, 3, 4, 5}};
+    migraphx::shape sb{migraphx::shape::int64_type, {1}};
+
+    migraphx::module m1;
+    {
+        auto data = m1.add_parameter("data", s);
+        auto ends = m1.add_parameter("ends", sb);
+        auto r    = m1.add_instruction(
+            migraphx::make_op("slice",
+                                 {{"axes", {3}},
+                                  {"starts", {0}},
+                                  {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                  {"mode", migraphx::value::array{"ends"}}}),
+            data,
+            ends);
+        m1.add_return({r});
+    }
+
+    migraphx::module m2;
+    {
+        auto data = m2.add_parameter("data", s);
+        auto ends = m2.add_parameter("ends", sb);
+        auto r    = m2.add_instruction(
+            migraphx::make_op(
+                "slice",
+                {{"axes", {3}},
+                    {"starts", {0}},
+                    {"ends",
+                     migraphx::value::array{migraphx::to_value(dd{migraphx::sym::min(n, lit(5))})}},
+                    {"mode", migraphx::value::array{"ends"}}}),
+            data,
+            ends);
+        m2.add_return({r});
+    }
     run_pass(m1);
 
     EXPECT(m1 == m2);
@@ -235,9 +231,39 @@ TEST_CASE(slice_sym_ends_clamped_test)
 TEST_CASE(slice_sym_ends_below_len_test)
 {
     // n < 5 is provable, so the bound keeps the bare symbol rather than gaining a min wrapper.
-    auto n  = var("n", {1, 4});
-    auto m1 = create_slice_sym({3}, bounds({int64_t{0}}), bounds({dd{n}}), "ends");
-    auto m2 = create_slice_sym({3}, bounds({int64_t{0}}), bounds({dd{n}}), "ends");
+    auto n = var("n", {1, 4});
+    migraphx::shape s{migraphx::shape::float_type, {2, 3, 4, 5}};
+    migraphx::shape sb{migraphx::shape::int64_type, {1}};
+
+    migraphx::module m1;
+    {
+        auto data = m1.add_parameter("data", s);
+        auto ends = m1.add_parameter("ends", sb);
+        auto r    = m1.add_instruction(
+            migraphx::make_op("slice",
+                                 {{"axes", {3}},
+                                  {"starts", {0}},
+                                  {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                  {"mode", migraphx::value::array{"ends"}}}),
+            data,
+            ends);
+        m1.add_return({r});
+    }
+
+    migraphx::module m2;
+    {
+        auto data = m2.add_parameter("data", s);
+        auto ends = m2.add_parameter("ends", sb);
+        auto r    = m2.add_instruction(
+            migraphx::make_op("slice",
+                                 {{"axes", {3}},
+                                  {"starts", {0}},
+                                  {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                  {"mode", migraphx::value::array{"ends"}}}),
+            data,
+            ends);
+        m2.add_return({r});
+    }
     run_pass(m1);
 
     EXPECT(m1 == m2);
@@ -246,9 +272,38 @@ TEST_CASE(slice_sym_ends_below_len_test)
 TEST_CASE(slice_sym_ends_at_len_test)
 {
     // n >= 5 is provable, so the bound collapses to the axis length and demotes to an integer.
-    auto n  = var("n", {6, 9});
-    auto m1 = create_slice_sym({3}, bounds({int64_t{0}}), bounds({dd{n}}), "ends");
-    auto m2 = create_slice_sym({3}, bounds({int64_t{0}}), bounds({int64_t{5}}), "ends");
+    auto n = var("n", {6, 9});
+    migraphx::shape s{migraphx::shape::float_type, {2, 3, 4, 5}};
+    migraphx::shape sb{migraphx::shape::int64_type, {1}};
+
+    migraphx::module m1;
+    {
+        auto data = m1.add_parameter("data", s);
+        auto ends = m1.add_parameter("ends", sb);
+        auto r    = m1.add_instruction(
+            migraphx::make_op("slice",
+                                 {{"axes", {3}},
+                                  {"starts", {0}},
+                                  {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                  {"mode", migraphx::value::array{"ends"}}}),
+            data,
+            ends);
+        m1.add_return({r});
+    }
+
+    migraphx::module m2;
+    {
+        auto data = m2.add_parameter("data", s);
+        auto ends = m2.add_parameter("ends", sb);
+        auto r    = m2.add_instruction(migraphx::make_op("slice",
+                                                         {{"axes", {3}},
+                                                          {"starts", {0}},
+                                                          {"ends", {5}},
+                                                          {"mode", migraphx::value::array{"ends"}}}),
+                                    data,
+                                    ends);
+        m2.add_return({r});
+    }
     run_pass(m1);
 
     EXPECT(m1 == m2);
@@ -257,10 +312,41 @@ TEST_CASE(slice_sym_ends_at_len_test)
 TEST_CASE(slice_sym_starts_clamped_test)
 {
     // The starts attribute normalizes the same way. Axis 1 has length 3.
-    auto s  = var("s", {0, 5});
-    auto m1 = create_slice_sym({1}, bounds({dd{s}}), bounds({int64_t{3}}), "starts");
-    auto m2 = create_slice_sym(
-        {1}, bounds({dd{migraphx::sym::min(s, lit(3))}}), bounds({int64_t{3}}), "starts");
+    auto n = var("n", {0, 5});
+    migraphx::shape s{migraphx::shape::float_type, {2, 3, 4, 5}};
+    migraphx::shape sb{migraphx::shape::int64_type, {1}};
+
+    migraphx::module m1;
+    {
+        auto data   = m1.add_parameter("data", s);
+        auto starts = m1.add_parameter("starts", sb);
+        auto r      = m1.add_instruction(
+            migraphx::make_op("slice",
+                                   {{"axes", {1}},
+                                    {"starts", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                    {"ends", {3}},
+                                    {"mode", migraphx::value::array{"starts"}}}),
+            data,
+            starts);
+        m1.add_return({r});
+    }
+
+    migraphx::module m2;
+    {
+        auto data   = m2.add_parameter("data", s);
+        auto starts = m2.add_parameter("starts", sb);
+        auto r      = m2.add_instruction(
+            migraphx::make_op(
+                "slice",
+                {{"axes", {1}},
+                      {"starts",
+                       migraphx::value::array{migraphx::to_value(dd{migraphx::sym::min(n, lit(3))})}},
+                      {"ends", {3}},
+                      {"mode", migraphx::value::array{"starts"}}}),
+            data,
+            starts);
+        m2.add_return({r});
+    }
     run_pass(m1);
 
     EXPECT(m1 == m2);
@@ -271,13 +357,41 @@ TEST_CASE(slice_sym_mixed_bounds_test)
     // One symbolic entry routes the whole attribute through the symbolic path. Each entry is
     // still clamped against its own axis length (3 for axis 1, 5 for axis 3), and the concrete
     // entry stays concrete.
-    auto n  = var("n", {1, 8});
-    auto m1 = create_slice_sym(
-        {1, 3}, bounds({int64_t{0}, int64_t{0}}), bounds({dd{n}, int64_t{9}}), "ends");
-    auto m2 = create_slice_sym({1, 3},
-                               bounds({int64_t{0}, int64_t{0}}),
-                               bounds({dd{migraphx::sym::min(n, lit(3))}, int64_t{5}}),
-                               "ends");
+    auto n = var("n", {1, 8});
+    migraphx::shape s{migraphx::shape::float_type, {2, 3, 4, 5}};
+    migraphx::shape sb{migraphx::shape::int64_type, {2}};
+
+    migraphx::module m1;
+    {
+        auto data = m1.add_parameter("data", s);
+        auto ends = m1.add_parameter("ends", sb);
+        auto r    = m1.add_instruction(
+            migraphx::make_op("slice",
+                                 {{"axes", {1, 3}},
+                                  {"starts", {0, 0}},
+                                  {"ends", migraphx::value::array{migraphx::to_value(dd{n}), 9}},
+                                  {"mode", migraphx::value::array{"ends"}}}),
+            data,
+            ends);
+        m1.add_return({r});
+    }
+
+    migraphx::module m2;
+    {
+        auto data = m2.add_parameter("data", s);
+        auto ends = m2.add_parameter("ends", sb);
+        auto r    = m2.add_instruction(
+            migraphx::make_op(
+                "slice",
+                {{"axes", {1, 3}},
+                    {"starts", {0, 0}},
+                    {"ends",
+                     migraphx::value::array{migraphx::to_value(dd{migraphx::sym::min(n, lit(3))}), 5}},
+                    {"mode", migraphx::value::array{"ends"}}}),
+            data,
+            ends);
+        m2.add_return({r});
+    }
     run_pass(m1);
 
     EXPECT(m1 == m2);
@@ -290,9 +404,38 @@ TEST_CASE(slice_sym_symbolic_axis_len_test)
     auto k = var("k", {2, 6});
     auto n = var("n", {1, 8});
     migraphx::shape s{migraphx::shape::float_type, {dd{k}, dd{lit(4)}}};
-    auto m1 = create_slice_sym({0}, bounds({int64_t{0}}), bounds({dd{n}}), "ends", s);
-    auto m2 = create_slice_sym(
-        {0}, bounds({int64_t{0}}), bounds({dd{migraphx::sym::min(n, k)}}), "ends", s);
+    migraphx::shape sb{migraphx::shape::int64_type, {1}};
+
+    migraphx::module m1;
+    {
+        auto data = m1.add_parameter("data", s);
+        auto ends = m1.add_parameter("ends", sb);
+        auto r    = m1.add_instruction(
+            migraphx::make_op("slice",
+                                 {{"axes", {0}},
+                                  {"starts", {0}},
+                                  {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                  {"mode", migraphx::value::array{"ends"}}}),
+            data,
+            ends);
+        m1.add_return({r});
+    }
+
+    migraphx::module m2;
+    {
+        auto data = m2.add_parameter("data", s);
+        auto ends = m2.add_parameter("ends", sb);
+        auto r    = m2.add_instruction(
+            migraphx::make_op(
+                "slice",
+                {{"axes", {0}},
+                    {"starts", {0}},
+                    {"ends", migraphx::value::array{migraphx::to_value(dd{migraphx::sym::min(n, k)})}},
+                    {"mode", migraphx::value::array{"ends"}}}),
+            data,
+            ends);
+        m2.add_return({r});
+    }
     run_pass(m1);
 
     EXPECT(m1 == m2);
@@ -301,8 +444,24 @@ TEST_CASE(slice_sym_symbolic_axis_len_test)
 TEST_CASE(slice_sym_normalize_idempotent_test)
 {
     // Normalizing an already normalized symbolic bound must not nest a second clamp.
-    auto n  = var("n", {1, 8});
-    auto m1 = create_slice_sym({3}, bounds({int64_t{0}}), bounds({dd{n}}), "ends");
+    auto n = var("n", {1, 8});
+    migraphx::shape s{migraphx::shape::float_type, {2, 3, 4, 5}};
+    migraphx::shape sb{migraphx::shape::int64_type, {1}};
+
+    migraphx::module m1;
+    {
+        auto data = m1.add_parameter("data", s);
+        auto ends = m1.add_parameter("ends", sb);
+        auto r    = m1.add_instruction(
+            migraphx::make_op("slice",
+                                 {{"axes", {3}},
+                                  {"starts", {0}},
+                                  {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                  {"mode", migraphx::value::array{"ends"}}}),
+            data,
+            ends);
+        m1.add_return({r});
+    }
     run_pass(m1);
     auto once = m1;
     run_pass(m1);
@@ -315,20 +474,23 @@ TEST_CASE(slice_sym_missing_axes_throws)
     // The axes come from a variable input, leaving the axes attribute empty, so there is no
     // axis to pair the symbolic bound with.
     auto n = var("n", {1, 8});
+    migraphx::shape s{migraphx::shape::float_type, {2, 3, 4, 5}};
+    migraphx::shape sb{migraphx::shape::int64_type, {1}};
+
     EXPECT(test::throws<migraphx::exception>(
         [&] {
             migraphx::module m;
-            auto data = m.add_parameter("data", slice_sym_data_shape());
-            migraphx::shape sb{migraphx::shape::int64_type, {1}};
+            auto data    = m.add_parameter("data", s);
             auto ends_in = m.add_parameter("ends", sb);
             auto axes_in = m.add_parameter("axes", sb);
-            m.add_instruction(migraphx::make_op("slice",
-                                                {{"starts", bounds({int64_t{0}})},
-                                                 {"ends", bounds({dd{n}})},
-                                                 {"mode", migraphx::value::array{"ends", "axes"}}}),
-                              data,
-                              ends_in,
-                              axes_in);
+            m.add_instruction(
+                migraphx::make_op("slice",
+                                  {{"starts", {0}},
+                                   {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                   {"mode", migraphx::value::array{"ends", "axes"}}}),
+                data,
+                ends_in,
+                axes_in);
         },
         "symbolic bounds require one axis per bound"));
 }
@@ -339,8 +501,22 @@ TEST_CASE(slice_sym_nonfixed_axis_throws)
     // to clamp the symbolic bound against.
     auto n = var("n", {1, 8});
     migraphx::shape s{migraphx::shape::float_type, {{2, 4}, {3, 3}}};
+    migraphx::shape sb{migraphx::shape::int64_type, {1}};
+
     EXPECT(test::throws<migraphx::exception>(
-        [&] { create_slice_sym({0}, bounds({int64_t{0}}), bounds({dd{n}}), "ends", s); },
+        [&] {
+            migraphx::module m;
+            auto data = m.add_parameter("data", s);
+            auto ends = m.add_parameter("ends", sb);
+            m.add_instruction(
+                migraphx::make_op("slice",
+                                  {{"axes", {0}},
+                                   {"starts", {0}},
+                                   {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                   {"mode", migraphx::value::array{"ends"}}}),
+                data,
+                ends);
+        },
         "cannot normalize a symbolic bound on a non-fixed axis"));
 }
 

--- a/test/onnx/parse/slice_var_input_default_steps.cpp
+++ b/test/onnx/parse/slice_var_input_default_steps.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/onnx/parse/slice_var_input_default_steps.cpp
+++ b/test/onnx/parse/slice_var_input_default_steps.cpp
@@ -35,7 +35,11 @@ TEST_CASE(slice_var_input_default_steps)
     auto axes   = mm->add_parameter("axes", migraphx::shape{migraphx::shape::int64_type, {2}});
     mm->add_literal({{migraphx::shape::int64_type, {2}}, {1, 1}});
     auto ret = mm->add_instruction(
-        migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}), data, starts, ends, axes);
+        migraphx::make_op("slice", {{"mode", migraphx::value::array{"starts", "ends", "axes"}}}),
+        data,
+        starts,
+        ends,
+        axes);
     mm->add_return({ret});
 
     migraphx::onnx_options options;

--- a/test/onnx/parse/slice_var_input_default_steps.cpp
+++ b/test/onnx/parse/slice_var_input_default_steps.cpp
@@ -34,7 +34,8 @@ TEST_CASE(slice_var_input_default_steps)
     auto ends   = mm->add_parameter("ends", migraphx::shape{migraphx::shape::int64_type, {2}});
     auto axes   = mm->add_parameter("axes", migraphx::shape{migraphx::shape::int64_type, {2}});
     mm->add_literal({{migraphx::shape::int64_type, {2}}, {1, 1}});
-    auto ret = mm->add_instruction(migraphx::make_op("slice"), data, starts, ends, axes);
+    auto ret = mm->add_instruction(
+        migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}), data, starts, ends, axes);
     mm->add_return({ret});
 
     migraphx::onnx_options options;

--- a/test/onnx/parse/slice_var_input_dyn0.cpp
+++ b/test/onnx/parse/slice_var_input_dyn0.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/onnx/parse/slice_var_input_dyn0.cpp
+++ b/test/onnx/parse/slice_var_input_dyn0.cpp
@@ -32,7 +32,7 @@ TEST_CASE(slice_var_input_dyn0)
         mm->add_parameter("data", migraphx::shape{migraphx::shape::float_type, {{3, 8}, {2, 2}}});
     auto starts = mm->add_parameter("starts", migraphx::shape{migraphx::shape::int32_type, {2}});
     auto ends   = mm->add_parameter("ends", migraphx::shape{migraphx::shape::int32_type, {2}});
-    auto ret = mm->add_instruction(
+    auto ret    = mm->add_instruction(
         migraphx::make_op("slice", {{"axes", {0, 1}}, {"mode", "starts_ends_input"}}),
         data,
         starts,

--- a/test/onnx/parse/slice_var_input_dyn0.cpp
+++ b/test/onnx/parse/slice_var_input_dyn0.cpp
@@ -32,8 +32,11 @@ TEST_CASE(slice_var_input_dyn0)
         mm->add_parameter("data", migraphx::shape{migraphx::shape::float_type, {{3, 8}, {2, 2}}});
     auto starts = mm->add_parameter("starts", migraphx::shape{migraphx::shape::int32_type, {2}});
     auto ends   = mm->add_parameter("ends", migraphx::shape{migraphx::shape::int32_type, {2}});
-    auto ret =
-        mm->add_instruction(migraphx::make_op("slice", {{"axes", {0, 1}}}), data, starts, ends);
+    auto ret = mm->add_instruction(
+        migraphx::make_op("slice", {{"axes", {0, 1}}, {"mode", "starts_ends_input"}}),
+        data,
+        starts,
+        ends);
     mm->add_return({ret});
 
     migraphx::onnx_options options;

--- a/test/onnx/parse/slice_var_input_dyn0.cpp
+++ b/test/onnx/parse/slice_var_input_dyn0.cpp
@@ -33,7 +33,8 @@ TEST_CASE(slice_var_input_dyn0)
     auto starts = mm->add_parameter("starts", migraphx::shape{migraphx::shape::int32_type, {2}});
     auto ends   = mm->add_parameter("ends", migraphx::shape{migraphx::shape::int32_type, {2}});
     auto ret    = mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {0, 1}}, {"mode", "starts_ends_input"}}),
+        migraphx::make_op("slice",
+                             {{"axes", {0, 1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
         data,
         starts,
         ends);

--- a/test/onnx/parse/slice_var_input_dyn1.cpp
+++ b/test/onnx/parse/slice_var_input_dyn1.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/onnx/parse/slice_var_input_dyn1.cpp
+++ b/test/onnx/parse/slice_var_input_dyn1.cpp
@@ -33,7 +33,8 @@ TEST_CASE(slice_var_input_dyn1)
     auto starts = mm->add_parameter("starts", migraphx::shape{migraphx::shape::int32_type, {2}});
     auto ends   = mm->add_parameter("ends", migraphx::shape{migraphx::shape::int32_type, {2}});
     auto axes   = mm->add_parameter("axes", migraphx::shape{migraphx::shape::int32_type, {2}});
-    auto ret    = mm->add_instruction(migraphx::make_op("slice"), data, starts, ends, axes);
+    auto ret = mm->add_instruction(
+        migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}), data, starts, ends, axes);
     mm->add_return({ret});
 
     migraphx::onnx_options options;

--- a/test/onnx/parse/slice_var_input_dyn1.cpp
+++ b/test/onnx/parse/slice_var_input_dyn1.cpp
@@ -33,7 +33,7 @@ TEST_CASE(slice_var_input_dyn1)
     auto starts = mm->add_parameter("starts", migraphx::shape{migraphx::shape::int32_type, {2}});
     auto ends   = mm->add_parameter("ends", migraphx::shape{migraphx::shape::int32_type, {2}});
     auto axes   = mm->add_parameter("axes", migraphx::shape{migraphx::shape::int32_type, {2}});
-    auto ret = mm->add_instruction(
+    auto ret    = mm->add_instruction(
         migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}), data, starts, ends, axes);
     mm->add_return({ret});
 

--- a/test/onnx/parse/slice_var_input_dyn1.cpp
+++ b/test/onnx/parse/slice_var_input_dyn1.cpp
@@ -34,7 +34,11 @@ TEST_CASE(slice_var_input_dyn1)
     auto ends   = mm->add_parameter("ends", migraphx::shape{migraphx::shape::int32_type, {2}});
     auto axes   = mm->add_parameter("axes", migraphx::shape{migraphx::shape::int32_type, {2}});
     auto ret    = mm->add_instruction(
-        migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}), data, starts, ends, axes);
+        migraphx::make_op("slice", {{"mode", migraphx::value::array{"starts", "ends", "axes"}}}),
+        data,
+        starts,
+        ends,
+        axes);
     mm->add_return({ret});
 
     migraphx::onnx_options options;

--- a/test/onnx/parse/slice_var_input_static0.cpp
+++ b/test/onnx/parse/slice_var_input_static0.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/onnx/parse/slice_var_input_static0.cpp
+++ b/test/onnx/parse/slice_var_input_static0.cpp
@@ -31,7 +31,11 @@ TEST_CASE(slice_var_input_static0)
     auto data   = mm->add_parameter("data", migraphx::shape{migraphx::shape::float_type, {3, 2}});
     auto starts = mm->add_parameter("starts", migraphx::shape{migraphx::shape::int32_type, {2}});
     auto ends   = mm->add_parameter("ends", migraphx::shape{migraphx::shape::int32_type, {2}});
-    mm->add_instruction(migraphx::make_op("slice", {{"axes", {0, 1}}}), data, starts, ends);
+    mm->add_instruction(
+        migraphx::make_op("slice", {{"axes", {0, 1}}, {"mode", "starts_ends_input"}}),
+        data,
+        starts,
+        ends);
     auto prog = optimize_onnx("slice_var_input_static0.onnx");
 
     EXPECT(p == prog);

--- a/test/onnx/parse/slice_var_input_static0.cpp
+++ b/test/onnx/parse/slice_var_input_static0.cpp
@@ -32,7 +32,8 @@ TEST_CASE(slice_var_input_static0)
     auto starts = mm->add_parameter("starts", migraphx::shape{migraphx::shape::int32_type, {2}});
     auto ends   = mm->add_parameter("ends", migraphx::shape{migraphx::shape::int32_type, {2}});
     mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {0, 1}}, {"mode", "starts_ends_input"}}),
+        migraphx::make_op("slice",
+                          {{"axes", {0, 1}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
         data,
         starts,
         ends);

--- a/test/onnx/parse/slice_var_input_static1.cpp
+++ b/test/onnx/parse/slice_var_input_static1.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/onnx/parse/slice_var_input_static1.cpp
+++ b/test/onnx/parse/slice_var_input_static1.cpp
@@ -33,7 +33,11 @@ TEST_CASE(slice_var_input_static1)
     auto ends   = mm->add_parameter("ends", migraphx::shape{migraphx::shape::int64_type, {2}});
     auto axes   = mm->add_parameter("axes", migraphx::shape{migraphx::shape::int64_type, {2}});
     mm->add_instruction(
-        migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}), data, starts, ends, axes);
+        migraphx::make_op("slice", {{"mode", migraphx::value::array{"starts", "ends", "axes"}}}),
+        data,
+        starts,
+        ends,
+        axes);
     auto prog = optimize_onnx("slice_var_input_static1.onnx");
 
     EXPECT(p == prog);

--- a/test/onnx/parse/slice_var_input_static1.cpp
+++ b/test/onnx/parse/slice_var_input_static1.cpp
@@ -32,7 +32,8 @@ TEST_CASE(slice_var_input_static1)
     auto starts = mm->add_parameter("starts", migraphx::shape{migraphx::shape::int64_type, {2}});
     auto ends   = mm->add_parameter("ends", migraphx::shape{migraphx::shape::int64_type, {2}});
     auto axes   = mm->add_parameter("axes", migraphx::shape{migraphx::shape::int64_type, {2}});
-    mm->add_instruction(migraphx::make_op("slice"), data, starts, ends, axes);
+    mm->add_instruction(
+        migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}), data, starts, ends, axes);
     auto prog = optimize_onnx("slice_var_input_static1.onnx");
 
     EXPECT(p == prog);

--- a/test/onnx/parse/split_dyn_input.cpp
+++ b/test/onnx/parse/split_dyn_input.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/onnx/parse/split_dyn_input.cpp
+++ b/test/onnx/parse/split_dyn_input.cpp
@@ -60,7 +60,8 @@ TEST_CASE(split_dyn_input_dyn_split_axis_test)
         mm->add_instruction(migraphx::make_op("add"), split_dim, num_outputs_minus_1_lit),
         num_outputs_lit);
     auto r1 = mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {0}}, {"mode", "starts_ends_input"}}),
+        migraphx::make_op("slice",
+                          {{"axes", {0}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
         input,
         mm->add_instruction(migraphx::make_op("mul"),
                             chunk_size,
@@ -69,7 +70,8 @@ TEST_CASE(split_dyn_input_dyn_split_axis_test)
                             chunk_size,
                             mm->add_literal(migraphx::literal{int64_scalar_shape, {1}})));
     auto r2 = mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {0}}, {"mode", "starts_ends_input"}}),
+        migraphx::make_op("slice",
+                          {{"axes", {0}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
         input,
         mm->add_instruction(migraphx::make_op("mul"),
                             chunk_size,
@@ -81,7 +83,7 @@ TEST_CASE(split_dyn_input_dyn_split_axis_test)
         migraphx::make_op("slice",
                           {{"axes", {0}},
                            {"ends", {std::numeric_limits<int64_t>::max()}},
-                           {"mode", "starts_input"}}),
+                           {"mode", migraphx::value::array{"starts"}}}),
         input,
         mm->add_instruction(migraphx::make_op("mul"),
                             chunk_size,

--- a/test/onnx/parse/split_dyn_input.cpp
+++ b/test/onnx/parse/split_dyn_input.cpp
@@ -60,7 +60,7 @@ TEST_CASE(split_dyn_input_dyn_split_axis_test)
         mm->add_instruction(migraphx::make_op("add"), split_dim, num_outputs_minus_1_lit),
         num_outputs_lit);
     auto r1 = mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {0}}}),
+        migraphx::make_op("slice", {{"axes", {0}}, {"mode", "starts_ends_input"}}),
         input,
         mm->add_instruction(migraphx::make_op("mul"),
                             chunk_size,
@@ -69,7 +69,7 @@ TEST_CASE(split_dyn_input_dyn_split_axis_test)
                             chunk_size,
                             mm->add_literal(migraphx::literal{int64_scalar_shape, {1}})));
     auto r2 = mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {0}}}),
+        migraphx::make_op("slice", {{"axes", {0}}, {"mode", "starts_ends_input"}}),
         input,
         mm->add_instruction(migraphx::make_op("mul"),
                             chunk_size,
@@ -79,7 +79,9 @@ TEST_CASE(split_dyn_input_dyn_split_axis_test)
                             mm->add_literal(migraphx::literal{int64_scalar_shape, {2}})));
     auto r3 = mm->add_instruction(
         migraphx::make_op("slice",
-                          {{"axes", {0}}, {"ends", {std::numeric_limits<int64_t>::max()}}}),
+                          {{"axes", {0}},
+                           {"ends", {std::numeric_limits<int64_t>::max()}},
+                           {"mode", "starts_input"}}),
         input,
         mm->add_instruction(migraphx::make_op("mul"),
                             chunk_size,

--- a/test/onnx/parse/topk_var_k_test.cpp
+++ b/test/onnx/parse/topk_var_k_test.cpp
@@ -37,8 +37,14 @@ TEST_CASE(topk_var_k_test)
         migraphx::make_op("topk", {{"k", 4}, {"axis", 1}, {"largest", 1}}), data);
     auto val = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), out);
     auto ind = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), out);
-    val = mm->add_instruction(migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}), val, k);
-    ind = mm->add_instruction(migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}), ind, k);
+    val      = mm->add_instruction(
+        migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}),
+        val,
+        k);
+    ind = mm->add_instruction(
+        migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}),
+        ind,
+        k);
     mm->add_return({val, ind});
 
     auto prog = read_onnx("topk_var_k_test.onnx");
@@ -58,8 +64,14 @@ TEST_CASE(topk_var_k_dynamic_test)
         migraphx::make_op("topk", {{"k", 4}, {"axis", 1}, {"largest", 1}}), data);
     auto val = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), out);
     auto ind = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), out);
-    val = mm->add_instruction(migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}), val, k);
-    ind = mm->add_instruction(migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}), ind, k);
+    val      = mm->add_instruction(
+        migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}),
+        val,
+        k);
+    ind = mm->add_instruction(
+        migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}),
+        ind,
+        k);
     mm->add_return({val, ind});
 
     migraphx::onnx_options options;

--- a/test/onnx/parse/topk_var_k_test.cpp
+++ b/test/onnx/parse/topk_var_k_test.cpp
@@ -37,8 +37,8 @@ TEST_CASE(topk_var_k_test)
         migraphx::make_op("topk", {{"k", 4}, {"axis", 1}, {"largest", 1}}), data);
     auto val = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), out);
     auto ind = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), out);
-    val = mm->add_instruction(migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}}), val, k);
-    ind = mm->add_instruction(migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}}), ind, k);
+    val = mm->add_instruction(migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}), val, k);
+    ind = mm->add_instruction(migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}), ind, k);
     mm->add_return({val, ind});
 
     auto prog = read_onnx("topk_var_k_test.onnx");
@@ -58,8 +58,8 @@ TEST_CASE(topk_var_k_dynamic_test)
         migraphx::make_op("topk", {{"k", 4}, {"axis", 1}, {"largest", 1}}), data);
     auto val = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), out);
     auto ind = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), out);
-    val = mm->add_instruction(migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}}), val, k);
-    ind = mm->add_instruction(migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}}), ind, k);
+    val = mm->add_instruction(migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}), val, k);
+    ind = mm->add_instruction(migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}), ind, k);
     mm->add_return({val, ind});
 
     migraphx::onnx_options options;

--- a/test/onnx/parse/topk_var_k_test.cpp
+++ b/test/onnx/parse/topk_var_k_test.cpp
@@ -38,11 +38,13 @@ TEST_CASE(topk_var_k_test)
     auto val = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), out);
     auto ind = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), out);
     val      = mm->add_instruction(
-        migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}),
+        migraphx::make_op(
+            "slice", {{"starts", {0}}, {"axes", {1}}, {"mode", migraphx::value::array{"ends"}}}),
         val,
         k);
     ind = mm->add_instruction(
-        migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}),
+        migraphx::make_op(
+            "slice", {{"starts", {0}}, {"axes", {1}}, {"mode", migraphx::value::array{"ends"}}}),
         ind,
         k);
     mm->add_return({val, ind});
@@ -65,11 +67,13 @@ TEST_CASE(topk_var_k_dynamic_test)
     auto val = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), out);
     auto ind = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), out);
     val      = mm->add_instruction(
-        migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}),
+        migraphx::make_op(
+            "slice", {{"starts", {0}}, {"axes", {1}}, {"mode", migraphx::value::array{"ends"}}}),
         val,
         k);
     ind = mm->add_instruction(
-        migraphx::make_op("slice", {{"starts", {0}}, {"axes", {1}}, {"mode", "ends_input"}}),
+        migraphx::make_op(
+            "slice", {{"starts", {0}}, {"axes", {1}}, {"mode", migraphx::value::array{"ends"}}}),
         ind,
         k);
     mm->add_return({val, ind});

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -4908,7 +4908,9 @@ TEST_CASE(slice_var_inputs_static_shape0)
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     expect_shape(
         migraphx::shape{migraphx::shape::float_type, {{3, 3}, {0, 4}, {0, 4}}},
-        migraphx::make_op("slice", {{"ends", {2, 3}}, {"axes", {1, 2}}, {"mode", "starts_input"}}),
+        migraphx::make_op(
+            "slice",
+            {{"ends", {2, 3}}, {"axes", {1, 2}}, {"mode", migraphx::value::array{"starts"}}}),
         input,
         starts);
 }
@@ -4920,7 +4922,9 @@ TEST_CASE(slice_var_inputs_static_shape1)
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     expect_shape(
         migraphx::shape{migraphx::shape::float_type, {{3, 3}, {0, 4}, {0, 4}}},
-        migraphx::make_op("slice", {{"starts", {0, 1}}, {"axes", {1, 2}}, {"mode", "ends_input"}}),
+        migraphx::make_op(
+            "slice",
+            {{"starts", {0, 1}}, {"axes", {1, 2}}, {"mode", migraphx::value::array{"ends"}}}),
         input,
         ends);
 }
@@ -4932,7 +4936,9 @@ TEST_CASE(slice_var_inputs_static_shape2)
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
     expect_shape(
         migraphx::shape{migraphx::shape::float_type, {{0, 3}, {0, 4}, {0, 4}}},
-        migraphx::make_op("slice", {{"starts", {0, 1}}, {"ends", {1, 2}}, {"mode", "axes_input"}}),
+        migraphx::make_op(
+            "slice",
+            {{"starts", {0, 1}}, {"ends", {1, 2}}, {"mode", migraphx::value::array{"axes"}}}),
         input,
         axes);
 }
@@ -4943,11 +4949,13 @@ TEST_CASE(slice_var_inputs_static_shape3)
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{3, 3}, {0, 4}, {0, 4}}},
-                 migraphx::make_op("slice", {{"axes", {1, 2}}, {"mode", "starts_ends_input"}}),
-                 input,
-                 starts,
-                 ends);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{3, 3}, {0, 4}, {0, 4}}},
+        migraphx::make_op("slice",
+                          {{"axes", {1, 2}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+        input,
+        starts,
+        ends);
 }
 
 TEST_CASE(slice_var_inputs_static_shape4)
@@ -4956,11 +4964,13 @@ TEST_CASE(slice_var_inputs_static_shape4)
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 3}, {0, 4}, {0, 4}}},
-                 migraphx::make_op("slice", {{"ends", {3, 4}}, {"mode", "starts_axes_input"}}),
-                 input,
-                 starts,
-                 axes);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{0, 3}, {0, 4}, {0, 4}}},
+        migraphx::make_op("slice",
+                          {{"ends", {3, 4}}, {"mode", migraphx::value::array{"starts", "axes"}}}),
+        input,
+        starts,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_static_shape5)
@@ -4969,11 +4979,13 @@ TEST_CASE(slice_var_inputs_static_shape5)
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 3}, {0, 4}, {0, 4}}},
-                 migraphx::make_op("slice", {{"starts", {0, 2}}, {"mode", "ends_axes_input"}}),
-                 input,
-                 ends,
-                 axes);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{0, 3}, {0, 4}, {0, 4}}},
+        migraphx::make_op("slice",
+                          {{"starts", {0, 2}}, {"mode", migraphx::value::array{"ends", "axes"}}}),
+        input,
+        ends,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_static_shape6)
@@ -4982,12 +4994,13 @@ TEST_CASE(slice_var_inputs_static_shape6)
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 3}, {0, 4}, {0, 4}}},
-                 migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}),
-                 input,
-                 starts,
-                 ends,
-                 axes);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{0, 3}, {0, 4}, {0, 4}}},
+        migraphx::make_op("slice", {{"mode", migraphx::value::array{"starts", "ends", "axes"}}}),
+        input,
+        starts,
+        ends,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_shape0)
@@ -4997,7 +5010,9 @@ TEST_CASE(slice_var_inputs_dyn_shape0)
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     expect_shape(
         migraphx::shape{migraphx::shape::float_type, {{3, 6}, {0, 6}, {0, 6}}},
-        migraphx::make_op("slice", {{"ends", {2, 3}}, {"axes", {1, 2}}, {"mode", "starts_input"}}),
+        migraphx::make_op(
+            "slice",
+            {{"ends", {2, 3}}, {"axes", {1, 2}}, {"mode", migraphx::value::array{"starts"}}}),
         input,
         starts);
 }
@@ -5009,7 +5024,9 @@ TEST_CASE(slice_var_inputs_dyn_shape1)
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     expect_shape(
         migraphx::shape{migraphx::shape::float_type, {{3, 6}, {0, 6}, {0, 6}}},
-        migraphx::make_op("slice", {{"starts", {0, 1}}, {"axes", {1, 2}}, {"mode", "ends_input"}}),
+        migraphx::make_op(
+            "slice",
+            {{"starts", {0, 1}}, {"axes", {1, 2}}, {"mode", migraphx::value::array{"ends"}}}),
         input,
         ends);
 }
@@ -5021,7 +5038,9 @@ TEST_CASE(slice_var_inputs_dyn_shape2)
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
     expect_shape(
         migraphx::shape{migraphx::shape::float_type, {{0, 6}, {0, 6}, {0, 6}}},
-        migraphx::make_op("slice", {{"starts", {0, 1}}, {"ends", {8, 8}}, {"mode", "axes_input"}}),
+        migraphx::make_op(
+            "slice",
+            {{"starts", {0, 1}}, {"ends", {8, 8}}, {"mode", migraphx::value::array{"axes"}}}),
         input,
         axes);
 }
@@ -5032,11 +5051,13 @@ TEST_CASE(slice_var_inputs_dyn_shape3)
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{3, 6}, {0, 6}, {0, 6}}},
-                 migraphx::make_op("slice", {{"axes", {1, 2}}, {"mode", "starts_ends_input"}}),
-                 input,
-                 starts,
-                 ends);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{3, 6}, {0, 6}, {0, 6}}},
+        migraphx::make_op("slice",
+                          {{"axes", {1, 2}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+        input,
+        starts,
+        ends);
 }
 
 TEST_CASE(slice_var_inputs_dyn_shape4)
@@ -5045,11 +5066,13 @@ TEST_CASE(slice_var_inputs_dyn_shape4)
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 6}, {0, 6}, {0, 6}}},
-                 migraphx::make_op("slice", {{"ends", {3, 4}}, {"mode", "starts_axes_input"}}),
-                 input,
-                 starts,
-                 axes);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{0, 6}, {0, 6}, {0, 6}}},
+        migraphx::make_op("slice",
+                          {{"ends", {3, 4}}, {"mode", migraphx::value::array{"starts", "axes"}}}),
+        input,
+        starts,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_shape5)
@@ -5058,11 +5081,13 @@ TEST_CASE(slice_var_inputs_dyn_shape5)
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 6}, {0, 6}, {0, 6}}},
-                 migraphx::make_op("slice", {{"starts", {0, 2}}, {"mode", "ends_axes_input"}}),
-                 input,
-                 ends,
-                 axes);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{0, 6}, {0, 6}, {0, 6}}},
+        migraphx::make_op("slice",
+                          {{"starts", {0, 2}}, {"mode", migraphx::value::array{"ends", "axes"}}}),
+        input,
+        ends,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_shape6)
@@ -5071,42 +5096,49 @@ TEST_CASE(slice_var_inputs_dyn_shape6)
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 6}, {0, 4}, {0, 4}}},
-                 migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}),
-                 input,
-                 starts,
-                 ends,
-                 axes);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{0, 6}, {0, 4}, {0, 4}}},
+        migraphx::make_op("slice", {{"mode", migraphx::value::array{"starts", "ends", "axes"}}}),
+        input,
+        starts,
+        ends,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_static_mismatch_error0)
 {
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op(
-                     "slice", {{"ends", {2, 3, 4}}, {"axes", {0, 1, 2}}, {"mode", "starts_input"}}),
-                 input,
-                 starts);
+    throws_shape(
+        migraphx::make_op(
+            "slice",
+            {{"ends", {2, 3, 4}}, {"axes", {0, 1, 2}}, {"mode", migraphx::value::array{"starts"}}}),
+        input,
+        starts);
 }
 
 TEST_CASE(slice_var_inputs_static_mismatch_error1)
 {
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op(
-                     "slice", {{"starts", {0, 1, 2}}, {"axes", {0, 1, 2}}, {"mode", "ends_input"}}),
-                 input,
-                 ends);
+    throws_shape(
+        migraphx::make_op(
+            "slice",
+            {{"starts", {0, 1, 2}}, {"axes", {0, 1, 2}}, {"mode", migraphx::value::array{"ends"}}}),
+        input,
+        ends);
 }
 
 TEST_CASE(slice_var_inputs_static_mismatch_error2)
 {
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op(
-                     "slice", {{"starts", {0, 1, 2}}, {"ends", {3, 4, 4}}, {"mode", "axes_input"}}),
-                 input,
-                 axes);
+    throws_shape(
+        migraphx::make_op(
+            "slice",
+            {{"starts", {0, 1, 2}}, {"ends", {3, 4, 4}}, {"mode", migraphx::value::array{"axes"}}}),
+        input,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_static_mismatch_error3)
@@ -5114,10 +5146,12 @@ TEST_CASE(slice_var_inputs_static_mismatch_error3)
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op("slice", {{"axes", {0, 1, 2}}, {"mode", "starts_ends_input"}}),
-                 input,
-                 starts,
-                 ends);
+    throws_shape(
+        migraphx::make_op(
+            "slice", {{"axes", {0, 1, 2}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+        input,
+        starts,
+        ends);
 }
 
 TEST_CASE(slice_var_inputs_static_mismatch_error4)
@@ -5125,10 +5159,12 @@ TEST_CASE(slice_var_inputs_static_mismatch_error4)
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op("slice", {{"ends", {3, 3, 3}}, {"mode", "starts_axes_input"}}),
-                 input,
-                 starts,
-                 axes);
+    throws_shape(
+        migraphx::make_op(
+            "slice", {{"ends", {3, 3, 3}}, {"mode", migraphx::value::array{"starts", "axes"}}}),
+        input,
+        starts,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_static_mismatch_error5)
@@ -5136,10 +5172,12 @@ TEST_CASE(slice_var_inputs_static_mismatch_error5)
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op("slice", {{"starts", {0, 1, 2}}, {"mode", "ends_axes_input"}}),
-                 input,
-                 ends,
-                 axes);
+    throws_shape(
+        migraphx::make_op(
+            "slice", {{"starts", {0, 1, 2}}, {"mode", migraphx::value::array{"ends", "axes"}}}),
+        input,
+        ends,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_static_mismatch_error6)
@@ -5148,41 +5186,48 @@ TEST_CASE(slice_var_inputs_static_mismatch_error6)
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {3}};
-    throws_shape(migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}),
-                 input,
-                 starts,
-                 ends,
-                 axes);
+    throws_shape(
+        migraphx::make_op("slice", {{"mode", migraphx::value::array{"starts", "ends", "axes"}}}),
+        input,
+        starts,
+        ends,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error0)
 {
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op(
-                     "slice", {{"ends", {2, 3, 4}}, {"axes", {0, 1, 2}}, {"mode", "starts_input"}}),
-                 input,
-                 starts);
+    throws_shape(
+        migraphx::make_op(
+            "slice",
+            {{"ends", {2, 3, 4}}, {"axes", {0, 1, 2}}, {"mode", migraphx::value::array{"starts"}}}),
+        input,
+        starts);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error1)
 {
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op(
-                     "slice", {{"starts", {0, 1, 2}}, {"axes", {0, 1, 2}}, {"mode", "ends_input"}}),
-                 input,
-                 ends);
+    throws_shape(
+        migraphx::make_op(
+            "slice",
+            {{"starts", {0, 1, 2}}, {"axes", {0, 1, 2}}, {"mode", migraphx::value::array{"ends"}}}),
+        input,
+        ends);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error2)
 {
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op(
-                     "slice", {{"starts", {0, 1, 2}}, {"ends", {3, 4, 4}}, {"mode", "axes_input"}}),
-                 input,
-                 axes);
+    throws_shape(
+        migraphx::make_op(
+            "slice",
+            {{"starts", {0, 1, 2}}, {"ends", {3, 4, 4}}, {"mode", migraphx::value::array{"axes"}}}),
+        input,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error3)
@@ -5190,10 +5235,12 @@ TEST_CASE(slice_var_inputs_dyn_mismatch_error3)
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op("slice", {{"axes", {0, 1, 2}}, {"mode", "starts_ends_input"}}),
-                 input,
-                 starts,
-                 ends);
+    throws_shape(
+        migraphx::make_op(
+            "slice", {{"axes", {0, 1, 2}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+        input,
+        starts,
+        ends);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error4)
@@ -5201,10 +5248,12 @@ TEST_CASE(slice_var_inputs_dyn_mismatch_error4)
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op("slice", {{"ends", {3, 3, 3}}, {"mode", "starts_axes_input"}}),
-                 input,
-                 starts,
-                 axes);
+    throws_shape(
+        migraphx::make_op(
+            "slice", {{"ends", {3, 3, 3}}, {"mode", migraphx::value::array{"starts", "axes"}}}),
+        input,
+        starts,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error5)
@@ -5212,10 +5261,12 @@ TEST_CASE(slice_var_inputs_dyn_mismatch_error5)
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op("slice", {{"starts", {0, 1, 2}}, {"mode", "ends_axes_input"}}),
-                 input,
-                 ends,
-                 axes);
+    throws_shape(
+        migraphx::make_op(
+            "slice", {{"starts", {0, 1, 2}}, {"mode", migraphx::value::array{"ends", "axes"}}}),
+        input,
+        ends,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error6)
@@ -5224,11 +5275,12 @@ TEST_CASE(slice_var_inputs_dyn_mismatch_error6)
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {3}};
-    throws_shape(migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}),
-                 input,
-                 starts,
-                 ends,
-                 axes);
+    throws_shape(
+        migraphx::make_op("slice", {{"mode", migraphx::value::array{"starts", "ends", "axes"}}}),
+        input,
+        starts,
+        ends,
+        axes);
 }
 
 TEST_CASE(slice_dyn_shape0)
@@ -5480,7 +5532,7 @@ TEST_CASE(slice_sym_symbolic_end_static_input)
                                 {{"axes", {0}},
                                  {"starts", {0}},
                                  {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
-                                 {"mode", "ends_input"}});
+                                 {"mode", migraphx::value::array{"ends"}}});
 
     // end=n is clamped to the axis length 10: dim = min(n, 10).
     migraphx::shape sin{migraphx::shape::float_type, {10}};
@@ -5506,7 +5558,7 @@ TEST_CASE(slice_sym_symbolic_bounds)
                                     {{"axes", {1}},
                                      {"starts", {2}},
                                      {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
-                                     {"mode", "ends_input"}});
+                                     {"mode", migraphx::value::array{"ends"}}});
         migraphx::shape sin{migraphx::shape::float_type, {dd{m}, dd{lit(12)}}};
         migraphx::shape ends_in{migraphx::shape::int64_type, {1}};
         migraphx::shape sout{migraphx::shape::float_type,
@@ -5525,7 +5577,7 @@ TEST_CASE(slice_sym_symbolic_bounds)
                                     {{"axes", {0}},
                                      {"starts", {2}},
                                      {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
-                                     {"mode", "ends_input"}});
+                                     {"mode", migraphx::value::array{"ends"}}});
         migraphx::shape sin{migraphx::shape::float_type, {dd{lit(12)}, dd{lit(4)}}};
         migraphx::shape ends_in{migraphx::shape::int64_type, {1}};
         migraphx::shape sout{
@@ -5539,7 +5591,7 @@ TEST_CASE(slice_sym_symbolic_bounds)
                                     {{"axes", {0}},
                                      {"starts", migraphx::value::array{migraphx::to_value(dd{n})}},
                                      {"ends", {8}},
-                                     {"mode", "starts_input"}});
+                                     {"mode", migraphx::value::array{"starts"}}});
         migraphx::shape sin{migraphx::shape::float_type, {dd{lit(10)}, dd{lit(4)}}};
         migraphx::shape starts_in{migraphx::shape::int64_type, {1}};
         migraphx::shape sout{
@@ -5557,7 +5609,7 @@ TEST_CASE(slice_sym_symbolic_bounds)
                                     {{"axes", {0}},
                                      {"starts", migraphx::value::array{migraphx::to_value(dd{m})}},
                                      {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
-                                     {"mode", "starts_ends_input"}});
+                                     {"mode", migraphx::value::array{"starts", "ends"}}});
         migraphx::shape sin{migraphx::shape::float_type, {dd{lit(20)}}};
         migraphx::shape starts_in{migraphx::shape::int64_type, {1}};
         migraphx::shape ends_in{migraphx::shape::int64_type, {1}};

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -5083,33 +5083,30 @@ TEST_CASE(slice_var_inputs_static_mismatch_error0)
 {
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice",
-                          {{"ends", {2, 3, 4}}, {"axes", {0, 1, 2}}, {"mode", "starts_input"}}),
-        input,
-        starts);
+    throws_shape(migraphx::make_op(
+                     "slice", {{"ends", {2, 3, 4}}, {"axes", {0, 1, 2}}, {"mode", "starts_input"}}),
+                 input,
+                 starts);
 }
 
 TEST_CASE(slice_var_inputs_static_mismatch_error1)
 {
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice",
-                          {{"starts", {0, 1, 2}}, {"axes", {0, 1, 2}}, {"mode", "ends_input"}}),
-        input,
-        ends);
+    throws_shape(migraphx::make_op(
+                     "slice", {{"starts", {0, 1, 2}}, {"axes", {0, 1, 2}}, {"mode", "ends_input"}}),
+                 input,
+                 ends);
 }
 
 TEST_CASE(slice_var_inputs_static_mismatch_error2)
 {
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice",
-                          {{"starts", {0, 1, 2}}, {"ends", {3, 4, 4}}, {"mode", "axes_input"}}),
-        input,
-        axes);
+    throws_shape(migraphx::make_op(
+                     "slice", {{"starts", {0, 1, 2}}, {"ends", {3, 4, 4}}, {"mode", "axes_input"}}),
+                 input,
+                 axes);
 }
 
 TEST_CASE(slice_var_inputs_static_mismatch_error3)
@@ -5117,11 +5114,10 @@ TEST_CASE(slice_var_inputs_static_mismatch_error3)
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice", {{"axes", {0, 1, 2}}, {"mode", "starts_ends_input"}}),
-        input,
-        starts,
-        ends);
+    throws_shape(migraphx::make_op("slice", {{"axes", {0, 1, 2}}, {"mode", "starts_ends_input"}}),
+                 input,
+                 starts,
+                 ends);
 }
 
 TEST_CASE(slice_var_inputs_static_mismatch_error4)
@@ -5129,11 +5125,10 @@ TEST_CASE(slice_var_inputs_static_mismatch_error4)
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice", {{"ends", {3, 3, 3}}, {"mode", "starts_axes_input"}}),
-        input,
-        starts,
-        axes);
+    throws_shape(migraphx::make_op("slice", {{"ends", {3, 3, 3}}, {"mode", "starts_axes_input"}}),
+                 input,
+                 starts,
+                 axes);
 }
 
 TEST_CASE(slice_var_inputs_static_mismatch_error5)
@@ -5141,11 +5136,10 @@ TEST_CASE(slice_var_inputs_static_mismatch_error5)
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice", {{"starts", {0, 1, 2}}, {"mode", "ends_axes_input"}}),
-        input,
-        ends,
-        axes);
+    throws_shape(migraphx::make_op("slice", {{"starts", {0, 1, 2}}, {"mode", "ends_axes_input"}}),
+                 input,
+                 ends,
+                 axes);
 }
 
 TEST_CASE(slice_var_inputs_static_mismatch_error6)
@@ -5165,33 +5159,30 @@ TEST_CASE(slice_var_inputs_dyn_mismatch_error0)
 {
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice",
-                          {{"ends", {2, 3, 4}}, {"axes", {0, 1, 2}}, {"mode", "starts_input"}}),
-        input,
-        starts);
+    throws_shape(migraphx::make_op(
+                     "slice", {{"ends", {2, 3, 4}}, {"axes", {0, 1, 2}}, {"mode", "starts_input"}}),
+                 input,
+                 starts);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error1)
 {
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice",
-                          {{"starts", {0, 1, 2}}, {"axes", {0, 1, 2}}, {"mode", "ends_input"}}),
-        input,
-        ends);
+    throws_shape(migraphx::make_op(
+                     "slice", {{"starts", {0, 1, 2}}, {"axes", {0, 1, 2}}, {"mode", "ends_input"}}),
+                 input,
+                 ends);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error2)
 {
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice",
-                          {{"starts", {0, 1, 2}}, {"ends", {3, 4, 4}}, {"mode", "axes_input"}}),
-        input,
-        axes);
+    throws_shape(migraphx::make_op(
+                     "slice", {{"starts", {0, 1, 2}}, {"ends", {3, 4, 4}}, {"mode", "axes_input"}}),
+                 input,
+                 axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error3)
@@ -5199,11 +5190,10 @@ TEST_CASE(slice_var_inputs_dyn_mismatch_error3)
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice", {{"axes", {0, 1, 2}}, {"mode", "starts_ends_input"}}),
-        input,
-        starts,
-        ends);
+    throws_shape(migraphx::make_op("slice", {{"axes", {0, 1, 2}}, {"mode", "starts_ends_input"}}),
+                 input,
+                 starts,
+                 ends);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error4)
@@ -5211,11 +5201,10 @@ TEST_CASE(slice_var_inputs_dyn_mismatch_error4)
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice", {{"ends", {3, 3, 3}}, {"mode", "starts_axes_input"}}),
-        input,
-        starts,
-        axes);
+    throws_shape(migraphx::make_op("slice", {{"ends", {3, 3, 3}}, {"mode", "starts_axes_input"}}),
+                 input,
+                 starts,
+                 axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error5)
@@ -5223,11 +5212,10 @@ TEST_CASE(slice_var_inputs_dyn_mismatch_error5)
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice", {{"starts", {0, 1, 2}}, {"mode", "ends_axes_input"}}),
-        input,
-        ends,
-        axes);
+    throws_shape(migraphx::make_op("slice", {{"starts", {0, 1, 2}}, {"mode", "ends_axes_input"}}),
+                 input,
+                 ends,
+                 axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error6)

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -4906,18 +4906,11 @@ TEST_CASE(slice_var_inputs_static_shape0)
     // attr ends and axes set; inputs are (data, input_starts)
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{3, 3}, {0, 4}, {0, 4}}},
-                 migraphx::make_op("slice", {{"ends", {2, 3}}, {"axes", {1, 2}}}),
-                 input,
-                 starts);
-}
-
-TEST_CASE(slice_var_inputs_static_mismatch_error0)
-{
-    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
-    migraphx::shape starts{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice", {{"ends", {2, 3, 4}}, {"axes", {0, 1, 2}}}), input, starts);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{3, 3}, {0, 4}, {0, 4}}},
+        migraphx::make_op("slice", {{"ends", {2, 3}}, {"axes", {1, 2}}, {"mode", "starts_input"}}),
+        input,
+        starts);
 }
 
 TEST_CASE(slice_var_inputs_static_shape1)
@@ -4925,18 +4918,11 @@ TEST_CASE(slice_var_inputs_static_shape1)
     // attr starts and axes set; inputs are (data, input_ends)
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{3, 3}, {0, 4}, {0, 4}}},
-                 migraphx::make_op("slice", {{"starts", {0, 1}}, {"axes", {1, 2}}}),
-                 input,
-                 ends);
-}
-
-TEST_CASE(slice_var_inputs_static_mismatch_error1)
-{
-    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
-    migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice", {{"starts", {0, 1, 2}}, {"axes", {0, 1, 2}}}), input, ends);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{3, 3}, {0, 4}, {0, 4}}},
+        migraphx::make_op("slice", {{"starts", {0, 1}}, {"axes", {1, 2}}, {"mode", "ends_input"}}),
+        input,
+        ends);
 }
 
 TEST_CASE(slice_var_inputs_static_shape2)
@@ -4944,18 +4930,11 @@ TEST_CASE(slice_var_inputs_static_shape2)
     // attr starts and ends set; inputs are (data, input_axes)
     migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 3}, {0, 4}, {0, 4}}},
-                 migraphx::make_op("slice", {{"starts", {0, 1}}, {"ends", {1, 2}}}),
-                 input,
-                 axes);
-}
-
-TEST_CASE(slice_var_inputs_static_mismatch_error2)
-{
-    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
-    migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice", {{"starts", {0, 1, 2}}, {"ends", {3, 4, 4}}}), input, axes);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{0, 3}, {0, 4}, {0, 4}}},
+        migraphx::make_op("slice", {{"starts", {0, 1}}, {"ends", {1, 2}}, {"mode", "axes_input"}}),
+        input,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_static_shape3)
@@ -4965,18 +4944,10 @@ TEST_CASE(slice_var_inputs_static_shape3)
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     expect_shape(migraphx::shape{migraphx::shape::float_type, {{3, 3}, {0, 4}, {0, 4}}},
-                 migraphx::make_op("slice", {{"axes", {1, 2}}}),
+                 migraphx::make_op("slice", {{"axes", {1, 2}}, {"mode", "starts_ends_input"}}),
                  input,
                  starts,
                  ends);
-}
-
-TEST_CASE(slice_var_inputs_static_mismatch_error3)
-{
-    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
-    migraphx::shape starts{migraphx::shape::int64_type, {2}};
-    migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op("slice", {{"axes", {0, 1, 2}}}), input, starts, ends);
 }
 
 TEST_CASE(slice_var_inputs_static_shape4)
@@ -4986,18 +4957,10 @@ TEST_CASE(slice_var_inputs_static_shape4)
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
     expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 3}, {0, 4}, {0, 4}}},
-                 migraphx::make_op("slice", {{"ends", {3, 4}}}),
+                 migraphx::make_op("slice", {{"ends", {3, 4}}, {"mode", "starts_axes_input"}}),
                  input,
                  starts,
                  axes);
-}
-
-TEST_CASE(slice_var_inputs_static_mismatch_error4)
-{
-    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
-    migraphx::shape starts{migraphx::shape::int64_type, {2}};
-    migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op("slice", {{"ends", {3, 3, 3}}}), input, starts, axes);
 }
 
 TEST_CASE(slice_var_inputs_static_shape5)
@@ -5007,18 +4970,10 @@ TEST_CASE(slice_var_inputs_static_shape5)
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
     expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 3}, {0, 4}, {0, 4}}},
-                 migraphx::make_op("slice", {{"starts", {0, 2}}}),
+                 migraphx::make_op("slice", {{"starts", {0, 2}}, {"mode", "ends_axes_input"}}),
                  input,
                  ends,
                  axes);
-}
-
-TEST_CASE(slice_var_inputs_static_mismatch_error5)
-{
-    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
-    migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op("slice", {{"starts", {0, 1, 2}}}), input, ends, axes);
 }
 
 TEST_CASE(slice_var_inputs_static_shape6)
@@ -5028,20 +4983,11 @@ TEST_CASE(slice_var_inputs_static_shape6)
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
     expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 3}, {0, 4}, {0, 4}}},
-                 migraphx::make_op("slice"),
+                 migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}),
                  input,
                  starts,
                  ends,
                  axes);
-}
-
-TEST_CASE(slice_var_inputs_static_mismatch_error6)
-{
-    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
-    migraphx::shape starts{migraphx::shape::int64_type, {2}};
-    migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    migraphx::shape axes{migraphx::shape::int64_type, {3}};
-    throws_shape(migraphx::make_op("slice"), input, starts, ends, axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_shape0)
@@ -5049,18 +4995,11 @@ TEST_CASE(slice_var_inputs_dyn_shape0)
     // attr ends and axes set; inputs are (data, input_starts)
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{3, 6}, {0, 6}, {0, 6}}},
-                 migraphx::make_op("slice", {{"ends", {2, 3}}, {"axes", {1, 2}}}),
-                 input,
-                 starts);
-}
-
-TEST_CASE(slice_var_inputs_dyn_mismatch_error0)
-{
-    migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
-    migraphx::shape starts{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice", {{"ends", {2, 3, 4}}, {"axes", {0, 1, 2}}}), input, starts);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{3, 6}, {0, 6}, {0, 6}}},
+        migraphx::make_op("slice", {{"ends", {2, 3}}, {"axes", {1, 2}}, {"mode", "starts_input"}}),
+        input,
+        starts);
 }
 
 TEST_CASE(slice_var_inputs_dyn_shape1)
@@ -5068,18 +5007,11 @@ TEST_CASE(slice_var_inputs_dyn_shape1)
     // attr starts and axes set; inputs are (data, input_ends)
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{3, 6}, {0, 6}, {0, 6}}},
-                 migraphx::make_op("slice", {{"starts", {0, 1}}, {"axes", {1, 2}}}),
-                 input,
-                 ends);
-}
-
-TEST_CASE(slice_var_inputs_dyn_mismatch_error1)
-{
-    migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
-    migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice", {{"starts", {0, 1, 2}}, {"axes", {0, 1, 2}}}), input, ends);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{3, 6}, {0, 6}, {0, 6}}},
+        migraphx::make_op("slice", {{"starts", {0, 1}}, {"axes", {1, 2}}, {"mode", "ends_input"}}),
+        input,
+        ends);
 }
 
 TEST_CASE(slice_var_inputs_dyn_shape2)
@@ -5087,18 +5019,11 @@ TEST_CASE(slice_var_inputs_dyn_shape2)
     // attr starts and ends set; inputs are (data, input_axes)
     migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 6}, {0, 6}, {0, 6}}},
-                 migraphx::make_op("slice", {{"starts", {0, 1}}, {"ends", {8, 8}}}),
-                 input,
-                 axes);
-}
-
-TEST_CASE(slice_var_inputs_dyn_mismatch_error2)
-{
-    migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
-    migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(
-        migraphx::make_op("slice", {{"starts", {0, 1, 2}}, {"ends", {3, 4, 4}}}), input, axes);
+    expect_shape(
+        migraphx::shape{migraphx::shape::float_type, {{0, 6}, {0, 6}, {0, 6}}},
+        migraphx::make_op("slice", {{"starts", {0, 1}}, {"ends", {8, 8}}, {"mode", "axes_input"}}),
+        input,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_shape3)
@@ -5108,18 +5033,10 @@ TEST_CASE(slice_var_inputs_dyn_shape3)
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     expect_shape(migraphx::shape{migraphx::shape::float_type, {{3, 6}, {0, 6}, {0, 6}}},
-                 migraphx::make_op("slice", {{"axes", {1, 2}}}),
+                 migraphx::make_op("slice", {{"axes", {1, 2}}, {"mode", "starts_ends_input"}}),
                  input,
                  starts,
                  ends);
-}
-
-TEST_CASE(slice_var_inputs_dyn_mismatch_error3)
-{
-    migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
-    migraphx::shape starts{migraphx::shape::int64_type, {2}};
-    migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op("slice", {{"axes", {0, 1, 2}}}), input, starts, ends);
 }
 
 TEST_CASE(slice_var_inputs_dyn_shape4)
@@ -5129,18 +5046,10 @@ TEST_CASE(slice_var_inputs_dyn_shape4)
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
     expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 6}, {0, 6}, {0, 6}}},
-                 migraphx::make_op("slice", {{"ends", {3, 4}}}),
+                 migraphx::make_op("slice", {{"ends", {3, 4}}, {"mode", "starts_axes_input"}}),
                  input,
                  starts,
                  axes);
-}
-
-TEST_CASE(slice_var_inputs_dyn_mismatch_error4)
-{
-    migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
-    migraphx::shape starts{migraphx::shape::int64_type, {2}};
-    migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op("slice", {{"ends", {3, 3, 3}}}), input, starts, axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_shape5)
@@ -5150,18 +5059,10 @@ TEST_CASE(slice_var_inputs_dyn_shape5)
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
     expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 6}, {0, 6}, {0, 6}}},
-                 migraphx::make_op("slice", {{"starts", {0, 2}}}),
+                 migraphx::make_op("slice", {{"starts", {0, 2}}, {"mode", "ends_axes_input"}}),
                  input,
                  ends,
                  axes);
-}
-
-TEST_CASE(slice_var_inputs_dyn_mismatch_error5)
-{
-    migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
-    migraphx::shape ends{migraphx::shape::int64_type, {2}};
-    migraphx::shape axes{migraphx::shape::int64_type, {2}};
-    throws_shape(migraphx::make_op("slice", {{"starts", {0, 1, 2}}}), input, ends, axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_shape6)
@@ -5171,11 +5072,162 @@ TEST_CASE(slice_var_inputs_dyn_shape6)
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {2}};
     expect_shape(migraphx::shape{migraphx::shape::float_type, {{0, 6}, {0, 4}, {0, 4}}},
-                 migraphx::make_op("slice"),
+                 migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}),
                  input,
                  starts,
                  ends,
                  axes);
+}
+
+TEST_CASE(slice_var_inputs_static_mismatch_error0)
+{
+    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
+    migraphx::shape starts{migraphx::shape::int64_type, {2}};
+    throws_shape(
+        migraphx::make_op("slice",
+                          {{"ends", {2, 3, 4}}, {"axes", {0, 1, 2}}, {"mode", "starts_input"}}),
+        input,
+        starts);
+}
+
+TEST_CASE(slice_var_inputs_static_mismatch_error1)
+{
+    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
+    migraphx::shape ends{migraphx::shape::int64_type, {2}};
+    throws_shape(
+        migraphx::make_op("slice",
+                          {{"starts", {0, 1, 2}}, {"axes", {0, 1, 2}}, {"mode", "ends_input"}}),
+        input,
+        ends);
+}
+
+TEST_CASE(slice_var_inputs_static_mismatch_error2)
+{
+    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
+    migraphx::shape axes{migraphx::shape::int64_type, {2}};
+    throws_shape(
+        migraphx::make_op("slice",
+                          {{"starts", {0, 1, 2}}, {"ends", {3, 4, 4}}, {"mode", "axes_input"}}),
+        input,
+        axes);
+}
+
+TEST_CASE(slice_var_inputs_static_mismatch_error3)
+{
+    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
+    migraphx::shape starts{migraphx::shape::int64_type, {2}};
+    migraphx::shape ends{migraphx::shape::int64_type, {2}};
+    throws_shape(
+        migraphx::make_op("slice", {{"axes", {0, 1, 2}}, {"mode", "starts_ends_input"}}),
+        input,
+        starts,
+        ends);
+}
+
+TEST_CASE(slice_var_inputs_static_mismatch_error4)
+{
+    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
+    migraphx::shape starts{migraphx::shape::int64_type, {2}};
+    migraphx::shape axes{migraphx::shape::int64_type, {2}};
+    throws_shape(
+        migraphx::make_op("slice", {{"ends", {3, 3, 3}}, {"mode", "starts_axes_input"}}),
+        input,
+        starts,
+        axes);
+}
+
+TEST_CASE(slice_var_inputs_static_mismatch_error5)
+{
+    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
+    migraphx::shape ends{migraphx::shape::int64_type, {2}};
+    migraphx::shape axes{migraphx::shape::int64_type, {2}};
+    throws_shape(
+        migraphx::make_op("slice", {{"starts", {0, 1, 2}}, {"mode", "ends_axes_input"}}),
+        input,
+        ends,
+        axes);
+}
+
+TEST_CASE(slice_var_inputs_static_mismatch_error6)
+{
+    migraphx::shape input{migraphx::shape::float_type, {3, 4, 4}};
+    migraphx::shape starts{migraphx::shape::int64_type, {2}};
+    migraphx::shape ends{migraphx::shape::int64_type, {2}};
+    migraphx::shape axes{migraphx::shape::int64_type, {3}};
+    throws_shape(migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}),
+                 input,
+                 starts,
+                 ends,
+                 axes);
+}
+
+TEST_CASE(slice_var_inputs_dyn_mismatch_error0)
+{
+    migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
+    migraphx::shape starts{migraphx::shape::int64_type, {2}};
+    throws_shape(
+        migraphx::make_op("slice",
+                          {{"ends", {2, 3, 4}}, {"axes", {0, 1, 2}}, {"mode", "starts_input"}}),
+        input,
+        starts);
+}
+
+TEST_CASE(slice_var_inputs_dyn_mismatch_error1)
+{
+    migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
+    migraphx::shape ends{migraphx::shape::int64_type, {2}};
+    throws_shape(
+        migraphx::make_op("slice",
+                          {{"starts", {0, 1, 2}}, {"axes", {0, 1, 2}}, {"mode", "ends_input"}}),
+        input,
+        ends);
+}
+
+TEST_CASE(slice_var_inputs_dyn_mismatch_error2)
+{
+    migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
+    migraphx::shape axes{migraphx::shape::int64_type, {2}};
+    throws_shape(
+        migraphx::make_op("slice",
+                          {{"starts", {0, 1, 2}}, {"ends", {3, 4, 4}}, {"mode", "axes_input"}}),
+        input,
+        axes);
+}
+
+TEST_CASE(slice_var_inputs_dyn_mismatch_error3)
+{
+    migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
+    migraphx::shape starts{migraphx::shape::int64_type, {2}};
+    migraphx::shape ends{migraphx::shape::int64_type, {2}};
+    throws_shape(
+        migraphx::make_op("slice", {{"axes", {0, 1, 2}}, {"mode", "starts_ends_input"}}),
+        input,
+        starts,
+        ends);
+}
+
+TEST_CASE(slice_var_inputs_dyn_mismatch_error4)
+{
+    migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
+    migraphx::shape starts{migraphx::shape::int64_type, {2}};
+    migraphx::shape axes{migraphx::shape::int64_type, {2}};
+    throws_shape(
+        migraphx::make_op("slice", {{"ends", {3, 3, 3}}, {"mode", "starts_axes_input"}}),
+        input,
+        starts,
+        axes);
+}
+
+TEST_CASE(slice_var_inputs_dyn_mismatch_error5)
+{
+    migraphx::shape input{migraphx::shape::float_type, {{3, 6}, {4, 6}, {4, 6}}};
+    migraphx::shape ends{migraphx::shape::int64_type, {2}};
+    migraphx::shape axes{migraphx::shape::int64_type, {2}};
+    throws_shape(
+        migraphx::make_op("slice", {{"starts", {0, 1, 2}}, {"mode", "ends_axes_input"}}),
+        input,
+        ends,
+        axes);
 }
 
 TEST_CASE(slice_var_inputs_dyn_mismatch_error6)
@@ -5184,7 +5236,11 @@ TEST_CASE(slice_var_inputs_dyn_mismatch_error6)
     migraphx::shape starts{migraphx::shape::int64_type, {2}};
     migraphx::shape ends{migraphx::shape::int64_type, {2}};
     migraphx::shape axes{migraphx::shape::int64_type, {3}};
-    throws_shape(migraphx::make_op("slice"), input, starts, ends, axes);
+    throws_shape(migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}),
+                 input,
+                 starts,
+                 ends,
+                 axes);
 }
 
 TEST_CASE(slice_dyn_shape0)
@@ -5366,12 +5422,18 @@ TEST_CASE(slice_sym_fixed_bound_var)
     EXPECT(sout.to_static(sym_map) == op.compute_shape({sin.to_static(sym_map)}));
 }
 
-TEST_CASE(slice_sym_non_fixed_throws)
+TEST_CASE(slice_sym_non_fixed_axis)
 {
-    // Slicing on a non-fixed symbolic axis is rejected (same contract as range).
-    auto n = var("n", {1, 8});
-    migraphx::shape sin{migraphx::shape::float_type, {dd{lit(4)}, dd{n}, dd{lit(8)}}};
-    throws_shape(migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {2}}}), sin);
+    // Slicing a non-fixed symbolic axis is allowed: the bounds are trusted to be valid at
+    // runtime, so the extent is just ends - starts (no clamping). The other symbol is kept.
+    auto n                                      = var("n", {1, 8});
+    auto m                                      = var("m", {1, 8});
+    std::unordered_map<se, std::size_t> sym_map = {{n, 5}, {m, 3}};
+    migraphx::shape sin{migraphx::shape::float_type, {dd{n}, dd{m}}};
+    auto op = migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {2}}});
+    migraphx::shape sout{migraphx::shape::float_type, {dd{lit(2)}, dd{m}}, sin.dyn_strides()};
+    expect_shape(sout, op, sin);
+    EXPECT(sout.to_static(sym_map) == op.compute_shape({sin.to_static(sym_map)}));
 }
 
 TEST_CASE(slice_sym_nonstandard_layout)
@@ -5385,6 +5447,138 @@ TEST_CASE(slice_sym_nonstandard_layout)
     auto op   = migraphx::make_op("slice", {{"axes", {3}}, {"starts", {1}}, {"ends", {6}}});
     auto sout = op.compute_shape({sin});
     EXPECT(sout.to_static(sym_map) == op.compute_shape({sin.to_static(sym_map)}));
+}
+
+TEST_CASE(slice_sym_clamped_and_negative_bounds)
+{
+    // Concrete bounds on a symbolic input are clipped/resolved against the fixed sliced axis
+    // like the static path; the symbolic axis is untouched.
+    auto n                                      = var("n", {1, 8});
+    std::unordered_map<se, std::size_t> sym_map = {{n, 5}};
+    migraphx::shape sin{migraphx::shape::float_type, {dd{n}, dd{lit(2)}, dd{lit(3)}}};
+
+    {
+        // end clipped to len 3: dim = 3 - 2 = 1.
+        auto op = migraphx::make_op("slice", {{"axes", {2}}, {"starts", {2}}, {"ends", {10}}});
+        migraphx::shape sout{
+            migraphx::shape::float_type, {dd{n}, dd{lit(2)}, dd{lit(1)}}, sin.dyn_strides()};
+        expect_shape(sout, op, sin);
+        EXPECT(sout.to_static(sym_map) == op.compute_shape({sin.to_static(sym_map)}));
+    }
+    {
+        // negative start: -1 -> 2, dim = 3 - 2 = 1.
+        auto op = migraphx::make_op("slice", {{"axes", {2}}, {"starts", {-1}}, {"ends", {10}}});
+        migraphx::shape sout{
+            migraphx::shape::float_type, {dd{n}, dd{lit(2)}, dd{lit(1)}}, sin.dyn_strides()};
+        expect_shape(sout, op, sin);
+        EXPECT(sout.to_static(sym_map) == op.compute_shape({sin.to_static(sym_map)}));
+    }
+    {
+        // negative end on axis 1 (len 2): -1 -> 1, dim = 1 - 0 = 1.
+        auto op = migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {-1}}});
+        migraphx::shape sout{
+            migraphx::shape::float_type, {dd{n}, dd{lit(1)}, dd{lit(3)}}, sin.dyn_strides()};
+        expect_shape(sout, op, sin);
+        EXPECT(sout.to_static(sym_map) == op.compute_shape({sin.to_static(sym_map)}));
+    }
+}
+
+TEST_CASE(slice_sym_symbolic_end_static_input)
+{
+    // Static input + symbolic end bound: output is symbolic (not fixed -> not demoted to static).
+    // Symbolic attributes require 2+ inputs, so the runtime end value is supplied as an input.
+    auto n  = var("n", {1, 16});
+    auto op = migraphx::make_op("slice",
+                                {{"axes", {0}},
+                                 {"starts", {0}},
+                                 {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                 {"mode", "ends_input"}});
+
+    // end=n is clamped to the axis length 10: dim = min(n, 10).
+    migraphx::shape sin{migraphx::shape::float_type, {10}};
+    migraphx::shape ends_in{migraphx::shape::int64_type, {1}};
+    migraphx::shape sout{
+        migraphx::shape::float_type, {dd{migraphx::sym::min(n, lit(10))}}, {lit(1)}};
+    expect_shape(sout, op, sin, ends_in);
+    EXPECT(sout.symbolic());
+    EXPECT(not sout.is_fixed());
+    EXPECT(sout.to_static({{n, 7}}) == migraphx::shape{migraphx::shape::float_type, {7}, {1}});
+    EXPECT(sout.to_static({{n, 10}}) == migraphx::shape{migraphx::shape::float_type, {10}, {1}});
+}
+
+TEST_CASE(slice_sym_symbolic_bounds)
+{
+    // The sliced extent (ends - starts) must be non-negative across the whole variable
+    // range, so each var range is chosen to keep end >= start.
+    {
+        // Symbolic end clamped to the axis length 12: dim = min(n, 12) - 2.
+        auto m  = var("m", {1, 16});
+        auto n  = var("n", {2, 16});
+        auto op = migraphx::make_op("slice",
+                                    {{"axes", {1}},
+                                     {"starts", {2}},
+                                     {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                     {"mode", "ends_input"}});
+        migraphx::shape sin{migraphx::shape::float_type, {dd{m}, dd{lit(12)}}};
+        migraphx::shape ends_in{migraphx::shape::int64_type, {1}};
+        migraphx::shape sout{migraphx::shape::float_type,
+                             {dd{m}, dd{migraphx::sym::min(n, lit(12)) - lit(2)}},
+                             sin.dyn_strides()};
+        expect_shape(sout, op, sin, ends_in);
+        EXPECT(sout.symbolic());
+        EXPECT(not sout.is_fixed());
+        EXPECT(sout.to_static({{m, 4}, {n, 9}}) ==
+               migraphx::shape{migraphx::shape::float_type, {4, 7}, {12, 1}});
+    }
+    {
+        // Symbolic end provably >= the axis length collapses to the length: extent is concrete.
+        auto n  = var("n", {13, 20});
+        auto op = migraphx::make_op("slice",
+                                    {{"axes", {0}},
+                                     {"starts", {2}},
+                                     {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                     {"mode", "ends_input"}});
+        migraphx::shape sin{migraphx::shape::float_type, {dd{lit(12)}, dd{lit(4)}}};
+        migraphx::shape ends_in{migraphx::shape::int64_type, {1}};
+        migraphx::shape sout{
+            migraphx::shape::float_type, {dd{lit(10)}, dd{lit(4)}}, sin.dyn_strides()};
+        expect_shape(sout, op, sin, ends_in);
+    }
+    {
+        // Symbolic start: dim = 8 - n (n <= 8 keeps the extent non-negative).
+        auto n  = var("n", {1, 8});
+        auto op = migraphx::make_op("slice",
+                                    {{"axes", {0}},
+                                     {"starts", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                     {"ends", {8}},
+                                     {"mode", "starts_input"}});
+        migraphx::shape sin{migraphx::shape::float_type, {dd{lit(10)}, dd{lit(4)}}};
+        migraphx::shape starts_in{migraphx::shape::int64_type, {1}};
+        migraphx::shape sout{
+            migraphx::shape::float_type, {dd{lit(8) - n}, dd{lit(4)}}, sin.dyn_strides()};
+        expect_shape(sout, op, sin, starts_in);
+        EXPECT(sout.symbolic());
+        EXPECT(sout.to_static({{n, 3}}) ==
+               migraphx::shape{migraphx::shape::float_type, {5, 4}, {4, 1}});
+    }
+    {
+        // Both bounds symbolic: dim = n - m (ranges disjoint so n >= m always).
+        auto m  = var("m", {1, 5});
+        auto n  = var("n", {5, 16});
+        auto op = migraphx::make_op("slice",
+                                    {{"axes", {0}},
+                                     {"starts", migraphx::value::array{migraphx::to_value(dd{m})}},
+                                     {"ends", migraphx::value::array{migraphx::to_value(dd{n})}},
+                                     {"mode", "starts_ends_input"}});
+        migraphx::shape sin{migraphx::shape::float_type, {dd{lit(20)}}};
+        migraphx::shape starts_in{migraphx::shape::int64_type, {1}};
+        migraphx::shape ends_in{migraphx::shape::int64_type, {1}};
+        migraphx::shape sout{migraphx::shape::float_type, {dd{n - m}}, sin.dyn_strides()};
+        expect_shape(sout, op, sin, starts_in, ends_in);
+        EXPECT(sout.symbolic());
+        EXPECT(sout.to_static({{m, 3}, {n, 9}}) ==
+               migraphx::shape{migraphx::shape::float_type, {6}, {1}});
+    }
 }
 
 TEST_CASE(test_scan_slice1)

--- a/test/ref/nonmaxsuppression.cpp
+++ b/test/ref/nonmaxsuppression.cpp
@@ -36,7 +36,9 @@ static migraphx::instruction_ref add_nms_dynamic_slice(migraphx::module* mm,
     auto idx = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), nms);
     auto cnt = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), nms);
     return mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}}), idx, cnt);
+        migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"mode", "ends_input"}}),
+        idx,
+        cnt);
 }
 
 TEST_CASE(nms_dyn_out_test)

--- a/test/ref/nonmaxsuppression.cpp
+++ b/test/ref/nonmaxsuppression.cpp
@@ -36,7 +36,8 @@ static migraphx::instruction_ref add_nms_dynamic_slice(migraphx::module* mm,
     auto idx = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), nms);
     auto cnt = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), nms);
     return mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"mode", "ends_input"}}),
+        migraphx::make_op(
+            "slice", {{"axes", {0}}, {"starts", {0}}, {"mode", migraphx::value::array{"ends"}}}),
         idx,
         cnt);
 }

--- a/test/ref/slice.cpp
+++ b/test/ref/slice.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/ref/slice.cpp
+++ b/test/ref/slice.cpp
@@ -87,11 +87,10 @@ TEST_CASE(slice_var_inputs_static0)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto ends   = mm->add_parameter("ends", s1);
-    mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
-        l0,
-        starts,
-        ends);
+    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
+                        l0,
+                        starts,
+                        ends);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -117,11 +116,10 @@ TEST_CASE(slice_var_inputs_static1)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto ends   = mm->add_parameter("ends", s1);
-    mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
-        l0,
-        starts,
-        ends);
+    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
+                        l0,
+                        starts,
+                        ends);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -259,11 +257,10 @@ TEST_CASE(slice_var_inputs_dyn3)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto ends   = mm->add_parameter("ends", s1);
-    mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
-        input,
-        starts,
-        ends);
+    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
+                        input,
+                        starts,
+                        ends);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -324,11 +321,10 @@ TEST_CASE(slice_var_inputs_dyn5)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto ends = mm->add_parameter("ends", s1);
     auto axes = mm->add_parameter("axes", s1);
-    mm->add_instruction(
-        migraphx::make_op("slice", {{"starts", {-4}}, {"mode", "ends_axes_input"}}),
-        input,
-        ends,
-        axes);
+    mm->add_instruction(migraphx::make_op("slice", {{"starts", {-4}}, {"mode", "ends_axes_input"}}),
+                        input,
+                        ends,
+                        axes);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -356,11 +352,10 @@ TEST_CASE(slice_var_inputs_dyn6)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto ends   = mm->add_parameter("ends", s1);
-    mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
-        input,
-        starts,
-        ends);
+    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
+                        input,
+                        starts,
+                        ends);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;

--- a/test/ref/slice.cpp
+++ b/test/ref/slice.cpp
@@ -87,10 +87,12 @@ TEST_CASE(slice_var_inputs_static0)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto ends   = mm->add_parameter("ends", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
-                        l0,
-                        starts,
-                        ends);
+    mm->add_instruction(
+        migraphx::make_op("slice",
+                          {{"axes", {2}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+        l0,
+        starts,
+        ends);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -116,10 +118,12 @@ TEST_CASE(slice_var_inputs_static1)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto ends   = mm->add_parameter("ends", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
-                        l0,
-                        starts,
-                        ends);
+    mm->add_instruction(
+        migraphx::make_op("slice",
+                          {{"axes", {2}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+        l0,
+        starts,
+        ends);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -147,7 +151,11 @@ TEST_CASE(slice_var_inputs_static2)
     auto ends   = mm->add_parameter("ends", s1);
     auto axes   = mm->add_parameter("axes", s1);
     mm->add_instruction(
-        migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}), l0, starts, ends, axes);
+        migraphx::make_op("slice", {{"mode", migraphx::value::array{"starts", "ends", "axes"}}}),
+        l0,
+        starts,
+        ends,
+        axes);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -173,7 +181,8 @@ TEST_CASE(slice_var_inputs_dyn0)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {2}}, {"ends", {10}}, {"mode", "starts_input"}}),
+        migraphx::make_op(
+            "slice", {{"axes", {2}}, {"ends", {10}}, {"mode", migraphx::value::array{"starts"}}}),
         input,
         starts);
     p.compile(migraphx::make_target("ref"));
@@ -201,7 +210,8 @@ TEST_CASE(slice_var_inputs_dyn1)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto ends = mm->add_parameter("ends", s1);
     mm->add_instruction(
-        migraphx::make_op("slice", {{"axes", {2}}, {"starts", {-5}}, {"mode", "ends_input"}}),
+        migraphx::make_op(
+            "slice", {{"axes", {2}}, {"starts", {-5}}, {"mode", migraphx::value::array{"ends"}}}),
         input,
         ends);
     p.compile(migraphx::make_target("ref"));
@@ -229,7 +239,8 @@ TEST_CASE(slice_var_inputs_dyn2)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto axes = mm->add_parameter("axes", s1);
     mm->add_instruction(
-        migraphx::make_op("slice", {{"starts", {1}}, {"ends", {-1}}, {"mode", "axes_input"}}),
+        migraphx::make_op(
+            "slice", {{"starts", {1}}, {"ends", {-1}}, {"mode", migraphx::value::array{"axes"}}}),
         input,
         axes);
     p.compile(migraphx::make_target("ref"));
@@ -257,10 +268,12 @@ TEST_CASE(slice_var_inputs_dyn3)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto ends   = mm->add_parameter("ends", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
-                        input,
-                        starts,
-                        ends);
+    mm->add_instruction(
+        migraphx::make_op("slice",
+                          {{"axes", {2}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+        input,
+        starts,
+        ends);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -288,12 +301,12 @@ TEST_CASE(slice_var_inputs_dyn4)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto axes   = mm->add_parameter("axes", s1);
-    mm->add_instruction(
-        migraphx::make_op(
-            "slice", {{"ends", {std::numeric_limits<int>::max()}}, {"mode", "starts_axes_input"}}),
-        input,
-        starts,
-        axes);
+    mm->add_instruction(migraphx::make_op("slice",
+                                          {{"ends", {std::numeric_limits<int>::max()}},
+                                           {"mode", migraphx::value::array{"starts", "axes"}}}),
+                        input,
+                        starts,
+                        axes);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -321,10 +334,12 @@ TEST_CASE(slice_var_inputs_dyn5)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto ends = mm->add_parameter("ends", s1);
     auto axes = mm->add_parameter("axes", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"starts", {-4}}, {"mode", "ends_axes_input"}}),
-                        input,
-                        ends,
-                        axes);
+    mm->add_instruction(
+        migraphx::make_op("slice",
+                          {{"starts", {-4}}, {"mode", migraphx::value::array{"ends", "axes"}}}),
+        input,
+        ends,
+        axes);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -352,10 +367,12 @@ TEST_CASE(slice_var_inputs_dyn6)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto ends   = mm->add_parameter("ends", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
-                        input,
-                        starts,
-                        ends);
+    mm->add_instruction(
+        migraphx::make_op("slice",
+                          {{"axes", {2}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
+        input,
+        starts,
+        ends);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;

--- a/test/ref/slice.cpp
+++ b/test/ref/slice.cpp
@@ -87,7 +87,11 @@ TEST_CASE(slice_var_inputs_static0)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto ends   = mm->add_parameter("ends", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}}), l0, starts, ends);
+    mm->add_instruction(
+        migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
+        l0,
+        starts,
+        ends);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -113,7 +117,11 @@ TEST_CASE(slice_var_inputs_static1)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto ends   = mm->add_parameter("ends", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}}), l0, starts, ends);
+    mm->add_instruction(
+        migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
+        l0,
+        starts,
+        ends);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -140,7 +148,8 @@ TEST_CASE(slice_var_inputs_static2)
     auto starts = mm->add_parameter("starts", s1);
     auto ends   = mm->add_parameter("ends", s1);
     auto axes   = mm->add_parameter("axes", s1);
-    mm->add_instruction(migraphx::make_op("slice"), l0, starts, ends, axes);
+    mm->add_instruction(
+        migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}), l0, starts, ends, axes);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -165,7 +174,10 @@ TEST_CASE(slice_var_inputs_dyn0)
     auto input = mm->add_parameter("input", s0);
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}, {"ends", {10}}}), input, starts);
+    mm->add_instruction(
+        migraphx::make_op("slice", {{"axes", {2}}, {"ends", {10}}, {"mode", "starts_input"}}),
+        input,
+        starts);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -190,7 +202,10 @@ TEST_CASE(slice_var_inputs_dyn1)
     auto input = mm->add_parameter("input", s0);
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto ends = mm->add_parameter("ends", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}, {"starts", {-5}}}), input, ends);
+    mm->add_instruction(
+        migraphx::make_op("slice", {{"axes", {2}}, {"starts", {-5}}, {"mode", "ends_input"}}),
+        input,
+        ends);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -215,7 +230,10 @@ TEST_CASE(slice_var_inputs_dyn2)
     auto input = mm->add_parameter("input", s0);
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto axes = mm->add_parameter("axes", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"starts", {1}}, {"ends", {-1}}}), input, axes);
+    mm->add_instruction(
+        migraphx::make_op("slice", {{"starts", {1}}, {"ends", {-1}}, {"mode", "axes_input"}}),
+        input,
+        axes);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -241,7 +259,11 @@ TEST_CASE(slice_var_inputs_dyn3)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto ends   = mm->add_parameter("ends", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}}), input, starts, ends);
+    mm->add_instruction(
+        migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
+        input,
+        starts,
+        ends);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -269,10 +291,12 @@ TEST_CASE(slice_var_inputs_dyn4)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto axes   = mm->add_parameter("axes", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"ends", {std::numeric_limits<int>::max()}}}),
-                        input,
-                        starts,
-                        axes);
+    mm->add_instruction(
+        migraphx::make_op(
+            "slice", {{"ends", {std::numeric_limits<int>::max()}}, {"mode", "starts_axes_input"}}),
+        input,
+        starts,
+        axes);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -300,7 +324,11 @@ TEST_CASE(slice_var_inputs_dyn5)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto ends = mm->add_parameter("ends", s1);
     auto axes = mm->add_parameter("axes", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"starts", {-4}}}), input, ends, axes);
+    mm->add_instruction(
+        migraphx::make_op("slice", {{"starts", {-4}}, {"mode", "ends_axes_input"}}),
+        input,
+        ends,
+        axes);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;
@@ -328,7 +356,11 @@ TEST_CASE(slice_var_inputs_dyn6)
     migraphx::shape s1{migraphx::shape::int32_type, {1}};
     auto starts = mm->add_parameter("starts", s1);
     auto ends   = mm->add_parameter("ends", s1);
-    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}}), input, starts, ends);
+    mm->add_instruction(
+        migraphx::make_op("slice", {{"axes", {2}}, {"mode", "starts_ends_input"}}),
+        input,
+        starts,
+        ends);
     p.compile(migraphx::make_target("ref"));
 
     migraphx::parameter_map params;

--- a/test/ref/slice.cpp
+++ b/test/ref/slice.cpp
@@ -26,9 +26,15 @@
 #include <migraphx/make_op.hpp>
 #include <migraphx/program.hpp>
 #include <migraphx/register_target.hpp>
+#include <migraphx/serialize.hpp>
+#include <migraphx/sym.hpp>
 #include <migraphx/verify.hpp>
 
 #include <test.hpp>
+
+using dd = migraphx::shape::dynamic_dimension;
+using migraphx::sym::lit;
+using migraphx::sym::var;
 
 TEST_CASE(slice_test_1)
 {
@@ -452,4 +458,340 @@ TEST_CASE(slice_dyn_test1)
     result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
     EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
     EXPECT(result.get_shape() == sresult);
+}
+
+TEST_CASE(slice_sym_data_test)
+{
+    // Symbolic input shape sliced on a fixed axis. The output is symbolic after compiling and
+    // is demoted back to static when compute_shape is re-run with the runtime static shape.
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape s{migraphx::shape::int32_type, {dd{var("n", {1, 4})}, dd{lit(2)}, dd{lit(3)}}};
+    auto x = mm->add_parameter("x", s);
+    mm->add_instruction(migraphx::make_op("slice", {{"axes", {2}}, {"starts", {1}}, {"ends", {3}}}),
+                        x);
+    p.compile(migraphx::make_target("ref"));
+
+    migraphx::shape input_fixed_shape{migraphx::shape::int32_type, {2, 2, 3}};
+    std::vector<int> data(2 * 2 * 3);
+    std::iota(data.begin(), data.end(), 0);
+    migraphx::parameter_map params;
+    params["x"] = migraphx::argument(input_fixed_shape, data.data());
+    auto result = p.eval(params).back();
+
+    std::vector<int> gold = {1, 2, 4, 5, 7, 8, 10, 11};
+    std::vector<int> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+    EXPECT(result.get_shape() ==
+           migraphx::shape{migraphx::shape::int32_type, {2, 2, 2}, {6, 3, 1}});
+}
+
+TEST_CASE(slice_sym_data_clamped_bounds_test)
+{
+    // Out-of-range bounds on the fixed axes of a symbolic shape are clamped against those axes'
+    // lengths: axis 0 end 5 clips to 2, axis 2 start -2 resolves to 1 and end 10 clips to 3.
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape s{migraphx::shape::int32_type, {dd{lit(2)}, dd{var("n", {1, 4})}, dd{lit(3)}}};
+    auto x = mm->add_parameter("x", s);
+    mm->add_instruction(
+        migraphx::make_op("slice", {{"axes", {0, 2}}, {"starts", {0, -2}}, {"ends", {5, 10}}}), x);
+    p.compile(migraphx::make_target("ref"));
+
+    migraphx::shape input_fixed_shape{migraphx::shape::int32_type, {2, 2, 3}};
+    std::vector<int> data(2 * 2 * 3);
+    std::iota(data.begin(), data.end(), 0);
+    migraphx::parameter_map params;
+    params["x"] = migraphx::argument(input_fixed_shape, data.data());
+    auto result = p.eval(params).back();
+
+    std::vector<int> gold = {1, 2, 4, 5, 7, 8, 10, 11};
+    std::vector<int> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+    EXPECT(result.get_shape() ==
+           migraphx::shape{migraphx::shape::int32_type, {2, 2, 2}, {6, 3, 1}});
+}
+
+TEST_CASE(slice_sym_data_symbolic_axis_test)
+{
+    // Slice the non-fixed symbolic axis itself. The bounds cannot be normalized against a
+    // compile-time length, so they are trusted and the extent is just ends - starts.
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape s{migraphx::shape::int32_type, {dd{var("n", {2, 4})}, dd{lit(2)}, dd{lit(3)}}};
+    auto x = mm->add_parameter("x", s);
+    mm->add_instruction(migraphx::make_op("slice", {{"axes", {0}}, {"starts", {1}}, {"ends", {3}}}),
+                        x);
+    p.compile(migraphx::make_target("ref"));
+
+    migraphx::shape input_fixed_shape{migraphx::shape::int32_type, {4, 2, 3}};
+    std::vector<int> data(4 * 2 * 3);
+    std::iota(data.begin(), data.end(), 0);
+    migraphx::parameter_map params;
+    params["x"] = migraphx::argument(input_fixed_shape, data.data());
+    auto result = p.eval(params).back();
+
+    std::vector<int> gold(2 * 2 * 3);
+    std::iota(gold.begin(), gold.end(), 6);
+    std::vector<int> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+    EXPECT(result.get_shape() ==
+           migraphx::shape{migraphx::shape::int32_type, {2, 2, 3}, {6, 3, 1}});
+}
+
+TEST_CASE(slice_sym_data_transposed_test)
+{
+    // The slice aliases a transposed symbolic shape, so both the offset and the result strides
+    // follow the permuted layout.
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape s{migraphx::shape::int32_type, {dd{var("n", {1, 4})}, dd{lit(2)}, dd{lit(3)}}};
+    auto x  = mm->add_parameter("x", s);
+    auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 1}}}), x);
+    mm->add_instruction(migraphx::make_op("slice", {{"axes", {1}}, {"starts", {1}}, {"ends", {3}}}),
+                        tx);
+    p.compile(migraphx::make_target("ref"));
+
+    migraphx::shape input_fixed_shape{migraphx::shape::int32_type, {2, 2, 3}};
+    std::vector<int> data(2 * 2 * 3);
+    std::iota(data.begin(), data.end(), 0);
+    migraphx::parameter_map params;
+    params["x"] = migraphx::argument(input_fixed_shape, data.data());
+    auto result = p.eval(params).back();
+
+    std::vector<int> gold = {1, 4, 2, 5, 7, 10, 8, 11};
+    std::vector<int> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+    EXPECT(result.get_shape() ==
+           migraphx::shape{migraphx::shape::int32_type, {2, 2, 2}, {6, 1, 3}});
+}
+
+TEST_CASE(slice_sym_ends_attr_test)
+{
+    // Symbolic `ends` bound with a variable input supplying its runtime value. Evaluating the
+    // same compiled program twice shows the input drives the output, not the compile-time symbol.
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    std::vector<int> data(2 * 2 * 3);
+    std::iota(data.begin(), data.end(), 0);
+    migraphx::shape s0{migraphx::shape::int32_type, {2, 2, 3}};
+    auto l0 = mm->add_literal(migraphx::literal{s0, data});
+    migraphx::shape s1{migraphx::shape::int64_type, {1}};
+    auto ends = mm->add_parameter("ends", s1);
+    mm->add_instruction(
+        migraphx::make_op(
+            "slice",
+            {{"axes", {2}},
+             {"starts", {1}},
+             {"ends", migraphx::value::array{migraphx::to_value(dd{var("n", {1, 3})})}},
+             {"mode", migraphx::value::array{"ends"}}}),
+        l0,
+        ends);
+    p.compile(migraphx::make_target("ref"));
+
+    std::vector<int64_t> ends_data0 = {3};
+    migraphx::parameter_map params0;
+    params0["ends"]        = migraphx::argument(s1, ends_data0.data());
+    auto result0           = p.eval(params0).back();
+    std::vector<int> gold0 = {1, 2, 4, 5, 7, 8, 10, 11};
+    std::vector<int> results_vector0;
+    result0.visit([&](auto output) { results_vector0.assign(output.begin(), output.end()); });
+    EXPECT(migraphx::verify::verify_rms_range(results_vector0, gold0));
+    EXPECT(result0.get_shape() ==
+           migraphx::shape{migraphx::shape::int32_type, {2, 2, 2}, {6, 3, 1}});
+
+    std::vector<int64_t> ends_data1 = {2};
+    migraphx::parameter_map params1;
+    params1["ends"]        = migraphx::argument(s1, ends_data1.data());
+    auto result1           = p.eval(params1).back();
+    std::vector<int> gold1 = {1, 4, 7, 10};
+    std::vector<int> results_vector1;
+    result1.visit([&](auto output) { results_vector1.assign(output.begin(), output.end()); });
+    EXPECT(migraphx::verify::verify_rms_range(results_vector1, gold1));
+    EXPECT(result1.get_shape() ==
+           migraphx::shape{migraphx::shape::int32_type, {2, 2, 1}, {6, 3, 1}});
+}
+
+TEST_CASE(slice_sym_starts_attr_test)
+{
+    // Symbolic `starts` bound with a variable input supplying its runtime value.
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    std::vector<int> data(2 * 2 * 3);
+    std::iota(data.begin(), data.end(), 0);
+    migraphx::shape s0{migraphx::shape::int32_type, {2, 2, 3}};
+    auto l0 = mm->add_literal(migraphx::literal{s0, data});
+    migraphx::shape s1{migraphx::shape::int64_type, {1}};
+    auto starts = mm->add_parameter("starts", s1);
+    mm->add_instruction(
+        migraphx::make_op(
+            "slice",
+            {{"axes", {2}},
+             {"starts", migraphx::value::array{migraphx::to_value(dd{var("m", {0, 2})})}},
+             {"ends", {3}},
+             {"mode", migraphx::value::array{"starts"}}}),
+        l0,
+        starts);
+    p.compile(migraphx::make_target("ref"));
+
+    migraphx::parameter_map params;
+    std::vector<int64_t> starts_data = {1};
+    params["starts"]                 = migraphx::argument(s1, starts_data.data());
+    auto result                      = p.eval(params).back();
+    std::vector<int> gold            = {1, 2, 4, 5, 7, 8, 10, 11};
+    std::vector<int> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+    EXPECT(result.get_shape() ==
+           migraphx::shape{migraphx::shape::int32_type, {2, 2, 2}, {6, 3, 1}});
+}
+
+TEST_CASE(slice_sym_both_bounds_attr_test)
+{
+    // Both bounds symbolic, each with its own variable input.
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    std::vector<int> data(2 * 2 * 3);
+    std::iota(data.begin(), data.end(), 0);
+    migraphx::shape s0{migraphx::shape::int32_type, {2, 2, 3}};
+    auto l0 = mm->add_literal(migraphx::literal{s0, data});
+    migraphx::shape s1{migraphx::shape::int64_type, {1}};
+    auto starts = mm->add_parameter("starts", s1);
+    auto ends   = mm->add_parameter("ends", s1);
+    mm->add_instruction(
+        migraphx::make_op(
+            "slice",
+            {{"axes", {2}},
+             {"starts", migraphx::value::array{migraphx::to_value(dd{var("m", {0, 1})})}},
+             {"ends", migraphx::value::array{migraphx::to_value(dd{var("n", {1, 3})})}},
+             {"mode", migraphx::value::array{"starts", "ends"}}}),
+        l0,
+        starts,
+        ends);
+    p.compile(migraphx::make_target("ref"));
+
+    migraphx::parameter_map params;
+    std::vector<int64_t> starts_data = {1};
+    std::vector<int64_t> ends_data   = {3};
+    params["starts"]                 = migraphx::argument(s1, starts_data.data());
+    params["ends"]                   = migraphx::argument(s1, ends_data.data());
+    auto result                      = p.eval(params).back();
+    std::vector<int> gold            = {1, 2, 4, 5, 7, 8, 10, 11};
+    std::vector<int> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+    EXPECT(result.get_shape() ==
+           migraphx::shape{migraphx::shape::int32_type, {2, 2, 2}, {6, 3, 1}});
+}
+
+TEST_CASE(slice_sym_bound_and_sym_data_test)
+{
+    // A symbolic bound on a symbolic input shape: the sliced axis is a fixed dimension of the
+    // symbolic shape, so the bound is clamped against it while axis 0 stays symbolic.
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape s0{migraphx::shape::int32_type, {dd{var("k", {1, 4})}, dd{lit(2)}, dd{lit(3)}}};
+    auto x = mm->add_parameter("x", s0);
+    migraphx::shape s1{migraphx::shape::int64_type, {1}};
+    auto ends = mm->add_parameter("ends", s1);
+    mm->add_instruction(
+        migraphx::make_op(
+            "slice",
+            {{"axes", {2}},
+             {"starts", {0}},
+             {"ends", migraphx::value::array{migraphx::to_value(dd{var("n", {1, 3})})}},
+             {"mode", migraphx::value::array{"ends"}}}),
+        x,
+        ends);
+    p.compile(migraphx::make_target("ref"));
+
+    migraphx::shape input_fixed_shape{migraphx::shape::int32_type, {2, 2, 3}};
+    std::vector<int> data(2 * 2 * 3);
+    std::iota(data.begin(), data.end(), 0);
+    migraphx::parameter_map params;
+    std::vector<int64_t> ends_data = {2};
+    params["x"]                    = migraphx::argument(input_fixed_shape, data.data());
+    params["ends"]                 = migraphx::argument(s1, ends_data.data());
+    auto result                    = p.eval(params).back();
+    std::vector<int> gold          = {0, 1, 3, 4, 6, 7, 9, 10};
+    std::vector<int> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+    EXPECT(result.get_shape() ==
+           migraphx::shape{migraphx::shape::int32_type, {2, 2, 2}, {6, 3, 1}});
+}
+
+TEST_CASE(slice_sym_bounds_multi_axes_test)
+{
+    // Two symbolic end bounds over two axes, so each bound is clamped against its own axis
+    // length and lens_calc runs over more than one axis.
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    std::vector<int> data(2 * 2 * 3);
+    std::iota(data.begin(), data.end(), 0);
+    migraphx::shape s0{migraphx::shape::int32_type, {2, 2, 3}};
+    auto l0 = mm->add_literal(migraphx::literal{s0, data});
+    migraphx::shape s1{migraphx::shape::int64_type, {2}};
+    auto ends = mm->add_parameter("ends", s1);
+    mm->add_instruction(
+        migraphx::make_op("slice",
+                          {{"axes", {1, 2}},
+                           {"starts", {1, 0}},
+                           {"ends",
+                            migraphx::value::array{migraphx::to_value(dd{var("n", {1, 2})}),
+                                                   migraphx::to_value(dd{var("m", {1, 3})})}},
+                           {"mode", migraphx::value::array{"ends"}}}),
+        l0,
+        ends);
+    p.compile(migraphx::make_target("ref"));
+
+    migraphx::parameter_map params;
+    std::vector<int64_t> ends_data = {2, 2};
+    params["ends"]                 = migraphx::argument(s1, ends_data.data());
+    auto result                    = p.eval(params).back();
+    std::vector<int> gold          = {3, 4, 9, 10};
+    std::vector<int> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+    EXPECT(result.get_shape() ==
+           migraphx::shape{migraphx::shape::int32_type, {2, 1, 2}, {6, 3, 1}});
+}
+
+TEST_CASE(slice_sym_bound_clamped_runtime_test)
+{
+    // A concrete negative start (normalized to 1 at compile time) alongside a symbolic end whose
+    // runtime value is out of range and has to be clamped to the axis length.
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    std::vector<int> data(2 * 2 * 3);
+    std::iota(data.begin(), data.end(), 0);
+    migraphx::shape s0{migraphx::shape::int32_type, {2, 2, 3}};
+    auto l0 = mm->add_literal(migraphx::literal{s0, data});
+    migraphx::shape s1{migraphx::shape::int64_type, {1}};
+    auto ends = mm->add_parameter("ends", s1);
+    mm->add_instruction(
+        migraphx::make_op(
+            "slice",
+            {{"axes", {2}},
+             {"starts", {-2}},
+             {"ends", migraphx::value::array{migraphx::to_value(dd{var("n", {1, 8})})}},
+             {"mode", migraphx::value::array{"ends"}}}),
+        l0,
+        ends);
+    p.compile(migraphx::make_target("ref"));
+
+    migraphx::parameter_map params;
+    std::vector<int64_t> ends_data = {100};
+    params["ends"]                 = migraphx::argument(s1, ends_data.data());
+    auto result                    = p.eval(params).back();
+    std::vector<int> gold          = {1, 2, 4, 5, 7, 8, 10, 11};
+    std::vector<int> results_vector;
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+    EXPECT(result.get_shape() ==
+           migraphx::shape{migraphx::shape::int32_type, {2, 2, 2}, {6, 3, 1}});
 }

--- a/test/simplify_dyn_ops_test.cpp
+++ b/test/simplify_dyn_ops_test.cpp
@@ -308,7 +308,9 @@ TEST_CASE(const_slice_2input_ends_axes)
         migraphx::shape s1{migraphx::shape::int32_type, {1}};
         auto input_starts = m0.add_literal(migraphx::literal{s1, {0}});
         auto slice_ins    = m0.add_instruction(
-            migraphx::make_op("slice", {{"ends", {3}}, {"axes", {0}}, {"mode", "starts_input"}}),
+            migraphx::make_op(
+                "slice",
+                {{"ends", {3}}, {"axes", {0}}, {"mode", migraphx::value::array{"starts"}}}),
             input,
             input_starts);
         m0.add_return({slice_ins});
@@ -335,7 +337,9 @@ TEST_CASE(const_slice_2input_starts_axes)
         migraphx::shape s1{migraphx::shape::int32_type, {1}};
         auto input_ends = m0.add_literal(migraphx::literal{s1, {3}});
         auto slice_ins  = m0.add_instruction(
-            migraphx::make_op("slice", {{"starts", {0}}, {"axes", {0}}, {"mode", "ends_input"}}),
+            migraphx::make_op(
+                "slice",
+                {{"starts", {0}}, {"axes", {0}}, {"mode", migraphx::value::array{"ends"}}}),
             input,
             input_ends);
         m0.add_return({slice_ins});
@@ -362,7 +366,9 @@ TEST_CASE(const_slice_2input_starts_ends)
         migraphx::shape s1{migraphx::shape::int32_type, {1}};
         auto input_axes = m0.add_literal(migraphx::literal{s1, {0}});
         auto slice_ins  = m0.add_instruction(
-            migraphx::make_op("slice", {{"starts", {0}}, {"ends", {3}}, {"mode", "axes_input"}}),
+            migraphx::make_op(
+                "slice",
+                {{"starts", {0}}, {"ends", {3}}, {"mode", migraphx::value::array{"axes"}}}),
             input,
             input_axes);
         m0.add_return({slice_ins});
@@ -390,7 +396,8 @@ TEST_CASE(const_slice_3input_axes_only)
         auto input_starts = m0.add_literal(migraphx::literal{s1, {0}});
         auto input_ends   = m0.add_literal(migraphx::literal{s1, {3}});
         auto slice_ins    = m0.add_instruction(
-            migraphx::make_op("slice", {{"axes", {0}}, {"mode", "starts_ends_input"}}),
+            migraphx::make_op("slice",
+                                 {{"axes", {0}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
             input,
             input_starts,
             input_ends);
@@ -419,7 +426,8 @@ TEST_CASE(const_slice_3input_ends_only)
         auto input_starts = m0.add_literal(migraphx::literal{s1, {0}});
         auto input_axes   = m0.add_literal(migraphx::literal{s1, {0}});
         auto slice_ins    = m0.add_instruction(
-            migraphx::make_op("slice", {{"ends", {3}}, {"mode", "starts_axes_input"}}),
+            migraphx::make_op("slice",
+                                 {{"ends", {3}}, {"mode", migraphx::value::array{"starts", "axes"}}}),
             input,
             input_starts,
             input_axes);
@@ -448,7 +456,8 @@ TEST_CASE(const_slice_3inputs_starts_only)
         auto input_ends = m0.add_literal(migraphx::literal{s1, {3}});
         auto input_axes = m0.add_literal(migraphx::literal{s1, {0}});
         auto slice_ins  = m0.add_instruction(
-            migraphx::make_op("slice", {{"starts", {0}}, {"mode", "ends_axes_input"}}),
+            migraphx::make_op("slice",
+                               {{"starts", {0}}, {"mode", migraphx::value::array{"ends", "axes"}}}),
             input,
             input_ends,
             input_axes);
@@ -476,7 +485,9 @@ TEST_CASE(const_slice_2input_ends_axes_dyn)
         migraphx::shape s1{migraphx::shape::int32_type, {1}};
         auto input_starts = m0.add_literal(migraphx::literal{s1, {0}});
         auto slice_ins    = m0.add_instruction(
-            migraphx::make_op("slice", {{"ends", {3}}, {"axes", {0}}, {"mode", "starts_input"}}),
+            migraphx::make_op(
+                "slice",
+                {{"ends", {3}}, {"axes", {0}}, {"mode", migraphx::value::array{"starts"}}}),
             input,
             input_starts);
         m0.add_return({slice_ins});
@@ -505,7 +516,8 @@ TEST_CASE(const_slice_3input_dyn)
         auto input_starts = m0.add_literal(migraphx::literal{s1, {0}});
         auto input_ends   = m0.add_literal(migraphx::literal{s1, {3}});
         auto slice_ins    = m0.add_instruction(
-            migraphx::make_op("slice", {{"axes", {0}}, {"mode", "starts_ends_input"}}),
+            migraphx::make_op("slice",
+                                 {{"axes", {0}}, {"mode", migraphx::value::array{"starts", "ends"}}}),
             input,
             input_starts,
             input_ends);
@@ -534,12 +546,13 @@ TEST_CASE(const_slice_4input)
         auto input_starts = m0.add_literal(migraphx::literal{s1, {0}});
         auto input_ends   = m0.add_literal(migraphx::literal{s1, {3}});
         auto input_axes   = m0.add_literal(migraphx::literal{s1, {0}});
-        auto slice_ins =
-            m0.add_instruction(migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}),
-                               input,
-                               input_starts,
-                               input_ends,
-                               input_axes);
+        auto slice_ins    = m0.add_instruction(
+            migraphx::make_op("slice",
+                                 {{"mode", migraphx::value::array{"starts", "ends", "axes"}}}),
+            input,
+            input_starts,
+            input_ends,
+            input_axes);
         m0.add_return({slice_ins});
     }
     run_pass(m0);

--- a/test/simplify_dyn_ops_test.cpp
+++ b/test/simplify_dyn_ops_test.cpp
@@ -308,7 +308,9 @@ TEST_CASE(const_slice_2input_ends_axes)
         migraphx::shape s1{migraphx::shape::int32_type, {1}};
         auto input_starts = m0.add_literal(migraphx::literal{s1, {0}});
         auto slice_ins    = m0.add_instruction(
-            migraphx::make_op("slice", {{"ends", {3}}, {"axes", {0}}}), input, input_starts);
+            migraphx::make_op("slice", {{"ends", {3}}, {"axes", {0}}, {"mode", "starts_input"}}),
+            input,
+            input_starts);
         m0.add_return({slice_ins});
     }
     run_pass(m0);
@@ -333,7 +335,9 @@ TEST_CASE(const_slice_2input_starts_axes)
         migraphx::shape s1{migraphx::shape::int32_type, {1}};
         auto input_ends = m0.add_literal(migraphx::literal{s1, {3}});
         auto slice_ins  = m0.add_instruction(
-            migraphx::make_op("slice", {{"starts", {0}}, {"axes", {0}}}), input, input_ends);
+            migraphx::make_op("slice", {{"starts", {0}}, {"axes", {0}}, {"mode", "ends_input"}}),
+            input,
+            input_ends);
         m0.add_return({slice_ins});
     }
     run_pass(m0);
@@ -358,7 +362,9 @@ TEST_CASE(const_slice_2input_starts_ends)
         migraphx::shape s1{migraphx::shape::int32_type, {1}};
         auto input_axes = m0.add_literal(migraphx::literal{s1, {0}});
         auto slice_ins  = m0.add_instruction(
-            migraphx::make_op("slice", {{"starts", {0}}, {"ends", {3}}}), input, input_axes);
+            migraphx::make_op("slice", {{"starts", {0}}, {"ends", {3}}, {"mode", "axes_input"}}),
+            input,
+            input_axes);
         m0.add_return({slice_ins});
     }
     run_pass(m0);
@@ -384,7 +390,10 @@ TEST_CASE(const_slice_3input_axes_only)
         auto input_starts = m0.add_literal(migraphx::literal{s1, {0}});
         auto input_ends   = m0.add_literal(migraphx::literal{s1, {3}});
         auto slice_ins    = m0.add_instruction(
-            migraphx::make_op("slice", {{"axes", {0}}}), input, input_starts, input_ends);
+            migraphx::make_op("slice", {{"axes", {0}}, {"mode", "starts_ends_input"}}),
+            input,
+            input_starts,
+            input_ends);
         m0.add_return({slice_ins});
     }
     run_pass(m0);
@@ -410,7 +419,10 @@ TEST_CASE(const_slice_3input_ends_only)
         auto input_starts = m0.add_literal(migraphx::literal{s1, {0}});
         auto input_axes   = m0.add_literal(migraphx::literal{s1, {0}});
         auto slice_ins    = m0.add_instruction(
-            migraphx::make_op("slice", {{"ends", {3}}}), input, input_starts, input_axes);
+            migraphx::make_op("slice", {{"ends", {3}}, {"mode", "starts_axes_input"}}),
+            input,
+            input_starts,
+            input_axes);
         m0.add_return({slice_ins});
     }
     run_pass(m0);
@@ -436,7 +448,10 @@ TEST_CASE(const_slice_3inputs_starts_only)
         auto input_ends = m0.add_literal(migraphx::literal{s1, {3}});
         auto input_axes = m0.add_literal(migraphx::literal{s1, {0}});
         auto slice_ins  = m0.add_instruction(
-            migraphx::make_op("slice", {{"starts", {0}}}), input, input_ends, input_axes);
+            migraphx::make_op("slice", {{"starts", {0}}, {"mode", "ends_axes_input"}}),
+            input,
+            input_ends,
+            input_axes);
         m0.add_return({slice_ins});
     }
     run_pass(m0);
@@ -461,7 +476,9 @@ TEST_CASE(const_slice_2input_ends_axes_dyn)
         migraphx::shape s1{migraphx::shape::int32_type, {1}};
         auto input_starts = m0.add_literal(migraphx::literal{s1, {0}});
         auto slice_ins    = m0.add_instruction(
-            migraphx::make_op("slice", {{"ends", {3}}, {"axes", {0}}}), input, input_starts);
+            migraphx::make_op("slice", {{"ends", {3}}, {"axes", {0}}, {"mode", "starts_input"}}),
+            input,
+            input_starts);
         m0.add_return({slice_ins});
     }
     run_pass(m0);
@@ -488,7 +505,10 @@ TEST_CASE(const_slice_3input_dyn)
         auto input_starts = m0.add_literal(migraphx::literal{s1, {0}});
         auto input_ends   = m0.add_literal(migraphx::literal{s1, {3}});
         auto slice_ins    = m0.add_instruction(
-            migraphx::make_op("slice", {{"axes", {0}}}), input, input_starts, input_ends);
+            migraphx::make_op("slice", {{"axes", {0}}, {"mode", "starts_ends_input"}}),
+            input,
+            input_starts,
+            input_ends);
         m0.add_return({slice_ins});
     }
     run_pass(m0);
@@ -515,7 +535,11 @@ TEST_CASE(const_slice_4input)
         auto input_ends   = m0.add_literal(migraphx::literal{s1, {3}});
         auto input_axes   = m0.add_literal(migraphx::literal{s1, {0}});
         auto slice_ins    = m0.add_instruction(
-            migraphx::make_op("slice"), input, input_starts, input_ends, input_axes);
+            migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}),
+            input,
+            input_starts,
+            input_ends,
+            input_axes);
         m0.add_return({slice_ins});
     }
     run_pass(m0);

--- a/test/simplify_dyn_ops_test.cpp
+++ b/test/simplify_dyn_ops_test.cpp
@@ -534,12 +534,12 @@ TEST_CASE(const_slice_4input)
         auto input_starts = m0.add_literal(migraphx::literal{s1, {0}});
         auto input_ends   = m0.add_literal(migraphx::literal{s1, {3}});
         auto input_axes   = m0.add_literal(migraphx::literal{s1, {0}});
-        auto slice_ins    = m0.add_instruction(
-            migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}),
-            input,
-            input_starts,
-            input_ends,
-            input_axes);
+        auto slice_ins =
+            m0.add_instruction(migraphx::make_op("slice", {{"mode", "starts_ends_axes_input"}}),
+                               input,
+                               input_starts,
+                               input_ends,
+                               input_axes);
         m0.add_return({slice_ins});
     }
     run_pass(m0);

--- a/test/sym.cpp
+++ b/test/sym.cpp
@@ -2647,6 +2647,84 @@ TEST_CASE(builtin_log_exp_nested)
     EXPECT(log(exp(x)) + log(exp(y)) == x + y);
 }
 
+TEST_CASE(builtin_min_already_clamped)
+{
+    auto x = var("x");
+    auto y = var("y");
+    // min(min(x, y), y) automatically folds to min(x, y)
+    EXPECT(min(min(x, y), y) == min(x, y));
+}
+
+TEST_CASE(builtin_max_already_clamped)
+{
+    auto x = var("x");
+    auto y = var("y");
+    // max(max(x, y), y) automatically folds to max(x, y)
+    EXPECT(max(max(x, y), y) == max(x, y));
+}
+
+TEST_CASE(builtin_min_max_already_clamped_literal_bound)
+{
+    auto x = var("x");
+    EXPECT(min(min(x, lit(5)), lit(5)) == min(x, lit(5)));
+    EXPECT(max(max(x, lit(0)), lit(0)) == max(x, lit(0)));
+}
+
+TEST_CASE(builtin_min_max_already_clamped_bound_first)
+{
+    auto x = var("x");
+    auto y = var("y");
+    // The inner node folds with the bound in either operand
+    EXPECT(min(min(y, x), y) == min(y, x));
+    EXPECT(max(max(y, x), y) == max(y, x));
+}
+
+TEST_CASE(builtin_min_max_already_clamped_literal_bound_first)
+{
+    auto x = var("x");
+    EXPECT(min(min(lit(5), x), lit(5)) == min(lit(5), x));
+    EXPECT(max(max(lit(0), x), lit(0)) == max(lit(0), x));
+}
+
+TEST_CASE(builtin_min_max_clamp_repeated)
+{
+    // Clamping a clamped expression any number of times keeps a single min/max node, as
+    // repeated attribute normalization does.
+    auto n    = var("n", interval{int64_t{1}, int64_t{8}});
+    auto len  = lit(5);
+    auto once = min(n, len);
+    EXPECT(min(once, len) == once);
+    EXPECT(min(min(once, len), len) == once);
+    auto zero      = lit(0);
+    auto once_from = max(n, zero);
+    EXPECT(max(once_from, zero) == once_from);
+    EXPECT(max(max(once_from, zero), zero) == once_from);
+}
+
+TEST_CASE(builtin_min_max_different_bound_not_folded)
+{
+    auto x = var("x");
+    auto y = var("y");
+    auto z = var("z");
+    // The inner bound is not the outer bound, so the nesting is meaningful and kept
+    EXPECT(min(min(x, y), z) != min(x, y));
+    EXPECT(min(min(x, y), z).children().front() == min(x, y));
+    EXPECT(max(max(x, y), z) != max(x, y));
+    EXPECT(max(max(x, y), z).children().front() == max(x, y));
+}
+
+TEST_CASE(builtin_min_max_already_clamped_eval)
+{
+    auto x = var("x");
+    auto y = var("y");
+    auto e = min(min(x, y), y);
+    EXPECT(e.eval({{var("x"), int64_t{7}}, {var("y"), int64_t{5}}}) == scalar{int64_t{5}});
+    EXPECT(e.eval({{var("x"), int64_t{3}}, {var("y"), int64_t{5}}}) == scalar{int64_t{3}});
+    auto f = max(max(x, y), y);
+    EXPECT(f.eval({{var("x"), int64_t{7}}, {var("y"), int64_t{5}}}) == scalar{int64_t{7}});
+    EXPECT(f.eval({{var("x"), int64_t{3}}, {var("y"), int64_t{5}}}) == scalar{int64_t{5}});
+}
+
 TEST_CASE(builtin_raw_no_leak)
 {
     auto x = var("x");


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
* Change `slice` operator's `compute_shape()` to be able to output symbolic shapes.
* Also setup to handle operators with data-dependent shape functions.
* Separated out code from my data-dependent handling prototype and Shivad's sym_slice PR.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
### Added `slice_mode`
* Need a way to determine what the input to slice is for 2+ inputs. Changed slice to have a mode enum.
* Also changed ONNX parser for slice to use flags to determine what to set the mode to.

### Slice symbolic shapes
* Always use 2+ input `slice` for handling symbolic shapes. Example:
```
input_shape = {2, 10}
slice(input, ends_input, starts = {0}, ends = {N}, axes = {1})
slice.compute_shape() => {2, N}
```
* When `slice.compute()` is called, the value at `ends_input` is used to determine the output shape.

### Slice range-based dynamic shapes
* Keep the previous behavior of going to `{0, max_of_interval}` until we remove range-based dynamic shapes.

### Other
* Update tests wrt. slice changes

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [x] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
