### PR TITLE
Fix find_concat_transpose with non-transposed inputs

### DIFF
--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -31,7 +31,6 @@
 #include <migraphx/argument.hpp>
 #include <migraphx/literal.hpp>
 #include <migraphx/op/as_shape.hpp>
-#include <migraphx/op/transpose.hpp>
 #include <migraphx/op/concat.hpp>
 #include <migraphx/op/slice.hpp>
 #include <migraphx/op/gather.hpp>

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -896,39 +896,40 @@ struct find_concat_transpose
         return match::name("concat")(match::all_of[match::inputs()](match::name("transpose")));
     }
 
+    // Use the permutation of the transpose operator instead of deducing it from the strides of
+    // its output shape, since the output shape may not be transposed at all.
+    static const std::vector<int64_t>& get_permutation(instruction_ref ins)
+    {
+        return any_cast<const op::transpose&>(ins->get_operator()).dims;
+    }
+
     void apply(module& m, const match::matcher_result& mr) const
     {
         auto ins          = mr.result;
         auto trans_inputs = ins->inputs();
-        auto s            = trans_inputs.front()->get_shape();
-        assert(s.transposed());
-        auto op          = any_cast<op::concat>(ins->get_operator());
-        auto permutation = find_permutation(s);
+        auto op           = any_cast<op::concat>(ins->get_operator());
+        auto permutation  = get_permutation(trans_inputs.front());
 
         // permutation should be the same for all inputs
         if(not std::all_of(trans_inputs.begin(), trans_inputs.end(), [&](auto in) {
-               return (find_permutation(in->get_shape()) == permutation);
+               return (get_permutation(in) == permutation);
            }))
         {
             return;
         }
 
         // axis could be a negative value
-        int64_t n_dim = s.lens().size();
-        op.axis       = tune_axis(n_dim, op.axis, op.name());
-
-        auto ipermutation = invert_permutation(permutation);
-        op.axis           = ipermutation[op.axis];
+        int64_t n_dim = ins->get_shape().ndim();
+        op.axis       = permutation[tune_axis(n_dim, op.axis, op.name())];
 
         std::vector<instruction_ref> inputs;
-        std::transform(
-            ins->inputs().begin(), ins->inputs().end(), std::back_inserter(inputs), [&](auto i) {
-                return m.insert_instruction(
-                    ins, make_op("transpose", {{"permutation", permutation}}), i);
-            });
+        std::transform(trans_inputs.begin(),
+                       trans_inputs.end(),
+                       std::back_inserter(inputs),
+                       [](instruction_ref i) { return i->inputs().front(); });
         auto concat = m.insert_instruction(ins, op, inputs);
-        auto t      = m.insert_instruction(
-            ins, make_op("transpose", {{"permutation", ipermutation}}), concat);
+        auto t =
+            m.insert_instruction(ins, make_op("transpose", {{"permutation", permutation}}), concat);
         assert(ins->get_shape().lens() == t->get_shape().lens());
         m.replace_instruction(ins, t);
     }

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -898,16 +898,16 @@ struct find_concat_transpose
 
     // Use the permutation of the transpose operator instead of deducing it from the strides of
     // its output shape, since the output shape may not be transposed at all.
-    static const std::vector<int64_t>& get_permutation(instruction_ref ins)
+    static std::vector<int64_t> get_permutation(instruction_ref ins)
     {
-        return any_cast<const op::transpose&>(ins->get_operator()).dims;
+        return ins->get_operator().to_value()["permutation"].to_vector<int64_t>();
     }
 
     void apply(module& m, const match::matcher_result& mr) const
     {
         auto ins          = mr.result;
         auto trans_inputs = ins->inputs();
-        auto op           = any_cast<op::concat>(ins->get_operator());
+        auto v            = ins->get_operator().to_value();
         auto permutation  = get_permutation(trans_inputs.front());
 
         // permutation should be the same for all inputs
@@ -920,14 +920,14 @@ struct find_concat_transpose
 
         // axis could be a negative value
         int64_t n_dim = ins->get_shape().ndim();
-        op.axis       = permutation[tune_axis(n_dim, op.axis, op.name())];
+        v["axis"]     = permutation[tune_axis(n_dim, v.at("axis").to<int64_t>(), ins->name())];
 
         std::vector<instruction_ref> inputs;
         std::transform(trans_inputs.begin(),
                        trans_inputs.end(),
                        std::back_inserter(inputs),
                        [](instruction_ref i) { return i->inputs().front(); });
-        auto concat = m.insert_instruction(ins, op, inputs);
+        auto concat = m.insert_instruction(ins, make_op(ins->name(), v), inputs);
         auto t =
             m.insert_instruction(ins, make_op("transpose", {{"permutation", permutation}}), concat);
         assert(ins->get_shape().lens() == t->get_shape().lens());

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -1203,6 +1203,87 @@ TEST_CASE(concat_transpose4)
     EXPECT(m1 == m);
 }
 
+TEST_CASE(concat_transpose_to_standard)
+{
+    // The transposes undo the layout of their inputs, so their output shapes are standard and
+    // the permutation cannot be recovered from the strides of those shapes.
+    auto s = migraphx::shape{migraphx::shape::float_type, {1, 2, 4, 3}, {24, 12, 1, 4}};
+    migraphx::module m1;
+    {
+        auto x = m1.add_parameter("x", s);
+        auto y = m1.add_parameter("y", s);
+        auto xt =
+            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), x);
+        auto yt =
+            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), y);
+        auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 2}}), xt, yt);
+        m1.add_return({concat});
+    }
+    run_pass(m1);
+
+    migraphx::module m2;
+    {
+        auto x      = m2.add_parameter("x", s);
+        auto y      = m2.add_parameter("y", s);
+        auto concat = m2.add_instruction(migraphx::make_op("concat", {{"axis", 3}}), x, y);
+        auto t = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}),
+                                    concat);
+        m2.add_return({t});
+    }
+    EXPECT(m1 == m2);
+}
+
+TEST_CASE(concat_transpose_to_standard_negative_axis)
+{
+    auto s = migraphx::shape{migraphx::shape::float_type, {1, 3, 4, 2}, {24, 4, 1, 12}};
+    migraphx::module m1;
+    {
+        auto x = m1.add_parameter("x", s);
+        auto y = m1.add_parameter("y", s);
+        auto xt =
+            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), x);
+        auto yt =
+            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), y);
+        auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", -1}}), xt, yt);
+        m1.add_return({concat});
+    }
+    run_pass(m1);
+
+    migraphx::module m2;
+    {
+        auto x      = m2.add_parameter("x", s);
+        auto y      = m2.add_parameter("y", s);
+        auto concat = m2.add_instruction(migraphx::make_op("concat", {{"axis", 2}}), x, y);
+        auto t = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}),
+                                    concat);
+        m2.add_return({t});
+    }
+    EXPECT(m1 == m2);
+}
+
+TEST_CASE(concat_transpose_to_standard_different_permutation)
+{
+    // Both transposes produce a standard shape, but they are not the same permutation, so the
+    // transpose cannot be moved past the concat.
+    auto sx = migraphx::shape{migraphx::shape::float_type, {1, 2, 4, 3}, {24, 12, 1, 4}};
+    auto sy = migraphx::shape{migraphx::shape::float_type, {1, 3, 2, 4}, {24, 4, 12, 1}};
+    migraphx::module m1;
+    {
+        auto x = m1.add_parameter("x", sx);
+        auto y = m1.add_parameter("y", sy);
+        auto xt =
+            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), x);
+        auto yt =
+            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 1, 3}}}), y);
+        auto concat = m1.add_instruction(migraphx::make_op("concat", {{"axis", 2}}), xt, yt);
+        m1.add_return({concat});
+    }
+    migraphx::module m2 = m1;
+    run_pass(m1);
+
+    EXPECT(m1 == m2);
+}
+
 TEST_CASE(concat_unsqueeze)
 {
     auto s = migraphx::shape{migraphx::shape::float_type, {11008, 4096}};


### PR DESCRIPTION
## Motivation
`find_concat_transpose` used `find_permutation` to get the permutation which breaks when the transpose return a non-transposed shape. This is updated to work correctly and removes the `assert(s.transposed())`. 

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
