### PR TITLE
Disable ccache when using #embed

### DIFF
--- a/cmake/Embed.cmake
+++ b/cmake/Embed.cmake
@@ -289,6 +289,24 @@ extern const size_t _binary_${OUTPUT_SYMBOL}_length = sizeof(_binary_${OUTPUT_SY
     set(OUTPUT_SYMBOL ${OUTPUT_SYMBOL} PARENT_SCOPE)
 endfunction()
 
+# The launcher is only cleared when it is ccache, so other launchers(such as distcc or
+# sccache) are left in place
+function(embed_disable_ccache TARGET)
+    foreach(LANG C CXX)
+        get_target_property(LAUNCHER ${TARGET} ${LANG}_COMPILER_LAUNCHER)
+        if(NOT LAUNCHER)
+            continue()
+        endif()
+        foreach(PROGRAM ${LAUNCHER})
+            get_filename_component(PROGRAM_NAME "${PROGRAM}" NAME_WE)
+            if(PROGRAM_NAME STREQUAL "ccache")
+                set_target_properties(${TARGET} PROPERTIES ${LANG}_COMPILER_LAUNCHER "")
+                break()
+            endif()
+        endforeach()
+    endforeach()
+endfunction()
+
 function(add_embed_library EMBED_NAME)
     set(options)
     set(oneValueArgs RELATIVE)
@@ -331,6 +349,11 @@ function(add_embed_library EMBED_NAME)
         endif()
     endforeach()
     set_target_properties(${INTERNAL_EMBED_LIB} PROPERTIES POSITION_INDEPENDENT_CODE On)
+    if(EMBED_USE STREQUAL "HASH_EMBED")
+        # ccache does not track the data files read by the #embed directive, so it will
+        # return a stale object when only the data file changes
+        embed_disable_ccache(${INTERNAL_EMBED_LIB})
+    endif()
     add_library(${EMBED_NAME} INTERFACE)
     if(EMBED_USE STREQUAL "RC")
         target_link_libraries(${EMBED_NAME} INTERFACE $<TARGET_OBJECTS:${INTERNAL_EMBED_LIB}>)

--- a/cmake/Embed.cmake
+++ b/cmake/Embed.cmake
@@ -289,7 +289,7 @@ extern const size_t _binary_${OUTPUT_SYMBOL}_length = sizeof(_binary_${OUTPUT_SY
     set(OUTPUT_SYMBOL ${OUTPUT_SYMBOL} PARENT_SCOPE)
 endfunction()
 
-# The launcher is only cleared when it is ccache, so other launchers(such as distcc or
+# The launcher is only cleared when it is ccache, so other launchers (such as distcc or
 # sccache) are left in place
 function(embed_disable_ccache TARGET)
     foreach(LANG C CXX)
@@ -297,13 +297,11 @@ function(embed_disable_ccache TARGET)
         if(NOT LAUNCHER)
             continue()
         endif()
-        foreach(PROGRAM ${LAUNCHER})
-            get_filename_component(PROGRAM_NAME "${PROGRAM}" NAME_WE)
-            if(PROGRAM_NAME STREQUAL "ccache")
-                set_target_properties(${TARGET} PROPERTIES ${LANG}_COMPILER_LAUNCHER "")
-                break()
-            endif()
-        endforeach()
+        list(GET LAUNCHER 0 PROGRAM)
+        get_filename_component(PROGRAM_NAME "${PROGRAM}" NAME_WE)
+        if(PROGRAM_NAME STREQUAL "ccache")
+            set_target_properties(${TARGET} PROPERTIES ${LANG}_COMPILER_LAUNCHER "")
+        endif()
     endforeach()
 endfunction()
 


### PR DESCRIPTION
## Motivation
The current ccache version doesnt handle `#embed` correctly causing to use stale files. This fixes it by disabling ccache on the embed target. 

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
