### PR TITLE
Avoid the output copy when the result is an aliased view

### DIFF
--- a/src/include/migraphx/algorithm.hpp
+++ b/src/include/migraphx/algorithm.hpp
@@ -180,6 +180,20 @@ Iterator adjacent_remove_if(Iterator first, Iterator last, Predicate p)
     return first;
 }
 
+/// Similiar to std::transform but instead pass adjacent pairs to the function. Unlike
+/// std::adjacent_difference, the first element is not copied to the output, so one less element is
+/// written and the output can have a different type than the input.
+template <class Iterator, class Output, class F>
+Output adjacent_transform(Iterator first, Iterator last, Output out, F f)
+{
+    if(first == last)
+        return out;
+    // Transform the range offset by one with the original range to get the adjacent pairs
+    return std::transform(std::next(first), last, first, out, [&](auto&& after, auto&& before) {
+        return f(before, after);
+    });
+}
+
 /// Similiar to std::for_each but instead pass adjacent pairs to the function
 template <class Iterator, class F>
 Iterator adjacent_for_each(Iterator first, Iterator last, F f)

--- a/src/include/migraphx/instruction_traversal.hpp
+++ b/src/include/migraphx/instruction_traversal.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/include/migraphx/instruction_traversal.hpp
+++ b/src/include/migraphx/instruction_traversal.hpp
@@ -42,6 +42,21 @@ inline auto get_output_path(instruction_ref ins)
     });
 }
 
+// The instructions that share the buffer of `ins`, starting with `ins` and ending with the
+// instruction that owns the buffer, such as an allocation or a parameter. The path stops early
+// when an instruction aliases more than one input since there is no single buffer to follow.
+inline auto get_alias_path(instruction_ref ins)
+{
+    return unfold(ins, [](instruction_ref in) -> std::optional<instruction_ref> {
+        auto aliases = instruction::get_output_alias(in, true);
+        if(aliases.size() != 1 or aliases.front() == in)
+            return std::nullopt;
+        // An instruction_ref points into the module and not into the local vector
+        // cppcheck-suppress returnDanglingLifetime
+        return aliases.front();
+    });
+}
+
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
 #endif // MIGRAPHX_GUARD_MIGRAPHX_INSTRUCTION_TRAVERSAL_HPP

--- a/src/include/migraphx/shape_transform_descriptor.hpp
+++ b/src/include/migraphx/shape_transform_descriptor.hpp
@@ -105,6 +105,10 @@ struct MIGRAPHX_EXPORT shape_transform_descriptor
     shape_transform_descriptor to_dst_from_common() const;
     shape_transform_descriptor to_src_from_common() const;
 
+    // Transform the destination dimensions back into the original dimensions. This is empty when
+    // there is no inverse, such as when a dimension is broadcasted.
+    shape_transform_descriptor invert() const;
+
     std::vector<std::vector<std::size_t>> common_axes_map_from_src() const;
     std::vector<std::vector<std::size_t>> common_axes_map_from_dst() const;
 

--- a/src/replace_allocate.cpp
+++ b/src/replace_allocate.cpp
@@ -33,6 +33,8 @@
 #include <migraphx/op/allocate.hpp>
 #include <migraphx/logger.hpp>
 #include <migraphx/optional.hpp>
+#include <migraphx/algorithm.hpp>
+#include <migraphx/instruction_traversal.hpp>
 #include <migraphx/shape_transform_descriptor.hpp>
 #include <algorithm>
 #include <map>
@@ -119,30 +121,22 @@ get_output_debug_symbols(const module& mod)
     return mod_output_debug_symbols;
 }
 
-// Collect the shape transformations that are applied to `alloc` to produce `ins`. Instructions
-// that alias their input without changing the shape are the identity transformation, so they are
-// skipped. This includes the operator writing into the allocation.
-optional<std::vector<operation>> get_alias_transforms(instruction_ref ins, instruction_ref alloc)
+// Collect the shape transformations that are applied to the allocation at the end of `path` to
+// produce the instruction at the start of it. Instructions that alias their input without changing
+// the shape are the identity transformation, so they are skipped. This includes the operator
+// writing into the allocation.
+std::vector<operation> get_alias_transforms(const std::vector<instruction_ref>& path)
 {
     std::vector<operation> ops;
-    while(ins != alloc)
-    {
-        auto aliases = instruction::get_output_alias(ins, true);
-        if(aliases.size() != 1)
-            return nullopt;
-        auto input = aliases.front();
-        if(input == ins)
-            return nullopt;
-        if(ins->get_shape() != input->get_shape())
-        {
-            auto op = ins->normalized_operator();
-            // The descriptor records reshapes with the non-lazy operator
-            if(op.name() == "reshape_lazy")
-                op = make_op("reshape", {{"dims", ins->get_shape().lens()}});
-            ops.push_back(op);
-        }
-        ins = input;
-    }
+    adjacent_for_each(path.begin(), path.end(), [&](instruction_ref ins, instruction_ref input) {
+        if(ins->get_shape() == input->get_shape())
+            return;
+        auto op = ins->normalized_operator();
+        // The descriptor records reshapes with the non-lazy operator
+        if(op.name() == "reshape_lazy")
+            op = make_op("reshape", {{"dims", ins->get_shape().lens()}});
+        ops.push_back(op);
+    });
     std::reverse(ops.begin(), ops.end());
     return ops;
 }
@@ -178,14 +172,10 @@ optional<std::vector<operation>> invert_alias_transforms(const shape& alloc_shap
                                                          const shape& out_shape,
                                                          const std::vector<operation>& ops)
 {
-    auto desc = shape_transform_descriptor::create(alloc_shape.lens(), ops);
-    // A broadcast cannot be inverted since it does not write to every element
-    if(desc.empty() or desc.has_broadcast())
+    auto inverse = shape_transform_descriptor::create(alloc_shape.lens(), ops).invert();
+    if(inverse.empty())
         return nullopt;
-    auto result = desc.to_common_from_dst().generate();
-    auto to_src = desc.to_src_from_common().generate();
-    result.insert(result.end(), to_src.begin(), to_src.end());
-    result = optimize_shape_transforms(out_shape.lens(), result);
+    auto result = inverse.generate();
     // Reshapes need to be lazy so the output buffer is aliased instead of copied
     std::transform(result.begin(), result.end(), result.begin(), [](const operation& op) {
         if(op.name() != "reshape")
@@ -203,10 +193,9 @@ optional<std::vector<operation>> invert_alias_transforms(const shape& alloc_shap
 // shape of the allocation and then write into it directly.
 bool replace_alias_allocation(module& m, instruction_ref ins)
 {
-    auto aliases = instruction::get_output_alias(ins);
-    if(aliases.size() != 1)
-        return false;
-    auto alloc = aliases.front();
+    auto path = get_alias_path(ins);
+    std::vector<instruction_ref> aliases(path.begin(), path.end());
+    auto alloc = aliases.back();
     if(alloc->name() != "allocate" or alloc->get_shape().any_of_dynamic())
         return false;
     // Each return value needs its own output parameter, so an allocation that is shared with
@@ -216,10 +205,8 @@ bool replace_alias_allocation(module& m, instruction_ref ins)
            return contains(instruction::get_output_alias(r), alloc);
        }) > 1)
         return false;
-    auto ops = get_alias_transforms(ins, alloc);
-    if(not ops.has_value())
-        return false;
-    auto inverse = invert_alias_transforms(alloc->get_shape(), ins->get_shape(), *ops);
+    auto inverse = invert_alias_transforms(
+        alloc->get_shape(), ins->get_shape(), get_alias_transforms(aliases));
     if(not inverse.has_value())
         return false;
     auto out = m.insert_instruction(

--- a/src/replace_allocate.cpp
+++ b/src/replace_allocate.cpp
@@ -122,21 +122,24 @@ get_output_debug_symbols(const module& mod)
 }
 
 // Collect the shape transformations that are applied to the allocation at the end of `path` to
-// produce the instruction at the start of it. Instructions that alias their input without changing
-// the shape are the identity transformation, so they are skipped. This includes the operator
-// writing into the allocation.
+// produce the instruction at the start of it. An instruction that aliases its input without
+// changing the shape is the identity transformation, which is recorded as a `contiguous` since the
+// descriptor ignores it. This includes the operator writing into the allocation.
 std::vector<operation> get_alias_transforms(const std::vector<instruction_ref>& path)
 {
     std::vector<operation> ops;
-    adjacent_for_each(path.begin(), path.end(), [&](instruction_ref ins, instruction_ref input) {
-        if(ins->get_shape() == input->get_shape())
-            return;
-        auto op = ins->normalized_operator();
-        // The descriptor records reshapes with the non-lazy operator
-        if(op.name() == "reshape_lazy")
-            op = make_op("reshape", {{"dims", ins->get_shape().lens()}});
-        ops.push_back(op);
-    });
+    adjacent_transform(path.begin(),
+                       path.end(),
+                       std::back_inserter(ops),
+                       [](instruction_ref ins, instruction_ref input) {
+                           if(ins->get_shape() == input->get_shape())
+                               return make_op("contiguous");
+                           auto op = ins->normalized_operator();
+                           // The descriptor records reshapes with the non-lazy operator
+                           if(op.name() == "reshape_lazy")
+                               return make_op("reshape", {{"dims", ins->get_shape().lens()}});
+                           return op;
+                       });
     std::reverse(ops.begin(), ops.end());
     return ops;
 }

--- a/src/replace_allocate.cpp
+++ b/src/replace_allocate.cpp
@@ -32,7 +32,11 @@
 #include <migraphx/output_iterator.hpp>
 #include <migraphx/op/allocate.hpp>
 #include <migraphx/logger.hpp>
+#include <migraphx/optional.hpp>
+#include <migraphx/shape_transform_descriptor.hpp>
+#include <algorithm>
 #include <map>
+#include <numeric>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -115,18 +119,135 @@ get_output_debug_symbols(const module& mod)
     return mod_output_debug_symbols;
 }
 
+// Collect the shape transformations that are applied to `alloc` to produce `ins`. Instructions
+// that alias their input without changing the shape are the identity transformation, so they are
+// skipped. This includes the operator writing into the allocation.
+optional<std::vector<operation>> get_alias_transforms(instruction_ref ins, instruction_ref alloc)
+{
+    std::vector<operation> ops;
+    while(ins != alloc)
+    {
+        auto aliases = instruction::get_output_alias(ins, true);
+        if(aliases.size() != 1)
+            return nullopt;
+        auto input = aliases.front();
+        if(input == ins)
+            return nullopt;
+        if(ins->get_shape() != input->get_shape())
+        {
+            auto op = ins->normalized_operator();
+            // The descriptor records reshapes with the non-lazy operator
+            if(op.name() == "reshape_lazy")
+                op = make_op("reshape", {{"dims", ins->get_shape().lens()}});
+            ops.push_back(op);
+        }
+        ins = input;
+    }
+    std::reverse(ops.begin(), ops.end());
+    return ops;
+}
+
+// Compute the shape that results from applying `ops` to `s`. Every operator must be an alias of
+// its input, since a copy is what is being avoided, and it must preserve the number of elements so
+// that every element of the buffer is written to exactly once.
+optional<shape> compute_alias_view(const std::vector<operation>& ops, const shape& s)
+{
+    shape result = s;
+    for(const auto& op : ops)
+    {
+        std::vector<shape> inputs = {result};
+        if(op.output_alias(inputs).empty())
+            return nullopt;
+        try
+        {
+            result = op.compute_shape(inputs);
+        }
+        catch(const migraphx::exception&)
+        {
+            return nullopt;
+        }
+        if(result.elements() != s.elements())
+            return nullopt;
+    }
+    return result;
+}
+
+// Compute the transformations that produce `alloc_shape` from `out_shape`, which is the inverse of
+// `ops`.
+optional<std::vector<operation>> invert_alias_transforms(const shape& alloc_shape,
+                                                         const shape& out_shape,
+                                                         const std::vector<operation>& ops)
+{
+    auto desc = shape_transform_descriptor::create(alloc_shape.lens(), ops);
+    // A broadcast cannot be inverted since it does not write to every element
+    if(desc.empty() or desc.has_broadcast())
+        return nullopt;
+    auto result = desc.to_common_from_dst().generate();
+    auto to_src = desc.to_src_from_common().generate();
+    result.insert(result.end(), to_src.begin(), to_src.end());
+    result = optimize_shape_transforms(out_shape.lens(), result);
+    // Reshapes need to be lazy so the output buffer is aliased instead of copied
+    std::transform(result.begin(), result.end(), result.begin(), [](const operation& op) {
+        if(op.name() != "reshape")
+            return op;
+        return make_op("reshape_lazy", op.to_value());
+    });
+    // The transformations are only the inverse when they produce the same shape the operator
+    // writes to, otherwise the buffer would be written to in a different order
+    if(compute_alias_view(result, out_shape) != alloc_shape)
+        return nullopt;
+    return result;
+}
+
+// Rather than copying the result into the output buffer, transform the output buffer into the
+// shape of the allocation and then write into it directly.
+bool replace_alias_allocation(module& m, instruction_ref ins)
+{
+    auto aliases = instruction::get_output_alias(ins);
+    if(aliases.size() != 1)
+        return false;
+    auto alloc = aliases.front();
+    if(alloc->name() != "allocate" or alloc->get_shape().any_of_dynamic())
+        return false;
+    // Each return value needs its own output parameter, so an allocation that is shared with
+    // another return value still needs to be copied
+    auto returns = m.get_returns();
+    if(std::count_if(returns.begin(), returns.end(), [&](instruction_ref r) {
+           return contains(instruction::get_output_alias(r), alloc);
+       }) > 1)
+        return false;
+    auto ops = get_alias_transforms(ins, alloc);
+    if(not ops.has_value())
+        return false;
+    auto inverse = invert_alias_transforms(alloc->get_shape(), ins->get_shape(), *ops);
+    if(not inverse.has_value())
+        return false;
+    auto out = m.insert_instruction(
+        alloc, make_op("allocate", migraphx::value{{"shape", to_value(ins->get_shape())}}));
+    out = std::accumulate(
+        inverse->begin(), inverse->end(), out, [&](instruction_ref input, const operation& op) {
+            return m.insert_instruction(alloc, op, input);
+        });
+    m.replace_instruction(alloc, out);
+    return true;
+}
+
 void insert_copy(module& m, const allocation_model& model)
 {
-    auto returns = m.get_returns();
-    std::unordered_set<instruction_ref> returns_set(returns.begin(), returns.end());
-    for(auto ins : returns_set)
+    // Rewriting a return can change the aliases of the other returns, so visit them in order
+    std::unordered_set<instruction_ref> visited;
+    for(auto ins : m.get_returns())
     {
+        if(not visited.insert(ins).second)
+            continue;
         if(ins->get_shape().any_of_dynamic())
             continue;
         auto aliases = instruction::get_output_alias(ins);
         if(std::any_of(aliases.begin(), aliases.end(), [&](instruction_ref alias) {
                return alias->get_shape() == ins->get_shape();
            }))
+            continue;
+        if(replace_alias_allocation(m, ins))
             continue;
         auto insert_ins = std::next(ins);
         auto alloc      = m.insert_instruction(

--- a/src/shape_transform_descriptor.cpp
+++ b/src/shape_transform_descriptor.cpp
@@ -1824,6 +1824,59 @@ shape_transform_descriptor shape_transform_descriptor::to_src_from_common() cons
     return result;
 }
 
+shape_transform_descriptor shape_transform_descriptor::invert() const
+{
+    auto all_subs = get_all_subdimensions(dimensions);
+    // A broadcasted dimension is duplicated, so it cant be inverted. A hidden axis is a dimension
+    // of 1 that was broadcasted, so it cant be inverted either.
+    if(std::any_of(all_subs.begin(), all_subs.end(), [](const dimension::sub& s) {
+           return s.has_hidden_axis() or (s.origin_axis().empty() and s.len != 1);
+       }))
+        return {};
+
+    // Set the axis of each subdimension to the dimension it is currently in, since that becomes
+    // the axis of the inverted transformation, while keeping the axis it originated from so the
+    // subdimensions can be regrouped.
+    std::vector<std::pair<std::vector<std::size_t>, dimension::sub>> origins;
+    for(std::size_t i : range(dimensions.size()))
+    {
+        const auto& subs = dimensions[i].subdimensions;
+        std::transform(subs.begin(),
+                       subs.end(),
+                       range(subs.size()).begin(),
+                       std::back_inserter(origins),
+                       [&](dimension::sub s, std::size_t j) {
+                           auto origin = s.origin_axis();
+                           set_origin_axis(s, {i});
+                           s.add_split_axis(j);
+                           return std::make_pair(origin, s);
+                       });
+    }
+    // Dimensions of 1 that dont come from the original dimensions have nothing to invert to
+    erase_if(origins, [](const auto& p) { return p.first.empty(); });
+    if(origins.empty())
+        return {};
+    std::sort(
+        origins.begin(), origins.end(), by(std::less<>{}, [](const auto& p) { return p.first; }));
+
+    // Each group of subdimensions that share an origin axis becomes one of the original dimensions
+    shape_transform_descriptor result;
+    result.rank = dimensions.size();
+    group_unique(
+        origins.begin(),
+        origins.end(),
+        [&](auto start, auto last) {
+            dimension d;
+            std::transform(start, last, std::back_inserter(d.subdimensions), [](const auto& p) {
+                return p.second;
+            });
+            result.dimensions.push_back(d);
+        },
+        [](const auto& x, const auto& y) { return x.first.front() == y.first.front(); });
+    result.simplify();
+    return result;
+}
+
 std::vector<std::vector<std::size_t>> shape_transform_descriptor::common_axes_map_from_src() const
 {
     std::vector<std::vector<std::size_t>> result;

--- a/test/algorithm.cpp
+++ b/test/algorithm.cpp
@@ -83,6 +83,42 @@ MIGRAPHX_FORWARD_CONTAINER_TEST_CASE(adjacent_remove_if_non_equivalence, int)
     EXPECT(v == Container{1, 1, 1, 4, 2, 4, 2, 5, 6});
 }
 
+MIGRAPHX_FORWARD_CONTAINER_TEST_CASE(adjacent_transform_basic, int)
+{
+    Container v = {1, 3, 6, 10, 15};
+    std::vector<int> result;
+    migraphx::adjacent_transform(
+        v.begin(), v.end(), std::back_inserter(result), [](int a, int b) { return b - a; });
+    EXPECT(result == std::vector<int>{2, 3, 4, 5});
+}
+
+// Unlike std::adjacent_difference the output can have a different type than the input
+MIGRAPHX_FORWARD_CONTAINER_TEST_CASE(adjacent_transform_different_type, int)
+{
+    Container v = {1, 2, 4, 4};
+    std::vector<bool> result;
+    migraphx::adjacent_transform(v.begin(), v.end(), std::back_inserter(result), std::less<>{});
+    EXPECT(result == std::vector<bool>{true, true, false});
+}
+
+MIGRAPHX_FORWARD_CONTAINER_TEST_CASE(adjacent_transform_single, int)
+{
+    Container v = {1};
+    std::vector<int> result;
+    migraphx::adjacent_transform(
+        v.begin(), v.end(), std::back_inserter(result), [](int a, int b) { return b - a; });
+    EXPECT(result.empty());
+}
+
+MIGRAPHX_FORWARD_CONTAINER_TEST_CASE(adjacent_transform_empty, int)
+{
+    Container v;
+    std::vector<int> result;
+    migraphx::adjacent_transform(
+        v.begin(), v.end(), std::back_inserter(result), [](int a, int b) { return b - a; });
+    EXPECT(result.empty());
+}
+
 MIGRAPHX_FORWARD_CONTAINER_TEST_CASE(min_element_if_basic, int)
 {
     Container v  = {5, 3, 7, 1, 9, 2};

--- a/test/instruction_traversal.cpp
+++ b/test/instruction_traversal.cpp
@@ -1,0 +1,137 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/instruction_traversal.hpp>
+#include <migraphx/module.hpp>
+#include <migraphx/make_op.hpp>
+#include <basic_ops.hpp>
+#include <test.hpp>
+
+using instruction_refs = std::vector<migraphx::instruction_ref>;
+
+template <class Range>
+static instruction_refs collect(const Range& r)
+{
+    return {r.begin(), r.end()};
+}
+
+static migraphx::instruction_ref add_allocate(migraphx::module& m, const migraphx::shape& s)
+{
+    return m.add_instruction(migraphx::make_op("allocate", {{"shape", migraphx::to_value(s)}}));
+}
+
+TEST_CASE(output_path_linear)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 3}};
+    migraphx::module m;
+    auto x  = m.add_parameter("x", s);
+    auto p1 = m.add_instruction(pass_op{}, x);
+    auto p2 = m.add_instruction(pass_op{}, p1);
+    auto p3 = m.add_instruction(pass_op{}, p2);
+
+    EXPECT(collect(migraphx::get_output_path(x)) == instruction_refs{x, p1, p2, p3});
+    EXPECT(collect(migraphx::get_output_path(p2)) == instruction_refs{p2, p3});
+}
+
+// The path cannot be followed past an instruction that is used more than once
+TEST_CASE(output_path_multiple_outputs)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 3}};
+    migraphx::module m;
+    auto x  = m.add_parameter("x", s);
+    auto p1 = m.add_instruction(pass_op{}, x);
+    m.add_instruction(pass_op{}, p1);
+    m.add_instruction(pass_op{}, p1);
+
+    EXPECT(collect(migraphx::get_output_path(x)) == instruction_refs{x, p1});
+}
+
+TEST_CASE(output_path_no_outputs)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 3}};
+    migraphx::module m;
+    auto x = m.add_parameter("x", s);
+
+    EXPECT(collect(migraphx::get_output_path(x)) == instruction_refs{x});
+}
+
+TEST_CASE(alias_path_allocation)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 3}};
+    migraphx::module m;
+    auto alloc = add_allocate(m, s);
+    auto p1    = m.add_instruction(pass_op{}, alloc);
+    auto p2    = m.add_instruction(pass_op{}, p1);
+
+    EXPECT(collect(migraphx::get_alias_path(p2)) == instruction_refs{p2, p1, alloc});
+    EXPECT(collect(migraphx::get_alias_path(alloc)) == instruction_refs{alloc});
+}
+
+// The buffer can be owned by a parameter instead of an allocation
+TEST_CASE(alias_path_parameter)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 3}};
+    migraphx::module m;
+    auto x  = m.add_parameter("x", s);
+    auto p1 = m.add_instruction(pass_op{}, x);
+
+    EXPECT(collect(migraphx::get_alias_path(p1)) == instruction_refs{p1, x});
+}
+
+TEST_CASE(alias_path_shape_transforms)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 4, 1}};
+    migraphx::module m;
+    auto alloc = add_allocate(m, s);
+    auto p1    = m.add_instruction(pass_op{}, alloc);
+    auto sq    = m.add_instruction(migraphx::make_op("squeeze", {{"axes", {2}}}), p1);
+    auto t     = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), sq);
+
+    EXPECT(collect(migraphx::get_alias_path(t)) == instruction_refs{t, sq, p1, alloc});
+}
+
+// An operator that does not alias its input owns its own buffer
+TEST_CASE(alias_path_no_alias)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 3}};
+    migraphx::module m;
+    auto x   = m.add_parameter("x", s);
+    auto y   = m.add_parameter("y", s);
+    auto sum = m.add_instruction(sum_op{}, x, y);
+
+    EXPECT(collect(migraphx::get_alias_path(sum)) == instruction_refs{sum});
+}
+
+// There is no single buffer to follow when more than one input is aliased
+TEST_CASE(alias_path_multiple_aliases)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 3}};
+    migraphx::module m;
+    auto x  = m.add_parameter("x", s);
+    auto y  = m.add_parameter("y", s);
+    auto ma = m.add_instruction(multi_alias_op{}, x, y);
+
+    EXPECT(collect(migraphx::get_alias_path(ma)) == instruction_refs{ma});
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/replace_allocate.cpp
+++ b/test/replace_allocate.cpp
@@ -263,6 +263,170 @@ TEST_CASE(allocate_copy_with_out)
     EXPECT(m1.sort() == m2.sort());
 }
 
+TEST_CASE(allocate_out_squeeze)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 4, 1}};
+    migraphx::shape out_s{migraphx::shape::float_type, {2, 4}};
+    migraphx::module m1;
+    {
+        auto alloc =
+            m1.add_instruction(migraphx::make_op("allocate", {{"shape", migraphx::to_value(s)}}));
+        auto p1 = m1.add_instruction(pass_op{}, alloc);
+        auto sq = m1.add_instruction(migraphx::make_op("squeeze", {{"axes", {2}}}), p1);
+        m1.add_return({sq});
+    }
+    run_pass(m1, allocation_with_out_model{});
+
+    migraphx::module m2;
+    {
+        auto output = m2.add_parameter("output", out_s);
+        auto us     = m2.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {2}}}), output);
+        auto p1     = m2.add_instruction(pass_op{}, us);
+        auto sq     = m2.add_instruction(migraphx::make_op("squeeze", {{"axes", {2}}}), p1);
+        m2.add_return({sq});
+    }
+    EXPECT(m1.sort() == m2.sort());
+}
+
+TEST_CASE(allocate_out_reshape_lazy)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 4, 3}};
+    migraphx::shape out_s{migraphx::shape::float_type, {8, 3}};
+    migraphx::module m1;
+    {
+        auto alloc =
+            m1.add_instruction(migraphx::make_op("allocate", {{"shape", migraphx::to_value(s)}}));
+        auto p1  = m1.add_instruction(pass_op{}, alloc);
+        auto rsp = m1.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {8, 3}}}), p1);
+        m1.add_return({rsp});
+    }
+    run_pass(m1, allocation_with_out_model{});
+
+    migraphx::module m2;
+    {
+        auto output = m2.add_parameter("output", out_s);
+        auto rsp1 =
+            m2.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {2, 4, 3}}}), output);
+        auto p1   = m2.add_instruction(pass_op{}, rsp1);
+        auto rsp2 = m2.add_instruction(migraphx::make_op("reshape_lazy", {{"dims", {8, 3}}}), p1);
+        m2.add_return({rsp2});
+    }
+    EXPECT(m1.sort() == m2.sort());
+}
+
+TEST_CASE(allocate_out_transpose)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 4}};
+    migraphx::shape out_s{migraphx::shape::float_type, {4, 2}, {1, 4}};
+    migraphx::module m1;
+    {
+        auto alloc =
+            m1.add_instruction(migraphx::make_op("allocate", {{"shape", migraphx::to_value(s)}}));
+        auto p1 = m1.add_instruction(pass_op{}, alloc);
+        auto t  = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), p1);
+        m1.add_return({t});
+    }
+    run_pass(m1, allocation_with_out_model{});
+
+    migraphx::module m2;
+    {
+        auto output = m2.add_parameter("output", out_s);
+        auto t1 =
+            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), output);
+        auto p1 = m2.add_instruction(pass_op{}, t1);
+        auto t2 = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), p1);
+        m2.add_return({t2});
+    }
+    EXPECT(m1.sort() == m2.sort());
+}
+
+// An allocation shared by two return values cannot become the output parameter for both of them
+TEST_CASE(allocate_out_shared_alloc_copy)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 4, 1}};
+    migraphx::shape out_s{migraphx::shape::float_type, {2, 4}};
+    migraphx::module m1;
+    {
+        auto alloc =
+            m1.add_instruction(migraphx::make_op("allocate", {{"shape", migraphx::to_value(s)}}));
+        auto p1 = m1.add_instruction(pass_op{}, alloc);
+        auto sq = m1.add_instruction(migraphx::make_op("squeeze", {{"axes", {2}}}), p1);
+        m1.add_return({sq, p1});
+    }
+    run_pass(m1, allocation_with_out_model{});
+
+    migraphx::module m2;
+    {
+        auto output0 = m2.add_parameter("output_0", out_s);
+        auto output1 = m2.add_parameter("output_1", s);
+        auto p1      = m2.add_instruction(pass_op{}, output1);
+        auto sq      = m2.add_instruction(migraphx::make_op("squeeze", {{"axes", {2}}}), p1);
+        auto copy    = m2.add_instruction(migraphx::make_op("test_copy"), sq, output0);
+        m2.add_return({copy, p1});
+    }
+    EXPECT(m1.sort() == m2.sort());
+}
+
+// A broadcast is not a bijection, so the output buffer still needs a copy
+TEST_CASE(allocate_out_broadcast_copy)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 1}};
+    migraphx::shape out_s{migraphx::shape::float_type, {2, 4}, {1, 0}};
+    migraphx::module m1;
+    {
+        auto alloc =
+            m1.add_instruction(migraphx::make_op("allocate", {{"shape", migraphx::to_value(s)}}));
+        auto p1 = m1.add_instruction(pass_op{}, alloc);
+        auto mb =
+            m1.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 4}}}), p1);
+        m1.add_return({mb});
+    }
+    run_pass(m1, allocation_with_out_model{});
+
+    migraphx::module m2;
+    {
+        auto output = m2.add_parameter("output", out_s);
+        auto alloc =
+            m2.add_instruction(migraphx::make_op("allocate_with_out", {{"shape", to_value(s)}}));
+        auto p1 = m2.add_instruction(pass_op{}, alloc);
+        auto mb =
+            m2.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 4}}}), p1);
+        auto copy = m2.add_instruction(migraphx::make_op("test_copy"), mb, output);
+        m2.add_return({copy});
+    }
+    EXPECT(m1.sort() == m2.sort());
+}
+
+// A slice does not cover the whole allocation, so the output buffer still needs a copy
+TEST_CASE(allocate_out_slice_copy)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 4}};
+    migraphx::shape out_s{migraphx::shape::float_type, {2, 2}, {4, 1}};
+    migraphx::module m1;
+    {
+        auto alloc =
+            m1.add_instruction(migraphx::make_op("allocate", {{"shape", migraphx::to_value(s)}}));
+        auto p1 = m1.add_instruction(pass_op{}, alloc);
+        auto sl = m1.add_instruction(
+            migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {2}}}), p1);
+        m1.add_return({sl});
+    }
+    run_pass(m1, allocation_with_out_model{});
+
+    migraphx::module m2;
+    {
+        auto output = m2.add_parameter("output", out_s);
+        auto alloc =
+            m2.add_instruction(migraphx::make_op("allocate_with_out", {{"shape", to_value(s)}}));
+        auto p1 = m2.add_instruction(pass_op{}, alloc);
+        auto sl = m2.add_instruction(
+            migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {2}}}), p1);
+        auto copy = m2.add_instruction(migraphx::make_op("test_copy"), sl, output);
+        m2.add_return({copy});
+    }
+    EXPECT(m1.sort() == m2.sort());
+}
+
 TEST_CASE(allocate_copy_with_no_out)
 {
     migraphx::shape s{migraphx::shape::float_type, {5}};

--- a/test/shape_transform_descriptor.cpp
+++ b/test/shape_transform_descriptor.cpp
@@ -106,6 +106,31 @@ static std::vector<int64_t> run_strided_view(const migraphx::shape& s, std::int6
     return l.get_argument().reshape(s).to_vector<int64_t>();
 }
 
+static std::vector<std::size_t> compute_dims(const std::vector<std::size_t>& dims,
+                                             const std::vector<migraphx::operation>& ops)
+{
+    migraphx::shape s{migraphx::shape::int64_type, dims};
+    for(const auto& op : ops)
+        s = op.compute_shape({s});
+    return s.lens();
+}
+
+// Generate the operators that invert `ops`, and check that applying them afterwards gives back
+// the original tensor
+static std::vector<migraphx::operation> check_invert(const std::vector<std::size_t>& dims,
+                                                     const std::vector<migraphx::operation>& ops)
+{
+    auto inverse = migraphx::shape_transform_descriptor::create(dims, ops).invert();
+    if(inverse.empty())
+        return {};
+    auto result = inverse.generate();
+    auto all    = ops;
+    all.insert(all.end(), result.begin(), result.end());
+    CHECK(compute_dims(dims, all) == dims);
+    CHECK(run_shape_transforms(dims, all) == run_shape_transforms(dims, {}));
+    return result;
+}
+
 static std::vector<migraphx::operation>
 check_optimize_shape_transforms(const std::vector<std::size_t>& dims,
                                 const std::vector<migraphx::operation>& ops)
@@ -1273,6 +1298,65 @@ TEST_CASE(rebase_adjust_squeeze_unsqueeze_broadcast)
         EXPECT(desc.generate() == ops{});
     }
 }
+
+TEST_CASE(invert_squeeze)
+{
+    EXPECT(check_invert({2, 8, 1}, {make_op("squeeze", {{"axes", {2}}})}) ==
+           ops{make_op("unsqueeze", {{"axes", {2}}})});
+    EXPECT(check_invert({1, 2, 8}, {make_op("squeeze", {{"axes", {0}}})}) ==
+           ops{make_op("unsqueeze", {{"axes", {0}}})});
+    EXPECT(check_invert({2, 8}, {make_op("unsqueeze", {{"axes", {1}}})}) ==
+           ops{make_op("squeeze", {{"axes", {1}}})});
+}
+
+TEST_CASE(invert_reshape)
+{
+    EXPECT(check_invert({2, 4, 3}, {make_op("reshape", {{"dims", {8, 3}}})}) ==
+           ops{make_op("reshape", {{"dims", {2, 4, 3}}})});
+    EXPECT(check_invert({8, 3}, {make_op("reshape", {{"dims", {2, 4, 3}}})}) ==
+           ops{make_op("reshape", {{"dims", {8, 3}}})});
+    // Splitting an axis and then merging it needs two reshapes
+    EXPECT(check_invert({2, 32, 2560}, {make_op("reshape", {{"dims", {2, 1280, 8, 8}}})}) ==
+           ops{make_op("reshape", {{"dims", {2, 32, 40, 8, 8}}}),
+               make_op("reshape", {{"dims", {2, 32, 2560}}})});
+}
+
+TEST_CASE(invert_transpose)
+{
+    EXPECT(check_invert({2, 4}, {make_op("transpose", {{"permutation", {1, 0}}})}) ==
+           ops{make_op("transpose", {{"permutation", {1, 0}}})});
+    EXPECT(check_invert({2, 4, 8}, {make_op("transpose", {{"permutation", {1, 2, 0}}})}) ==
+           ops{make_op("transpose", {{"permutation", {2, 0, 1}}})});
+}
+
+TEST_CASE(invert_multiple)
+{
+    EXPECT(check_invert({2, 4, 3},
+                        {make_op("reshape", {{"dims", {8, 3}}}),
+                         make_op("transpose", {{"permutation", {1, 0}}})}) ==
+           ops{make_op("reshape", {{"dims", {3, 2, 4}}}),
+               make_op("transpose", {{"permutation", {1, 2, 0}}})});
+    EXPECT(check_invert({2, 4, 1},
+                        {make_op("squeeze", {{"axes", {2}}}),
+                         make_op("transpose", {{"permutation", {1, 0}}})}) ==
+           ops{make_op("unsqueeze", {{"axes", {1}}}),
+               make_op("transpose", {{"permutation", {2, 0, 1}}})});
+}
+
+TEST_CASE(invert_broadcast)
+{
+    // A broadcast duplicates elements so it has no inverse
+    EXPECT(migraphx::shape_transform_descriptor::create(
+               {2, 1}, {make_op("multibroadcast", {{"out_lens", {2, 4}}})})
+               .invert()
+               .empty());
+    EXPECT(migraphx::shape_transform_descriptor::create(
+               {2}, {make_op("broadcast", {{"axis", 0}, {"out_lens", {2, 4}}})})
+               .invert()
+               .empty());
+}
+
+TEST_CASE(invert_empty) { EXPECT(migraphx::shape_transform_descriptor{}.invert().empty()); }
 
 TEST_CASE(generate_shape_transforms_for)
 {

--- a/test/shape_transform_descriptor.cpp
+++ b/test/shape_transform_descriptor.cpp
@@ -1343,6 +1343,15 @@ TEST_CASE(invert_multiple)
                make_op("transpose", {{"permutation", {2, 0, 1}}})});
 }
 
+TEST_CASE(invert_contiguous)
+{
+    // A contiguous does not change the dimensions so it is ignored
+    EXPECT(check_invert({2, 8, 1},
+                        {make_op("contiguous"),
+                         make_op("squeeze", {{"axes", {2}}}),
+                         make_op("contiguous")}) == ops{make_op("unsqueeze", {{"axes", {2}}})});
+}
+
 TEST_CASE(invert_broadcast)
 {
     // A broadcast duplicates elements so it has no inverse


### PR DESCRIPTION
## Motivation

When a program's return value is a shape transformation of the buffer an operator wrote
into, `replace_allocate` inserted a copy into the output parameter. Consider a reduction
whose result gets squeezed:

```
@alloc = allocate[{2, 8192, 1}]
@y     = fused_reduce(@x, @alloc)     ; {2, 8192, 1}
@r     = squeeze[axes={2}](@y)        ; {2, 8192}
@return @r
```

The output parameter has shape `{2, 8192}` while the allocation the kernel writes into has
shape `{2, 8192, 1}`. Those shapes aren't equal, so the pass allocated a scratch buffer, ran
the kernel into it, and appended a `hip::copy` to move the result into the parameter.

That copy is pure overhead. `squeeze` is an aliasing operator — it doesn't move any data, it
just relabels the dimensions. The bytes the kernel writes are already in exactly the layout
the caller expects; only the descriptor of those bytes differs. Rather than writing to
scratch and copying, the output parameter itself can be unsqueezed to `{2, 8192, 1}` and
handed to the kernel as its output buffer. The result is one fewer kernel launch, one fewer
scratch allocation, and one less full pass over the output.

This generalizes past `squeeze`. Any chain of aliasing view operators between the allocation
and the return — squeeze, unsqueeze, transpose, lazy reshape, and combinations — can be
inverted and applied to the output parameter instead. Chains that genuinely move data still
get their copy.

## Technical Details

### `replace_allocate`

Before falling back to a copy, `insert_copy` now attempts `replace_alias_allocation`:

1. **Walk the alias chain.** `get_alias_path` yields the instructions sharing the return
   value's buffer, ending at whatever owns it. The rewrite only applies when that owner is an
   `allocate` with a static shape.

2. **Collect the forward transformation.** Each adjacent pair in the path contributes the
   transformation the aliasing instruction applies to the buffer it aliases. Instructions
   whose shape matches what they alias are the identity — this includes the operator writing
   into the allocation — and are recorded as `contiguous`, which
   `shape_transform_descriptor::apply` already skips. `reshape_lazy` is recorded as a plain
   `reshape` because that's the operator the descriptor understands.

3. **Invert.** A descriptor is built from the allocation's lengths plus those operators, then
   inverted; generated `reshape`s become `reshape_lazy` so the buffer is aliased rather than
   copied.

4. **Verify before committing.** The inverse operators are folded over the output shape, and
   the result must equal the allocation's shape exactly, strides included. Since every
   operator is an offset-free aliasing view, matching shapes means the composition of the
   forward chain over the inverse is the identity address map on the output buffer — the
   kernel writes precisely the bytes the caller expects. Anything that isn't an alias,
   doesn't preserve the element count, or throws during `compute_shape` aborts the rewrite.

5. **Rewrite.** A new allocation with the return's shape is inserted, the inverse operators
   applied, and the old allocation replaced by that view. The return then aliases an
   allocation whose shape already matches, so the pass's existing machinery turns it into the
   output parameter unchanged.

Copies still happen where they must: broadcasts aren't surjective; slices aren't recordable
by the descriptor at all; and an allocation reachable from more than one return value is
skipped, because collapsing two return values onto one output parameter would leave a gap in
the `#output_N` numbering that `select_module` and `gpu/loop.cpp` both key off. The return
loop also now iterates in order rather than through an `unordered_set`, since a rewrite can
change another return's aliases and the previous iteration order was nondeterministic.

### `shape_transform_descriptor::invert()`

Returns a descriptor for the reverse transformation, or an empty one when no inverse exists.
The construction is a regrouping: each subdimension takes the axis of the dimension it
currently sits in — that becomes the axis of the inverted transformation — while remembering
the axis it came from, and subdimensions sharing an origin axis are grouped back into the
original dimensions. `simplify()` restores destination axes of length 1 that were dropped, so
the generated operators squeeze them.

It returns empty for anything non-injective: a broadcast subdimension, or a hidden axis,
which is a length-1 dimension that was broadcast. Since `create` already yields an empty
descriptor for operators it cannot record, the caller's bail-out is a single `empty()` check.

The output is canonical, not merely correct — on split, merge, transpose, and squeeze cases
it matches `create(dst_lens, inverse_ops)` exactly, so `invert().generate()` is already what
`optimize_shape_transforms` would produce and no separate optimization step is needed.

### `get_alias_path`

An `unfold`-based range in `instruction_traversal.hpp`, alongside the existing
`get_output_path`. It stops early when an instruction aliases more than one input, since
there's no single buffer to follow, which lets callers simply check whether the last element
is what they expected.

### `adjacent_transform`

A new algorithm in `algorithm.hpp` next to `adjacent_remove_if` and `adjacent_for_each`,
implemented by driving `std::transform` with the range offset by one against the original. It
exists because `std::adjacent_difference` cannot express this: that algorithm emits one
output per input and copies the first input element through unchanged, which forces the
output's value type to match the input's — a `std::vector<operation>` cannot receive an
`instruction_ref`. `adjacent_transform` writes n−1 outputs and places no such constraint on
the output type.

### Tests

- `test/replace_allocate.cpp`: squeeze, `reshape_lazy`, and transpose chains, plus the
  broadcast, slice, and shared-allocation fallbacks.
- `test/shape_transform_descriptor.cpp`: inversion of squeeze, reshape, transpose, composed
  chains, `contiguous`, broadcast, and empty. Each round-trips — the generated inverse is
  appended to the original operators and both the resulting lengths and the actual element
  ordering must come back unchanged.
- `test/algorithm.cpp`: `adjacent_transform` over `vector`, `list`, and `forward_list`,
  including a different-output-type case and the single-element and empty ranges.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
