### PR TITLE
[AIMIGRAPHX-1209] optimize kernel 2 for non kv cache flash decoding and update tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Full documentation for MIGraphX is available at
 * Fixed `slice_concat_gather` matcher and interaction between same table and cross table gather fusions(#5038).
 
 ### Optimized
+* Optimized flash decoding recombination in `fuse_attention` to use the exp-normalize form (#5090).
 * Reduced tuning time by scaling the per-candidate benchmark bundle to the candidate's op count (#4989).
 * Enabled tensor vectorization for GPU fused `argmin` and `argmax` (`gpu::arg_reduce`) (#4790).
 * Replaced Hillis-Steele scan algorithm with a wave-based hierarchical scan, reducing work complexity from O(N log N) to O(N) and synchronization from O(log N) to 2 `__syncthreads()` calls (#4720).

--- a/src/fuse_attention.cpp
+++ b/src/fuse_attention.cpp
@@ -755,51 +755,49 @@ struct find_flash_decoding
         auto lse = mm.insert_instruction(
             attn_group_ins, make_op("get_tuple_elem", {{"index", 1}}), new_group_ins);
 
-        // kernel 2
-        // the partial outputs O'[g] are already weighted by their group's softmax,
-        // LSE[g] contains log(sum(exp(S[g]))) for each group
-        // To combine: weight by exp(LSE[g]) / sum_g(exp(LSE[g']))
-
-        // compute global max for numerical stability
+        // kernel 2: combine using exp-normalize trick
+        // O = sum(O' * exp(LSE - max)) / sum(exp(LSE - max))
+        // find max LSE across groups for numerical stability
         auto lse_max =
             mm.insert_instruction(attn_group_ins, make_op("reduce_max", {{"axes", {g_axis}}}), lse);
+
         auto lse_max_bcast = mm.insert_instruction(
             attn_group_ins,
             make_op("multibroadcast", {{"out_lens", lse->get_shape().lens()}}),
             lse_max);
 
-        // exp(LSE - max_LSE)
+        // compute unnormalized weights
+        // exp(LSE - max)
         auto lse_sub = mm.insert_instruction(attn_group_ins, make_op("sub"), lse, lse_max_bcast);
+
         auto lse_exp = mm.insert_instruction(attn_group_ins, make_op("exp"), lse_sub);
 
-        // sum across groups
-        auto lse_sum = mm.insert_instruction(
-            attn_group_ins, make_op("reduce_sum", {{"axes", {g_axis}}}), lse_exp);
-        auto lse_sum_bcast = mm.insert_instruction(
-            attn_group_ins,
-            make_op("multibroadcast", {{"out_lens", lse_exp->get_shape().lens()}}),
-            lse_sum);
-
-        // scale factor: exp(LSE[g] - max_LSE) / sum(exp(LSE - max_LSE))
-        auto scale = mm.insert_instruction(attn_group_ins, make_op("div"), lse_exp, lse_sum_bcast);
-
-        auto scale_bcast = mm.insert_instruction(
+        // broadcast weights to match O' shape
+        // [B, G, M] -> [B, G, M, D]
+        auto lse_exp_bcast = mm.insert_instruction(
             attn_group_ins,
             make_op("multibroadcast", {{"out_lens", partial_output_o_prime->get_shape().lens()}}),
-            scale);
+            lse_exp);
 
-        // convert scale to match the type of partial_output_o_prime
-        auto output_type     = partial_output_o_prime->get_shape().type();
-        auto scale_converted = mm.insert_instruction(
-            attn_group_ins, make_op("convert", {{"target_type", output_type}}), scale_bcast);
+        // convert weights to output type
+        auto output_type = partial_output_o_prime->get_shape().type();
+        auto weights     = mm.insert_instruction(
+            attn_group_ins, make_op("convert", {{"target_type", output_type}}), lse_exp_bcast);
 
-        // R = mul(O', broadcasted_scale)
-        auto scaled_r = mm.insert_instruction(
-            attn_group_ins, make_op("mul"), partial_output_o_prime, scale_converted);
+        // compute weighted sum: numerator = sum(O' * weights)
+        auto weighted_o =
+            mm.insert_instruction(attn_group_ins, make_op("mul"), partial_output_o_prime, weights);
 
-        // O = sum(R, axis=G_axis)
-        auto final_output_o = mm.insert_instruction(
-            attn_group_ins, make_op("reduce_sum", {{"axes", {g_axis}}}), scaled_r);
+        auto numerator = mm.insert_instruction(
+            attn_group_ins, make_op("reduce_sum", {{"axes", {g_axis}}}), weighted_o);
+
+        // compute sum of weights: denominator = sum(weights)
+        auto denominator = mm.insert_instruction(
+            attn_group_ins, make_op("reduce_sum", {{"axes", {g_axis}}}), weights);
+
+        // final division: O = numerator / denominator
+        auto final_output_o =
+            mm.insert_instruction(attn_group_ins, make_op("div"), numerator, denominator);
 
         // squeeze G to match the original output shape
         auto final_squeezed_o = mm.insert_instruction(

--- a/test/fuse_attention.cpp
+++ b/test/fuse_attention.cpp
@@ -903,20 +903,18 @@ TEST_CASE(gemm_softmax_gemm_flash_decoding)
             migraphx::make_op("multibroadcast", {{"out_lens", {1, 12, 2, 256, 1}}}), k2_rmax);
         auto k2_sub = mm->add_instruction(migraphx::make_op("sub"), lse, k2_broad1);
         auto k2_exp = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
-        auto k2_rsum1 =
-            mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {2}}}), k2_exp);
-        auto k2_broad2 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {1, 12, 2, 256, 1}}}), k2_rsum1);
-        auto k2_div    = mm->add_instruction(migraphx::make_op("div"), k2_exp, k2_broad2);
         auto k2_broad3 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {1, 12, 2, 256, 256}}}), k2_div);
+            migraphx::make_op("multibroadcast", {{"out_lens", {1, 12, 2, 256, 256}}}), k2_exp);
         auto k2_convert = mm->add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), k2_broad3);
         auto k2_mul = mm->add_instruction(migraphx::make_op("mul"), o_p, k2_convert);
-        auto k2_rsum2 =
+        auto k2_rsum1 =
             mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {2}}}), k2_mul);
+        auto k2_rsum2 =
+            mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {2}}}), k2_convert);
+        auto k2_div = mm->add_instruction(migraphx::make_op("div"), k2_rsum1, k2_rsum2);
         auto k2_squeeze =
-            mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {2}}}), k2_rsum2);
+            mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {2}}}), k2_div);
         mm->add_return({k2_squeeze});
     }
     EXPECT(p1.sort() == p2.sort());
@@ -1019,20 +1017,18 @@ TEST_CASE(flash_decoding_3d)
             migraphx::make_op("multibroadcast", {{"out_lens", {1, num_splits, 256, 1}}}), k2_rmax);
         auto k2_sub = mm->add_instruction(migraphx::make_op("sub"), lse, k2_broad1);
         auto k2_exp = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
-        auto k2_rsum1 =
-            mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {g_axis}}}), k2_exp);
-        auto k2_broad2 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {1, num_splits, 256, 1}}}), k2_rsum1);
-        auto k2_div    = mm->add_instruction(migraphx::make_op("div"), k2_exp, k2_broad2);
         auto k2_broad3 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", q_prime_shape}}), k2_div);
+            migraphx::make_op("multibroadcast", {{"out_lens", q_prime_shape}}), k2_exp);
         auto k2_convert = mm->add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), k2_broad3);
         auto k2_mul = mm->add_instruction(migraphx::make_op("mul"), o_p, k2_convert);
-        auto k2_rsum2 =
+        auto k2_rsum1 =
             mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {g_axis}}}), k2_mul);
+        auto k2_rsum2 =
+            mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {g_axis}}}), k2_convert);
+        auto k2_div = mm->add_instruction(migraphx::make_op("div"), k2_rsum1, k2_rsum2);
         auto k2_squeeze =
-            mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {g_axis}}}), k2_rsum2);
+            mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {g_axis}}}), k2_div);
         mm->add_return({k2_squeeze});
     }
     EXPECT(p1.sort() == p2.sort());
@@ -1143,20 +1139,18 @@ TEST_CASE(flash_decoding_3d_rectangular)
             migraphx::make_op("multibroadcast", {{"out_lens", {1, num_splits, 240, 1}}}), k2_rmax);
         auto k2_sub = mm->add_instruction(migraphx::make_op("sub"), lse, k2_broad1);
         auto k2_exp = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
-        auto k2_rsum1 =
-            mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {g_axis}}}), k2_exp);
-        auto k2_broad2 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {1, num_splits, 240, 1}}}), k2_rsum1);
-        auto k2_div    = mm->add_instruction(migraphx::make_op("div"), k2_exp, k2_broad2);
         auto k2_broad3 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", q_prime_shape}}), k2_div);
+            migraphx::make_op("multibroadcast", {{"out_lens", q_prime_shape}}), k2_exp);
         auto k2_convert = mm->add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), k2_broad3);
         auto k2_mul = mm->add_instruction(migraphx::make_op("mul"), o_p, k2_convert);
-        auto k2_rsum2 =
+        auto k2_rsum1 =
             mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {g_axis}}}), k2_mul);
+        auto k2_rsum2 =
+            mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {g_axis}}}), k2_convert);
+        auto k2_div = mm->add_instruction(migraphx::make_op("div"), k2_rsum1, k2_rsum2);
         auto k2_squeeze =
-            mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {g_axis}}}), k2_rsum2);
+            mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {g_axis}}}), k2_div);
         mm->add_return({k2_squeeze});
     }
     EXPECT(p1.sort() == p2.sort());
@@ -1275,20 +1269,18 @@ TEST_CASE(flash_decoding_3d_padding)
             migraphx::make_op("multibroadcast", {{"out_lens", {1, num_splits, 242, 1}}}), k2_rmax);
         auto k2_sub = mm->add_instruction(migraphx::make_op("sub"), lse, k2_broad1);
         auto k2_exp = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
-        auto k2_rsum1 =
-            mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {g_axis}}}), k2_exp);
-        auto k2_broad2 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {1, num_splits, 242, 1}}}), k2_rsum1);
-        auto k2_div    = mm->add_instruction(migraphx::make_op("div"), k2_exp, k2_broad2);
         auto k2_broad3 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", q_prime_shape}}), k2_div);
+            migraphx::make_op("multibroadcast", {{"out_lens", q_prime_shape}}), k2_exp);
         auto k2_convert = mm->add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), k2_broad3);
         auto k2_mul = mm->add_instruction(migraphx::make_op("mul"), o_p, k2_convert);
-        auto k2_rsum2 =
+        auto k2_rsum1 =
             mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {g_axis}}}), k2_mul);
+        auto k2_rsum2 =
+            mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {g_axis}}}), k2_convert);
+        auto k2_div = mm->add_instruction(migraphx::make_op("div"), k2_rsum1, k2_rsum2);
         auto k2_squeeze =
-            mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {g_axis}}}), k2_rsum2);
+            mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {g_axis}}}), k2_div);
 
         // Slice to remove padding: [1, 242, 256] -> [1, 241, 256]
         auto sliced = mm->add_instruction(
@@ -1906,21 +1898,18 @@ TEST_CASE(flash_decoding_3d_auto_split_large_sequence)
             k2_rmax);
         auto k2_sub = mm->add_instruction(migraphx::make_op("sub"), lse, k2_broad1);
         auto k2_exp = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
-        auto k2_rsum1 =
-            mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {g_axis}}}), k2_exp);
-        auto k2_broad2 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {1, expected_splits, 512, 1}}}),
-            k2_rsum1);
-        auto k2_div    = mm->add_instruction(migraphx::make_op("div"), k2_exp, k2_broad2);
         auto k2_broad3 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", q_prime_shape}}), k2_div);
+            migraphx::make_op("multibroadcast", {{"out_lens", q_prime_shape}}), k2_exp);
         auto k2_convert = mm->add_instruction(
             migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), k2_broad3);
         auto k2_mul = mm->add_instruction(migraphx::make_op("mul"), o_p, k2_convert);
-        auto k2_rsum2 =
+        auto k2_rsum1 =
             mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {g_axis}}}), k2_mul);
+        auto k2_rsum2 =
+            mm->add_instruction(migraphx::make_op("reduce_sum", {{"axes", {g_axis}}}), k2_convert);
+        auto k2_div = mm->add_instruction(migraphx::make_op("div"), k2_rsum1, k2_rsum2);
         auto k2_squeeze =
-            mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {g_axis}}}), k2_rsum2);
+            mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {g_axis}}}), k2_div);
         mm->add_return({k2_squeeze});
     }
     EXPECT(p1.sort() == p2.sort());

--- a/test/fuse_attention.cpp
+++ b/test/fuse_attention.cpp
@@ -902,7 +902,7 @@ TEST_CASE(gemm_softmax_gemm_flash_decoding)
         auto k2_broad1 = mm->add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", {1, 12, 2, 256, 1}}}), k2_rmax);
         auto k2_sub = mm->add_instruction(migraphx::make_op("sub"), lse, k2_broad1);
-        auto k2_exp = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
+        auto k2_exp    = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
         auto k2_broad3 = mm->add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", {1, 12, 2, 256, 256}}}), k2_exp);
         auto k2_convert = mm->add_instruction(
@@ -1016,7 +1016,7 @@ TEST_CASE(flash_decoding_3d)
         auto k2_broad1 = mm->add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", {1, num_splits, 256, 1}}}), k2_rmax);
         auto k2_sub = mm->add_instruction(migraphx::make_op("sub"), lse, k2_broad1);
-        auto k2_exp = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
+        auto k2_exp    = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
         auto k2_broad3 = mm->add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", q_prime_shape}}), k2_exp);
         auto k2_convert = mm->add_instruction(
@@ -1138,7 +1138,7 @@ TEST_CASE(flash_decoding_3d_rectangular)
         auto k2_broad1 = mm->add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", {1, num_splits, 240, 1}}}), k2_rmax);
         auto k2_sub = mm->add_instruction(migraphx::make_op("sub"), lse, k2_broad1);
-        auto k2_exp = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
+        auto k2_exp    = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
         auto k2_broad3 = mm->add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", q_prime_shape}}), k2_exp);
         auto k2_convert = mm->add_instruction(
@@ -1268,7 +1268,7 @@ TEST_CASE(flash_decoding_3d_padding)
         auto k2_broad1 = mm->add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", {1, num_splits, 242, 1}}}), k2_rmax);
         auto k2_sub = mm->add_instruction(migraphx::make_op("sub"), lse, k2_broad1);
-        auto k2_exp = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
+        auto k2_exp    = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
         auto k2_broad3 = mm->add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", q_prime_shape}}), k2_exp);
         auto k2_convert = mm->add_instruction(
@@ -1897,7 +1897,7 @@ TEST_CASE(flash_decoding_3d_auto_split_large_sequence)
             migraphx::make_op("multibroadcast", {{"out_lens", {1, expected_splits, 512, 1}}}),
             k2_rmax);
         auto k2_sub = mm->add_instruction(migraphx::make_op("sub"), lse, k2_broad1);
-        auto k2_exp = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
+        auto k2_exp    = mm->add_instruction(migraphx::make_op("exp"), k2_sub);
         auto k2_broad3 = mm->add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", q_prime_shape}}), k2_exp);
         auto k2_convert = mm->add_instruction(


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Rewrites the flash decoding kernel 2 recombination step in find_flash_decoding to use the exp-normalize form:

`O = sum(O' * exp(LSE - max)) / sum(exp(LSE - max))`

instead of normalizing weights first, then scaling and summing partial outputs. The result is mathematically equivalent but produces IR that fuses more cleanly downstream (e.g. with rewrite_broadcast in a follow-up PR).

This is a standalone slice extracted from [#4546](https://github.com/ROCm/AMDMIGraphX/pull/4546).

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
After kernel 1, flash decoding returns partial outputs `O'` and log-sum-exp values `LSE` per group. Kernel 2 combines them into the final attention output.

The previous IR did:

```
scale = exp(LSE - max) / sum(exp(LSE - max))
broadcast scale to O' shape
mul(O', scale) → reduce_sum
```
The new form avoids the intermediate normalized scale broadcast and instead computes numerator and denominator separately:
```
broadcast exp(LSE - max) to O' shape
numerator = sum(O' * weights)
denominator = sum(weights)
O = numerator / denominator
```
A follow-up PR will introduce a `rewrite_broadcast` pass that further optimizes this down the line by rewriting `multibroadcast → convert` into `convert → multibroadcast` and `multibroadcast → reduce` into `reduce → multibroadcast`, so convert and reduction run on the smaller tensor before broadcasting to the full `O'` shape.

Opus was used to make this PR description more concise.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [x] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
