### PR TITLE
skip elimination when reshape_lazy

### DIFF
--- a/src/eliminate_concat.cpp
+++ b/src/eliminate_concat.cpp
@@ -29,15 +29,24 @@
 #include <migraphx/iterator_for.hpp>
 #include <migraphx/ranges.hpp>
 #include <migraphx/make_op.hpp>
+#include <migraphx/reshape_dims.hpp>
 
 #include <migraphx/dfor.hpp>
 #include <migraphx/tune_axis.hpp>
 #include <iterator>
+#include <unordered_map>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
 namespace {
+
+bool reshape_lazy_accepts_input_shape(instruction_ref ins, const shape& input_shape)
+{
+    if(ins->name() != "reshape_lazy")
+        return true;
+    return reshape_dims(input_shape, ins->get_shape().lens(), {.lazy = true}).has_value();
+}
 
 struct concat_optimizer
 {
@@ -66,14 +75,60 @@ struct concat_optimizer
         return ins->name() == "allocate" or ins->name() == am.name();
     }
 
-    bool need_copy(instruction_ref ins) const { return not is_allocation(get_output_alias(ins)); }
+    bool need_copy(instruction_ref ins, const shape& replacement_shape) const
+    {
+        auto alias = get_output_alias(ins);
+        return not is_allocation(alias) or
+               not replacement_supports_reshape_lazy(alias, replacement_shape);
+    }
+
+    bool replacement_supports_reshape_lazy(instruction_ref replaced,
+                                           const shape& replacement_shape) const
+    {
+        std::unordered_map<instruction_ref, shape> shapes = {{replaced, replacement_shape}};
+        auto downstream_range                             = range(std::next(replaced), m->end());
+        auto downstream_refs                              = iterator_for(downstream_range);
+        return std::all_of(
+            downstream_refs.begin(), downstream_refs.end(), [&](instruction_ref ins) {
+                bool changed      = false;
+                auto input_shapes = to_shapes(ins->inputs());
+                std::transform(ins->inputs().begin(),
+                               ins->inputs().end(),
+                               input_shapes.begin(),
+                               [&](instruction_ref arg) {
+                                   auto it = shapes.find(arg);
+                                   if(it == shapes.end())
+                                       return arg->get_shape();
+                                   changed = true;
+                                   return it->second;
+                               });
+                if(not changed)
+                    return true;
+                if(not reshape_lazy_accepts_input_shape(ins, input_shapes.front()))
+                    return false;
+                shape output_shape;
+                try
+                {
+                    output_shape =
+                        ins->get_operator().compute_shape(input_shapes, ins->module_inputs());
+                }
+                catch(const std::exception&)
+                {
+                    return false;
+                }
+                if(output_shape != ins->get_shape())
+                    shapes.emplace(ins, std::move(output_shape));
+                return true;
+            });
+    }
 
     instruction_ref
     insert_copy(const operation& op, instruction_ref input, instruction_ref super) const
     {
         auto slice = m->insert_instruction(std::next(super), op, super);
         // If its packed then replace the allocation with the slice instead
-        if(not need_copy(input) and slice->get_shape().packed() and input->outputs().size() == 1)
+        if(not need_copy(input, slice->get_shape()) and slice->get_shape().packed() and
+           input->outputs().size() == 1)
         {
             m->replace_instruction(get_output_alias(input), slice);
             return input;
@@ -142,9 +197,23 @@ void eliminate_concat::apply(module& m) const
             continue;
         auto lens        = ins->inputs().front()->get_shape().lens();
         std::size_t axis = tune_axis(lens.size(), concat_op->axis, concat_op->name());
-        auto ncopies     = std::count_if(
+        if(std::any_of(
+               ins->inputs().begin(), std::prev(ins->inputs().end()), [&](instruction_ref input) {
+                   auto slice_shape = shape{input->get_shape().type(),
+                                            input->get_shape().lens(),
+                                            ins->get_shape().strides()};
+                   auto needs_copy = co.need_copy(input, slice_shape) or not slice_shape.packed() or
+                                     input->outputs().size() != 1;
+                   return needs_copy and
+                          not co.replacement_supports_reshape_lazy(input, slice_shape);
+               }))
+            continue;
+        auto ncopies = std::count_if(
             ins->inputs().begin(), std::prev(ins->inputs().end()), [&](instruction_ref input) {
-                if(co.need_copy(input))
+                auto slice_shape = shape{input->get_shape().type(),
+                                         input->get_shape().lens(),
+                                         ins->get_shape().strides()};
+                if(co.need_copy(input, slice_shape))
                     return true;
                 if(is_packed(input, axis))
                     return false;


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Prevent concat elimination by introducing a special operations checks. This issue caused YOLOv3 compilation to fail with: reshape_lazy on axis that is not packed

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
Concat elimination replaces an input's buffer with a non-packed slice of the super-buffer. reshape_lazy can only alias a packed input, so if the input feeds a reshape_lazy the elimination is illegal; force a copy instead.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
