### PR TITLE
[AIRADSW-732] Fix reshape layout propagation

### DIFF
--- a/src/targets/gpu/propagate_reshape_layout.cpp
+++ b/src/targets/gpu/propagate_reshape_layout.cpp
@@ -25,16 +25,48 @@
 #include <migraphx/matcher.hpp>
 #include <migraphx/module.hpp>
 #include <migraphx/instruction.hpp>
+#include <migraphx/errors.hpp>
 #include <migraphx/make_op.hpp>
 #include <migraphx/permutation.hpp>
 #include <migraphx/reshape_dims.hpp>
 #include <migraphx/value.hpp>
+#include <unordered_map>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
 namespace {
+bool can_propagate_shape(module& m, instruction_ref start, const shape& start_shape)
+{
+    std::unordered_map<const instruction*, shape> shapes = {{&*start, start_shape}};
+    return std::all_of(std::next(start), m.end(), [&](const instruction& ins) {
+        if(std::none_of(ins.inputs().begin(), ins.inputs().end(), [&](instruction_ref input) {
+               return shapes.count(&*input) > 0;
+           }))
+            return true;
+
+        std::vector<shape> input_shapes;
+        std::transform(ins.inputs().begin(),
+                       ins.inputs().end(),
+                       std::back_inserter(input_shapes),
+                       [&](instruction_ref input) {
+                           auto iter = shapes.find(&*input);
+                           return iter == shapes.end() ? input->get_shape() : iter->second;
+                       });
+        try
+        {
+            shapes.emplace(
+                &ins, ins.get_operator().compute_shape(input_shapes, ins.module_inputs()));
+        }
+        catch(const exception&)
+        {
+            return false;
+        }
+        return true;
+    });
+}
+
 struct find_reshape_lazy_contiguous : match::supports_dynamic_shapes
 {
     // eliminate_contiguous only leaves a standardizing gpu::contiguous in front of a
@@ -75,6 +107,12 @@ struct find_reshape_lazy_contiguous : match::supports_dynamic_shapes
 
         auto layout_op    = make_op("layout", {{"permutation", find_permutation(*relayout)}});
         auto layout_shape = layout_op.compute_shape({s});
+        // Singleton dimensions can make a stride order ambiguous. In that case,
+        // find_permutation may produce a packed shape different from relayout that cannot
+        // alias the reshape output. Keep the standardizing contiguous instead.
+        auto reshaped = reshape_dims(layout_shape, rl->get_shape().sym_dims(), {.lazy = true});
+        if(not reshaped or not can_propagate_shape(m, rl, *reshaped))
+            return;
         auto alloc =
             m.insert_instruction(rl, make_op("allocate", {{"shape", to_value(layout_shape)}}));
         auto layout = m.insert_instruction(

--- a/src/targets/gpu/propagate_reshape_layout.cpp
+++ b/src/targets/gpu/propagate_reshape_layout.cpp
@@ -56,8 +56,8 @@ bool can_propagate_shape(module& m, instruction_ref start, const shape& start_sh
                        });
         try
         {
-            shapes.emplace(
-                &ins, ins.get_operator().compute_shape(input_shapes, ins.module_inputs()));
+            shapes.emplace(&ins,
+                           ins.get_operator().compute_shape(input_shapes, ins.module_inputs()));
         }
         catch(const exception&)
         {

--- a/test/gpu/propagate_reshape_layout.cpp
+++ b/test/gpu/propagate_reshape_layout.cpp
@@ -209,13 +209,12 @@ TEST_CASE(downstream_reshape_lazy_noop)
     migraphx::module m1;
     {
         migraphx::shape input_shape{migraphx::shape::float_type, {1, 4}, {1, 1}};
-        auto x = m1.add_parameter("x", input_shape);
-        auto alloc =
-            m1.add_instruction(migraphx::make_op(
-                "allocate",
-                {{"shape",
-                  migraphx::to_value(
-                      migraphx::shape{migraphx::shape::float_type, input_shape.lens()})}}));
+        auto x     = m1.add_parameter("x", input_shape);
+        auto alloc = m1.add_instruction(
+            migraphx::make_op("allocate",
+                              {{"shape",
+                                migraphx::to_value(migraphx::shape{migraphx::shape::float_type,
+                                                                   input_shape.lens()})}}));
         auto c   = m1.add_instruction(migraphx::make_op("gpu::contiguous"), x, alloc);
         auto rl1 = m1.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {1, 4}}}), c);
         auto rl2 = m1.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {2, 2}}}), rl1);

--- a/test/gpu/propagate_reshape_layout.cpp
+++ b/test/gpu/propagate_reshape_layout.cpp
@@ -181,4 +181,51 @@ TEST_CASE(no_permutation_noop)
     EXPECT(m1 == m2);
 }
 
+// Singleton dimensions make some stride orders ambiguous. The permutation recovered from the
+// desired layout can then produce a shape that reshape_lazy cannot alias.
+TEST_CASE(ambiguous_singleton_strides_noop)
+{
+    migraphx::module m1;
+    {
+        migraphx::shape input_shape{
+            migraphx::shape::float_type, {1, 1, 2}, {1, 2, 1}};
+        auto x = m1.add_parameter("x", input_shape);
+        auto alloc =
+            m1.add_instruction(migraphx::make_op(
+                "allocate",
+                {{"shape",
+                  migraphx::to_value(
+                      migraphx::shape{migraphx::shape::float_type, input_shape.lens()})}}));
+        auto c  = m1.add_instruction(migraphx::make_op("gpu::contiguous"), x, alloc);
+        auto rl = m1.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {1, 2}}}), c);
+        m1.add_return({rl});
+    }
+    migraphx::module m2 = m1;
+    run_pass(m1);
+    EXPECT(m1 == m2);
+}
+
+// A replacement can be valid for the matched reshape but make a downstream lazy reshape invalid.
+TEST_CASE(downstream_reshape_lazy_noop)
+{
+    migraphx::module m1;
+    {
+        migraphx::shape input_shape{migraphx::shape::float_type, {1, 4}, {1, 1}};
+        auto x = m1.add_parameter("x", input_shape);
+        auto alloc =
+            m1.add_instruction(migraphx::make_op(
+                "allocate",
+                {{"shape",
+                  migraphx::to_value(
+                      migraphx::shape{migraphx::shape::float_type, input_shape.lens()})}}));
+        auto c   = m1.add_instruction(migraphx::make_op("gpu::contiguous"), x, alloc);
+        auto rl1 = m1.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {1, 4}}}), c);
+        auto rl2 = m1.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {2, 2}}}), rl1);
+        m1.add_return({rl2});
+    }
+    migraphx::module m2 = m1;
+    run_pass(m1);
+    EXPECT(m1 == m2);
+}
+
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/gpu/propagate_reshape_layout.cpp
+++ b/test/gpu/propagate_reshape_layout.cpp
@@ -187,15 +187,13 @@ TEST_CASE(ambiguous_singleton_strides_noop)
 {
     migraphx::module m1;
     {
-        migraphx::shape input_shape{
-            migraphx::shape::float_type, {1, 1, 2}, {1, 2, 1}};
-        auto x = m1.add_parameter("x", input_shape);
-        auto alloc =
-            m1.add_instruction(migraphx::make_op(
-                "allocate",
-                {{"shape",
-                  migraphx::to_value(
-                      migraphx::shape{migraphx::shape::float_type, input_shape.lens()})}}));
+        migraphx::shape input_shape{migraphx::shape::float_type, {1, 1, 2}, {1, 2, 1}};
+        auto x     = m1.add_parameter("x", input_shape);
+        auto alloc = m1.add_instruction(
+            migraphx::make_op("allocate",
+                              {{"shape",
+                                migraphx::to_value(migraphx::shape{migraphx::shape::float_type,
+                                                                   input_shape.lens()})}}));
         auto c  = m1.add_instruction(migraphx::make_op("gpu::contiguous"), x, alloc);
         auto rl = m1.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {1, 2}}}), c);
         m1.add_return({rl});


### PR DESCRIPTION
## Motivation
Prevent gpu::propagate_reshape_layout from producing layouts that cause downstream reshape_lazy operations to fail with an unpacked-axis error.

## Technical Details
* Validate the proposed layout before modifying the graph.
* Simulate shape propagation through downstream instructions.
* Keep the original gpu::contiguous path when propagation is unsafe.
* Add regression tests for singleton dimensions and downstream reshape

A potential follow-up is to traverse only dependent instructions to reduce compile-time overhead.This adds traversal and topological-ordering complexity, may not improve dense graphs.
## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
