### PR TITLE
Refactor to use a device_description instead of using the hipDeviceProps struct

### DIFF
--- a/docs/dev/cross_compilation.rst
+++ b/docs/dev/cross_compilation.rst
@@ -90,21 +90,21 @@ The cross-compile target and context
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The GPU ``target`` (``src/targets/gpu/include/migraphx/gpu/target.hpp``) stores
-the requested architecture and synthetic device parameters. It reports
+the requested architecture and device parameters in a ``device_description``
+(``src/targets/gpu/include/migraphx/gpu/device_description.hpp``). It reports
 cross-compile mode when an architecture is set:
 
 .. code-block:: cpp
 
-    bool is_cross_compile() const { return not gpu_arch.empty(); }
+    bool is_cross_compile() const { return not desc.arch.empty(); }
 
-In cross-compile mode, ``target::get_context()`` builds a context backed by a
-synthetic ``hipDeviceProp_t`` instead of querying a real device. The synthetic
-properties are filled in by ``make_cross_compile_device_props``
-(``src/targets/gpu/cross_compile_device.cpp``), which sets the arch name, compute
-unit count, chiplet count, max threads, and wavefront size. When
-``gpu_wavefront_size`` is ``0``, wavefront size is inferred from the architecture
-(wave32 for RDNA ``gfx10``/``gfx11``/``gfx12``, wave64 otherwise); otherwise the
-explicit ``32`` or ``64`` override is used.
+In cross-compile mode, ``target::get_context()`` builds a context from that
+description instead of querying a real device with
+``device_description::from_device``. The description is completed by
+``device_description::normalize``, so when ``gpu_wavefront_size`` is ``0`` the
+wavefront size is inferred from the architecture (wave32 for RDNA
+``gfx10``/``gfx11``/``gfx12``, wave64 otherwise); otherwise the explicit ``32``
+or ``64`` override is used.
 
 A cross-compile context cannot touch a device. The target's ``copy_to``,
 ``copy_from``, and ``allocate`` all throw in this mode, and the context's

--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -211,7 +211,7 @@ add_library(migraphx_gpu
     compile_miopen.cpp
     compile_pointwise.cpp
     compiler.cpp
-    cross_compile_device.cpp
+    device_description.cpp
     device_name.cpp
     eliminate_data_type_for_gpu.cpp
     fixed_pad.cpp

--- a/src/targets/gpu/device_description.cpp
+++ b/src/targets/gpu/device_description.cpp
@@ -21,10 +21,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include <migraphx/gpu/cross_compile_device.hpp>
+#include <migraphx/gpu/device_description.hpp>
 #include <migraphx/gpu/device_name.hpp>
+#include <migraphx/gpu/hip.hpp>
+#include <migraphx/gpu/hsa_chiplet.hpp>
 #include <migraphx/errors.hpp>
 #include <migraphx/stringutils.hpp>
+#include <hip/hip_runtime_api.h>
 #include <algorithm>
 
 namespace migraphx {
@@ -32,7 +35,7 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
 // RDNA architectures use wave32
-static int arch_wavefront_size(const std::string& arch_name)
+static std::size_t arch_wavefront_size(const std::string& arch_name)
 {
     const auto gfx = get_gfx_name(arch_name);
     if(starts_with(gfx, "gfx10") or starts_with(gfx, "gfx11") or starts_with(gfx, "gfx12"))
@@ -40,24 +43,34 @@ static int arch_wavefront_size(const std::string& arch_name)
     return 64;
 }
 
-hipDeviceProp_t make_cross_compile_device_props(const std::string& arch_name,
-                                                std::size_t cu_count,
-                                                std::size_t max_threads_per_cu,
-                                                std::size_t max_threads_per_block,
-                                                std::size_t wavefront_size)
+device_description device_description::from_device(std::size_t device)
+{
+    hipDeviceProp_t props{};
+    auto status = hipGetDeviceProperties(&props, device);
+    if(status != hipSuccess)
+        MIGRAPHX_THROW("Failed to get device properties: " + hip_error(status));
+
+    device_description result;
+    result.arch                  = props.gcnArchName;
+    result.num_cu                = props.multiProcessorCount;
+    result.num_chiplets          = get_hsa_chiplet_count(device);
+    result.max_threads_per_cu    = props.maxThreadsPerMultiProcessor;
+    result.max_threads_per_block = props.maxThreadsPerBlock;
+    result.wavefront_size        = props.warpSize;
+    return result;
+}
+
+void device_description::normalize()
 {
     if(wavefront_size != 0 and wavefront_size != 32 and wavefront_size != 64)
-        MIGRAPHX_THROW("Invalid cross-compile wavefront_size: expected 0 (auto), 32, or 64");
+        MIGRAPHX_THROW("Invalid wavefront_size: expected 0 (auto), 32, or 64");
 
-    hipDeviceProp_t props{};
-    auto n = std::min(arch_name.size(), sizeof(props.gcnArchName) - 1);
-    std::copy_n(arch_name.begin(), n, props.gcnArchName);
-    props.gcnArchName[n] = '\0';
-    props.warpSize       = wavefront_size == 0 ? arch_wavefront_size(arch_name) : wavefront_size;
-    props.maxThreadsPerMultiProcessor = std::max<std::size_t>(max_threads_per_cu, 1);
-    props.maxThreadsPerBlock          = std::max<std::size_t>(max_threads_per_block, 1);
-    props.multiProcessorCount         = std::max<std::size_t>(cu_count, 1);
-    return props;
+    if(wavefront_size == 0)
+        wavefront_size = arch_wavefront_size(arch);
+    num_cu                = std::max<std::size_t>(num_cu, 1);
+    num_chiplets          = std::max<std::size_t>(num_chiplets, 1);
+    max_threads_per_cu    = std::max<std::size_t>(max_threads_per_cu, 1);
+    max_threads_per_block = std::max<std::size_t>(max_threads_per_block, 1);
 }
 
 } // namespace gpu

--- a/src/targets/gpu/include/migraphx/gpu/context.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/context.hpp
@@ -284,16 +284,14 @@ struct context
     context(std::size_t device_id = 0, std::size_t n = value_of(MIGRAPHX_NSTREAMS{}, 1))
         : current_device(std::make_shared<hip_device>(device_id, n)),
           begin_event(create_event()),
-          finish_event(create_event()),
-          pc(std::make_shared<auto_save_problem_cache>())
+          finish_event(create_event())
     {
     }
 
     /// Construct a context for a device that is not present, which can only be
     /// used to compile and not to execute.
     explicit context(const device_description& desc)
-        : current_device(std::make_shared<hip_device>(desc)),
-          pc(std::make_shared<auto_save_problem_cache>())
+        : current_device(std::make_shared<hip_device>(desc))
     {
     }
 
@@ -469,7 +467,7 @@ struct context
     // for stream synchronization
     shared<hip_event_ptr> begin_event           = nullptr;
     shared<hip_event_ptr> finish_event          = nullptr;
-    std::shared_ptr<auto_save_problem_cache> pc = nullptr;
+    std::shared_ptr<auto_save_problem_cache> pc = std::make_shared<auto_save_problem_cache>();
 };
 
 inline void migraphx_to_value(value& v, const context& ctx) { v = ctx.to_value(); }

--- a/src/targets/gpu/include/migraphx/gpu/context.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/context.hpp
@@ -70,6 +70,8 @@ struct hip_device
     explicit hip_device(const device_description& d) : cross_compile_mode(true), desc(d)
     {
         desc.normalize();
+        if(desc.arch.empty())
+            MIGRAPHX_THROW("Cross-compile device_description.arch must be set");
         add_stream();
     }
 

--- a/src/targets/gpu/include/migraphx/gpu/context.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/context.hpp
@@ -39,8 +39,7 @@
 #include <migraphx/config.hpp>
 #include <migraphx/gpu/device_name.hpp>
 #include <migraphx/gpu/problem_cache.hpp>
-#include <migraphx/gpu/hsa_chiplet.hpp>
-#include <migraphx/gpu/cross_compile_device.hpp>
+#include <migraphx/gpu/device_description.hpp>
 #include <unordered_map>
 #include <memory>
 #include <optional>
@@ -56,14 +55,11 @@ using hip_event_ptr = MIGRAPHX_MANAGE_PTR(hipEvent_t, hipEventDestroy);
 
 struct hip_device
 {
-    hip_device() : device_props{} { add_stream(); }
+    hip_device() { add_stream(); }
 
-    hip_device(std::size_t id, std::size_t n) : device_id(id)
+    hip_device(std::size_t id, std::size_t n)
+        : device_id(id), desc(device_description::from_device(id))
     {
-        auto status = hipGetDeviceProperties(&device_props, device_id);
-        if(status != hipSuccess)
-            MIGRAPHX_THROW("Failed to get device properties: " + hip_error(status));
-
         // Set the device prior to Events that get created within a Context.
         set_device(device_id);
 
@@ -71,17 +67,9 @@ struct hip_device
             add_stream();
     }
 
-    hip_device(const std::string& arch_name,
-               std::size_t cu_count,
-               std::size_t chiplets,
-               std::size_t max_threads_per_cu    = 2048,
-               std::size_t max_threads_per_block = 1024,
-               std::size_t wavefront_size        = 0)
-        : cross_compile_mode(true),
-          chiplet_count_override(std::max<std::size_t>(chiplets, 1)),
-          device_props(make_cross_compile_device_props(
-              arch_name, cu_count, max_threads_per_cu, max_threads_per_block, wavefront_size))
+    explicit hip_device(const device_description& d) : cross_compile_mode(true), desc(d)
     {
+        desc.normalize();
         add_stream();
     }
 
@@ -248,41 +236,30 @@ struct hip_device
 
     std::size_t stream_id() const { return current_stream; }
 
-    std::string get_device_name() const { return device_props.gcnArchName; }
+    const device_description& get_device_description() const { return desc; }
+
+    std::string get_device_name() const { return desc.arch; }
 
     std::string get_gfx_name() const { return gpu::get_gfx_name(get_device_name()); }
 
-    std::size_t get_device_major() const { return device_props.major; }
+    std::size_t get_cu_count() const { return desc.num_cu; }
 
-    std::size_t get_device_minor() const { return device_props.minor; }
-
-    std::size_t get_cu_count() const { return device_props.multiProcessorCount; }
-
-    std::size_t get_chiplet_count() const
-    {
-        if(cross_compile_mode)
-            return chiplet_count_override;
-        return get_hsa_chiplet_count(device_id);
-    }
+    std::size_t get_chiplet_count() const { return desc.num_chiplets; }
 
     bool is_cross_compile() const { return cross_compile_mode; }
 
-    std::size_t get_max_workitems_per_cu() const
-    {
-        return device_props.maxThreadsPerMultiProcessor;
-    }
+    std::size_t get_max_workitems_per_cu() const { return desc.max_threads_per_cu; }
 
-    std::size_t get_max_workitems_per_block() const { return device_props.maxThreadsPerBlock; }
+    std::size_t get_max_workitems_per_block() const { return desc.max_threads_per_block; }
 
-    std::size_t get_wavefront_size() const { return device_props.warpSize; }
+    std::size_t get_wavefront_size() const { return desc.wavefront_size; }
 
     private:
-    std::size_t device_id              = 0;
-    std::size_t current_stream         = 0;
-    bool cross_compile_mode            = false;
-    std::size_t chiplet_count_override = 1;
+    std::size_t device_id      = 0;
+    std::size_t current_stream = 0;
+    bool cross_compile_mode    = false;
     std::vector<stream> streams;
-    hipDeviceProp_t device_props;
+    device_description desc = {};
 
     public:
     std::unordered_map<std::string, argument> preallocations{};
@@ -312,18 +289,10 @@ struct context
     {
     }
 
-    context(const std::string& arch_name,
-            std::size_t cu_count,
-            std::size_t chiplets,
-            std::size_t max_threads_per_cu    = 2048,
-            std::size_t max_threads_per_block = 1024,
-            std::size_t wavefront_size        = 0)
-        : current_device(std::make_shared<hip_device>(arch_name,
-                                                      cu_count,
-                                                      chiplets,
-                                                      max_threads_per_cu,
-                                                      max_threads_per_block,
-                                                      wavefront_size)),
+    /// Construct a context for a device that is not present, which can only be
+    /// used to compile and not to execute.
+    explicit context(const device_description& desc)
+        : current_device(std::make_shared<hip_device>(desc)),
           pc(std::make_shared<auto_save_problem_cache>())
     {
     }

--- a/src/targets/gpu/include/migraphx/gpu/device_description.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/device_description.hpp
@@ -21,29 +21,40 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef MIGRAPHX_GUARD_GPU_CROSS_COMPILE_DEVICE_HPP
-#define MIGRAPHX_GUARD_GPU_CROSS_COMPILE_DEVICE_HPP
+#ifndef MIGRAPHX_GUARD_GPU_DEVICE_DESCRIPTION_HPP
+#define MIGRAPHX_GUARD_GPU_DEVICE_DESCRIPTION_HPP
 
-#include <migraphx/gpu/export.h>
-#include <migraphx/config.hpp>
-#include <hip/hip_runtime_api.h>
+#include <migraphx/gpu/config.hpp>
+#include <cstddef>
 #include <string>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
-/// Populate a hipDeviceProp_t with synthetic values for cross-compilation.
-/// Used when no physical GPU is present.
-MIGRAPHX_GPU_EXPORT hipDeviceProp_t
-make_cross_compile_device_props(const std::string& arch_name,
-                                std::size_t cu_count,
-                                std::size_t max_threads_per_cu    = 2048,
-                                std::size_t max_threads_per_block = 1024,
-                                std::size_t wavefront_size        = 0);
+/// The properties of a GPU that are needed to compile for it. It can either be
+/// queried from a local device or filled in by the user to compile for a device
+/// that is not present.
+struct MIGRAPHX_GPU_EXPORT device_description
+{
+    /// Query the properties of the device with the given hip device id.
+    static device_description from_device(std::size_t device);
+
+    /// Resolve the fields that can be derived from the other fields: a
+    /// `wavefront_size` of 0 is derived from the `arch`. Counts are clamped to
+    /// at least one. Throws when a field is set to an unsupported value.
+    void normalize();
+
+    std::string arch                  = {};
+    std::size_t num_cu                = 120;
+    std::size_t num_chiplets          = 1;
+    std::size_t max_threads_per_cu    = 2048;
+    std::size_t max_threads_per_block = 1024;
+    std::size_t wavefront_size        = 0;
+};
 
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
 
-#endif
+#endif // MIGRAPHX_GUARD_GPU_DEVICE_DESCRIPTION_HPP

--- a/src/targets/gpu/include/migraphx/gpu/target.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/target.hpp
@@ -24,12 +24,12 @@
 #ifndef MIGRAPHX_GUARD_MIGRAPHLIB_MIOPEN_TARGET_HPP
 #define MIGRAPHX_GUARD_MIGRAPHLIB_MIOPEN_TARGET_HPP
 
-#include <cstddef>
 #include <string>
 #include <migraphx/program.hpp>
 #include <migraphx/compile_options.hpp>
 #include <migraphx/reflect.hpp>
 #include <migraphx/gpu/config.hpp>
+#include <migraphx/gpu/device_description.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -37,26 +37,21 @@ namespace gpu {
 
 struct MIGRAPHX_GPU_EXPORT target
 {
-    /// Cross-compile arch name (e.g. "gfx942"). Empty means use the local device.
-    std::string gpu_arch                  = {};
-    std::size_t gpu_num_cu                = 120;
-    std::size_t gpu_num_chiplets          = 1;
-    std::size_t gpu_max_threads_per_cu    = 2048;
-    std::size_t gpu_max_threads_per_block = 1024;
-    std::size_t gpu_wavefront_size        = 0;
+    /// The device to compile for. An empty arch means use the local device.
+    device_description desc = {};
 
     template <class Self, class F>
     static auto reflect(Self& self, F f)
     {
-        return pack(f(self.gpu_arch, "gpu_arch"),
-                    f(self.gpu_num_cu, "gpu_num_cu"),
-                    f(self.gpu_num_chiplets, "gpu_num_chiplets"),
-                    f(self.gpu_max_threads_per_cu, "gpu_max_threads_per_cu"),
-                    f(self.gpu_max_threads_per_block, "gpu_max_threads_per_block"),
-                    f(self.gpu_wavefront_size, "gpu_wavefront_size"));
+        return pack(f(self.desc.arch, "gpu_arch"),
+                    f(self.desc.num_cu, "gpu_num_cu"),
+                    f(self.desc.num_chiplets, "gpu_num_chiplets"),
+                    f(self.desc.max_threads_per_cu, "gpu_max_threads_per_cu"),
+                    f(self.desc.max_threads_per_block, "gpu_max_threads_per_block"),
+                    f(self.desc.wavefront_size, "gpu_wavefront_size"));
     }
 
-    bool is_cross_compile() const { return not gpu_arch.empty(); }
+    bool is_cross_compile() const { return not desc.arch.empty(); }
 
     std::string name() const;
     std::vector<pass> get_passes(migraphx::context& gctx, const compile_options& options) const;

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -298,12 +298,7 @@ std::string target::name() const { return "gpu"; }
 migraphx::context target::get_context() const
 {
     if(is_cross_compile())
-        return context(gpu_arch,
-                       gpu_num_cu,
-                       gpu_num_chiplets,
-                       gpu_max_threads_per_cu,
-                       gpu_max_threads_per_block,
-                       gpu_wavefront_size);
+        return context(desc);
     return context(gpu::get_device_id());
 }
 

--- a/test/gpu/jit.cpp
+++ b/test/gpu/jit.cpp
@@ -37,7 +37,7 @@
 #include <migraphx/gpu/compile_hip.hpp>
 #include <migraphx/gpu/compile_hip_code_object.hpp>
 #include <migraphx/gpu/compiler.hpp>
-#include <migraphx/gpu/cross_compile_device.hpp>
+#include <migraphx/gpu/device_description.hpp>
 
 // NOLINTNEXTLINE
 const std::string write_2s = R"__migraphx__(
@@ -234,8 +234,7 @@ TEST_CASE(compile_target)
 TEST_CASE(cross_compile_gpu_target_gfx1101)
 {
     // Verify a cross-compile gpu::context produces a code object for the requested arch.
-    // ctx args: (arch: gfx1101, cu_count: 60, chiplets: 1).
-    migraphx::gpu::context ctx{"gfx1101", 60, 1};
+    migraphx::gpu::context ctx{migraphx::gpu::device_description{"gfx1101", 60, 1}};
     auto binaries = migraphx::gpu::compile_hip_src(
         {make_src_file("main.cpp", add_2s_binary)}, {}, ctx.get_current_device().get_device_name());
     EXPECT(binaries.size() == 1);
@@ -245,13 +244,18 @@ TEST_CASE(cross_compile_gpu_target_gfx1101)
 
 TEST_CASE(cross_compile_wavefront_size)
 {
-    EXPECT(migraphx::gpu::make_cross_compile_device_props("gfx1101", 1).warpSize == 32);
-    EXPECT(migraphx::gpu::make_cross_compile_device_props("gfx942", 1).warpSize == 64);
-    EXPECT(migraphx::gpu::make_cross_compile_device_props("gfx942", 1, 2048, 1024, 32).warpSize ==
-           32);
-    EXPECT(migraphx::gpu::make_cross_compile_device_props("gfx12xx", 1).warpSize == 32);
-    EXPECT(migraphx::gpu::make_cross_compile_device_props("gfx12xx", 1, 2048, 1024, 64).warpSize ==
-           64);
+    auto wavefront_size = [](const std::string& arch, std::size_t ws = 0) {
+        migraphx::gpu::device_description desc{arch, 1};
+        desc.wavefront_size = ws;
+        desc.normalize();
+        return desc.wavefront_size;
+    };
+    EXPECT(wavefront_size("gfx1101") == 32);
+    EXPECT(wavefront_size("gfx942") == 64);
+    EXPECT(wavefront_size("gfx942", 32) == 32);
+    EXPECT(wavefront_size("gfx12xx") == 32);
+    EXPECT(wavefront_size("gfx12xx", 64) == 64);
+    EXPECT(test::throws([&] { wavefront_size("gfx942", 16); }));
 }
 
 TEST_CASE(compile_errors)


### PR DESCRIPTION
## Motivation
This simplifies the context constructor so that it can be more easily extended in the future. 

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
