### PR TITLE
Add adaptive benchmarking to MIGraphX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,15 @@ Full documentation for MIGraphX is available at
 * Added slice squeeze matcher to propagate squeeze downstream and allow for parallel branches to merge together (#5004).
 * Added GPU kernel for ONNX `NonMaxSuppression` operation and redesigned the `nonmaxsuppression` operation to better represent the data-dependent output shape in the MIGraphX IR (#4893).
 * Added mixed length gather fusion in same_table_gather_horizontal_fusion to bundle gather kernels that share the same data (#5044).
+* Added a verbose terminate handler for exceptions on Windows (#5084).
+* Added a `--start-from` or `-s` flag to test binaries which resumes from a test name in the list instead of the beginning (#5072).
+* Added a `promote_storage_type` pass that treats the given types as storage-only, computing elementwise and reduction instructions of those types in float instead, and enabled it on the GPU target for `bf16` on architectures without native bf16 arithmetic instructions (#5138).
+* Added a `dyn_slice` operator, `dyn_slice(data, starts, ends)`, whose symbolic `starts`/`ends` attributes describe the run-time bound inputs so a data-dependent slice keeps a symbolic output shape; the axes are an attribute since they must be known when the shape is computed (#5112).
+* Added symbolic normalization of operator attributes holding `sym::expr`, clamping each value against its axis length symbolically (#5148).
+* Added symbolic evaluation of tensor values to preserve ONNX shape-tensor expressions through arithmetic and dynamic shape consumers, including `Reshape`, `Range`, `Slice`, `Expand`, `ConstantOfShape`, and `Trilu` (#5148).
+* Added a `find_slice_reshaped_concat` matcher to `simplify_reshapes` that forwards a slice reading exactly one segment of a concat through intervening reshape/transpose view ops, removing the concat entirely (#5183).
+* Added find_concat_same_broadcast matcher to convert concat of identical broadcasts into a single multibroadcast to reduce hipCopy() (#5179).
+* Added adaptive GPU JIT tuning that briefly benchmarks each valid candidate, then remeasures the fastest candidates with a larger timing budget.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,14 +100,6 @@ Full documentation for MIGraphX is available at
 * Added slice squeeze matcher to propagate squeeze downstream and allow for parallel branches to merge together (#5004).
 * Added GPU kernel for ONNX `NonMaxSuppression` operation and redesigned the `nonmaxsuppression` operation to better represent the data-dependent output shape in the MIGraphX IR (#4893).
 * Added mixed length gather fusion in same_table_gather_horizontal_fusion to bundle gather kernels that share the same data (#5044).
-* Added a verbose terminate handler for exceptions on Windows (#5084).
-* Added a `--start-from` or `-s` flag to test binaries which resumes from a test name in the list instead of the beginning (#5072).
-* Added a `promote_storage_type` pass that treats the given types as storage-only, computing elementwise and reduction instructions of those types in float instead, and enabled it on the GPU target for `bf16` on architectures without native bf16 arithmetic instructions (#5138).
-* Added a `dyn_slice` operator, `dyn_slice(data, starts, ends)`, whose symbolic `starts`/`ends` attributes describe the run-time bound inputs so a data-dependent slice keeps a symbolic output shape; the axes are an attribute since they must be known when the shape is computed (#5112).
-* Added symbolic normalization of operator attributes holding `sym::expr`, clamping each value against its axis length symbolically (#5148).
-* Added symbolic evaluation of tensor values to preserve ONNX shape-tensor expressions through arithmetic and dynamic shape consumers, including `Reshape`, `Range`, `Slice`, `Expand`, `ConstantOfShape`, and `Trilu` (#5148).
-* Added a `find_slice_reshaped_concat` matcher to `simplify_reshapes` that forwards a slice reading exactly one segment of a concat through intervening reshape/transpose view ops, removing the concat entirely (#5183).
-* Added find_concat_same_broadcast matcher to convert concat of identical broadcasts into a single multibroadcast to reduce hipCopy() (#5179).
 * Added adaptive GPU JIT tuning that briefly benchmarks each valid candidate, then remeasures the fastest candidates with a larger timing budget.
 
 

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -46,6 +46,7 @@
 #include <migraphx/gpu/lower_device_ops.hpp>
 #include <migraphx/gpu/time_op.hpp>
 #include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <functional>
 
@@ -57,6 +58,9 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GPU_COMPILE_PARALLEL);
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_TRACE_BENCHMARKING);
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_SKIP_BENCHMARKING);
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GPU_DUMP_BENCHMARK_MXR);
+
+// Match the fixed per-candidate work budget used before adaptive timing.
+constexpr std::size_t benchmark_samples = 20;
 
 adaptive_tuning_options compile_ops_tuning_overrides::resolve() const
 {
@@ -486,10 +490,25 @@ struct compile_plan
             return *results[i];
         }
 
+        auto tuning_options = tuning;
+        if(tuning_options.top_k >= valid_indices.size())
+            tuning_options.top_k = 0;
+
         // GPU failures tend to be sticky, so one broken candidate usually takes every later one
         // down with it. Keep the first message to report instead of a more general message.
         std::string first_error;
+        std::vector<optional<prepared_time_program>> prepared(results.size());
+        std::vector<std::size_t> benchmark_bundles(results.size());
+        std::vector<std::size_t> execution_budgets(results.size());
+        std::vector<std::size_t> execution_counts(results.size());
+        // Coarse candidates share input buffers with identical fill policies. Their prepared
+        // state is released before precise timing so finalists are measured from fresh state.
+        std::vector<std::pair<std::unordered_map<std::string, double>,
+                              std::shared_ptr<parameter_map>>>
+            shared_parameter_maps;
+        bool precise_started = false;
         auto time_solution = [&](std::size_t i,
+                                 adaptive_time_stage stage,
                                  const adaptive_time_options& input_options) -> optional<double> {
             if(not results[i].has_value())
             {
@@ -499,28 +518,102 @@ struct compile_plan
             }
 
             if(trace_level > 1)
-                std::cout << "Benchmarking solution: " << config->solutions.at(i) << std::endl;
+                std::cout << (stage == adaptive_time_stage::coarse ? "Coarsely" : "Precisely")
+                          << " benchmarking solution: " << config->solutions.at(i) << std::endl;
+            std::size_t prepared_executions = 0;
             try
             {
                 if(trace_level > 2)
                     std::cout << *results[i] << std::endl;
-                /*
-                 * Replacing the instruction in this small program inserts every code object and
-                 * prefill required by the candidate, so split-k is timed end to end.
-                 */
-                auto bench_prog = results[i]->make_program();
-                if(trace_level > 2)
-                    std::cout << bench_prog << std::endl;
+                if(stage == adaptive_time_stage::precise and not precise_started)
+                {
+                    // Precise candidates start with fresh programs and parameters, while coarse
+                    // executions remain charged to each candidate's lifetime execution budget.
+                    std::fill(prepared.begin(), prepared.end(), nullopt);
+                    shared_parameter_maps.clear();
+                    precise_started = true;
+                }
+                if(not prepared[i].has_value())
+                {
+                    /*
+                     * Replacing the instruction in this small program inserts every code object
+                     * and prefill required by the candidate, so split-k is timed end to end.
+                     */
+                    auto bench_prog = results[i]->make_program();
+                    if(trace_level > 2)
+                        std::cout << bench_prog << std::endl;
+                    benchmark_bundles[i] =
+                        compute_benchmark_bundle(*bench_prog.get_main_module());
+                    if(execution_budgets[i] == 0)
+                        execution_budgets[i] =
+                            1 + benchmark_samples * benchmark_bundles[i];
+                    const auto& fill_map = results[i]->replace.fill_map;
+                    auto params = shared_parameter_maps.end();
+                    if(stage == adaptive_time_stage::coarse)
+                    {
+                        params = std::find_if(
+                            shared_parameter_maps.begin(),
+                            shared_parameter_maps.end(),
+                            [&](const auto& x) { return x.first == fill_map; });
+                    }
+                    auto benchmark = prepare_time_program(
+                        *ctx,
+                        std::move(bench_prog),
+                        fill_map,
+                        params == shared_parameter_maps.end() ? nullptr : params->second);
+                    if(stage == adaptive_time_stage::coarse and
+                       params == shared_parameter_maps.end())
+                        shared_parameter_maps.emplace_back(fill_map, benchmark.params);
+                    prepared[i] = std::move(benchmark);
+                    if(trace_level > 1)
+                        std::cout << "Prepared benchmark solution: " << config->solutions.at(i)
+                                  << std::endl;
+                }
+
+                auto& benchmark = *prepared[i];
+                prepared_executions = benchmark.executions;
+                const auto used     = execution_counts[i];
+                if(used >= execution_budgets[i])
+                {
+                    prepared[i] = nullopt;
+                    return nullopt;
+                }
+                const auto remaining = execution_budgets[i] - used;
+
                 auto options             = input_options;
-                options.preferred_bundle = compute_benchmark_bundle(*bench_prog.get_main_module());
-                auto measured            = adaptive_time_program(
-                    *ctx, std::move(bench_prog), results[i]->replace.fill_map, options);
+                options.preferred_bundle = benchmark_bundles[i];
+                options.max_executions   = std::min(options.max_executions, remaining);
+                adaptive_time_budget budget;
+                budget.max_executions = remaining;
+                if(stage == adaptive_time_stage::coarse)
+                {
+                    // Coarse timing only needs lazy initialization, one estimate, and one short
+                    // bundled ranking measurement. Precise timing receives the lifetime budget
+                    // left by this call.
+                    budget.max_executions =
+                        std::min(budget.max_executions, 2 + options.preferred_bundle);
+                }
+                auto measured = adaptive_time_program(benchmark, options, budget);
+                execution_counts[i] += benchmark.executions - prepared_executions;
+                if(not std::isfinite(measured) or measured <= 0.0)
+                {
+                    prepared[i] = nullopt;
+                    return measured;
+                }
+
+                if(stage == adaptive_time_stage::precise)
+                    prepared[i] = nullopt;
                 if(trace_level > 1)
                     std::cout << measured << "ms" << std::endl;
                 return measured;
             }
             catch(const std::exception& e)
             {
+                if(prepared[i].has_value())
+                {
+                    execution_counts[i] += prepared[i]->executions - prepared_executions;
+                    prepared[i] = nullopt;
+                }
                 if(first_error.empty())
                     first_error =
                         "solution " + to_string(config->solutions.at(i)) + ": " + e.what();
@@ -531,10 +624,8 @@ struct compile_plan
             }
         };
 
-        auto tuning_options = tuning;
-        if(tuning_options.top_k >= valid_indices.size())
-            tuning_options.top_k = 0;
-        const auto winner = adaptive_time_topk(results.size(), tuning_options, time_solution);
+        const auto winner =
+            adaptive_time_topk_staged(results.size(), tuning_options, time_solution);
         if(not winner.has_value())
             MIGRAPHX_THROW("No valid tuned benchmark for " + preop.name() + " with " +
                            problem_string() +
@@ -732,3 +823,4 @@ void compile_ops::apply(module_pass_manager& mpm) const
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
+

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -62,6 +62,11 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GPU_DUMP_BENCHMARK_MXR);
 // Match the fixed per-candidate work budget used before adaptive timing.
 constexpr std::size_t benchmark_samples = 20;
 
+// Samples the coarse stage may spend on one candidate. Ranking a fast candidate from a single
+// bundled run lets event overhead decide the order, and four is the smallest count that
+// common_average trims. Slow candidates still collapse to fewer samples through min_samples.
+constexpr std::size_t coarse_samples = 4;
+
 adaptive_tuning_options compile_ops_tuning_overrides::resolve() const
 {
     const auto apply = [](std::size_t& output,
@@ -497,16 +502,12 @@ struct compile_plan
         // GPU failures tend to be sticky, so one broken candidate usually takes every later one
         // down with it. Keep the first message to report instead of a more general message.
         std::string first_error;
-        std::vector<optional<prepared_time_program>> prepared(results.size());
-        std::vector<std::size_t> benchmark_bundles(results.size());
-        std::vector<std::size_t> execution_budgets(results.size());
         std::vector<std::size_t> execution_counts(results.size());
-        // Coarse candidates share input buffers with identical fill policies. Their prepared
-        // state is released before precise timing so finalists are measured from fresh state.
+        // Coarse candidates share input buffers with identical fill policies. The buffers are
+        // released before precise timing so finalists are measured from fresh state.
         std::vector<std::pair<std::unordered_map<std::string, double>,
                               std::shared_ptr<parameter_map>>>
             shared_parameter_maps;
-        bool precise_started = false;
         auto time_solution = [&](std::size_t i,
                                  adaptive_time_stage stage,
                                  const adaptive_time_options& input_options) -> optional<double> {
@@ -520,100 +521,75 @@ struct compile_plan
             if(trace_level > 1)
                 std::cout << (stage == adaptive_time_stage::coarse ? "Coarsely" : "Precisely")
                           << " benchmarking solution: " << config->solutions.at(i) << std::endl;
-            std::size_t prepared_executions = 0;
+            // Held for one timing only so that loaded code objects and input buffers are not
+            // retained for every candidate at once.
+            optional<prepared_time_program> prepared;
             try
             {
                 if(trace_level > 2)
                     std::cout << *results[i] << std::endl;
-                if(stage == adaptive_time_stage::precise and not precise_started)
-                {
-                    // Precise candidates start with fresh programs and parameters, while coarse
-                    // executions remain charged to each candidate's lifetime execution budget.
-                    std::fill(prepared.begin(), prepared.end(), nullopt);
+                // Precise candidates start from fresh programs and parameters, while coarse
+                // executions remain charged to each candidate's lifetime execution budget.
+                if(stage == adaptive_time_stage::precise)
                     shared_parameter_maps.clear();
-                    precise_started = true;
-                }
-                if(not prepared[i].has_value())
-                {
-                    /*
-                     * Replacing the instruction in this small program inserts every code object
-                     * and prefill required by the candidate, so split-k is timed end to end.
-                     */
-                    auto bench_prog = results[i]->make_program();
-                    if(trace_level > 2)
-                        std::cout << bench_prog << std::endl;
-                    benchmark_bundles[i] =
-                        compute_benchmark_bundle(*bench_prog.get_main_module());
-                    if(execution_budgets[i] == 0)
-                        execution_budgets[i] =
-                            1 + benchmark_samples * benchmark_bundles[i];
-                    const auto& fill_map = results[i]->replace.fill_map;
-                    auto params = shared_parameter_maps.end();
-                    if(stage == adaptive_time_stage::coarse)
-                    {
-                        params = std::find_if(
-                            shared_parameter_maps.begin(),
-                            shared_parameter_maps.end(),
-                            [&](const auto& x) { return x.first == fill_map; });
-                    }
-                    auto benchmark = prepare_time_program(
-                        *ctx,
-                        std::move(bench_prog),
-                        fill_map,
-                        params == shared_parameter_maps.end() ? nullptr : params->second);
-                    if(stage == adaptive_time_stage::coarse and
-                       params == shared_parameter_maps.end())
-                        shared_parameter_maps.emplace_back(fill_map, benchmark.params);
-                    prepared[i] = std::move(benchmark);
-                    if(trace_level > 1)
-                        std::cout << "Prepared benchmark solution: " << config->solutions.at(i)
-                                  << std::endl;
-                }
+                /*
+                 * Replacing the instruction in this small program inserts every code object
+                 * and prefill required by the candidate, so split-k is timed end to end.
+                 */
+                auto bench_prog = results[i]->make_program();
+                if(trace_level > 2)
+                    std::cout << bench_prog << std::endl;
+                const auto bundle = compute_benchmark_bundle(*bench_prog.get_main_module());
 
-                auto& benchmark = *prepared[i];
-                prepared_executions = benchmark.executions;
-                const auto used     = execution_counts[i];
-                if(used >= execution_budgets[i])
-                {
-                    prepared[i] = nullopt;
+                // Lifetime budget for this candidate, drawn down by both timing stages.
+                const auto candidate_budget = 1 + benchmark_samples * bundle;
+                const auto used             = execution_counts[i];
+                if(used >= candidate_budget)
                     return nullopt;
-                }
-                const auto remaining = execution_budgets[i] - used;
+                const auto remaining = candidate_budget - used;
+
+                const auto& fill_map = results[i]->replace.fill_map;
+                auto params          = shared_parameter_maps.end();
+                if(stage == adaptive_time_stage::coarse)
+                    params = std::find_if(shared_parameter_maps.begin(),
+                                          shared_parameter_maps.end(),
+                                          [&](const auto& x) { return x.first == fill_map; });
+                prepared = prepare_time_program(
+                    *ctx,
+                    std::move(bench_prog),
+                    fill_map,
+                    params == shared_parameter_maps.end() ? nullptr : params->second);
+                if(stage == adaptive_time_stage::coarse and params == shared_parameter_maps.end())
+                    shared_parameter_maps.emplace_back(fill_map, prepared->params);
+                if(trace_level > 1)
+                    std::cout << "Prepared benchmark solution: " << config->solutions.at(i)
+                              << std::endl;
 
                 auto options             = input_options;
-                options.preferred_bundle = benchmark_bundles[i];
+                options.preferred_bundle = bundle;
                 options.max_executions   = std::min(options.max_executions, remaining);
                 adaptive_time_budget budget;
                 budget.max_executions = remaining;
                 if(stage == adaptive_time_stage::coarse)
                 {
-                    // Coarse timing only needs lazy initialization, one estimate, and one short
-                    // bundled ranking measurement. Precise timing receives the lifetime budget
-                    // left by this call.
+                    // Coarse timing needs lazy initialization, one estimate, and up to
+                    // coarse_samples bundled ranking measurements. Precise timing receives the
+                    // lifetime budget left by this call.
                     budget.max_executions =
-                        std::min(budget.max_executions, 2 + options.preferred_bundle);
+                        std::min(budget.max_executions, 2 + coarse_samples * bundle);
                 }
-                auto measured = adaptive_time_program(benchmark, options, budget);
-                execution_counts[i] += benchmark.executions - prepared_executions;
+                auto measured = adaptive_time_program(*prepared, options, budget);
+                execution_counts[i] += prepared->executions;
                 if(not std::isfinite(measured) or measured <= 0.0)
-                {
-                    prepared[i] = nullopt;
-                    return measured;
-                }
-
-                if(stage == adaptive_time_stage::precise)
-                    prepared[i] = nullopt;
+                    return nullopt;
                 if(trace_level > 1)
                     std::cout << measured << "ms" << std::endl;
                 return measured;
             }
             catch(const std::exception& e)
             {
-                if(prepared[i].has_value())
-                {
-                    execution_counts[i] += prepared[i]->executions - prepared_executions;
-                    prepared[i] = nullopt;
-                }
+                if(prepared.has_value())
+                    execution_counts[i] += prepared->executions;
                 if(first_error.empty())
                     first_error =
                         "solution " + to_string(config->solutions.at(i)) + ": " + e.what();

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -334,6 +334,21 @@ struct compiled_result
     }
 };
 
+// Input buffers reused across coarsely timed candidates. Candidates for one problem can allocate
+// different workspaces, so the parameter layout is part of the key and not just the fill policy.
+struct shared_benchmark_inputs
+{
+    std::unordered_map<std::string, double> fill_map;
+    std::unordered_map<std::string, shape> parameter_shapes;
+    std::shared_ptr<parameter_map> params;
+
+    bool matches(const std::unordered_map<std::string, double>& other_fill_map,
+                 const std::unordered_map<std::string, shape>& other_shapes) const
+    {
+        return fill_map == other_fill_map and parameter_shapes == other_shapes;
+    }
+};
+
 // forward declared since it requires compile_manager
 static void replace_inserted_device_ops(context& ctx, module& m);
 
@@ -503,11 +518,10 @@ struct compile_plan
         // down with it. Keep the first message to report instead of a more general message.
         std::string first_error;
         std::vector<std::size_t> execution_counts(results.size());
-        // Coarse candidates share input buffers with identical fill policies. The buffers are
-        // released before precise timing so finalists are measured from fresh state.
-        std::vector<std::pair<std::unordered_map<std::string, double>,
-                              std::shared_ptr<parameter_map>>>
-            shared_parameter_maps;
+        // Coarse candidates share input buffers when their fill policy and parameter layout agree.
+        // The buffers are released before precise timing so finalists are measured from fresh
+        // state.
+        std::vector<shared_benchmark_inputs> shared_inputs;
         auto time_solution = [&](std::size_t i,
                                  adaptive_time_stage stage,
                                  const adaptive_time_options& input_options) -> optional<double> {
@@ -531,7 +545,7 @@ struct compile_plan
                 // Precise candidates start from fresh programs and parameters, while coarse
                 // executions remain charged to each candidate's lifetime execution budget.
                 if(stage == adaptive_time_stage::precise)
-                    shared_parameter_maps.clear();
+                    shared_inputs.clear();
                 /*
                  * Replacing the instruction in this small program inserts every code object
                  * and prefill required by the candidate, so split-k is timed end to end.
@@ -548,19 +562,22 @@ struct compile_plan
                     return nullopt;
                 const auto remaining = candidate_budget - used;
 
-                const auto& fill_map = results[i]->replace.fill_map;
-                auto params          = shared_parameter_maps.end();
+                const auto& fill_map  = results[i]->replace.fill_map;
+                auto parameter_shapes = bench_prog.get_parameter_shapes();
+                auto shared           = shared_inputs.end();
                 if(stage == adaptive_time_stage::coarse)
-                    params = std::find_if(shared_parameter_maps.begin(),
-                                          shared_parameter_maps.end(),
-                                          [&](const auto& x) { return x.first == fill_map; });
-                prepared = prepare_time_program(
-                    *ctx,
-                    std::move(bench_prog),
-                    fill_map,
-                    params == shared_parameter_maps.end() ? nullptr : params->second);
-                if(stage == adaptive_time_stage::coarse and params == shared_parameter_maps.end())
-                    shared_parameter_maps.emplace_back(fill_map, prepared->params);
+                    shared = std::find_if(
+                        shared_inputs.begin(), shared_inputs.end(), [&](const auto& x) {
+                            return x.matches(fill_map, parameter_shapes);
+                        });
+                prepared =
+                    prepare_time_program(*ctx,
+                                         std::move(bench_prog),
+                                         fill_map,
+                                         shared == shared_inputs.end() ? nullptr : shared->params);
+                if(stage == adaptive_time_stage::coarse and shared == shared_inputs.end())
+                    shared_inputs.push_back(
+                        {fill_map, std::move(parameter_shapes), prepared->params});
                 if(trace_level > 1)
                     std::cout << "Prepared benchmark solution: " << config->solutions.at(i)
                               << std::endl;

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -58,6 +58,32 @@ MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_TRACE_BENCHMARKING);
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_SKIP_BENCHMARKING);
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_GPU_DUMP_BENCHMARK_MXR);
 
+adaptive_tuning_options compile_ops_tuning_overrides::resolve() const
+{
+    const auto apply = [](std::size_t& output,
+                          const optional<std::int64_t>& input,
+                          const char* name,
+                          bool allow_zero) {
+        if(not input.has_value())
+            return;
+        if(*input < 0)
+            MIGRAPHX_THROW(std::string{name} + " must not be negative");
+        if(not allow_zero and *input == 0)
+            MIGRAPHX_THROW(std::string{name} + " must be greater than zero");
+        output = static_cast<std::size_t>(*input);
+    };
+
+    adaptive_tuning_options result;
+    apply(result.top_k, top_k, "tuning_top_k", true);
+    apply(result.coarse.target_ms, coarse_target_ms, "tuning_coarse_target_ms", false);
+    apply(result.precise.target_ms, precise_target_ms, "tuning_precise_target_ms", false);
+    apply(result.coarse.max_samples, max_samples, "tuning_max_samples", false);
+    if(max_samples.has_value())
+        result.precise.max_samples = result.coarse.max_samples;
+    apply(result.sleep_us, sleep_us, "tuning_sleep_us", true);
+    return result;
+}
+
 // Inner repeat count when timing a candidate, raised for split-k (kernel + prefill).
 static std::size_t compute_benchmark_bundle(const module& m)
 {
@@ -310,6 +336,7 @@ struct compile_plan
     module_ref mod;
     optional<tuning_config> config                 = nullopt;
     std::vector<optional<compiled_result>> results = {};
+    adaptive_tuning_options tuning                 = {};
     void update_config(bool exhaustive)
     {
         config = get_tuning_config(*ctx, ins, preop, exhaustive);
@@ -441,44 +468,79 @@ struct compile_plan
             MIGRAPHX_THROW("Multiple kernels without config for " + preop.name());
         if(trace_level > 1)
             std::cout << "Problem: " << config->problem << std::endl;
-        std::vector<double> times;
-        times.reserve(results.size());
-        std::transform(results.begin(),
-                       results.end(),
-                       config->solutions.begin(),
-                       std::back_inserter(times),
-                       [&](const auto& cr, const auto& solution) {
-                           if(trace_level > 1)
-                               std::cout << "Benchmarking solution: " << solution << std::endl;
-                           if(not cr.has_value())
-                           {
-                               if(trace_level > 1)
-                                   std::cout << "No binary" << std::endl;
-                               return std::numeric_limits<double>::max();
-                           }
-                           if(trace_level > 2)
-                               std::cout << *cr << std::endl;
-                           /*
-                           create a small program with insturction being compiled and call "replace"
-                           on that which would insert all the compiled code objects, prefills etc.
-                           necessary to run candidate code object
-                           */
-                           auto bench_prog = cr->make_program();
-                           if(trace_level > 2)
-                               std::cout << bench_prog << std::endl;
-                           auto bundle = compute_benchmark_bundle(*bench_prog.get_main_module());
-                           auto t      = time_program(*ctx,
-                                                 std::move(bench_prog),
-                                                 cr->replace.fill_map,
-                                                 bundle,
-                                                 /* nrun */ 20,
-                                                 /* target_ms */ 100);
-                           if(trace_level > 1)
-                               std::cout << t << "ms" << std::endl;
-                           return t;
-                       });
-        std::this_thread::sleep_for(std::chrono::milliseconds{50});
-        auto i = std::distance(times.begin(), std::min_element(times.begin(), times.end()));
+
+        std::vector<std::size_t> valid_indices;
+        auto indices = range(results.size());
+        std::copy_if(indices.begin(),
+                     indices.end(),
+                     std::back_inserter(valid_indices),
+                     [&](auto i) { return results[i].has_value(); });
+        if(valid_indices.empty())
+            MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
+                           problem_string() + "\n\n" + print_modules());
+
+        if(valid_indices.size() == 1)
+        {
+            const auto i = valid_indices.front();
+            ctx->get_problem_cache().insert(preop.name(), config->problem, config->solutions.at(i));
+            return *results[i];
+        }
+
+        // GPU failures tend to be sticky, so one broken candidate usually takes every later one
+        // down with it. Keep the first message to report instead of a more general message.
+        std::string first_error;
+        auto time_solution = [&](std::size_t i,
+                                 const adaptive_time_options& input_options) -> optional<double> {
+            if(not results[i].has_value())
+            {
+                if(trace_level > 1)
+                    std::cout << "No binary for solution: " << config->solutions.at(i) << std::endl;
+                return nullopt;
+            }
+
+            if(trace_level > 1)
+                std::cout << "Benchmarking solution: " << config->solutions.at(i) << std::endl;
+            try
+            {
+                if(trace_level > 2)
+                    std::cout << *results[i] << std::endl;
+                /*
+                 * Replacing the instruction in this small program inserts every code object and
+                 * prefill required by the candidate, so split-k is timed end to end.
+                 */
+                auto bench_prog = results[i]->make_program();
+                if(trace_level > 2)
+                    std::cout << bench_prog << std::endl;
+                auto options             = input_options;
+                options.preferred_bundle = compute_benchmark_bundle(*bench_prog.get_main_module());
+                auto measured            = adaptive_time_program(
+                    *ctx, std::move(bench_prog), results[i]->replace.fill_map, options);
+                if(trace_level > 1)
+                    std::cout << measured << "ms" << std::endl;
+                return measured;
+            }
+            catch(const std::exception& e)
+            {
+                if(first_error.empty())
+                    first_error =
+                        "solution " + to_string(config->solutions.at(i)) + ": " + e.what();
+                if(trace_level > 0)
+                    std::cerr << "Exception benchmarking " << preop.name() << " solution "
+                              << config->solutions.at(i) << ": " << e.what() << std::endl;
+                return nullopt;
+            }
+        };
+
+        auto tuning_options = tuning;
+        if(tuning_options.top_k >= valid_indices.size())
+            tuning_options.top_k = 0;
+        const auto winner = adaptive_time_topk(results.size(), tuning_options, time_solution);
+        if(not winner.has_value())
+            MIGRAPHX_THROW("No valid tuned benchmark for " + preop.name() + " with " +
+                           problem_string() +
+                           (first_error.empty() ? "" : "\n\nFirst error: " + first_error) + "\n\n" +
+                           print_modules());
+        const auto i = *winner;
         ctx->get_problem_cache().insert(preop.name(), config->problem, config->solutions.at(i));
         if(trace_level > 0)
         {
@@ -551,13 +613,13 @@ static void par_compile(std::size_t n, F f)
 struct compile_manager
 {
     std::vector<compile_plan> cps;
-    bool exhaustive     = false;
-    bool skip_benchmark = false;
+    bool exhaustive                = false;
+    bool skip_benchmark            = false;
+    adaptive_tuning_options tuning = {};
 
-    template <class... Ts>
-    void add_plan(Ts&&... xs)
+    void add_plan(context* ctx, const operation& preop, instruction_ref ins, module_ref mod)
     {
-        cps.push_back({std::forward<Ts>(xs)...});
+        cps.push_back({ctx, preop, ins, mod, nullopt, {}, tuning});
     }
 
     void update_configs()
@@ -648,6 +710,7 @@ void compile_ops::apply(module_pass_manager& mpm) const
     compile_manager cm;
     cm.exhaustive     = exhaustive_tune;
     cm.skip_benchmark = skip_benchmark;
+    cm.tuning         = tuning;
     // Find all precompile ops
     for(auto ins : iterator_for(m))
     {

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -46,6 +46,7 @@
 #include <migraphx/gpu/lower_device_ops.hpp>
 #include <migraphx/gpu/time_op.hpp>
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <functional>
@@ -102,6 +103,30 @@ static std::size_t compute_benchmark_bundle(const module& m)
                not starts_with(ins.name(), "@");
     });
     return std::max(1, 4 * n - 2);
+}
+
+// Executions one candidate may still spend. The lifetime total matches the fixed per-candidate
+// work of the pre-adaptive schedule and is drawn down by both timing stages.
+struct candidate_budget
+{
+    std::size_t remaining   = 0;
+    std::size_t stage_limit = 0;
+
+    bool exhausted() const { return remaining == 0; }
+};
+
+static candidate_budget
+make_candidate_budget(adaptive_time_stage stage, std::size_t bundle, std::size_t used)
+{
+    const auto lifetime = 1 + benchmark_samples * bundle;
+    if(used >= lifetime)
+        return {};
+    const auto remaining = lifetime - used;
+    if(stage == adaptive_time_stage::precise)
+        return {remaining, remaining};
+    // Coarse timing only needs lazy initialization, one estimate, and up to coarse_samples bundled
+    // ranking measurements, so it leaves most of the lifetime budget to the finalists.
+    return {remaining, std::min(remaining, 2 + coarse_samples * bundle)};
 }
 
 struct precompile_op
@@ -349,6 +374,36 @@ struct shared_benchmark_inputs
     }
 };
 
+// State that has to survive from one benchmarked candidate to the next.
+struct benchmark_state
+{
+    explicit benchmark_state(std::size_t candidate_count) : execution_counts(candidate_count) {}
+
+    std::vector<shared_benchmark_inputs> shared_inputs;
+    // How much of each candidate's lifetime execution budget the timing stages have spent.
+    std::vector<std::size_t> execution_counts;
+    // GPU failures tend to be sticky, so one broken candidate usually takes every later one down
+    // with it. Keep the first message to report instead of a more general message.
+    std::string first_error;
+
+    std::shared_ptr<parameter_map>
+    find_reusable(const std::unordered_map<std::string, double>& fill_map,
+                  const std::unordered_map<std::string, shape>& parameter_shapes) const
+    {
+        auto it = std::find_if(shared_inputs.begin(), shared_inputs.end(), [&](const auto& x) {
+            return x.matches(fill_map, parameter_shapes);
+        });
+        return it == shared_inputs.end() ? nullptr : it->params;
+    }
+
+    void keep_for_reuse(const std::unordered_map<std::string, double>& fill_map,
+                        std::unordered_map<std::string, shape> parameter_shapes,
+                        std::shared_ptr<parameter_map> params)
+    {
+        shared_inputs.push_back({fill_map, std::move(parameter_shapes), std::move(params)});
+    }
+};
+
 // forward declared since it requires compile_manager
 static void replace_inserted_device_ops(context& ctx, module& m);
 
@@ -469,6 +524,110 @@ struct compile_plan
         }
         return input_shapes.str();
     }
+    std::string no_valid_compilation_message() const
+    {
+        return "No valid tuned compilation for " + preop.name() + " with " + problem_string() +
+               "\n\n" + print_modules();
+    }
+    std::string no_valid_benchmark_message(const std::string& first_error) const
+    {
+        return "No valid tuned benchmark for " + preop.name() + " with " + problem_string() +
+               (first_error.empty() ? "" : "\n\nFirst error: " + first_error) + "\n\n" +
+               print_modules();
+    }
+
+    // Builds the runnable form of one candidate, reusing input buffers from an earlier candidate
+    // when both the fill policy and the parameter layout agree.
+    prepared_time_program prepare_candidate(benchmark_state& state,
+                                            std::size_t i,
+                                            adaptive_time_stage stage,
+                                            program bench_prog) const
+    {
+        // Finalists are measured from fresh buffers, so release what the coarse stage was sharing
+        // before this candidate allocates its own.
+        if(stage == adaptive_time_stage::precise)
+            state.shared_inputs.clear();
+
+        const auto& fill_map  = results[i]->replace.fill_map;
+        auto parameter_shapes = bench_prog.get_parameter_shapes();
+        auto reusable         = state.find_reusable(fill_map, parameter_shapes);
+
+        auto prepared = prepare_time_program(*ctx, std::move(bench_prog), fill_map, reusable);
+        // find_reusable already matched the parameter layout, so the hint is never rejected.
+        assert(reusable == nullptr or prepared.params == reusable);
+        if(stage == adaptive_time_stage::coarse and reusable == nullptr)
+            state.keep_for_reuse(fill_map, std::move(parameter_shapes), prepared.params);
+        return prepared;
+    }
+
+    // Times a single candidate, as required by adaptive_time_topk_staged. A candidate that cannot
+    // be timed is reported as unmeasured rather than as an error so that tuning can continue.
+    optional<double> time_solution(benchmark_state& state,
+                                   std::size_t i,
+                                   adaptive_time_stage stage,
+                                   const adaptive_time_options& input_options) const
+    {
+        const auto trace_level = value_of(MIGRAPHX_TRACE_BENCHMARKING{});
+        if(not results[i].has_value())
+        {
+            if(trace_level > 1)
+                std::cout << "No binary for solution: " << config->solutions.at(i) << std::endl;
+            return nullopt;
+        }
+
+        if(trace_level > 1)
+            std::cout << (stage == adaptive_time_stage::coarse ? "Coarsely" : "Precisely")
+                      << " benchmarking solution: " << config->solutions.at(i) << std::endl;
+        // Held for one timing only so that loaded code objects and input buffers are not
+        // retained for every candidate at once.
+        optional<prepared_time_program> prepared;
+        try
+        {
+            if(trace_level > 2)
+                std::cout << *results[i] << std::endl;
+            /*
+             * Replacing the instruction in this small program inserts every code object
+             * and prefill required by the candidate, so split-k is timed end to end.
+             */
+            auto bench_prog = results[i]->make_program();
+            if(trace_level > 2)
+                std::cout << bench_prog << std::endl;
+            const auto bundle = compute_benchmark_bundle(*bench_prog.get_main_module());
+            const auto budget = make_candidate_budget(stage, bundle, state.execution_counts[i]);
+            if(budget.exhausted())
+                return nullopt;
+
+            prepared = prepare_candidate(state, i, stage, std::move(bench_prog));
+            if(trace_level > 1)
+                std::cout << "Prepared benchmark solution: " << config->solutions.at(i)
+                          << std::endl;
+
+            auto options             = input_options;
+            options.preferred_bundle = bundle;
+            options.max_executions   = std::min(options.max_executions, budget.remaining);
+            adaptive_time_budget stage_budget;
+            stage_budget.max_executions = budget.stage_limit;
+            auto measured               = adaptive_time_program(*prepared, options, stage_budget);
+            state.execution_counts[i] += prepared->executions;
+            if(not std::isfinite(measured) or measured <= 0.0)
+                return nullopt;
+            if(trace_level > 1)
+                std::cout << measured << "ms" << std::endl;
+            return measured;
+        }
+        catch(const std::exception& e)
+        {
+            if(prepared.has_value())
+                state.execution_counts[i] += prepared->executions;
+            if(state.first_error.empty())
+                state.first_error =
+                    "solution " + to_string(config->solutions.at(i)) + ": " + e.what();
+            if(trace_level > 0)
+                std::cerr << "Exception benchmarking " << preop.name() << " solution "
+                          << config->solutions.at(i) << ": " << e.what() << std::endl;
+            return nullopt;
+        }
+    }
 
     const compiled_result& benchmark() const
     {
@@ -479,13 +638,11 @@ struct compile_plan
                       << std::endl;
         }
         if(results.empty())
-            MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
-                           problem_string() + "\n\n" + print_modules());
+            MIGRAPHX_THROW(no_valid_compilation_message());
         if(results.size() == 1)
         {
             if(not results.front().has_value())
-                MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
-                               problem_string() + "\n\n" + print_modules());
+                MIGRAPHX_THROW(no_valid_compilation_message());
             return *results.front();
         }
         if(not config)
@@ -500,8 +657,7 @@ struct compile_plan
                      std::back_inserter(valid_indices),
                      [&](auto i) { return results[i].has_value(); });
         if(valid_indices.empty())
-            MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
-                           problem_string() + "\n\n" + print_modules());
+            MIGRAPHX_THROW(no_valid_compilation_message());
 
         if(valid_indices.size() == 1)
         {
@@ -511,119 +667,17 @@ struct compile_plan
         }
 
         auto tuning_options = tuning;
+        // Every valid candidate would reach precise timing anyway, so skip the ranking stage.
         if(tuning_options.top_k >= valid_indices.size())
             tuning_options.top_k = 0;
 
-        // GPU failures tend to be sticky, so one broken candidate usually takes every later one
-        // down with it. Keep the first message to report instead of a more general message.
-        std::string first_error;
-        std::vector<std::size_t> execution_counts(results.size());
-        // Coarse candidates share input buffers when their fill policy and parameter layout agree.
-        // The buffers are released before precise timing so finalists are measured from fresh
-        // state.
-        std::vector<shared_benchmark_inputs> shared_inputs;
-        auto time_solution = [&](std::size_t i,
-                                 adaptive_time_stage stage,
-                                 const adaptive_time_options& input_options) -> optional<double> {
-            if(not results[i].has_value())
-            {
-                if(trace_level > 1)
-                    std::cout << "No binary for solution: " << config->solutions.at(i) << std::endl;
-                return nullopt;
-            }
-
-            if(trace_level > 1)
-                std::cout << (stage == adaptive_time_stage::coarse ? "Coarsely" : "Precisely")
-                          << " benchmarking solution: " << config->solutions.at(i) << std::endl;
-            // Held for one timing only so that loaded code objects and input buffers are not
-            // retained for every candidate at once.
-            optional<prepared_time_program> prepared;
-            try
-            {
-                if(trace_level > 2)
-                    std::cout << *results[i] << std::endl;
-                // Precise candidates start from fresh programs and parameters, while coarse
-                // executions remain charged to each candidate's lifetime execution budget.
-                if(stage == adaptive_time_stage::precise)
-                    shared_inputs.clear();
-                /*
-                 * Replacing the instruction in this small program inserts every code object
-                 * and prefill required by the candidate, so split-k is timed end to end.
-                 */
-                auto bench_prog = results[i]->make_program();
-                if(trace_level > 2)
-                    std::cout << bench_prog << std::endl;
-                const auto bundle = compute_benchmark_bundle(*bench_prog.get_main_module());
-
-                // Lifetime budget for this candidate, drawn down by both timing stages.
-                const auto candidate_budget = 1 + benchmark_samples * bundle;
-                const auto used             = execution_counts[i];
-                if(used >= candidate_budget)
-                    return nullopt;
-                const auto remaining = candidate_budget - used;
-
-                const auto& fill_map  = results[i]->replace.fill_map;
-                auto parameter_shapes = bench_prog.get_parameter_shapes();
-                auto shared           = shared_inputs.end();
-                if(stage == adaptive_time_stage::coarse)
-                    shared = std::find_if(
-                        shared_inputs.begin(), shared_inputs.end(), [&](const auto& x) {
-                            return x.matches(fill_map, parameter_shapes);
-                        });
-                prepared =
-                    prepare_time_program(*ctx,
-                                         std::move(bench_prog),
-                                         fill_map,
-                                         shared == shared_inputs.end() ? nullptr : shared->params);
-                if(stage == adaptive_time_stage::coarse and shared == shared_inputs.end())
-                    shared_inputs.push_back(
-                        {fill_map, std::move(parameter_shapes), prepared->params});
-                if(trace_level > 1)
-                    std::cout << "Prepared benchmark solution: " << config->solutions.at(i)
-                              << std::endl;
-
-                auto options             = input_options;
-                options.preferred_bundle = bundle;
-                options.max_executions   = std::min(options.max_executions, remaining);
-                adaptive_time_budget budget;
-                budget.max_executions = remaining;
-                if(stage == adaptive_time_stage::coarse)
-                {
-                    // Coarse timing needs lazy initialization, one estimate, and up to
-                    // coarse_samples bundled ranking measurements. Precise timing receives the
-                    // lifetime budget left by this call.
-                    budget.max_executions =
-                        std::min(budget.max_executions, 2 + coarse_samples * bundle);
-                }
-                auto measured = adaptive_time_program(*prepared, options, budget);
-                execution_counts[i] += prepared->executions;
-                if(not std::isfinite(measured) or measured <= 0.0)
-                    return nullopt;
-                if(trace_level > 1)
-                    std::cout << measured << "ms" << std::endl;
-                return measured;
-            }
-            catch(const std::exception& e)
-            {
-                if(prepared.has_value())
-                    execution_counts[i] += prepared->executions;
-                if(first_error.empty())
-                    first_error =
-                        "solution " + to_string(config->solutions.at(i)) + ": " + e.what();
-                if(trace_level > 0)
-                    std::cerr << "Exception benchmarking " << preop.name() << " solution "
-                              << config->solutions.at(i) << ": " << e.what() << std::endl;
-                return nullopt;
-            }
-        };
-
-        const auto winner =
-            adaptive_time_topk_staged(results.size(), tuning_options, time_solution);
+        benchmark_state state{results.size()};
+        const auto winner = adaptive_time_topk_staged(
+            results.size(), tuning_options, [&](auto i, auto stage, const auto& options) {
+                return time_solution(state, i, stage, options);
+            });
         if(not winner.has_value())
-            MIGRAPHX_THROW("No valid tuned benchmark for " + preop.name() + " with " +
-                           problem_string() +
-                           (first_error.empty() ? "" : "\n\nFirst error: " + first_error) + "\n\n" +
-                           print_modules());
+            MIGRAPHX_THROW(no_valid_benchmark_message(state.first_error));
         const auto i = *winner;
         ctx->get_problem_cache().insert(preop.name(), config->problem, config->solutions.at(i));
         if(trace_level > 0)
@@ -632,8 +686,7 @@ struct compile_plan
             ctx->get_problem_cache().save();
         }
         if(not results[i].has_value())
-            MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +
-                           problem_string() + "\n\n" + print_modules());
+            MIGRAPHX_THROW(no_valid_compilation_message());
         auto skipped = std::count_if(
             results.begin(), results.end(), [](const auto& cr) { return not cr.has_value(); });
         if(skipped > 0)
@@ -816,4 +869,3 @@ void compile_ops::apply(module_pass_manager& mpm) const
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
-

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -471,7 +471,8 @@ struct compile_plan
                                                  std::move(bench_prog),
                                                  cr->replace.fill_map,
                                                  bundle,
-                                                 /* nrun */ 20);
+                                                 /* nrun */ 20,
+                                                 /* target_ms */ 100);
                            if(trace_level > 1)
                                std::cout << t << "ms" << std::endl;
                            return t;

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -129,6 +129,12 @@ make_candidate_budget(adaptive_time_stage stage, std::size_t bundle, std::size_t
     return {remaining, std::min(remaining, 2 + coarse_samples * bundle)};
 }
 
+// A timing stage needs three executions to initialize, estimate, and measure, and it reports a
+// tighter budget than that by throwing. Keeping the coarse stage this far below the lifetime is
+// what guarantees every finalist still has a workable precise budget.
+static_assert(coarse_samples >= 1 and benchmark_samples >= coarse_samples + 4,
+              "Coarse timing must leave the precise stage at least three executions");
+
 struct precompile_op
 {
     operation op                      = op::identity{};
@@ -382,9 +388,6 @@ struct benchmark_state
     std::vector<shared_benchmark_inputs> shared_inputs;
     // How much of each candidate's lifetime execution budget the timing stages have spent.
     std::vector<std::size_t> execution_counts;
-    // GPU failures tend to be sticky, so one broken candidate usually takes every later one down
-    // with it. Keep the first message to report instead of a more general message.
-    std::string first_error;
 
     std::shared_ptr<parameter_map>
     find_reusable(const std::unordered_map<std::string, double>& fill_map,
@@ -529,11 +532,10 @@ struct compile_plan
         return "No valid tuned compilation for " + preop.name() + " with " + problem_string() +
                "\n\n" + print_modules();
     }
-    std::string no_valid_benchmark_message(const std::string& first_error) const
+    std::string no_valid_benchmark_message() const
     {
         return "No valid tuned benchmark for " + preop.name() + " with " + problem_string() +
-               (first_error.empty() ? "" : "\n\nFirst error: " + first_error) + "\n\n" +
-               print_modules();
+               "\n\n" + print_modules();
     }
 
     // Builds the runnable form of one candidate, reusing input buffers from an earlier candidate
@@ -560,8 +562,10 @@ struct compile_plan
         return prepared;
     }
 
-    // Times a single candidate, as required by adaptive_time_topk_staged. A candidate that cannot
-    // be timed is reported as unmeasured rather than as an error so that tuning can continue.
+    // Times a single candidate, as required by adaptive_time_topk_staged. A candidate with no
+    // binary, no budget left, or an unusable measurement is reported as unmeasured so that tuning
+    // can continue. Candidates that cannot run at all are already filtered out when they fail to
+    // compile, so a failure here is a real error and is left to propagate.
     optional<double> time_solution(benchmark_state& state,
                                    std::size_t i,
                                    adaptive_time_stage stage,
@@ -578,55 +582,38 @@ struct compile_plan
         if(trace_level > 1)
             std::cout << (stage == adaptive_time_stage::coarse ? "Coarsely" : "Precisely")
                       << " benchmarking solution: " << config->solutions.at(i) << std::endl;
+        if(trace_level > 2)
+            std::cout << *results[i] << std::endl;
+        /*
+         * Replacing the instruction in this small program inserts every code object
+         * and prefill required by the candidate, so split-k is timed end to end.
+         */
+        auto bench_prog = results[i]->make_program();
+        if(trace_level > 2)
+            std::cout << bench_prog << std::endl;
+        const auto bundle = compute_benchmark_bundle(*bench_prog.get_main_module());
+        const auto budget = make_candidate_budget(stage, bundle, state.execution_counts[i]);
+        if(budget.exhausted())
+            return nullopt;
+
         // Held for one timing only so that loaded code objects and input buffers are not
         // retained for every candidate at once.
-        optional<prepared_time_program> prepared;
-        try
-        {
-            if(trace_level > 2)
-                std::cout << *results[i] << std::endl;
-            /*
-             * Replacing the instruction in this small program inserts every code object
-             * and prefill required by the candidate, so split-k is timed end to end.
-             */
-            auto bench_prog = results[i]->make_program();
-            if(trace_level > 2)
-                std::cout << bench_prog << std::endl;
-            const auto bundle = compute_benchmark_bundle(*bench_prog.get_main_module());
-            const auto budget = make_candidate_budget(stage, bundle, state.execution_counts[i]);
-            if(budget.exhausted())
-                return nullopt;
+        auto prepared = prepare_candidate(state, i, stage, std::move(bench_prog));
+        if(trace_level > 1)
+            std::cout << "Prepared benchmark solution: " << config->solutions.at(i) << std::endl;
 
-            prepared = prepare_candidate(state, i, stage, std::move(bench_prog));
-            if(trace_level > 1)
-                std::cout << "Prepared benchmark solution: " << config->solutions.at(i)
-                          << std::endl;
-
-            auto options             = input_options;
-            options.preferred_bundle = bundle;
-            options.max_executions   = std::min(options.max_executions, budget.remaining);
-            adaptive_time_budget stage_budget;
-            stage_budget.max_executions = budget.stage_limit;
-            auto measured               = adaptive_time_program(*prepared, options, stage_budget);
-            state.execution_counts[i] += prepared->executions;
-            if(not std::isfinite(measured) or measured <= 0.0)
-                return nullopt;
-            if(trace_level > 1)
-                std::cout << measured << "ms" << std::endl;
-            return measured;
-        }
-        catch(const std::exception& e)
-        {
-            if(prepared.has_value())
-                state.execution_counts[i] += prepared->executions;
-            if(state.first_error.empty())
-                state.first_error =
-                    "solution " + to_string(config->solutions.at(i)) + ": " + e.what();
-            if(trace_level > 0)
-                std::cerr << "Exception benchmarking " << preop.name() << " solution "
-                          << config->solutions.at(i) << ": " << e.what() << std::endl;
+        auto options             = input_options;
+        options.preferred_bundle = bundle;
+        options.max_executions   = std::min(options.max_executions, budget.remaining);
+        adaptive_time_budget stage_budget;
+        stage_budget.max_executions = budget.stage_limit;
+        auto measured               = adaptive_time_program(prepared, options, stage_budget);
+        state.execution_counts[i] += prepared.executions;
+        if(not std::isfinite(measured) or measured <= 0.0)
             return nullopt;
-        }
+        if(trace_level > 1)
+            std::cout << measured << "ms" << std::endl;
+        return measured;
     }
 
     const compiled_result& benchmark() const
@@ -677,7 +664,7 @@ struct compile_plan
                 return time_solution(state, i, stage, options);
             });
         if(not winner.has_value())
-            MIGRAPHX_THROW(no_valid_benchmark_message(state.first_error));
+            MIGRAPHX_THROW(no_valid_benchmark_message());
         const auto i = *winner;
         ctx->get_problem_cache().insert(preop.name(), config->problem, config->solutions.at(i));
         if(trace_level > 0)

--- a/src/targets/gpu/include/migraphx/gpu/compile_ops.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/compile_ops.hpp
@@ -25,6 +25,10 @@
 #define MIGRAPHX_GUARD_GPU_COMPILE_OPS_HPP
 
 #include <migraphx/gpu/config.hpp>
+#include <migraphx/gpu/time_op.hpp>
+#include <migraphx/optional.hpp>
+#include <migraphx/reflect.hpp>
+#include <cstdint>
 #include <string>
 
 namespace migraphx {
@@ -36,11 +40,33 @@ namespace gpu {
 
 struct context;
 
+struct MIGRAPHX_GPU_EXPORT compile_ops_tuning_overrides
+{
+    optional<std::int64_t> top_k             = nullopt;
+    optional<std::int64_t> coarse_target_ms  = nullopt;
+    optional<std::int64_t> precise_target_ms = nullopt;
+    optional<std::int64_t> max_samples       = nullopt;
+    optional<std::int64_t> sleep_us          = nullopt;
+
+    template <class Self, class F>
+    static auto reflect(Self& self, F f)
+    {
+        return pack(f(self.top_k, "tuning_top_k"),
+                    f(self.coarse_target_ms, "tuning_coarse_target_ms"),
+                    f(self.precise_target_ms, "tuning_precise_target_ms"),
+                    f(self.max_samples, "tuning_max_samples"),
+                    f(self.sleep_us, "tuning_sleep_us"));
+    }
+
+    adaptive_tuning_options resolve() const;
+};
+
 struct MIGRAPHX_GPU_EXPORT compile_ops
 {
     context* ctx         = nullptr;
     bool exhaustive_tune = false;
     bool skip_benchmark  = false;
+    adaptive_tuning_options tuning{};
     std::string name() const { return "gpu::compile_ops"; }
     void apply(module_pass_manager& mpm) const;
 };

--- a/src/targets/gpu/include/migraphx/gpu/time_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/time_op.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/targets/gpu/include/migraphx/gpu/time_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/time_op.hpp
@@ -29,6 +29,7 @@
 #include <migraphx/gpu/context.hpp>
 #include <migraphx/operation.hpp>
 #include <migraphx/optional.hpp>
+#include <memory>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -36,14 +37,14 @@ namespace gpu {
 
 struct adaptive_time_options
 {
-    std::size_t target_ms        = 100;
+    std::size_t target_ms        = 20;
     std::size_t preferred_bundle = 1;
     // Floor on the sample count, taken even when it overruns target_ms, so that a candidate slower
     // than the budget is still measured enough times to reject an interfered run.
     std::size_t min_samples     = 4;
     std::size_t max_samples     = 20;
     std::size_t max_executions  = 10000;
-    std::size_t warmup_ms       = 25;
+    std::size_t warmup_ms       = 5;
     std::size_t max_warmup_runs = 50;
     std::size_t estimate_runs   = 1;
     double estimated_ms         = 0.0;
@@ -62,11 +63,12 @@ struct adaptive_tuning_options
     adaptive_tuning_options()
     {
         coarse.target_ms = 10;
-        coarse.warmup_ms = 5;
+        coarse.warmup_ms = 0;
         // The coarse stage only has to rank candidates and it runs on every one of them, so it
         // keeps a single sample for slow candidates instead of paying the min_samples floor.
         coarse.min_samples    = 1;
-        precise.estimate_runs = 5;
+        precise.warmup_ms     = 0;
+        precise.estimate_runs = 1;
     }
 
     // Number of successful precise timings to collect. Zero precisely times every candidate.
@@ -77,8 +79,47 @@ struct adaptive_tuning_options
     std::size_t sleep_us = 100;
 };
 
+enum class adaptive_time_stage
+{
+    coarse,
+    precise
+};
+
 using adaptive_time_callback =
     std::function<optional<double>(std::size_t, const adaptive_time_options&)>;
+
+using adaptive_time_stage_callback =
+    std::function<optional<double>(
+        std::size_t, adaptive_time_stage, const adaptive_time_options&)>;
+
+struct adaptive_time_budget
+{
+    // Maximum number of calls made by one adaptive_time_loop invocation, including lazy
+    // initialization, estimation, warmup, and measured executions. Zero leaves it unlimited.
+    std::size_t max_executions = 0;
+    bool skip_initialization   = false;
+};
+
+struct MIGRAPHX_GPU_EXPORT prepared_time_program
+{
+    program p;
+    std::vector<migraphx::context> contexts;
+    std::shared_ptr<parameter_map> params;
+    std::size_t executions = 0;
+
+    prepared_time_program(program input,
+                          std::vector<migraphx::context> input_contexts,
+                          std::shared_ptr<parameter_map> input_params);
+
+    migraphx::gpu::context& get_context();
+    void run();
+};
+
+MIGRAPHX_GPU_EXPORT prepared_time_program
+prepare_time_program(const context& ictx,
+                     program p,
+                     const std::unordered_map<std::string, double>& fill_map,
+                     std::shared_ptr<parameter_map> params = {});
 
 MIGRAPHX_GPU_EXPORT timing_schedule make_timing_schedule(double estimate_ms,
                                                          const adaptive_time_options& options);
@@ -87,10 +128,20 @@ MIGRAPHX_GPU_EXPORT double adaptive_time_loop(migraphx::gpu::context& gctx,
                                               const adaptive_time_options& options,
                                               const std::function<void()>& f);
 
+MIGRAPHX_GPU_EXPORT double adaptive_time_loop(migraphx::gpu::context& gctx,
+                                              const adaptive_time_options& options,
+                                              const adaptive_time_budget& budget,
+                                              const std::function<void()>& f);
+
 MIGRAPHX_GPU_EXPORT optional<std::size_t>
 adaptive_time_topk(std::size_t candidate_count,
                    const adaptive_tuning_options& options,
                    const adaptive_time_callback& benchmark);
+
+MIGRAPHX_GPU_EXPORT optional<std::size_t>
+adaptive_time_topk_staged(std::size_t candidate_count,
+                          const adaptive_tuning_options& options,
+                          const adaptive_time_stage_callback& benchmark);
 
 MIGRAPHX_GPU_EXPORT double time_op(const context& ictx,
                                    operation op,
@@ -110,6 +161,13 @@ adaptive_time_program(const context& ictx,
                       const std::unordered_map<std::string, double>& fill_map,
                       const adaptive_time_options& options);
 
+MIGRAPHX_GPU_EXPORT double
+adaptive_time_program(prepared_time_program& prepared, const adaptive_time_options& options);
+
+MIGRAPHX_GPU_EXPORT double adaptive_time_program(prepared_time_program& prepared,
+                                                 const adaptive_time_options& options,
+                                                 const adaptive_time_budget& budget);
+
 /* benchmark gpu::code_object with expected input shapes over n iterations */
 MIGRAPHX_GPU_EXPORT double
 time_op(const context& ictx, operation op, int bundle = 1, int nruns = 100);
@@ -121,3 +179,4 @@ time_loop(migraphx::gpu::context& gctx, int bundle, int nruns, const std::functi
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
 #endif // MIGRAPHX_GUARD_GPU_DRIVER_PERF_HPP
+

--- a/src/targets/gpu/include/migraphx/gpu/time_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/time_op.hpp
@@ -43,7 +43,8 @@ MIGRAPHX_GPU_EXPORT double time_program(const context& ictx,
                                         program p,
                                         const std::unordered_map<std::string, double>& fill_map,
                                         int bundle = 1,
-                                        int nruns  = 100);
+                                        int nruns  = 100,
+                                        std::size_t target_ms = 0);
 
 /* benchmark gpu::code_object with expected input shapes over n iterations */
 MIGRAPHX_GPU_EXPORT double

--- a/src/targets/gpu/include/migraphx/gpu/time_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/time_op.hpp
@@ -28,10 +28,69 @@
 #include <migraphx/config.hpp>
 #include <migraphx/gpu/context.hpp>
 #include <migraphx/operation.hpp>
+#include <migraphx/optional.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
+
+struct adaptive_time_options
+{
+    std::size_t target_ms        = 100;
+    std::size_t preferred_bundle = 1;
+    // Floor on the sample count, taken even when it overruns target_ms, so that a candidate slower
+    // than the budget is still measured enough times to reject an interfered run.
+    std::size_t min_samples     = 4;
+    std::size_t max_samples     = 20;
+    std::size_t max_executions  = 10000;
+    std::size_t warmup_ms       = 25;
+    std::size_t max_warmup_runs = 50;
+    std::size_t estimate_runs   = 1;
+    double estimated_ms         = 0.0;
+};
+
+struct timing_schedule
+{
+    std::size_t bundle      = 1;
+    std::size_t samples     = 1;
+    std::size_t executions  = 1;
+    std::size_t warmup_runs = 1;
+};
+
+struct adaptive_tuning_options
+{
+    adaptive_tuning_options()
+    {
+        coarse.target_ms = 10;
+        coarse.warmup_ms = 5;
+        // The coarse stage only has to rank candidates and it runs on every one of them, so it
+        // keeps a single sample for slow candidates instead of paying the min_samples floor.
+        coarse.min_samples    = 1;
+        precise.estimate_runs = 5;
+    }
+
+    // Number of successful precise timings to collect. Zero precisely times every candidate.
+    std::size_t top_k = 10;
+    adaptive_time_options coarse{};
+    adaptive_time_options precise{};
+    // Delay after each candidate-stage timing to reduce thermal interference.
+    std::size_t sleep_us = 100;
+};
+
+using adaptive_time_callback =
+    std::function<optional<double>(std::size_t, const adaptive_time_options&)>;
+
+MIGRAPHX_GPU_EXPORT timing_schedule make_timing_schedule(double estimate_ms,
+                                                         const adaptive_time_options& options);
+
+MIGRAPHX_GPU_EXPORT double adaptive_time_loop(migraphx::gpu::context& gctx,
+                                              const adaptive_time_options& options,
+                                              const std::function<void()>& f);
+
+MIGRAPHX_GPU_EXPORT optional<std::size_t>
+adaptive_time_topk(std::size_t candidate_count,
+                   const adaptive_tuning_options& options,
+                   const adaptive_time_callback& benchmark);
 
 MIGRAPHX_GPU_EXPORT double time_op(const context& ictx,
                                    operation op,
@@ -43,8 +102,13 @@ MIGRAPHX_GPU_EXPORT double time_program(const context& ictx,
                                         program p,
                                         const std::unordered_map<std::string, double>& fill_map,
                                         int bundle = 1,
-                                        int nruns  = 100,
-                                        std::size_t target_ms = 0);
+                                        int nruns  = 100);
+
+MIGRAPHX_GPU_EXPORT double
+adaptive_time_program(const context& ictx,
+                      program p,
+                      const std::unordered_map<std::string, double>& fill_map,
+                      const adaptive_time_options& options);
 
 /* benchmark gpu::code_object with expected input shapes over n iterations */
 MIGRAPHX_GPU_EXPORT double

--- a/src/targets/gpu/include/migraphx/gpu/time_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/time_op.hpp
@@ -29,7 +29,12 @@
 #include <migraphx/gpu/context.hpp>
 #include <migraphx/operation.hpp>
 #include <migraphx/optional.hpp>
+#include <cstddef>
+#include <functional>
 #include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {

--- a/src/targets/gpu/include/migraphx/gpu/time_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/time_op.hpp
@@ -120,6 +120,8 @@ struct MIGRAPHX_GPU_EXPORT prepared_time_program
     void run();
 };
 
+// params is a hint for reusing input buffers across programs. It is adopted only when it covers
+// every parameter of p with a matching shape, and freshly generated buffers are used otherwise.
 MIGRAPHX_GPU_EXPORT prepared_time_program
 prepare_time_program(const context& ictx,
                      program p,

--- a/src/targets/gpu/include/migraphx/gpu/time_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/time_op.hpp
@@ -94,8 +94,7 @@ using adaptive_time_callback =
     std::function<optional<double>(std::size_t, const adaptive_time_options&)>;
 
 using adaptive_time_stage_callback =
-    std::function<optional<double>(
-        std::size_t, adaptive_time_stage, const adaptive_time_options&)>;
+    std::function<optional<double>(std::size_t, adaptive_time_stage, const adaptive_time_options&)>;
 
 struct adaptive_time_budget
 {
@@ -128,15 +127,15 @@ prepare_time_program(const context& ictx,
                      const std::unordered_map<std::string, double>& fill_map,
                      std::shared_ptr<parameter_map> params = {});
 
-MIGRAPHX_GPU_EXPORT timing_schedule make_timing_schedule(double estimate_ms,
-                                                         const adaptive_time_options& options);
+MIGRAPHX_GPU_EXPORT timing_schedule
+make_timing_schedule(double estimate_ms, const adaptive_time_options& input_options);
 
 MIGRAPHX_GPU_EXPORT double adaptive_time_loop(migraphx::gpu::context& gctx,
                                               const adaptive_time_options& options,
                                               const std::function<void()>& f);
 
 MIGRAPHX_GPU_EXPORT double adaptive_time_loop(migraphx::gpu::context& gctx,
-                                              const adaptive_time_options& options,
+                                              const adaptive_time_options& input_options,
                                               const adaptive_time_budget& budget,
                                               const std::function<void()>& f);
 
@@ -168,12 +167,12 @@ adaptive_time_program(const context& ictx,
                       const std::unordered_map<std::string, double>& fill_map,
                       const adaptive_time_options& options);
 
-MIGRAPHX_GPU_EXPORT double
-adaptive_time_program(prepared_time_program& prepared, const adaptive_time_options& options);
+MIGRAPHX_GPU_EXPORT double adaptive_time_program(prepared_time_program& prepared,
+                                                 const adaptive_time_options& options);
 
 MIGRAPHX_GPU_EXPORT double adaptive_time_program(prepared_time_program& prepared,
                                                  const adaptive_time_options& options,
-                                                 const adaptive_time_budget& budget);
+                                                 const adaptive_time_budget& input_budget);
 
 /* benchmark gpu::code_object with expected input shapes over n iterations */
 MIGRAPHX_GPU_EXPORT double
@@ -186,4 +185,3 @@ time_loop(migraphx::gpu::context& gctx, int bundle, int nruns, const std::functi
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
 #endif // MIGRAPHX_GUARD_GPU_DRIVER_PERF_HPP
-

--- a/src/targets/gpu/include/migraphx/gpu/time_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/time_op.hpp
@@ -155,6 +155,7 @@ MIGRAPHX_GPU_EXPORT double time_op(const context& ictx,
                                    int bundle = 1,
                                    int nruns  = 100);
 
+// TODO: Unused in-tree after adaptive timing; remove once external callers are confirmed gone.
 MIGRAPHX_GPU_EXPORT double time_program(const context& ictx,
                                         program p,
                                         const std::unordered_map<std::string, double>& fill_map,

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -119,15 +119,18 @@ struct backend_options
     layout_convolution::layout_order convolution_layout = layout_convolution::channels_auto;
     // When true, skip spawning migraphx-hiprtc-driver and compile hiprtc in-process.
     bool hiprtc_disable_processes = false;
+    compile_ops_tuning_overrides tuning{};
 
     template <class Self, class F>
     static auto reflect(Self& self, F f)
     {
-        return pack(f(self.mlss_use_specific_ops, "mlss_use_specific_ops"),
-                    f(self.convolution_layout, "convolution_layout"),
-                    f(self.hiprtc_disable_processes, "hiprtc_disable_processes"),
-                    f(self.problem_cache_files, "problem_cache_files"),
-                    f(self.read_only_problem_cache_files, "read_only_problem_cache_files"));
+        return pack_join(
+            pack(f(self.mlss_use_specific_ops, "mlss_use_specific_ops"),
+                 f(self.convolution_layout, "convolution_layout"),
+                 f(self.hiprtc_disable_processes, "hiprtc_disable_processes"),
+                 f(self.problem_cache_files, "problem_cache_files"),
+                 f(self.read_only_problem_cache_files, "read_only_problem_cache_files")),
+            migraphx::reflect(self.tuning, f));
     }
 };
 
@@ -291,7 +294,8 @@ struct pipeline_factory
             lower_device_ops{},
             compile_ops{get_context(),
                         options.exhaustive_tune,
-                        options.compile_mode == compile_modes::eager},
+                        options.compile_mode == compile_modes::eager,
+                        backend_opts.tuning.resolve()},
             dead_code_elimination{},
             promote_literals{},
             dead_code_elimination{},

--- a/src/targets/gpu/time_op.cpp
+++ b/src/targets/gpu/time_op.cpp
@@ -170,10 +170,10 @@ timing_schedule make_timing_schedule(double estimate_ms, const adaptive_time_opt
     // min_samples is a floor rather than another budget cap: a candidate slower than target_ms
     // would otherwise be measured once, leaving common_average nothing to reject noise with.
     const auto preferred_samples = std::max<std::size_t>(1, executions / options.preferred_bundle);
-    const auto samples = std::min(
-        options.max_executions,
-        std::min(options.max_samples, std::max(options.min_samples, preferred_samples)));
-    const auto bundle = std::max<std::size_t>(1, executions / samples);
+    const auto samples           = std::min({options.max_executions,
+                                             options.max_samples,
+                                             std::max(options.min_samples, preferred_samples)});
+    const auto bundle            = std::max<std::size_t>(1, executions / samples);
 
     std::size_t warmup_runs = 0;
     if(options.warmup_ms > 0)
@@ -188,10 +188,10 @@ timing_schedule make_timing_schedule(double estimate_ms, const adaptive_time_opt
 }
 
 double adaptive_time_loop(migraphx::gpu::context& gctx,
-                          const adaptive_time_options& input_options,
+                          const adaptive_time_options& options,
                           const std::function<void()>& f)
 {
-    return adaptive_time_loop(gctx, input_options, adaptive_time_budget{}, f);
+    return adaptive_time_loop(gctx, options, adaptive_time_budget{}, f);
 }
 
 double adaptive_time_loop(migraphx::gpu::context& gctx,
@@ -203,9 +203,9 @@ double adaptive_time_loop(migraphx::gpu::context& gctx,
     if(options.estimated_ms <= 0.0 and options.estimate_runs == 0)
         MIGRAPHX_THROW("Adaptive timing estimate runs must be greater than zero");
 
-    const auto limited = budget.max_executions > 0;
+    const auto limited     = budget.max_executions > 0;
     std::size_t executions = 0;
-    auto run = [&] {
+    auto run               = [&] {
         if(limited and executions >= budget.max_executions)
             MIGRAPHX_THROW("Adaptive timing exhausted its total execution budget");
         f();
@@ -325,19 +325,22 @@ optional<std::size_t> adaptive_time_topk_staged(std::size_t candidate_count,
         });
 
         const auto top_k = std::min(options.top_k, ranked.size());
-        std::accumulate(ranked.begin(), ranked.end(), std::size_t{0}, [&](auto measured, auto i) {
-            if(measured >= top_k)
-                return measured;
-            auto candidate_options = precise_options;
-            if(coarse[i].has_value())
-                candidate_options.estimated_ms = *coarse[i];
-            precise[i] = time_candidate(i,
-                                        adaptive_time_stage::precise,
-                                        candidate_options,
-                                        options.sleep_us,
-                                        benchmark);
-            return measured + precise[i].has_value();
-        });
+        // The accumulator counts measurements rather than attempts, so a candidate that fails to
+        // time does not consume one of the top_k slots.
+        (void)std::accumulate(
+            ranked.begin(), ranked.end(), std::size_t{0}, [&](auto measured, auto i) {
+                if(measured >= top_k)
+                    return measured;
+                auto candidate_options = precise_options;
+                if(coarse[i].has_value())
+                    candidate_options.estimated_ms = *coarse[i];
+                precise[i] = time_candidate(i,
+                                            adaptive_time_stage::precise,
+                                            candidate_options,
+                                            options.sleep_us,
+                                            benchmark);
+                return measured + precise[i].has_value();
+            });
     }
 
     std::vector<std::size_t> measured;
@@ -400,9 +403,7 @@ double time_op(const context& ictx, operation op, int bundle, int nruns)
 prepared_time_program::prepared_time_program(program input,
                                              std::vector<migraphx::context> input_contexts,
                                              std::shared_ptr<parameter_map> input_params)
-    : p(std::move(input)),
-      contexts(std::move(input_contexts)),
-      params(std::move(input_params))
+    : p(std::move(input)), contexts(std::move(input_contexts)), params(std::move(input_params))
 {
 }
 
@@ -426,11 +427,10 @@ static bool covers_parameters(const parameter_map& params,
     });
 }
 
-prepared_time_program
-prepare_time_program(const context& ictx,
-                     program p,
-                     const std::unordered_map<std::string, double>& fill_map,
-                     std::shared_ptr<parameter_map> params)
+prepared_time_program prepare_time_program(const context& ictx,
+                                           program p,
+                                           const std::unordered_map<std::string, double>& fill_map,
+                                           std::shared_ptr<parameter_map> params)
 {
     std::vector<migraphx::context> contexts = {ictx};
     auto& gctx                              = any_cast<migraphx::gpu::context>(contexts.front());
@@ -499,24 +499,22 @@ double adaptive_time_program(const context& ictx,
     });
 }
 
-double
-adaptive_time_program(prepared_time_program& prepared, const adaptive_time_options& input_options)
+double adaptive_time_program(prepared_time_program& prepared, const adaptive_time_options& options)
 {
-    return adaptive_time_program(prepared, input_options, adaptive_time_budget{});
+    return adaptive_time_program(prepared, options, adaptive_time_budget{});
 }
 
 double adaptive_time_program(prepared_time_program& prepared,
-                             const adaptive_time_options& input_options,
+                             const adaptive_time_options& options,
                              const adaptive_time_budget& input_budget)
 {
     auto budget = input_budget;
     if(prepared.executions > 0)
         budget.skip_initialization = true;
     auto run = [&] { prepared.run(); };
-    return adaptive_time_loop(prepared.get_context(), input_options, budget, run);
+    return adaptive_time_loop(prepared.get_context(), options, budget, run);
 }
 
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
-

--- a/src/targets/gpu/time_op.cpp
+++ b/src/targets/gpu/time_op.cpp
@@ -159,8 +159,9 @@ timing_schedule make_timing_schedule(double estimate_ms, const adaptive_time_opt
     // min_samples is a floor rather than another budget cap: a candidate slower than target_ms
     // would otherwise be measured once, leaving common_average nothing to reject noise with.
     const auto preferred_samples = std::max<std::size_t>(1, executions / options.preferred_bundle);
-    const auto samples =
-        std::min(options.max_samples, std::max(options.min_samples, preferred_samples));
+    const auto samples = std::min(
+        options.max_executions,
+        std::min(options.max_samples, std::max(options.min_samples, preferred_samples)));
     const auto bundle = std::max<std::size_t>(1, executions / samples);
 
     std::size_t warmup_runs = 0;
@@ -179,43 +180,88 @@ double adaptive_time_loop(migraphx::gpu::context& gctx,
                           const adaptive_time_options& input_options,
                           const std::function<void()>& f)
 {
-    const auto options = resolve_options(input_options);
+    return adaptive_time_loop(gctx, input_options, adaptive_time_budget{}, f);
+}
+
+double adaptive_time_loop(migraphx::gpu::context& gctx,
+                          const adaptive_time_options& input_options,
+                          const adaptive_time_budget& budget,
+                          const std::function<void()>& f)
+{
+    auto options = resolve_options(input_options);
     if(options.estimated_ms <= 0.0 and options.estimate_runs == 0)
         MIGRAPHX_THROW("Adaptive timing estimate runs must be greater than zero");
 
-    // Run once to initialize lazy GPU resources and count it toward the warmup budget.
-    f();
-    std::size_t completed_warmup_runs = 1;
+    const auto limited = budget.max_executions > 0;
+    std::size_t executions = 0;
+    auto run = [&] {
+        if(limited and executions >= budget.max_executions)
+            MIGRAPHX_THROW("Adaptive timing exhausted its total execution budget");
+        f();
+        executions++;
+    };
+
+    // Run once to initialize lazy GPU resources and count it toward the warmup budget. A prepared
+    // candidate promoted from coarse timing has already initialized those resources.
+    std::size_t completed_warmup_runs = 0;
+    if(not budget.skip_initialization)
+    {
+        run();
+        completed_warmup_runs = 1;
+    }
 
     double estimate_ms = options.estimated_ms;
     if(estimate_ms <= 0.0)
     {
-        estimate_ms = estimate_time(gctx, options.estimate_runs, f);
-        completed_warmup_runs += options.estimate_runs;
+        auto estimate_runs = options.estimate_runs;
+        if(limited)
+        {
+            const auto remaining = budget.max_executions - executions;
+            if(remaining <= 1)
+                MIGRAPHX_THROW("Adaptive timing budget must include an estimate and measurement");
+            estimate_runs = std::min(estimate_runs, remaining - 1);
+        }
+        estimate_ms = estimate_time(gctx, estimate_runs, run);
+        completed_warmup_runs += estimate_runs;
     }
     estimate_ms = std::max(estimate_ms, min_execution_ms);
 
+    if(limited)
+    {
+        const auto remaining = budget.max_executions - executions;
+        if(remaining == 0)
+            MIGRAPHX_THROW("Adaptive timing budget must include a measured execution");
+        options.max_executions = std::min(options.max_executions, remaining);
+    }
     const auto schedule = make_timing_schedule(estimate_ms, options);
     if(schedule.warmup_runs > completed_warmup_runs)
     {
-        const auto additional_warmup_runs = schedule.warmup_runs - completed_warmup_runs;
+        auto additional_warmup_runs = schedule.warmup_runs - completed_warmup_runs;
+        if(limited)
+        {
+            const auto remaining = budget.max_executions - executions;
+            const auto spare =
+                remaining > schedule.executions ? remaining - schedule.executions : 0;
+            additional_warmup_runs = std::min(additional_warmup_runs, spare);
+        }
         for(auto i : range(additional_warmup_runs))
         {
             (void)i;
-            f();
+            run();
         }
     }
 
-    auto times = measure_loop(gctx, schedule.bundle, schedule.samples, f);
+    auto times = measure_loop(gctx, schedule.bundle, schedule.samples, run);
     return common_average(std::move(times));
 }
 
 static optional<double> time_candidate(std::size_t i,
+                                       adaptive_time_stage stage,
                                        const adaptive_time_options& options,
                                        std::size_t candidate_delay_us,
-                                       const adaptive_time_callback& benchmark)
+                                       const adaptive_time_stage_callback& benchmark)
 {
-    auto result = benchmark(i, options);
+    auto result = benchmark(i, stage, options);
     if(result.has_value() and (not std::isfinite(*result) or *result <= 0.0))
         result = nullopt;
     if(candidate_delay_us > 0)
@@ -224,9 +270,9 @@ static optional<double> time_candidate(std::size_t i,
     return result;
 }
 
-optional<std::size_t> adaptive_time_topk(std::size_t candidate_count,
-                                         const adaptive_tuning_options& options,
-                                         const adaptive_time_callback& benchmark)
+optional<std::size_t> adaptive_time_topk_staged(std::size_t candidate_count,
+                                                const adaptive_tuning_options& options,
+                                                const adaptive_time_stage_callback& benchmark)
 {
     using delay_rep = std::chrono::microseconds::rep;
     if(options.sleep_us > static_cast<std::size_t>(std::numeric_limits<delay_rep>::max()))
@@ -241,13 +287,15 @@ optional<std::size_t> adaptive_time_topk(std::size_t candidate_count,
     if(options.top_k == 0)
     {
         std::transform(indices.begin(), indices.end(), precise.begin(), [&](auto i) {
-            return time_candidate(i, precise_options, options.sleep_us, benchmark);
+            return time_candidate(
+                i, adaptive_time_stage::precise, precise_options, options.sleep_us, benchmark);
         });
     }
     else
     {
         std::transform(indices.begin(), indices.end(), coarse.begin(), [&](auto i) {
-            return time_candidate(i, coarse_options, options.sleep_us, benchmark);
+            return time_candidate(
+                i, adaptive_time_stage::coarse, coarse_options, options.sleep_us, benchmark);
         });
 
         std::vector<std::size_t> ranked;
@@ -266,7 +314,11 @@ optional<std::size_t> adaptive_time_topk(std::size_t candidate_count,
                 return measured;
             auto candidate_options         = precise_options;
             candidate_options.estimated_ms = *coarse[i];
-            precise[i] = time_candidate(i, candidate_options, options.sleep_us, benchmark);
+            precise[i] = time_candidate(i,
+                                        adaptive_time_stage::precise,
+                                        candidate_options,
+                                        options.sleep_us,
+                                        benchmark);
             return measured + precise[i].has_value();
         });
     }
@@ -282,6 +334,16 @@ optional<std::size_t> adaptive_time_topk(std::size_t candidate_count,
         const auto ytime = *precise[y];
         return std::tie(xtime, x) < std::tie(ytime, y);
     });
+}
+
+optional<std::size_t> adaptive_time_topk(std::size_t candidate_count,
+                                         const adaptive_tuning_options& options,
+                                         const adaptive_time_callback& benchmark)
+{
+    return adaptive_time_topk_staged(
+        candidate_count, options, [&](auto i, auto, const auto& timing) {
+            return benchmark(i, timing);
+        });
 }
 
 double
@@ -318,38 +380,71 @@ double time_op(const context& ictx, operation op, int bundle, int nruns)
     return time_op(ictx, op, inputs, bundle, nruns);
 }
 
+prepared_time_program::prepared_time_program(program input,
+                                             std::vector<migraphx::context> input_contexts,
+                                             std::shared_ptr<parameter_map> input_params)
+    : p(std::move(input)),
+      contexts(std::move(input_contexts)),
+      params(std::move(input_params))
+{
+}
+
+migraphx::gpu::context& prepared_time_program::get_context()
+{
+    return any_cast<migraphx::gpu::context>(contexts.front());
+}
+
+void prepared_time_program::run()
+{
+    executions++;
+    p.eval_with_context(contexts, *params);
+}
+
+prepared_time_program
+prepare_time_program(const context& ictx,
+                     program p,
+                     const std::unordered_map<std::string, double>& fill_map,
+                     std::shared_ptr<parameter_map> params)
+{
+    std::vector<migraphx::context> contexts = {ictx};
+    auto& gctx                              = any_cast<migraphx::gpu::context>(contexts.front());
+    auto* mm                                = p.get_main_module();
+    mm->finalize(contexts);
+    if(not params)
+    {
+        params             = std::make_shared<parameter_map>();
+        auto in_shapes     = p.get_parameter_shapes();
+        unsigned long seed = 0;
+        for(const auto& [name, shape] : in_shapes)
+        {
+            std::string id = "";
+            if(shape.type() != migraphx::shape::tuple_type)
+                id = shape.type_string() + migraphx::shape::to_sizes_string({shape.as_standard()});
+
+            // fill_map inputs need specific values (host fill); the rest are generated
+            // on the GPU to skip the host PRNG + H2D copy per candidate.
+            if(contains(fill_map, id))
+            {
+                (*params)[name] = to_gpu(fill_argument(shape, fill_map.at(id)));
+            }
+            else
+            {
+                (*params)[name] = gpu_generate_random(gctx, shape, seed++);
+            }
+        }
+    }
+    return {std::move(p), std::move(contexts), std::move(params)};
+}
+
 template <class F>
 static auto time_program_impl(const context& ictx,
                               program p,
                               const std::unordered_map<std::string, double>& fill_map,
                               F f)
 {
-    std::vector<migraphx::context> contexts = {ictx};
-    auto& gctx                              = any_cast<migraphx::gpu::context>(contexts.front());
-    auto* mm                                = p.get_main_module();
-    mm->finalize(contexts);
-    auto in_shapes = p.get_parameter_shapes();
-    parameter_map params;
-    unsigned long seed = 0;
-    for(const auto& [name, shape] : in_shapes)
-    {
-        std::string id = "";
-        if(shape.type() != migraphx::shape::tuple_type)
-            id = shape.type_string() + migraphx::shape::to_sizes_string({shape.as_standard()});
-
-        // fill_map inputs need specific values (host fill); the rest are generated
-        // on the GPU to skip the host PRNG + H2D copy per candidate.
-        if(contains(fill_map, id))
-        {
-            params[name] = to_gpu(fill_argument(shape, fill_map.at(id)));
-        }
-        else
-        {
-            params[name] = gpu_generate_random(gctx, shape, seed++);
-        }
-    }
-    auto run = [&] { p.eval_with_context(contexts, params); };
-    return f(gctx, run);
+    auto prepared = prepare_time_program(ictx, std::move(p), fill_map);
+    auto run      = [&] { prepared.run(); };
+    return f(prepared.get_context(), run);
 }
 
 double time_program(const context& ictx,
@@ -373,6 +468,24 @@ double adaptive_time_program(const context& ictx,
     });
 }
 
+double
+adaptive_time_program(prepared_time_program& prepared, const adaptive_time_options& input_options)
+{
+    return adaptive_time_program(prepared, input_options, adaptive_time_budget{});
+}
+
+double adaptive_time_program(prepared_time_program& prepared,
+                             const adaptive_time_options& input_options,
+                             const adaptive_time_budget& input_budget)
+{
+    auto budget = input_budget;
+    if(prepared.executions > 0)
+        budget.skip_initialization = true;
+    auto run = [&] { prepared.run(); };
+    return adaptive_time_loop(prepared.get_context(), input_options, budget, run);
+}
+
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
+

--- a/src/targets/gpu/time_op.cpp
+++ b/src/targets/gpu/time_op.cpp
@@ -25,14 +25,21 @@
 #include <migraphx/gpu/time_op.hpp>
 #include <migraphx/gpu/code_object_op.hpp>
 #include <migraphx/context.hpp>
+#include <migraphx/env.hpp>
+#include <migraphx/errors.hpp>
 #include <migraphx/generate.hpp>
+#include <migraphx/ranges.hpp>
 #include <migraphx/gpu/hip.hpp>
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <functional>
+#include <iterator>
 #include <limits>
+#include <numeric>
 #include <thread>
 #include <tuple>
+#include <utility>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {

--- a/src/targets/gpu/time_op.cpp
+++ b/src/targets/gpu/time_op.cpp
@@ -26,9 +26,13 @@
 #include <migraphx/gpu/code_object_op.hpp>
 #include <migraphx/context.hpp>
 #include <migraphx/generate.hpp>
-#include <migraphx/time.hpp>
 #include <migraphx/gpu/hip.hpp>
+#include <algorithm>
+#include <chrono>
 #include <cmath>
+#include <limits>
+#include <thread>
+#include <tuple>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -36,6 +40,8 @@ namespace gpu {
 
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_BENCHMARKING_BUNDLE);
 MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_BENCHMARKING_NRUNS);
+
+constexpr double min_execution_ms = 0.001;
 
 static std::vector<argument> generate_arguments(const std::vector<shape>& shapes,
                                                 unsigned long seed = 0,
@@ -48,46 +54,71 @@ static std::vector<argument> generate_arguments(const std::vector<shape>& shapes
     return args;
 }
 
-static double time_loop_impl(migraphx::gpu::context& gctx,
-                             int bundle,
-                             int nruns,
-                             const std::function<void()>& f,
-                             std::size_t target_ms)
+static double common_average(std::vector<double> times)
 {
-    // check for manual overrides
-    bundle = value_of(MIGRAPHX_BENCHMARKING_BUNDLE{}, bundle);
-    nruns  = value_of(MIGRAPHX_BENCHMARKING_NRUNS{}, nruns);
+    std::sort(times.begin(), times.end());
+    const std::size_t quarters = times.size() / 4;
+    // With fewer than four samples there is nothing to trim, and an untrimmed mean lets a single
+    // interfered run dominate. Interference can only slow a run down, so use the fastest sample.
+    if(quarters == 0)
+        return times.front();
+    const auto first = times.begin() + quarters;
+    const auto last  = times.end() - quarters;
+    return std::accumulate(first, last, 0.0) / std::distance(first, last);
+}
 
-    if(target_ms > 0)
-    {
-        // Estimate one launch, then choose a bounded run count for the requested time budget.
-        f();
-        auto estimate_start = context::create_event_for_timing();
-        auto estimate_stop  = context::create_event_for_timing();
-        gctx.get_stream().record(estimate_start.get());
-        f();
-        gctx.get_stream().record(estimate_stop.get());
-        gctx.finish();
+template <class Env>
+static optional<std::size_t> benchmarking_override(Env e)
+{
+    const auto v = value_of(e, 0);
+    if(v == 0)
+        return nullopt;
+    return v;
+}
 
-        constexpr double min_time_ms = 0.001;
-        const auto estimate_ms =
-            std::max<double>(context::get_elapsed_ms(estimate_start.get(), estimate_stop.get()),
-                             min_time_ms);
-        bundle                     = std::max(bundle, 1);
-        const auto requested_nruns = std::ceil(target_ms / (estimate_ms * bundle));
-        nruns                      = static_cast<int>(
-            std::clamp(requested_nruns, 1.0, static_cast<double>(std::max(nruns, 1))));
-    }
+static void validate_options(const adaptive_time_options& options)
+{
+    if(options.target_ms == 0)
+        MIGRAPHX_THROW("Adaptive timing target must be greater than zero");
+    if(options.preferred_bundle == 0)
+        MIGRAPHX_THROW("Adaptive timing bundle must be greater than zero");
+    if(options.min_samples == 0 or options.max_samples == 0)
+        MIGRAPHX_THROW("Adaptive timing samples must be greater than zero");
+    if(options.max_executions == 0)
+        MIGRAPHX_THROW("Adaptive timing executions must be greater than zero");
+    if(options.warmup_ms > 0 and options.max_warmup_runs == 0)
+        MIGRAPHX_THROW("Adaptive timing warmup runs must be greater than zero");
+}
 
-    std::vector<std::pair<hip_event_ptr, hip_event_ptr>> events(nruns);
+// max_samples is settable from the outside while min_samples is not, so lowering only max_samples
+// must clamp the floor rather than be rejected as an inconsistent pair.
+static adaptive_time_options normalize_options(adaptive_time_options options)
+{
+    validate_options(options);
+    options.min_samples = std::min(options.min_samples, options.max_samples);
+    return options;
+}
+
+static adaptive_time_options resolve_options(adaptive_time_options options)
+{
+    if(const auto bundle = benchmarking_override(MIGRAPHX_BENCHMARKING_BUNDLE{}))
+        options.preferred_bundle = *bundle;
+    if(const auto samples = benchmarking_override(MIGRAPHX_BENCHMARKING_NRUNS{}))
+        options.max_samples = *samples;
+    return normalize_options(options);
+}
+
+static std::vector<double> measure_loop(migraphx::gpu::context& gctx,
+                                        std::size_t bundle,
+                                        std::size_t samples,
+                                        const std::function<void()>& f)
+{
+    std::vector<std::pair<hip_event_ptr, hip_event_ptr>> events(samples);
     std::generate(events.begin(), events.end(), [] {
         return std::make_pair(context::create_event_for_timing(),
                               context::create_event_for_timing());
     });
-    std::vector<double> times;
-    if(target_ms == 0)
-        f();
-    for(auto i : range(nruns))
+    for(auto i : range(samples))
     {
         gctx.get_stream().record(events[i].first.get());
         for(auto j : range(bundle))
@@ -98,21 +129,174 @@ static double time_loop_impl(migraphx::gpu::context& gctx,
         gctx.get_stream().record(events[i].second.get());
     }
     gctx.finish();
+    std::vector<double> times;
+    times.reserve(samples);
     std::transform(events.begin(), events.end(), std::back_inserter(times), [&](const auto& p) {
         return context::get_elapsed_ms(p.first.get(), p.second.get()) / bundle;
     });
-    std::sort(times.begin(), times.end());
+    return times;
+}
 
-    // compute common average by removing top and bottom 25% of values
-    std::size_t quarters = times.size() / 4;
-    double total         = std::accumulate(times.begin() + quarters, times.end() - quarters, 0.0);
-    return total / std::distance(times.begin() + quarters, times.end() - quarters);
+static double
+estimate_time(migraphx::gpu::context& gctx, std::size_t nruns, const std::function<void()>& f)
+{
+    const auto times = measure_loop(gctx, nruns, 1, f);
+    return std::max(times.front(), min_execution_ms);
+}
+
+timing_schedule make_timing_schedule(double estimate_ms, const adaptive_time_options& input_options)
+{
+    const auto options = normalize_options(input_options);
+    if(not std::isfinite(estimate_ms) or estimate_ms <= 0.0)
+        MIGRAPHX_THROW("Adaptive timing estimate must be finite and greater than zero");
+    estimate_ms = std::max(estimate_ms, min_execution_ms);
+
+    const double requested_executions = std::floor(options.target_ms / estimate_ms);
+    const auto executions =
+        requested_executions >= options.max_executions
+            ? options.max_executions
+            : std::max<std::size_t>(1, static_cast<std::size_t>(requested_executions));
+    // min_samples is a floor rather than another budget cap: a candidate slower than target_ms
+    // would otherwise be measured once, leaving common_average nothing to reject noise with.
+    const auto preferred_samples = std::max<std::size_t>(1, executions / options.preferred_bundle);
+    const auto samples =
+        std::min(options.max_samples, std::max(options.min_samples, preferred_samples));
+    const auto bundle = std::max<std::size_t>(1, executions / samples);
+
+    std::size_t warmup_runs = 0;
+    if(options.warmup_ms > 0)
+    {
+        const double requested_warmup_runs = std::ceil(options.warmup_ms / estimate_ms);
+        warmup_runs =
+            requested_warmup_runs >= options.max_warmup_runs
+                ? options.max_warmup_runs
+                : std::max<std::size_t>(1, static_cast<std::size_t>(requested_warmup_runs));
+    }
+    return {bundle, samples, bundle * samples, warmup_runs};
+}
+
+double adaptive_time_loop(migraphx::gpu::context& gctx,
+                          const adaptive_time_options& input_options,
+                          const std::function<void()>& f)
+{
+    const auto options = resolve_options(input_options);
+    if(options.estimated_ms <= 0.0 and options.estimate_runs == 0)
+        MIGRAPHX_THROW("Adaptive timing estimate runs must be greater than zero");
+
+    // Run once to initialize lazy GPU resources and count it toward the warmup budget.
+    f();
+    std::size_t completed_warmup_runs = 1;
+
+    double estimate_ms = options.estimated_ms;
+    if(estimate_ms <= 0.0)
+    {
+        estimate_ms = estimate_time(gctx, options.estimate_runs, f);
+        completed_warmup_runs += options.estimate_runs;
+    }
+    estimate_ms = std::max(estimate_ms, min_execution_ms);
+
+    const auto schedule = make_timing_schedule(estimate_ms, options);
+    if(schedule.warmup_runs > completed_warmup_runs)
+    {
+        const auto additional_warmup_runs = schedule.warmup_runs - completed_warmup_runs;
+        for(auto i : range(additional_warmup_runs))
+        {
+            (void)i;
+            f();
+        }
+    }
+
+    auto times = measure_loop(gctx, schedule.bundle, schedule.samples, f);
+    return common_average(std::move(times));
+}
+
+static optional<double> time_candidate(std::size_t i,
+                                       const adaptive_time_options& options,
+                                       std::size_t candidate_delay_us,
+                                       const adaptive_time_callback& benchmark)
+{
+    auto result = benchmark(i, options);
+    if(result.has_value() and (not std::isfinite(*result) or *result <= 0.0))
+        result = nullopt;
+    if(candidate_delay_us > 0)
+        std::this_thread::sleep_for(std::chrono::microseconds{
+            static_cast<std::chrono::microseconds::rep>(candidate_delay_us)});
+    return result;
+}
+
+optional<std::size_t> adaptive_time_topk(std::size_t candidate_count,
+                                         const adaptive_tuning_options& options,
+                                         const adaptive_time_callback& benchmark)
+{
+    using delay_rep = std::chrono::microseconds::rep;
+    if(options.sleep_us > static_cast<std::size_t>(std::numeric_limits<delay_rep>::max()))
+        MIGRAPHX_THROW("Adaptive tuning candidate delay is too large");
+    const auto coarse_options  = normalize_options(options.coarse);
+    const auto precise_options = normalize_options(options.precise);
+
+    std::vector<optional<double>> coarse(candidate_count);
+    std::vector<optional<double>> precise(candidate_count);
+    auto indices = range(candidate_count);
+
+    if(options.top_k == 0)
+    {
+        std::transform(indices.begin(), indices.end(), precise.begin(), [&](auto i) {
+            return time_candidate(i, precise_options, options.sleep_us, benchmark);
+        });
+    }
+    else
+    {
+        std::transform(indices.begin(), indices.end(), coarse.begin(), [&](auto i) {
+            return time_candidate(i, coarse_options, options.sleep_us, benchmark);
+        });
+
+        std::vector<std::size_t> ranked;
+        std::copy_if(indices.begin(), indices.end(), std::back_inserter(ranked), [&](auto i) {
+            return coarse[i].has_value();
+        });
+        std::sort(ranked.begin(), ranked.end(), [&](auto x, auto y) {
+            const auto xtime = *coarse[x];
+            const auto ytime = *coarse[y];
+            return std::tie(xtime, x) < std::tie(ytime, y);
+        });
+
+        const auto top_k = std::min(options.top_k, ranked.size());
+        std::accumulate(ranked.begin(), ranked.end(), std::size_t{0}, [&](auto measured, auto i) {
+            if(measured >= top_k)
+                return measured;
+            auto candidate_options         = precise_options;
+            candidate_options.estimated_ms = *coarse[i];
+            precise[i] = time_candidate(i, candidate_options, options.sleep_us, benchmark);
+            return measured + precise[i].has_value();
+        });
+    }
+
+    std::vector<std::size_t> measured;
+    std::copy_if(indices.begin(), indices.end(), std::back_inserter(measured), [&](auto i) {
+        return precise[i].has_value();
+    });
+    if(measured.empty())
+        return nullopt;
+    return *std::min_element(measured.begin(), measured.end(), [&](auto x, auto y) {
+        const auto xtime = *precise[x];
+        const auto ytime = *precise[y];
+        return std::tie(xtime, x) < std::tie(ytime, y);
+    });
 }
 
 double
 time_loop(migraphx::gpu::context& gctx, int bundle, int nruns, const std::function<void()>& f)
 {
-    return time_loop_impl(gctx, bundle, nruns, f, 0);
+    if(bundle <= 0 or nruns <= 0)
+        MIGRAPHX_THROW("Timing bundle and runs must be greater than zero");
+    auto repeats = static_cast<std::size_t>(bundle);
+    auto samples = static_cast<std::size_t>(nruns);
+    if(const auto env_bundle = benchmarking_override(MIGRAPHX_BENCHMARKING_BUNDLE{}))
+        repeats = *env_bundle;
+    if(const auto env_samples = benchmarking_override(MIGRAPHX_BENCHMARKING_NRUNS{}))
+        samples = *env_samples;
+    f();
+    return common_average(measure_loop(gctx, repeats, samples, f));
 }
 
 double
@@ -134,19 +318,18 @@ double time_op(const context& ictx, operation op, int bundle, int nruns)
     return time_op(ictx, op, inputs, bundle, nruns);
 }
 
-double time_program(const context& ictx,
-                    program p,
-                    const std::unordered_map<std::string, double>& fill_map,
-                    int bundle,
-                    int nruns,
-                    std::size_t target_ms)
+template <class F>
+static auto time_program_impl(const context& ictx,
+                              program p,
+                              const std::unordered_map<std::string, double>& fill_map,
+                              F f)
 {
-    std::vector<migraphx::context> ctx_vec = {ictx};
-    auto& gctx                             = any_cast<migraphx::gpu::context>(ctx_vec.front());
-    auto* mm                               = p.get_main_module();
-    mm->finalize(ctx_vec);
+    std::vector<migraphx::context> contexts = {ictx};
+    auto& gctx                              = any_cast<migraphx::gpu::context>(contexts.front());
+    auto* mm                                = p.get_main_module();
+    mm->finalize(contexts);
     auto in_shapes = p.get_parameter_shapes();
-    std::unordered_map<std::string, migraphx::argument> param_map;
+    parameter_map params;
     unsigned long seed = 0;
     for(const auto& [name, shape] : in_shapes)
     {
@@ -158,15 +341,36 @@ double time_program(const context& ictx,
         // on the GPU to skip the host PRNG + H2D copy per candidate.
         if(contains(fill_map, id))
         {
-            param_map[name] = to_gpu(fill_argument(shape, fill_map.at(id)));
+            params[name] = to_gpu(fill_argument(shape, fill_map.at(id)));
         }
         else
         {
-            param_map[name] = gpu_generate_random(gctx, shape, seed++);
+            params[name] = gpu_generate_random(gctx, shape, seed++);
         }
     }
-    auto run = [&] { p.eval_with_context(ctx_vec, param_map); };
-    return time_loop_impl(gctx, bundle, nruns, run, target_ms);
+    auto run = [&] { p.eval_with_context(contexts, params); };
+    return f(gctx, run);
+}
+
+double time_program(const context& ictx,
+                    program p,
+                    const std::unordered_map<std::string, double>& fill_map,
+                    int bundle,
+                    int nruns)
+{
+    return time_program_impl(ictx, std::move(p), fill_map, [&](auto& gctx, const auto& run) {
+        return time_loop(gctx, bundle, nruns, run);
+    });
+}
+
+double adaptive_time_program(const context& ictx,
+                             program p,
+                             const std::unordered_map<std::string, double>& fill_map,
+                             const adaptive_time_options& options)
+{
+    return time_program_impl(ictx, std::move(p), fill_map, [&](auto& gctx, const auto& run) {
+        return adaptive_time_loop(gctx, options, run);
+    });
 }
 
 } // namespace gpu

--- a/src/targets/gpu/time_op.cpp
+++ b/src/targets/gpu/time_op.cpp
@@ -31,6 +31,7 @@
 #include <migraphx/ranges.hpp>
 #include <migraphx/gpu/hip.hpp>
 #include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <cmath>
 #include <functional>
@@ -63,14 +64,17 @@ static std::vector<argument> generate_arguments(const std::vector<shape>& shapes
 
 static double common_average(std::vector<double> times)
 {
+    assert(not times.empty());
     std::sort(times.begin(), times.end());
     const std::size_t quarters = times.size() / 4;
-    // With fewer than four samples there is nothing to trim, and an untrimmed mean lets a single
-    // interfered run dominate. Interference can only slow a run down, so use the fastest sample.
+    auto first                 = times.begin() + quarters;
+    auto last                  = times.end() - quarters;
+
     if(quarters == 0)
-        return times.front();
-    const auto first = times.begin() + quarters;
-    const auto last  = times.end() - quarters;
+    {
+        first = times.begin() + (times.size() - 1) / 2;
+        last  = times.begin() + times.size() / 2 + 1;
+    }
     return std::accumulate(first, last, 0.0) / std::distance(first, last);
 }
 
@@ -314,13 +318,19 @@ optional<std::size_t> adaptive_time_topk_staged(std::size_t candidate_count,
             const auto ytime = *coarse[y];
             return std::tie(xtime, x) < std::tie(ytime, y);
         });
+        // A candidate the coarse stage could not time is not known to be slow, only unmeasured, so
+        // it stays eligible for a precise measurement once the ranked candidates are exhausted.
+        std::copy_if(indices.begin(), indices.end(), std::back_inserter(ranked), [&](auto i) {
+            return not coarse[i].has_value();
+        });
 
         const auto top_k = std::min(options.top_k, ranked.size());
         std::accumulate(ranked.begin(), ranked.end(), std::size_t{0}, [&](auto measured, auto i) {
             if(measured >= top_k)
                 return measured;
-            auto candidate_options         = precise_options;
-            candidate_options.estimated_ms = *coarse[i];
+            auto candidate_options = precise_options;
+            if(coarse[i].has_value())
+                candidate_options.estimated_ms = *coarse[i];
             precise[i] = time_candidate(i,
                                         adaptive_time_stage::precise,
                                         candidate_options,
@@ -407,6 +417,15 @@ void prepared_time_program::run()
     p.eval_with_context(contexts, *params);
 }
 
+static bool covers_parameters(const parameter_map& params,
+                              const std::unordered_map<std::string, shape>& in_shapes)
+{
+    return std::all_of(in_shapes.begin(), in_shapes.end(), [&](const auto& p) {
+        const auto it = params.find(p.first);
+        return it != params.end() and it->second.get_shape() == p.second;
+    });
+}
+
 prepared_time_program
 prepare_time_program(const context& ictx,
                      program p,
@@ -417,10 +436,15 @@ prepare_time_program(const context& ictx,
     auto& gctx                              = any_cast<migraphx::gpu::context>(contexts.front());
     auto* mm                                = p.get_main_module();
     mm->finalize(contexts);
+    auto in_shapes = p.get_parameter_shapes();
+    // Buffers are only a reuse hint. Tuning candidates for one problem can allocate different
+    // workspaces, so a map that does not cover every parameter is replaced instead of being
+    // passed to a program that would reject it.
+    if(params and not covers_parameters(*params, in_shapes))
+        params = nullptr;
     if(not params)
     {
         params             = std::make_shared<parameter_map>();
-        auto in_shapes     = p.get_parameter_shapes();
         unsigned long seed = 0;
         for(const auto& [name, shape] : in_shapes)
         {

--- a/src/targets/gpu/time_op.cpp
+++ b/src/targets/gpu/time_op.cpp
@@ -28,6 +28,7 @@
 #include <migraphx/generate.hpp>
 #include <migraphx/time.hpp>
 #include <migraphx/gpu/hip.hpp>
+#include <cmath>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -47,12 +48,36 @@ static std::vector<argument> generate_arguments(const std::vector<shape>& shapes
     return args;
 }
 
-double
-time_loop(migraphx::gpu::context& gctx, int bundle, int nruns, const std::function<void()>& f)
+static double time_loop_impl(migraphx::gpu::context& gctx,
+                             int bundle,
+                             int nruns,
+                             const std::function<void()>& f,
+                             std::size_t target_ms)
 {
     // check for manual overrides
     bundle = value_of(MIGRAPHX_BENCHMARKING_BUNDLE{}, bundle);
     nruns  = value_of(MIGRAPHX_BENCHMARKING_NRUNS{}, nruns);
+
+    if(target_ms > 0)
+    {
+        // Estimate one launch, then choose a bounded run count for the requested time budget.
+        f();
+        auto estimate_start = context::create_event_for_timing();
+        auto estimate_stop  = context::create_event_for_timing();
+        gctx.get_stream().record(estimate_start.get());
+        f();
+        gctx.get_stream().record(estimate_stop.get());
+        gctx.finish();
+
+        constexpr double min_time_ms = 0.001;
+        const auto estimate_ms =
+            std::max<double>(context::get_elapsed_ms(estimate_start.get(), estimate_stop.get()),
+                             min_time_ms);
+        bundle                     = std::max(bundle, 1);
+        const auto requested_nruns = std::ceil(target_ms / (estimate_ms * bundle));
+        nruns                      = static_cast<int>(
+            std::clamp(requested_nruns, 1.0, static_cast<double>(std::max(nruns, 1))));
+    }
 
     std::vector<std::pair<hip_event_ptr, hip_event_ptr>> events(nruns);
     std::generate(events.begin(), events.end(), [] {
@@ -60,8 +85,8 @@ time_loop(migraphx::gpu::context& gctx, int bundle, int nruns, const std::functi
                               context::create_event_for_timing());
     });
     std::vector<double> times;
-    // Warmup
-    f();
+    if(target_ms == 0)
+        f();
     for(auto i : range(nruns))
     {
         gctx.get_stream().record(events[i].first.get());
@@ -82,6 +107,12 @@ time_loop(migraphx::gpu::context& gctx, int bundle, int nruns, const std::functi
     std::size_t quarters = times.size() / 4;
     double total         = std::accumulate(times.begin() + quarters, times.end() - quarters, 0.0);
     return total / std::distance(times.begin() + quarters, times.end() - quarters);
+}
+
+double
+time_loop(migraphx::gpu::context& gctx, int bundle, int nruns, const std::function<void()>& f)
+{
+    return time_loop_impl(gctx, bundle, nruns, f, 0);
 }
 
 double
@@ -107,7 +138,8 @@ double time_program(const context& ictx,
                     program p,
                     const std::unordered_map<std::string, double>& fill_map,
                     int bundle,
-                    int nruns)
+                    int nruns,
+                    std::size_t target_ms)
 {
     std::vector<migraphx::context> ctx_vec = {ictx};
     auto& gctx                             = any_cast<migraphx::gpu::context>(ctx_vec.front());
@@ -134,7 +166,7 @@ double time_program(const context& ictx,
         }
     }
     auto run = [&] { p.eval_with_context(ctx_vec, param_map); };
-    return time_loop(gctx, bundle, nruns, run);
+    return time_loop_impl(gctx, bundle, nruns, run, target_ms);
 }
 
 } // namespace gpu

--- a/src/targets/gpu/time_op.cpp
+++ b/src/targets/gpu/time_op.cpp
@@ -371,8 +371,8 @@ time_loop(migraphx::gpu::context& gctx, int bundle, int nruns, const std::functi
 {
     if(bundle <= 0 or nruns <= 0)
         MIGRAPHX_THROW("Timing bundle and runs must be greater than zero");
-    auto repeats = static_cast<std::size_t>(bundle);
-    auto samples = static_cast<std::size_t>(nruns);
+    std::size_t repeats = bundle;
+    std::size_t samples = nruns;
     if(const auto env_bundle = benchmarking_override(MIGRAPHX_BENCHMARKING_BUNDLE{}))
         repeats = *env_bundle;
     if(const auto env_samples = benchmarking_override(MIGRAPHX_BENCHMARKING_NRUNS{}))

--- a/test/gpu/time_op.cpp
+++ b/test/gpu/time_op.cpp
@@ -192,7 +192,7 @@ TEST_CASE(adaptive_time_loop_shares_coarse_and_precise_total_budget)
     migraphx::gpu::adaptive_tuning_options tuning;
     constexpr std::size_t preferred_bundle = 10;
     constexpr std::size_t candidate_budget = 1 + 20 * preferred_bundle;
-    std::size_t executions = 0;
+    std::size_t executions                 = 0;
 
     auto coarse             = tuning.coarse;
     coarse.preferred_bundle = preferred_bundle;
@@ -207,9 +207,8 @@ TEST_CASE(adaptive_time_loop_shares_coarse_and_precise_total_budget)
     migraphx::gpu::adaptive_time_budget precise_budget;
     precise_budget.skip_initialization = true;
     precise_budget.max_executions      = candidate_budget - executions;
-    precise.max_executions = precise_budget.max_executions;
-    migraphx::gpu::adaptive_time_loop(
-        ctx, precise, precise_budget, [&] { executions++; });
+    precise.max_executions             = precise_budget.max_executions;
+    migraphx::gpu::adaptive_time_loop(ctx, precise, precise_budget, [&] { executions++; });
 
     EXPECT(executions <= candidate_budget);
 }
@@ -218,12 +217,11 @@ TEST_CASE(adaptive_time_program_reuses_prepared_setup_and_budget)
 {
     migraphx::program p;
     auto* mm  = p.get_main_module();
-    auto data = mm->add_parameter(
-        "data", migraphx::shape{migraphx::shape::float_type, {1}});
+    auto data = mm->add_parameter("data", migraphx::shape{migraphx::shape::float_type, {1}});
     mm->add_return({data});
 
     migraphx::gpu::context ctx;
-    auto prepared = migraphx::gpu::prepare_time_program(ctx, std::move(p), {});
+    auto prepared     = migraphx::gpu::prepare_time_program(ctx, std::move(p), {});
     const auto params = prepared.params;
     constexpr std::size_t candidate_budget = 21;
 
@@ -344,8 +342,9 @@ TEST_CASE(adaptive_time_topk_zero_measures_every_candidate_precisely)
     std::size_t precise_calls               = 0;
 
     const auto result = migraphx::gpu::adaptive_time_topk_staged(
-        precise_times.size(), options, [&](auto i, auto stage, const auto&)
-                                          -> migraphx::optional<double> {
+        precise_times.size(),
+        options,
+        [&](auto i, auto stage, const auto&) -> migraphx::optional<double> {
             EXPECT(stage == migraphx::gpu::adaptive_time_stage::precise);
             precise_calls++;
             return precise_times[i];
@@ -426,4 +425,3 @@ TEST_CASE(adaptive_time_topk_promotes_after_coarse_failure)
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }
-

--- a/test/gpu/time_op.cpp
+++ b/test/gpu/time_op.cpp
@@ -70,6 +70,39 @@ TEST_CASE(adaptive_time_schedule_coarse_stage_keeps_slow_candidate_cheap)
     EXPECT(schedule.executions == 1);
 }
 
+TEST_CASE(adaptive_time_schedule_coarse_stage_samples_fast_candidate)
+{
+    const migraphx::gpu::adaptive_tuning_options tuning;
+    auto options = tuning.coarse;
+    // Executions the coarse stage has left for measurement once its initialization and estimate
+    // runs are paid for.
+    options.max_executions = 4;
+
+    const auto schedule = migraphx::gpu::make_timing_schedule(0.01, options);
+
+    // Ranking a fast candidate from a single run would let event overhead decide the order, so the
+    // coarse budget is spent on several samples that common_average can trim.
+    EXPECT(schedule.bundle == 1);
+    EXPECT(schedule.samples == options.max_executions);
+    EXPECT(schedule.executions == options.max_executions);
+}
+
+TEST_CASE(adaptive_time_schedule_coarse_stage_bundles_split_k_candidate)
+{
+    const migraphx::gpu::adaptive_tuning_options tuning;
+    auto options             = tuning.coarse;
+    options.preferred_bundle = 5;
+    options.max_executions   = 4 * options.preferred_bundle;
+
+    const auto schedule = migraphx::gpu::make_timing_schedule(0.01, options);
+
+    // A split-k candidate keeps its prefill bundled into every sample rather than trading the
+    // bundle away for more samples.
+    EXPECT(schedule.bundle == options.preferred_bundle);
+    EXPECT(schedule.samples == 4);
+    EXPECT(schedule.executions == options.max_executions);
+}
+
 TEST_CASE(adaptive_time_schedule_clamps_max_samples_below_min)
 {
     migraphx::gpu::adaptive_time_options options;

--- a/test/gpu/time_op.cpp
+++ b/test/gpu/time_op.cpp
@@ -1,0 +1,229 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <migraphx/gpu/compile_ops.hpp>
+#include <migraphx/serialize.hpp>
+#include <test.hpp>
+#include <algorithm>
+#include <limits>
+
+TEST_CASE(adaptive_time_schedule_slow_candidate)
+{
+    migraphx::gpu::adaptive_time_options options;
+    options.target_ms        = 100;
+    options.preferred_bundle = 10;
+
+    const auto schedule = migraphx::gpu::make_timing_schedule(1000.0, options);
+
+    // A candidate slower than the whole budget still takes min_samples samples, otherwise a
+    // single interfered run would decide the result.
+    EXPECT(schedule.bundle == 1);
+    EXPECT(schedule.samples == options.min_samples);
+    EXPECT(schedule.executions == options.min_samples);
+    EXPECT(schedule.warmup_runs == 1);
+}
+
+TEST_CASE(adaptive_time_schedule_coarse_stage_keeps_slow_candidate_cheap)
+{
+    const migraphx::gpu::adaptive_tuning_options tuning;
+
+    const auto schedule = migraphx::gpu::make_timing_schedule(1000.0, tuning.coarse);
+
+    // The coarse stage runs on every candidate and only has to rank them, so it does not pay the
+    // min_samples floor.
+    EXPECT(schedule.bundle == 1);
+    EXPECT(schedule.samples == 1);
+    EXPECT(schedule.executions == 1);
+}
+
+TEST_CASE(adaptive_time_schedule_clamps_max_samples_below_min)
+{
+    migraphx::gpu::adaptive_time_options options;
+    options.target_ms   = 100;
+    options.max_samples = 2;
+
+    const auto schedule = migraphx::gpu::make_timing_schedule(1000.0, options);
+
+    EXPECT(options.max_samples < options.min_samples);
+    EXPECT(schedule.samples == options.max_samples);
+}
+
+TEST_CASE(adaptive_time_schedule_uses_preferred_bundle)
+{
+    migraphx::gpu::adaptive_time_options options;
+    options.target_ms        = 100;
+    options.preferred_bundle = 10;
+
+    const auto schedule = migraphx::gpu::make_timing_schedule(1.0, options);
+
+    EXPECT(schedule.bundle == 10);
+    EXPECT(schedule.samples == 10);
+    EXPECT(schedule.executions == 100);
+    EXPECT(schedule.warmup_runs == 25);
+}
+
+TEST_CASE(adaptive_time_schedule_caps_fast_candidate)
+{
+    migraphx::gpu::adaptive_time_options options;
+    options.target_ms        = 100;
+    options.preferred_bundle = 10;
+
+    const auto schedule = migraphx::gpu::make_timing_schedule(0.001, options);
+
+    EXPECT(schedule.bundle == 500);
+    EXPECT(schedule.samples == 20);
+    EXPECT(schedule.executions == options.max_executions);
+    EXPECT(schedule.warmup_runs == options.max_warmup_runs);
+}
+
+TEST_CASE(adaptive_time_schedule_rejects_nonfinite_estimate)
+{
+    migraphx::gpu::adaptive_time_options options;
+    EXPECT(test::throws([&] {
+        migraphx::gpu::make_timing_schedule(std::numeric_limits<double>::quiet_NaN(), options);
+    }));
+}
+
+TEST_CASE(compile_ops_tuning_overrides_resolve)
+{
+    migraphx::value values;
+    values["tuning_top_k"]             = 0;
+    values["tuning_coarse_target_ms"]  = 3;
+    values["tuning_precise_target_ms"] = 30;
+    values["tuning_max_samples"]       = 8;
+    values["tuning_sleep_us"]          = 0;
+
+    const auto overrides =
+        migraphx::from_value<migraphx::gpu::compile_ops_tuning_overrides>(values);
+    const auto options = overrides.resolve();
+    EXPECT(options.top_k == 0);
+    EXPECT(options.coarse.target_ms == 3);
+    EXPECT(options.precise.target_ms == 30);
+    EXPECT(options.coarse.max_samples == 8);
+    EXPECT(options.precise.max_samples == 8);
+    EXPECT(options.sleep_us == 0);
+}
+
+TEST_CASE(compile_ops_tuning_overrides_reject_invalid_values)
+{
+    migraphx::gpu::compile_ops_tuning_overrides negative_top_k;
+    negative_top_k.top_k = -1;
+    EXPECT(test::throws([&] { negative_top_k.resolve(); }));
+
+    migraphx::gpu::compile_ops_tuning_overrides zero_target;
+    zero_target.coarse_target_ms = 0;
+    EXPECT(test::throws([&] { zero_target.resolve(); }));
+}
+
+TEST_CASE(adaptive_time_topk_shortlists_candidates)
+{
+    migraphx::gpu::adaptive_tuning_options options;
+    options.top_k                           = 2;
+    options.sleep_us                        = 0;
+    const std::vector<double> coarse_times  = {5.0, 1.0, 3.0, 2.0, 4.0};
+    const std::vector<double> precise_times = {5.0, 4.0, 3.0, 1.0, 2.0};
+    std::vector<std::size_t> coarse_calls(coarse_times.size());
+    std::vector<std::size_t> precise_calls(precise_times.size());
+
+    const auto result = migraphx::gpu::adaptive_time_topk(
+        coarse_times.size(),
+        options,
+        [&](auto i, const auto& timing) -> migraphx::optional<double> {
+            if(timing.estimated_ms == 0.0)
+            {
+                coarse_calls[i]++;
+                return coarse_times[i];
+            }
+            precise_calls[i]++;
+            return precise_times[i];
+        });
+
+    EXPECT(result == 3);
+    EXPECT(std::all_of(coarse_calls.begin(), coarse_calls.end(), [](auto n) { return n == 1; }));
+    EXPECT(precise_calls == std::vector<std::size_t>{0, 1, 0, 1, 0});
+}
+
+TEST_CASE(adaptive_time_topk_zero_measures_every_candidate_precisely)
+{
+    migraphx::gpu::adaptive_tuning_options options;
+    options.top_k                           = 0;
+    options.sleep_us                        = 0;
+    const std::vector<double> precise_times = {3.0, 1.0, 2.0};
+    std::size_t precise_calls               = 0;
+
+    const auto result = migraphx::gpu::adaptive_time_topk(
+        precise_times.size(), options, [&](auto i, const auto&) -> migraphx::optional<double> {
+            precise_calls++;
+            return precise_times[i];
+        });
+
+    EXPECT(result == 1);
+    EXPECT(precise_calls == precise_times.size());
+}
+
+TEST_CASE(adaptive_time_topk_allows_max_samples_below_min)
+{
+    migraphx::gpu::adaptive_tuning_options options;
+    options.top_k               = 0;
+    options.sleep_us            = 0;
+    options.precise.max_samples = 2;
+    std::vector<migraphx::gpu::adaptive_time_options> seen;
+
+    const auto result = migraphx::gpu::adaptive_time_topk(
+        2, options, [&](auto i, const auto& o) -> migraphx::optional<double> {
+            seen.push_back(o);
+            return i == 0 ? 2.0 : 1.0;
+        });
+
+    EXPECT(result == 1);
+    EXPECT(seen.size() == 2);
+    EXPECT(std::all_of(
+        seen.begin(), seen.end(), [](const auto& o) { return o.min_samples <= o.max_samples; }));
+}
+
+TEST_CASE(adaptive_time_topk_promotes_after_precise_failure)
+{
+    migraphx::gpu::adaptive_tuning_options options;
+    options.top_k                          = 2;
+    options.sleep_us                       = 0;
+    const std::vector<double> coarse_times = {1.0, 2.0, 3.0, 4.0};
+    std::vector<std::size_t> precise_calls(coarse_times.size());
+
+    const auto result = migraphx::gpu::adaptive_time_topk(
+        coarse_times.size(),
+        options,
+        [&](auto i, const auto& timing) -> migraphx::optional<double> {
+            if(timing.estimated_ms == 0.0)
+                return coarse_times[i];
+            precise_calls[i]++;
+            if(i == 0)
+                return migraphx::nullopt;
+            return i == 2 ? 1.0 : 2.0;
+        });
+
+    EXPECT(result == 2);
+    EXPECT(precise_calls == std::vector<std::size_t>{1, 1, 1, 0});
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/gpu/time_op.cpp
+++ b/test/gpu/time_op.cpp
@@ -245,6 +245,29 @@ TEST_CASE(adaptive_time_program_reuses_prepared_setup_and_budget)
     EXPECT(prepared.executions <= candidate_budget);
 }
 
+TEST_CASE(prepare_time_program_rejects_mismatched_parameters)
+{
+    const auto make_prog = [](std::size_t n) {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        mm->add_return(
+            {mm->add_parameter("data", migraphx::shape{migraphx::shape::float_type, {n}})});
+        return p;
+    };
+
+    migraphx::gpu::context ctx;
+    auto prepared = migraphx::gpu::prepare_time_program(ctx, make_prog(2), {});
+    // Tuning candidates for one problem can allocate different workspaces, so buffers shaped for
+    // one candidate must not be handed to another.
+    auto mismatched = migraphx::gpu::prepare_time_program(ctx, make_prog(4), {}, prepared.params);
+    auto matched    = migraphx::gpu::prepare_time_program(ctx, make_prog(2), {}, prepared.params);
+
+    EXPECT(mismatched.params != prepared.params);
+    EXPECT(matched.params == prepared.params);
+    mismatched.run();
+    matched.run();
+}
+
 TEST_CASE(adaptive_time_schedule_rejects_nonfinite_estimate)
 {
     migraphx::gpu::adaptive_time_options options;
@@ -374,6 +397,32 @@ TEST_CASE(adaptive_time_topk_promotes_after_precise_failure)
 
     EXPECT(result == 2);
     EXPECT(precise_calls == std::vector<std::size_t>{1, 1, 1, 0});
+}
+
+TEST_CASE(adaptive_time_topk_promotes_after_coarse_failure)
+{
+    migraphx::gpu::adaptive_tuning_options options;
+    options.top_k                           = 2;
+    options.sleep_us                        = 0;
+    const std::vector<double> precise_times = {5.0, 1.0, 2.0, 3.0};
+    std::vector<std::size_t> precise_calls(precise_times.size());
+
+    const auto result = migraphx::gpu::adaptive_time_topk_staged(
+        precise_times.size(),
+        options,
+        [&](auto i, auto stage, const auto& timing) -> migraphx::optional<double> {
+            if(stage == migraphx::gpu::adaptive_time_stage::coarse)
+                return i == 0 ? migraphx::optional<double>{5.0} : migraphx::nullopt;
+            // Only a coarsely ranked candidate carries an estimate into precise timing.
+            EXPECT((timing.estimated_ms > 0.0) == (i == 0));
+            precise_calls[i]++;
+            return precise_times[i];
+        });
+
+    // A candidate the coarse stage could not measure is unranked, not rejected, so it is still
+    // eligible for precise timing and can win.
+    EXPECT(result == 1);
+    EXPECT(precise_calls == std::vector<std::size_t>{1, 1, 0, 0});
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/gpu/time_op.cpp
+++ b/test/gpu/time_op.cpp
@@ -28,6 +28,19 @@
 #include <algorithm>
 #include <limits>
 
+TEST_CASE(adaptive_tuning_default_budgets)
+{
+    const migraphx::gpu::adaptive_tuning_options options;
+
+    EXPECT(options.coarse.target_ms == 10);
+    EXPECT(options.precise.target_ms == 20);
+    EXPECT(options.coarse.warmup_ms == 0);
+    EXPECT(options.precise.warmup_ms == 0);
+    EXPECT(options.coarse.estimate_runs == 1);
+    EXPECT(options.precise.estimate_runs == 1);
+    EXPECT(options.top_k == 10);
+}
+
 TEST_CASE(adaptive_time_schedule_slow_candidate)
 {
     migraphx::gpu::adaptive_time_options options;
@@ -80,7 +93,7 @@ TEST_CASE(adaptive_time_schedule_uses_preferred_bundle)
     EXPECT(schedule.bundle == 10);
     EXPECT(schedule.samples == 10);
     EXPECT(schedule.executions == 100);
-    EXPECT(schedule.warmup_runs == 25);
+    EXPECT(schedule.warmup_runs == options.warmup_ms);
 }
 
 TEST_CASE(adaptive_time_schedule_caps_fast_candidate)
@@ -95,6 +108,108 @@ TEST_CASE(adaptive_time_schedule_caps_fast_candidate)
     EXPECT(schedule.samples == 20);
     EXPECT(schedule.executions == options.max_executions);
     EXPECT(schedule.warmup_runs == options.max_warmup_runs);
+}
+
+TEST_CASE(adaptive_time_schedule_caps_at_fixed_benchmark_work)
+{
+    migraphx::gpu::adaptive_time_options options;
+    options.target_ms        = 20;
+    options.preferred_bundle = 10;
+    options.max_executions   = 20 * options.preferred_bundle;
+
+    const auto schedule = migraphx::gpu::make_timing_schedule(0.001, options);
+
+    EXPECT(schedule.bundle == options.preferred_bundle);
+    EXPECT(schedule.samples == options.max_samples);
+    EXPECT(schedule.executions == options.max_executions);
+}
+
+TEST_CASE(adaptive_time_schedule_hard_cap_includes_minimum_samples)
+{
+    migraphx::gpu::adaptive_time_options options;
+    options.target_ms      = 20;
+    options.min_samples    = 4;
+    options.max_executions = 3;
+
+    const auto schedule = migraphx::gpu::make_timing_schedule(1000.0, options);
+
+    EXPECT(schedule.bundle == 1);
+    EXPECT(schedule.samples == options.max_executions);
+    EXPECT(schedule.executions == options.max_executions);
+}
+
+TEST_CASE(adaptive_time_loop_respects_precise_total_budget)
+{
+    migraphx::gpu::context ctx;
+    migraphx::gpu::adaptive_time_options options;
+    options.warmup_ms     = 5;
+    options.estimate_runs = 1;
+    migraphx::gpu::adaptive_time_budget budget;
+    budget.max_executions  = 21;
+    std::size_t executions = 0;
+
+    migraphx::gpu::adaptive_time_loop(ctx, options, budget, [&] { executions++; });
+
+    EXPECT(executions <= budget.max_executions);
+}
+
+TEST_CASE(adaptive_time_loop_shares_coarse_and_precise_total_budget)
+{
+    migraphx::gpu::context ctx;
+    migraphx::gpu::adaptive_tuning_options tuning;
+    constexpr std::size_t preferred_bundle = 10;
+    constexpr std::size_t candidate_budget = 1 + 20 * preferred_bundle;
+    std::size_t executions = 0;
+
+    auto coarse             = tuning.coarse;
+    coarse.preferred_bundle = preferred_bundle;
+    migraphx::gpu::adaptive_time_budget coarse_budget;
+    coarse_budget.max_executions = 2 + preferred_bundle;
+    const auto coarse_time =
+        migraphx::gpu::adaptive_time_loop(ctx, coarse, coarse_budget, [&] { executions++; });
+
+    auto precise             = tuning.precise;
+    precise.preferred_bundle = preferred_bundle;
+    precise.estimated_ms     = coarse_time;
+    migraphx::gpu::adaptive_time_budget precise_budget;
+    precise_budget.skip_initialization = true;
+    precise_budget.max_executions      = candidate_budget - executions;
+    precise.max_executions = precise_budget.max_executions;
+    migraphx::gpu::adaptive_time_loop(
+        ctx, precise, precise_budget, [&] { executions++; });
+
+    EXPECT(executions <= candidate_budget);
+}
+
+TEST_CASE(adaptive_time_program_reuses_prepared_setup_and_budget)
+{
+    migraphx::program p;
+    auto* mm  = p.get_main_module();
+    auto data = mm->add_parameter(
+        "data", migraphx::shape{migraphx::shape::float_type, {1}});
+    mm->add_return({data});
+
+    migraphx::gpu::context ctx;
+    auto prepared = migraphx::gpu::prepare_time_program(ctx, std::move(p), {});
+    const auto params = prepared.params;
+    constexpr std::size_t candidate_budget = 21;
+
+    migraphx::gpu::adaptive_tuning_options tuning;
+    migraphx::gpu::adaptive_time_budget coarse_budget;
+    coarse_budget.max_executions = 3;
+    const auto coarse_time =
+        migraphx::gpu::adaptive_time_program(prepared, tuning.coarse, coarse_budget);
+    const auto coarse_executions = prepared.executions;
+
+    auto precise         = tuning.precise;
+    precise.estimated_ms = coarse_time;
+    migraphx::gpu::adaptive_time_budget precise_budget;
+    precise_budget.max_executions = candidate_budget - coarse_executions;
+    migraphx::gpu::adaptive_time_program(prepared, precise, precise_budget);
+
+    EXPECT(prepared.params == params);
+    EXPECT(coarse_executions > 0);
+    EXPECT(prepared.executions <= candidate_budget);
 }
 
 TEST_CASE(adaptive_time_schedule_rejects_nonfinite_estimate)
@@ -146,11 +261,11 @@ TEST_CASE(adaptive_time_topk_shortlists_candidates)
     std::vector<std::size_t> coarse_calls(coarse_times.size());
     std::vector<std::size_t> precise_calls(precise_times.size());
 
-    const auto result = migraphx::gpu::adaptive_time_topk(
+    const auto result = migraphx::gpu::adaptive_time_topk_staged(
         coarse_times.size(),
         options,
-        [&](auto i, const auto& timing) -> migraphx::optional<double> {
-            if(timing.estimated_ms == 0.0)
+        [&](auto i, auto stage, const auto&) -> migraphx::optional<double> {
+            if(stage == migraphx::gpu::adaptive_time_stage::coarse)
             {
                 coarse_calls[i]++;
                 return coarse_times[i];
@@ -172,8 +287,10 @@ TEST_CASE(adaptive_time_topk_zero_measures_every_candidate_precisely)
     const std::vector<double> precise_times = {3.0, 1.0, 2.0};
     std::size_t precise_calls               = 0;
 
-    const auto result = migraphx::gpu::adaptive_time_topk(
-        precise_times.size(), options, [&](auto i, const auto&) -> migraphx::optional<double> {
+    const auto result = migraphx::gpu::adaptive_time_topk_staged(
+        precise_times.size(), options, [&](auto i, auto stage, const auto&)
+                                          -> migraphx::optional<double> {
+            EXPECT(stage == migraphx::gpu::adaptive_time_stage::precise);
             precise_calls++;
             return precise_times[i];
         });
@@ -210,11 +327,11 @@ TEST_CASE(adaptive_time_topk_promotes_after_precise_failure)
     const std::vector<double> coarse_times = {1.0, 2.0, 3.0, 4.0};
     std::vector<std::size_t> precise_calls(coarse_times.size());
 
-    const auto result = migraphx::gpu::adaptive_time_topk(
+    const auto result = migraphx::gpu::adaptive_time_topk_staged(
         coarse_times.size(),
         options,
-        [&](auto i, const auto& timing) -> migraphx::optional<double> {
-            if(timing.estimated_ms == 0.0)
+        [&](auto i, auto stage, const auto&) -> migraphx::optional<double> {
+            if(stage == migraphx::gpu::adaptive_time_stage::coarse)
                 return coarse_times[i];
             precise_calls[i]++;
             if(i == 0)
@@ -227,3 +344,4 @@ TEST_CASE(adaptive_time_topk_promotes_after_precise_failure)
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }
+


### PR DESCRIPTION
## Motivation
GPU JIT tuning timed every solution candidate with a fixed schedule (20 samples of a `bundle`-sized inner loop), so the wall-clock cost of tuning scaled with how slow the candidates happened to be. A problem with a long solution list, or with candidates in the tens of milliseconds, could spend minutes in `compile_ops` and hit compile timeouts, and there was no way to cap or configure that cost.

## Technical Details

### Two-stage candidate selection
When more than 10 valid candidates are available:
1. Briefly benchmark every candidate in a coarse ranking stage.
2. Precisely benchmark the fastest 10 candidates.
3. Select the fastest successful precise result.

When there are 10 or fewer candidates, every candidate is measured precisely and the coarse stage is skipped. If a shortlisted candidate fails, the next coarse-ranked candidate is promoted.

### Hard per-candidate execution budget
Each candidate is capped at `1 + 20 × benchmark_bundle` executions across initialization, estimation, coarse timing, and precise timing. This matches the work allowed by the previous fixed 20-sample benchmark rather than adding coarse and precise work on top of it.

The timing scheduler still adapts bundle and sample counts to candidate speed, but cannot exceed this lifetime budget.

### Performance

Compared with `develop` across tier-1 models:
- 28.0% geomean compile-time reduction (1.39× speedup)
- 46.3% reduction in total compilation time
    - 6,579 seconds reduced to 3,533 seconds
- Inference geomean improved by 1.26%

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [X] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
