### PR TITLE
Remove MIGRAPHX_ENABLE_NHWC and make convolution layout a backend option

### DIFF
--- a/docs/driver/compile.rst
+++ b/docs/driver/compile.rst
@@ -34,6 +34,10 @@ Number of chiplets (XCCs) to assume for cross-compilation. Only used when ``--gp
 
 Device properties to assume for cross-compilation, as a JSON object (e.g. ``"{arch:gfx942, num_cu:120, num_chiplets:1, max_threads_per_cu:2048, max_threads_per_block:1024}"``). Overrides ``--gpu-arch``, ``--gpu-num-cus`` and ``--gpu-num-chiplets`` for any keys present. Specifying ``arch`` here is sufficient to enable cross-compilation without ``--gpu-arch``.
 
+.. option::  --backend-options [std::string]
+
+Target-specific compile options, as a JSON object (e.g. ``"{convolution_layout:channels_last}"``). Options the target does not recognize are ignored. 
+
 .. option::  --enable-offload-copy
 
 Enable implicit offload copying

--- a/docs/reference/MIGraphX-dev-env-vars.rst
+++ b/docs/reference/MIGraphX-dev-env-vars.rst
@@ -21,14 +21,6 @@ Model performance tunable variables change the compilation behavior of a model. 
   * - Environment variable
     - Values
 
-  * - | ``MIGRAPHX_ENABLE_NHWC``
-      | Forces the model to use the NHWC layout.
-      
-    - | ``1``: Forces the use of the NHWC layout.
-      | ``0``: Returns to default behavior.
-
-      | Default: The use of the NHWC layout isn't forced.
-
   * - | ``MIGRAPHX_DISABLE_MLIR``
       | When set, the rocMLIR library won't be used.
       

--- a/docs/reference/MIGraphX-dev-env-vars.rst
+++ b/docs/reference/MIGraphX-dev-env-vars.rst
@@ -21,6 +21,15 @@ Model performance tunable variables change the compilation behavior of a model. 
   * - Environment variable
     - Values
 
+  * - | ``MIGRAPHX_GPU_OPTIONS``
+      | Overrides the backend options the gpu target is compiled with.
+
+    - | A JSON object of backend options, such as ``{convolution_layout:channels_last}``.
+      | Quotes around the keys and values are optional. Options the target doesn't
+      | recognize are ignored.
+
+      | Default: The backend options passed to compile are used unchanged.
+
   * - | ``MIGRAPHX_DISABLE_MLIR``
       | When set, the rocMLIR library won't be used.
       

--- a/docs/reference/MIGraphX-py.rst
+++ b/docs/reference/MIGraphX-py.rst
@@ -279,7 +279,7 @@ program
 
     :rtype: list[shape]
 
-.. py:method:: compile(t, offload_copy=True, fast_math=True, exhaustive_tune=False)
+.. py:method:: compile(t, offload_copy=True, fast_math=True, exhaustive_tune=False, advance_backend_options={})
 
     Compiles the program for the target and optimizes it.
 
@@ -287,6 +287,7 @@ program
     :param bool offload_copy: For targets with offloaded memory(such as the gpu), this will insert instructions during compilation to copy the input parameters to the offloaded memory and to copy the final result from the offloaded memory back to main memory.
     :param bool fast_math: Optimize math functions to use faster approximate versions. There may be slight accuracy degredation when enabled.
     :param exhaustive_tune: Flag to enable exhaustive search to find the fastest version of generated kernels for selected backend.
+    :param dict advance_backend_options: Backend-specific compilation options. Options unknown to the target are ignored. 
 
 .. py:method:: get_main_module()
     

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -47,6 +47,7 @@
 #endif
 #include <migraphx/sym.hpp>
 #include <migraphx/stringutils.hpp>
+#include <migraphx/compile_options.hpp>
 #include <migraphx/convert_to_json.hpp>
 #include <migraphx/load_save.hpp>
 #include <migraphx/json.hpp>
@@ -842,6 +843,8 @@ struct compiler
     bool to_int8 = false;
     bool to_int4 = false;
 
+    std::string backend_options;
+
     std::vector<std::string> fill0;
     std::vector<std::string> fill1;
     void parse(argument_parser& ap)
@@ -849,6 +852,12 @@ struct compiler
         l.parse(ap);
         parameters.parse(ap);
         ct.parse(ap);
+        ap(backend_options,
+           {"--backend-options"},
+           ap.help("Target-specific compile options, as a JSON object (format: "
+                   "\"{convolution_layout:channels_last}\"). Options the target does not "
+                   "recognize are ignored."));
+        ap.post_action([this](auto&&) { this->apply_backend_options(); });
         ap(co.offload_copy,
            {"--enable-offload-copy"},
            ap.help("Enable implicit offload copying"),
@@ -866,6 +875,16 @@ struct compiler
         ap(to_int8, {"--int8"}, ap.help("Quantize for int8"), ap.set_value(true));
         ap(to_fp8, {"--fp8"}, ap.help("Quantize for fp8"), ap.set_value(true));
         ap(to_int4, {"--int4-weights"}, ap.help("Quantize weights for int4"), ap.set_value(true));
+    }
+
+    void apply_backend_options()
+    {
+        if(backend_options.empty())
+            return;
+        auto v = from_json_string(convert_to_json(backend_options));
+        if(not v.is_object())
+            MIGRAPHX_THROW("--backend-options must be a JSON object");
+        migraphx::set_backend_options(co, v);
     }
 
     auto params(const program& p)

--- a/src/include/migraphx/layout_convolution.hpp
+++ b/src/include/migraphx/layout_convolution.hpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <migraphx/instruction_ref.hpp>
 #include <migraphx/config.hpp>
+#include <migraphx/enum.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -38,12 +39,7 @@ struct module_pass_manager;
  */
 struct MIGRAPHX_EXPORT layout_convolution
 {
-    enum layout_order
-    {
-        channels_first,
-        channels_last,
-        channels_auto
-    };
+    MIGRAPHX_NESTED_ENUM(layout_order, channels_first, channels_last, channels_auto)
     layout_order order = channels_first;
     std::string name() const { return "layout_convolution"; }
     void apply(module_pass_manager& mpm) const;

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -91,7 +91,6 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_DISABLE_SCHEDULE_PASS)
-MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_NHWC)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_REWRITE_DOT)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_REWRITE_LRN)
 #ifndef _WIN32
@@ -106,11 +105,14 @@ namespace {
 struct backend_options
 {
     std::vector<std::string> mlss_use_specific_ops = {};
+    // Layout used for convolutions, by name: channels_first, channels_last, or channels_auto.
+    layout_convolution::layout_order convolution_layout = layout_convolution::channels_auto;
 
     template <class Self, class F>
     static auto reflect(Self& self, F f)
     {
-        return pack(f(self.mlss_use_specific_ops, "mlss_use_specific_ops"));
+        return pack(f(self.mlss_use_specific_ops, "mlss_use_specific_ops"),
+                    f(self.convolution_layout, "convolution_layout"));
     }
 };
 
@@ -177,9 +179,7 @@ struct pipeline_factory
             dead_code_elimination{},
             rewrite_gelu{options.fast_math},
             optimize_module{},
-            layout_convolution{.order = enabled(MIGRAPHX_ENABLE_NHWC{})
-                                            ? layout_convolution::channels_last
-                                            : layout_convolution::channels_auto},
+            layout_convolution{.order = backend_opts.convolution_layout},
             dead_code_elimination{},
             enable_pass(disabled(MIGRAPHX_ENABLE_FULL_DYNAMIC{}), fuse_horizontal{}),
             dead_code_elimination{},

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -24,6 +24,7 @@
 #include <migraphx/adjust_allocation.hpp>
 #include <migraphx/auto_contiguous.hpp>
 #include <migraphx/check_context.hpp>
+#include <migraphx/convert_to_json.hpp>
 #include <migraphx/dead_code_elimination.hpp>
 #include <migraphx/eliminate_allocation.hpp>
 #include <migraphx/eliminate_concat.hpp>
@@ -37,6 +38,7 @@
 #include <migraphx/fuse_pointwise_reduce.hpp>
 #include <migraphx/inline_module.hpp>
 #include <migraphx/insert_pad.hpp>
+#include <migraphx/json.hpp>
 #include <migraphx/layout_convolution.hpp>
 #include <migraphx/memory_coloring.hpp>
 #include <migraphx/normalize_ops.hpp>
@@ -91,6 +93,7 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_DISABLE_SCHEDULE_PASS)
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GPU_OPTIONS)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_ENABLE_REWRITE_DOT)
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_REWRITE_LRN)
 #ifndef _WIN32
@@ -115,6 +118,23 @@ struct backend_options
                     f(self.convolution_layout, "convolution_layout"));
     }
 };
+
+// The backend options passed to compile, with any key set by MIGRAPHX_GPU_OPTIONS (a json-like
+// object such as "{convolution_layout:channels_last}") overriding it.
+backend_options get_backend_options(const compile_options& options)
+{
+    auto opts = options.backend_options;
+    auto env  = string_value_of(MIGRAPHX_GPU_OPTIONS{});
+    if(not env.empty())
+    {
+        auto v = from_json_string(convert_to_json(env));
+        if(not v.is_object())
+            MIGRAPHX_THROW("MIGRAPHX_GPU_OPTIONS must be a json object");
+        for(const auto& opt : v)
+            opts[opt.get_key()] = opt.without_key();
+    }
+    return from_value<backend_options>(value(opts));
+}
 
 struct pipeline_factory
 {
@@ -278,7 +298,7 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
     ctx.set_exhaustive_tune_flag(options.exhaustive_tune);
     ctx.load_problem_cache(); // TODO: update load_problem_cache to include gpu arch
 
-    pipeline_factory p{&gctx, options, from_value<backend_options>(value(options.backend_options))};
+    pipeline_factory p{&gctx, options, get_backend_options(options)};
 
     std::vector<std::vector<pass>> pipelines = {
         p.dynamic_shapes_pipeline(),

--- a/test/gpu/layout_convolution_option.cpp
+++ b/test/gpu/layout_convolution_option.cpp
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/compile_options.hpp>
+#include <migraphx/instruction.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/module.hpp>
+#include <migraphx/permutation.hpp>
+#include <migraphx/program.hpp>
+#include <migraphx/register_target.hpp>
+#include <migraphx/shape.hpp>
+#include <test.hpp>
+
+static migraphx::program compile_conv(const std::string& order)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    auto x   = mm->add_parameter("x", {migraphx::shape::float_type, {1, 8, 8, 8}});
+    auto w   = mm->add_parameter("w", {migraphx::shape::float_type, {8, 8, 3, 3}});
+    mm->add_return({mm->add_instruction(migraphx::make_op("convolution"), x, w)});
+
+    migraphx::compile_options options;
+    options.backend_options["convolution_layout"] = order;
+    p.compile(migraphx::make_target("gpu"), options);
+    return p;
+}
+
+static bool has_channels_last(const migraphx::program& p)
+{
+    const auto* mm = p.get_main_module();
+    return std::any_of(mm->begin(), mm->end(), [](const migraphx::instruction& ins) {
+        const auto& s = ins.get_shape();
+        return s.ndim() == 4 and
+               migraphx::find_permutation(s) == std::vector<std::int64_t>{0, 2, 3, 1};
+    });
+}
+
+TEST_CASE(channels_first) { EXPECT(not has_channels_last(compile_conv("channels_first"))); }
+
+TEST_CASE(channels_last) { EXPECT(has_channels_last(compile_conv("channels_last"))); }
+
+TEST_CASE(unknown_order)
+{
+    EXPECT(test::throws([] { compile_conv("nhwc"); }));
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/tools/autotune_perf/autotune_perf.py
+++ b/tools/autotune_perf/autotune_perf.py
@@ -34,7 +34,6 @@ written out as a sourceable ``export`` file with one ``export`` line per
 env var in the winning row. Pass ``--no-combos`` to skip the multi-knob
 combinations (faster, but cannot find coupled wins). The probed knobs are:
 
-* ``MIGRAPHX_ENABLE_NHWC`` - prefer NHWC layout for convolutions.
 * ``MIGRAPHX_SET_GEMM_PROVIDER`` - select the GEMM backend (rocBLAS).
 * ``MIGRAPHX_ENABLE_CK`` - enable Composable Kernel GEMMs.
 * ``MIGRAPHX_DISABLE_MLIR`` - disable the MLIR code path.
@@ -66,7 +65,6 @@ Setting = tuple[str, str]
 Settings = tuple[Setting, ...]
 
 KNOBS: tuple[tuple[str, Setting], ...] = (
-    ("NHWC layout", ("MIGRAPHX_ENABLE_NHWC", "1")),
     ("GEMM provider rocBLAS", ("MIGRAPHX_SET_GEMM_PROVIDER", "rocblas")),
     ("Enable CK GEMM", ("MIGRAPHX_ENABLE_CK", "1")),
     ("Disable MLIR", ("MIGRAPHX_DISABLE_MLIR", "1")),
@@ -92,12 +90,7 @@ COMBOS: tuple[tuple[str, Settings], ...] = (
         ("MIGRAPHX_ENABLE_CK", "1"),
         ("MIGRAPHX_MLIR_USE_SPECIFIC_OPS", _MLIR_OPS_WHITELIST),
     )),
-    ("NHWC + MIOpen pooling", (
-        ("MIGRAPHX_ENABLE_NHWC", "1"),
-        ("MIGRAPHX_ENABLE_MIOPEN_POOLING", "1"),
-    )),
-    ("NHWC + Conv->dot + rocBLAS", (
-        ("MIGRAPHX_ENABLE_NHWC", "1"),
+    ("Conv->dot + rocBLAS", (
         ("MIGRAPHX_ENABLE_REWRITE_DOT", "1"),
         ("MIGRAPHX_SET_GEMM_PROVIDER", "rocblas"),
     )),


### PR DESCRIPTION
## Motivation
The env variable couldnt force NCHW when NHWC is automatically picked. This moves it to a backend option as we move towards using backend options instead of env variables to get better per model control.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
