### PR TITLE
Select the fused reduce algorithm in the tuning config and tune block_tile block sizes

### DIFF
--- a/src/targets/gpu/jit/reduce.cpp
+++ b/src/targets/gpu/jit/reduce.cpp
@@ -665,7 +665,19 @@ struct fused_reduce_compiler : compiler<fused_reduce_compiler>
             if(plan.algo == "block")
             {
                 if(tile.has_value() and plan.assign == "assign_none")
-                    tc.solutions.push_back({{"algo", "block_tile"}});
+                {
+                    // For the cache-bound tiled reduction a smaller workgroup
+                    // that leaves about 4 elements per lane pipelines enough
+                    // loads to often beat the default block size, so offer
+                    // both and let benchmarking decide
+                    std::size_t max_block = tile->size == 2 ? 512 : 256;
+                    add_block_size_solutions(
+                        tc,
+                        "block_tile",
+                        compute_block_size(
+                            ctx, std::max<std::size_t>(plan.relements / 4, 1), max_block),
+                        compute_block_size(ctx, plan.relements, max_block));
+                }
                 add_block_size_solutions(tc,
                                          "block",
                                          compute_block_size(ctx, plan.relements, 256),

--- a/src/targets/gpu/jit/reduce.cpp
+++ b/src/targets/gpu/jit/reduce.cpp
@@ -538,7 +538,7 @@ struct fused_reduce_compiler : compiler<fused_reduce_compiler>
         if(algo == "block" or algo == "block_tile")
         {
             auto n_per_block = v.get("n_per_block", std::size_t{1});
-            auto block_size = v.get("block_size", compute_block_size(ctx, relements, 1024));
+            auto block_size  = v.get("block_size", compute_block_size(ctx, relements, 1024));
             assert(n_per_block > 0);
             assert(block_size > 0);
             assert(nelements % n_per_block == 0);

--- a/src/targets/gpu/jit/reduce.cpp
+++ b/src/targets/gpu/jit/reduce.cpp
@@ -537,8 +537,11 @@ struct fused_reduce_compiler : compiler<fused_reduce_compiler>
         options.virtual_inputs = plan.virtual_inputs;
         if(algo == "block" or algo == "block_tile")
         {
+            auto n_per_block = v.get("n_per_block", std::size_t{1});
             auto block_size = v.get("block_size", compute_block_size(ctx, relements, 1024));
+            assert(n_per_block > 0);
             assert(block_size > 0);
+            assert(nelements % n_per_block == 0);
             if(relements >= (block_size - 1) * 256)
             {
                 algo = "block_large";
@@ -546,18 +549,14 @@ struct fused_reduce_compiler : compiler<fused_reduce_compiler>
             else if(algo == "block_tile")
             {
                 auto tile_axis   = v.at("tile_axis").to<std::size_t>();
-                auto n_per_block = v.at("n_per_block").to<std::size_t>();
-                assert(n_per_block > 0);
-                assert(nelements % n_per_block == 0);
                 // Smaller workgroups keep the reused loads resident in cache
                 block_size = v.get(
                     "block_size", compute_block_size(ctx, relements, n_per_block == 2 ? 512 : 256));
                 algo = "block_tile<" + std::to_string(tile_axis) + ", " +
                        std::to_string(n_per_block) + ">";
-                nelements /= n_per_block;
             }
             options.set_launch_params(
-                v, compute_global_for(ctx, nelements * block_size, 256), block_size);
+                v, compute_global_for(ctx, nelements * block_size / n_per_block, 256), block_size);
         }
         else if(algo == "wave")
         {

--- a/src/targets/gpu/jit/reduce.cpp
+++ b/src/targets/gpu/jit/reduce.cpp
@@ -532,68 +532,54 @@ struct fused_reduce_compiler : compiler<fused_reduce_compiler>
         auto nelements = plan.reduce_output_shape.elements();
 
         hip_compile_options options;
-        options.inputs             = plan.finputs;
+        options.inputs         = plan.finputs;
         options.output         = inputs.back();
-        options.virtual_inputs     = plan.virtual_inputs;
-        optional<reduce_tile> tile = nullopt;
-        if(plan.assign == "assign_none" and
-           (algo == "block_tile" or (algo == "block" and not v.contains("algo"))))
-            tile = find_reduce_tile(options.virtual_inputs,
-                                    noutputs,
-                                    plan.reduce_output_shape,
-                                    plan.reduction_shape.lens());
-        if(algo == "block_tile")
-            algo = "block";
-        if(algo == "block" or algo == "wave")
+        options.virtual_inputs = plan.virtual_inputs;
+        if(algo == "block" or algo == "block_tile")
         {
-            if(algo == "block")
+            auto block_size = v.get("block_size", compute_block_size(ctx, relements, 1024));
+            assert(block_size > 0);
+            if(relements >= (block_size - 1) * 256)
             {
-                auto block_size = v.get("block_size", compute_block_size(ctx, relements, 1024));
-                assert(block_size > 0);
-                if(relements >= (block_size - 1) * 256)
-                {
-                    algo = "block_large";
-                }
-                else if(tile.has_value())
-                {
-                    // Smaller workgroups keep the reused loads resident in cache
-                    auto max_block = tile->size == 2 ? 512 : 256;
-                    block_size = v.get("block_size", compute_block_size(ctx, relements, max_block));
-                    algo       = "block_tile<" + std::to_string(tile->axis) + ", " +
-                           std::to_string(tile->size) + ">";
-                    nelements /= tile->size;
-                }
-                options.set_launch_params(
-                    v, compute_global_for(ctx, nelements * block_size, 256), block_size);
+                algo = "block_large";
             }
-            else
+            else if(algo == "block_tile")
             {
-                auto subwave_size = v.get("subwave_size", compute_subwave_size(ctx, relements));
-                algo              = "subwave<" + std::to_string(subwave_size) + ">";
-                options.set_launch_params(v,
-                                          compute_global_for(ctx, nelements * subwave_size, 256),
-                                          ctx.get_current_device().get_wavefront_size());
+                auto tile_axis   = v.at("tile_axis").to<std::size_t>();
+                auto n_per_block = v.at("n_per_block").to<std::size_t>();
+                assert(n_per_block > 0);
+                assert(nelements % n_per_block == 0);
+                // Smaller workgroups keep the reused loads resident in cache
+                block_size = v.get(
+                    "block_size", compute_block_size(ctx, relements, n_per_block == 2 ? 512 : 256));
+                algo = "block_tile<" + std::to_string(tile_axis) + ", " +
+                       std::to_string(n_per_block) + ">";
+                nelements /= n_per_block;
             }
+            options.set_launch_params(
+                v, compute_global_for(ctx, nelements * block_size, 256), block_size);
         }
-        else if(algo == "lane" or algo == "block_strided")
+        else if(algo == "wave")
         {
-            optional<strided_tile> stile;
-            if(algo == "block_strided" or
-               (prefer_block_strided(ctx, plan, noutputs) and not v.contains("algo")))
-                stile = find_strided_tile(ctx, relements, v.get("block_size", 256));
-            if(stile.has_value())
-            {
-                algo         = stile->algo();
-                auto ngroups = (nelements + stile->out_tile - 1) / stile->out_tile;
-                options.set_launch_params(v,
-                                          compute_global_for(ctx, ngroups * stile->block_size, 256),
-                                          stile->block_size);
-            }
-            else
-            {
-                algo = "lane";
-                options.set_launch_params(v, compute_global_for(ctx, nelements, 256));
-            }
+            auto subwave_size = v.get("subwave_size", compute_subwave_size(ctx, relements));
+            algo              = "subwave<" + std::to_string(subwave_size) + ">";
+            options.set_launch_params(v,
+                                      compute_global_for(ctx, nelements * subwave_size, 256),
+                                      ctx.get_current_device().get_wavefront_size());
+        }
+        else if(algo == "block_strided")
+        {
+            auto stile = find_strided_tile(ctx, relements, v.get("block_size", 256));
+            if(not stile.has_value())
+                MIGRAPHX_THROW("Invalid block_size for block_strided reduce");
+            algo         = stile->algo();
+            auto ngroups = (nelements + stile->out_tile - 1) / stile->out_tile;
+            options.set_launch_params(
+                v, compute_global_for(ctx, ngroups * stile->block_size, 256), stile->block_size);
+        }
+        else if(algo == "lane")
+        {
+            options.set_launch_params(v, compute_global_for(ctx, nelements, 256));
         }
         else
         {
@@ -633,15 +619,23 @@ struct fused_reduce_compiler : compiler<fused_reduce_compiler>
     }
 
     /// Add a solution for the algo with the given block size, plus the
-    /// larger-block alternative when it differs
+    /// larger-block alternative when it differs. The extra parameters are
+    /// included in each solution.
     static void add_block_size_solutions(tuning_config& tc,
                                          const std::string& algo,
                                          std::size_t block_size,
-                                         std::size_t large_block_size)
+                                         std::size_t large_block_size,
+                                         const value& extra = value::object{})
     {
-        tc.solutions.push_back({{"algo", algo}, {"block_size", block_size}});
+        auto solution          = extra;
+        solution["algo"]       = algo;
+        solution["block_size"] = block_size;
+        tc.solutions.push_back(solution);
         if(large_block_size != block_size)
-            tc.solutions.push_back({{"algo", algo}, {"block_size", large_block_size}});
+        {
+            solution["block_size"] = large_block_size;
+            tc.solutions.push_back(solution);
+        }
     }
 
     optional<tuning_config>
@@ -658,8 +652,8 @@ struct fused_reduce_compiler : compiler<fused_reduce_compiler>
             plan.virtual_inputs, noutputs, plan.reduce_output_shape, plan.reduction_shape.lens());
         if(not exhaustive)
         {
-            // Without exhaustive tuning, offer the algorithms compile_op would pick on its own
-            // plus a few alternatives so benchmarking can decide: block_tile when a tile is
+            // Without exhaustive tuning, offer the heuristic default algorithm plus a few
+            // alternatives so benchmarking can decide: block_tile when a tile is
             // found, a larger block size (max 1024 instead of 256) for block, and
             // block_strided when the lane heuristics prefer it.
             if(plan.algo == "block")
@@ -676,7 +670,8 @@ struct fused_reduce_compiler : compiler<fused_reduce_compiler>
                         "block_tile",
                         compute_block_size(
                             ctx, std::max<std::size_t>(plan.relements / 4, 1), max_block),
-                        compute_block_size(ctx, plan.relements, max_block));
+                        compute_block_size(ctx, plan.relements, max_block),
+                        {{"tile_axis", tile->axis}, {"n_per_block", tile->size}});
                 }
                 add_block_size_solutions(tc,
                                          "block",
@@ -726,10 +721,13 @@ struct fused_reduce_compiler : compiler<fused_reduce_compiler>
         tc.solutions.push_back({{"algo", "lane"}});
         for(auto block_size : {128, 256, 512, 1024})
             tc.solutions.push_back({{"algo", "block_strided"}, {"block_size", block_size}});
-        if(tile.has_value())
+        if(tile.has_value() and plan.assign == "assign_none")
         {
             for(auto block_size : {64, 128, 256, 512})
-                tc.solutions.push_back({{"algo", "block_tile"}, {"block_size", block_size}});
+                tc.solutions.push_back({{"algo", "block_tile"},
+                                        {"block_size", block_size},
+                                        {"tile_axis", tile->axis},
+                                        {"n_per_block", tile->size}});
         }
         return tc;
     }

--- a/src/targets/gpu/jit/reduce.cpp
+++ b/src/targets/gpu/jit/reduce.cpp
@@ -548,7 +548,7 @@ struct fused_reduce_compiler : compiler<fused_reduce_compiler>
             }
             else if(algo == "block_tile")
             {
-                auto tile_axis   = v.at("tile_axis").to<std::size_t>();
+                auto tile_axis = v.at("tile_axis").to<std::size_t>();
                 // Smaller workgroups keep the reused loads resident in cache
                 block_size = v.get(
                     "block_size", compute_block_size(ctx, relements, n_per_block == 2 ? 512 : 256));


### PR DESCRIPTION
## Motivation

A broadcast-heavy reduction (batch-2 GEMV pattern: `{2, 8192, 4096}` fp16 mul + reduce over
the last axis) ran at 0.0595ms when the `block_tile` algorithm can do it at 0.0448ms (1.33x
faster). The default tuning config only offered `block_tile` at its heuristic block size
(512), where it loses the compile-time benchmark to plain `block/256` — smaller block sizes
pipeline more loads per lane and reduce the cross-wave LDS combine, but were only reachable
with `--exhaustive-tune`.

Fixing this also exposed a structural problem: `compile_op` re-derived the algorithm on its
own (re-running `find_reduce_tile`, promoting `block` to `block_tile`, falling back from
`block_strided` to `lane`), so the solution picked by benchmarking didn't fully determine
the compiled kernel.

## Technical Details

- `get_tuning_config` now always sets the algorithm in each solution; `compile_op` only
  materializes the kernel template and launch parameters for the algo it is given. The one
  remaining algo change in `compile_op` is the `block_large` upgrade when `relements`
  exceeds the unrolled-loop limit for the block size.
- `block_tile` solutions carry explicit `tile_axis` and `n_per_block` (the tile size, which
  divides `nelements` for the launch grid) instead of `compile_op` recomputing the tile via
  `find_reduce_tile`. `add_block_size_solutions` takes an optional `extra` value to attach
  these parameters.
- The non-exhaustive config now offers `block_tile` at two block sizes: the previous
  default plus one targeting ~4 elements per lane
  (`compute_block_size(relements / 4, max_block)`), letting benchmarking pick the winner.
- Cleanups from centralizing the decision: exhaustive `block_tile` candidates are gated on
  `assign_none` (previously they silently degraded to plain `block` for
  `split_fused_reduce`), and an invalid explicit `block_strided` block size now throws
  instead of silently becoming `lane`.

Verified on gfx1201: the motivating reduction now compiles to `block_tile<0, 2>` with
block_size 128 by default (0.0595ms → 0.0448ms), and the `wave`, `block_strided`, `lane`,
exhaustive-tune, and `split_fused_reduce` paths all still verify correctly.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
