### PR TITLE
[Release merge - no review] Problem cache (#5117) -> gpuep-rel-2610

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Full documentation for MIGraphX is available at
 
 ### Added
 
+* Added a layered problem-cache priority list (searched in order, first hit wins), delivered to the GPU target through the `problem_cache_files` backend option.
 * Added `ArrayFeatureExtractor` ONNX operator support (#4742).
 * Added YOLO26 object detection example notebook.
 * Added `auto_pad` attribute support for the ONNX `ConvTranspose` operator, supporting `SAME_UPPER`, `SAME_LOWER`, and `VALID` padding modes for static shapes (#4638).

--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -223,6 +223,7 @@ add_library(migraphx_gpu
     hipblaslt.cpp
     hip_gemm_impl.cpp
     hsa_chiplet.cpp
+    json_problem_cache.cpp
     kernel.cpp
     lower_device_ops.cpp
     lowering.cpp
@@ -240,6 +241,7 @@ add_library(migraphx_gpu
     propagate_reshape_layout.cpp
     rocblas.cpp
     schedule_model.cpp
+    sqlite_problem_cache.cpp
     sync_device.cpp
     target.cpp
     time_op.cpp

--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -342,7 +342,9 @@ struct compile_plan
         if(config.has_value())
         {
             const auto& problem = config->problem;
-            if(auto sol = ctx->get_problem_cache().get(preop.name(), problem))
+            // Priority search (read-only layers first, then writable; first hit
+            // wins) is handled inside problem_cache.
+            if(auto sol = ctx->problem_cache_get(preop.name(), problem))
             {
                 const auto& solution = sol.value();
                 // No solution yet until benchmarked so skip for now
@@ -362,13 +364,14 @@ struct compile_plan
                 if(skip_benchmark or enabled(MIGRAPHX_SKIP_BENCHMARKING{}) or
                    (ctx->is_cross_compile() and not dump_mxr) or solutions.size() == 1)
                 {
-                    ctx->get_problem_cache().insert(preop.name(), problem, solutions.front());
+                    // Write to writable cache only (never to shipped/read-only)
+                    ctx->problem_cache_insert(preop.name(), problem, solutions.front());
                     results.resize(1);
                     insert_compiles(compiles, solutions.front(), 0);
                 }
                 else
                 {
-                    ctx->get_problem_cache().mark(preop.name(), problem);
+                    ctx->problem_cache_mark(preop.name(), problem);
                     results.resize(solutions.size());
                     for(auto i : range(solutions.size()))
                     {
@@ -478,11 +481,12 @@ struct compile_plan
                        });
         std::this_thread::sleep_for(std::chrono::milliseconds{50});
         auto i = std::distance(times.begin(), std::min_element(times.begin(), times.end()));
-        ctx->get_problem_cache().insert(preop.name(), config->problem, config->solutions.at(i));
+        // Write winner to writable cache only (never shipped/read-only caches)
+        ctx->problem_cache_insert(preop.name(), config->problem, config->solutions.at(i));
         if(trace_level > 0)
         {
             std::cout << "Fastest solution: " << config->solutions.at(i) << std::endl;
-            ctx->get_problem_cache().save();
+            ctx->save_problem_cache();
         }
         if(not results[i].has_value())
             MIGRAPHX_THROW("No valid tuned compilation for " + preop.name() + " with " +

--- a/src/targets/gpu/gemm_impl.cpp
+++ b/src/targets/gpu/gemm_impl.cpp
@@ -592,16 +592,15 @@ static void gemm_save_solution(context& ctx,
                                const std::vector<shape>& input_shapes,
                                int32_t solution_idx)
 {
-    ctx.get_problem_cache().insert(
-        "rocblas", gemm_problem(output_shape, input_shapes), solution_idx);
+    ctx.problem_cache_insert("rocblas", gemm_problem(output_shape, input_shapes), solution_idx);
 }
 #endif
 
-int32_t gemm_default_solution(context& ctx,
+int32_t gemm_default_solution(const context& ctx,
                               const shape& output_shape,
                               const std::vector<shape>& input_shapes)
 {
-    auto sol = ctx.get_problem_cache().get("rocblas", gemm_problem(output_shape, input_shapes));
+    auto sol = ctx.problem_cache_get("rocblas", gemm_problem(output_shape, input_shapes));
     if(sol.has_value())
         return sol->to<int32_t>();
     return 0;

--- a/src/targets/gpu/hip_gemm_impl.cpp
+++ b/src/targets/gpu/hip_gemm_impl.cpp
@@ -708,7 +708,7 @@ static void hip_gemm_save_solution(context& ctx,
                                    const std::vector<shape>& input_shapes,
                                    int32_t solution_idx)
 {
-    ctx.get_problem_cache().insert(
+    ctx.problem_cache_insert(
         "hipblaslt", hip_gemm_problem(output_shape, input_shapes), solution_idx);
 }
 
@@ -734,12 +734,11 @@ int32_t hip_gemm_finalize(context& ctx,
     return solution_idx;
 }
 
-int32_t hip_gemm_default_solution(context& ctx,
+int32_t hip_gemm_default_solution(const context& ctx,
                                   const shape& output_shape,
                                   const std::vector<shape>& input_shapes)
 {
-    auto sol =
-        ctx.get_problem_cache().get("hipblaslt", hip_gemm_problem(output_shape, input_shapes));
+    auto sol = ctx.problem_cache_get("hipblaslt", hip_gemm_problem(output_shape, input_shapes));
     if(sol.has_value())
         return sol->to<int32_t>();
     return 0;

--- a/src/targets/gpu/include/migraphx/gpu/cache_device_key.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/cache_device_key.hpp
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+#ifndef MIGRAPHX_GUARD_GPU_CACHE_DEVICE_KEY_HPP
+#define MIGRAPHX_GUARD_GPU_CACHE_DEVICE_KEY_HPP
+
+#include <migraphx/config.hpp>
+#include <migraphx/hash.hpp>
+#include <migraphx/reflect.hpp>
+#include <cstddef>
+#include <string>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
+
+// Identifies the device a problem_cache bucket was populated for.
+struct cache_device_key
+{
+    std::string device_name    = {};
+    std::string gfx_name       = {};
+    std::size_t cu_count       = 0;
+    std::size_t wavefront_size = 0;
+
+    template <class Self, class F>
+    static auto reflect(Self& self, F f)
+    {
+        return pack(f(self.device_name, "device_name"),
+                    f(self.gfx_name, "gfx_name"),
+                    f(self.cu_count, "cu_count"),
+                    f(self.wavefront_size, "wavefront_size"));
+    }
+
+    friend bool operator==(const cache_device_key& a, const cache_device_key& b)
+    {
+        return a.device_name == b.device_name and a.gfx_name == b.gfx_name and
+               a.cu_count == b.cu_count and a.wavefront_size == b.wavefront_size;
+    }
+    friend bool operator!=(const cache_device_key& a, const cache_device_key& b)
+    {
+        return not(a == b);
+    }
+};
+
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+
+namespace std {
+template <>
+struct hash<migraphx::gpu::cache_device_key>
+{
+    std::size_t operator()(const migraphx::gpu::cache_device_key& k) const noexcept
+    {
+        std::size_t seed = 0;
+        migraphx::hash_combine(seed, k.device_name);
+        migraphx::hash_combine(seed, k.gfx_name);
+        migraphx::hash_combine(seed, k.cu_count);
+        migraphx::hash_combine(seed, k.wavefront_size);
+        return seed;
+    }
+};
+} // namespace std
+
+#endif // MIGRAPHX_GUARD_GPU_CACHE_DEVICE_KEY_HPP

--- a/src/targets/gpu/include/migraphx/gpu/context.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/context.hpp
@@ -37,6 +37,7 @@
 #include <migraphx/gpu/hip.hpp>
 #include <migraphx/env.hpp>
 #include <migraphx/config.hpp>
+#include <migraphx/logger.hpp>
 #include <migraphx/gpu/device_name.hpp>
 #include <migraphx/gpu/problem_cache.hpp>
 #include <migraphx/gpu/device_description.hpp>
@@ -279,8 +280,22 @@ struct context
         auto_save_problem_cache& operator=(const auto_save_problem_cache&) = delete;
         virtual ~auto_save_problem_cache()
         {
-            if(auto_save)
+            if(not auto_save)
+                return;
+            // The destructor is implicitly noexcept, so a save() failure (disk
+            // full, permissions) must be swallowed here or it would terminate.
+            try
+            {
                 this->save();
+            }
+            catch(const std::exception& e)
+            {
+                log::warn() << "auto_save_problem_cache: save failed: " << e.what();
+            }
+            catch(...)
+            {
+                log::warn() << "auto_save_problem_cache: save failed: unknown error";
+            }
         }
     };
     context(std::size_t device_id = 0, std::size_t n = value_of(MIGRAPHX_NSTREAMS{}, 1))
@@ -457,11 +472,37 @@ struct context
     }
 
     problem_cache& get_problem_cache() { return *pc; }
-    void load_problem_cache()
+
+    /// Configure the problem cache from a priority list of files (first hit
+    /// wins). A single file is writable (solutions save back); multiple files
+    /// are a read-only priority list. The layered search lives in problem_cache.
+    void load_problem_caches(const std::vector<std::string>& paths)
     {
-        pc->load();
-        pc->auto_save = true;
+        pc->load(paths);
+        pc->auto_save = (paths.size() == 1);
     }
+
+    /// Look up a problem across the configured caches (read-only layers first,
+    /// then writable); returns the first hit. This is what compile_ops calls.
+    optional<value> problem_cache_get(const std::string& name, const value& problem) const
+    {
+        return pc->get(name, problem);
+    }
+
+    /// Insert into the writable cache only (new tuning solutions go here).
+    void problem_cache_insert(const std::string& name, const value& problem, const value& solution)
+    {
+        pc->insert(name, problem, solution);
+    }
+
+    /// Mark a problem as seen in the writable cache.
+    void problem_cache_mark(const std::string& name, const value& problem)
+    {
+        pc->mark(name, problem);
+    }
+
+    /// Save the writable cache (called explicitly or via auto_save on destruction).
+    void save_problem_cache() const { pc->save(); }
 
     private:
     // TODO: Make this a vector to support multiple devices

--- a/src/targets/gpu/include/migraphx/gpu/gemm_impl.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/gemm_impl.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -88,7 +88,7 @@ int32_t gemm_finalize(context& ctx,
                       bool compute_fp32,
                       int32_t solution_idx);
 
-int32_t gemm_default_solution(context& ctx,
+int32_t gemm_default_solution(const context& ctx,
                               const shape& output_shape,
                               const std::vector<shape>& input_shapes);
 

--- a/src/targets/gpu/include/migraphx/gpu/hip_gemm_impl.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/hip_gemm_impl.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -69,7 +69,7 @@ int32_t hip_gemm_finalize(context& ctx,
                           float beta,
                           int32_t solution_idx);
 
-MIGRAPHX_GPU_EXPORT int32_t hip_gemm_default_solution(context& ctx,
+MIGRAPHX_GPU_EXPORT int32_t hip_gemm_default_solution(const context& ctx,
                                                       const shape& output_shape,
                                                       const std::vector<shape>& input_shapes);
 

--- a/src/targets/gpu/include/migraphx/gpu/json_problem_cache.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/json_problem_cache.hpp
@@ -20,55 +20,43 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
+ *
  */
-#ifndef MIGRAPHX_GUARD_RTGLIB_COMPILE_OPTIONS_HPP
-#define MIGRAPHX_GUARD_RTGLIB_COMPILE_OPTIONS_HPP
+#ifndef MIGRAPHX_GUARD_GPU_JSON_PROBLEM_CACHE_HPP
+#define MIGRAPHX_GUARD_GPU_JSON_PROBLEM_CACHE_HPP
 
 #include <migraphx/config.hpp>
-#include <migraphx/compile_modes.hpp>
-#include <migraphx/tracer.hpp>
 #include <migraphx/value.hpp>
+#include <migraphx/optional.hpp>
+#include <migraphx/gpu/export.h>
+#include <migraphx/gpu/cache_device_key.hpp>
+
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
 
-struct compile_options
+// A problem_cache_backend that persists entries as JSON, using the same
+// on-disk format as problem_cache::save() (an array of [cache_device_key,
+// inner_map] pairs). Path resolution is the caller's job.
+struct MIGRAPHX_GPU_EXPORT json_problem_cache
 {
-    /**
-     * Have MIGX allocate memory for parameters and add instructions
-     * to copy parameters and output to/from an offload device like a GPU.
-     */
-    bool offload_copy = false;
+    // problem_cache_backend concept members:
+    void load(const std::string& path);
+    void save(const std::string& path) const;
+    void insert(const cache_device_key& dk, const value& key, const value& solution);
+    void mark(const cache_device_key& dk, const value& key);
+    optional<value> get(const cache_device_key& dk, const value& key) const;
+    bool has(const cache_device_key& dk, const value& key) const;
 
-    bool fast_math       = true;
-    bool exhaustive_tune = false;
-
-    compile_modes compile_mode = compile_modes::balanced;
-    /**
-     * Backend-specific options keyed by name. Targets can read these to
-     * configure compilation in a way that is opaque to the core engine.
-     */
-    std::unordered_map<std::string, value> backend_options;
-
-    tracer trace{};
+    // Device bucket -> ({name, problem} -> solution).
+    std::unordered_map<cache_device_key, std::unordered_map<value, value>> cache;
 };
 
-/**
- * Merge the backend options from an object value into the compile options.
- * Each top-level key of the object becomes an entry in backend_options.
- */
-inline void set_backend_options(compile_options& options, const value& v)
-{
-    if(not v.is_object())
-        MIGRAPHX_THROW("set_backend_options expects an object value");
-    for(const auto& opt : v)
-        options.backend_options[opt.get_key()] = opt.without_key();
-}
-
+} // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
 
-#endif
+#endif // MIGRAPHX_GUARD_GPU_JSON_PROBLEM_CACHE_HPP

--- a/src/targets/gpu/include/migraphx/gpu/problem_cache.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/problem_cache.hpp
@@ -28,64 +28,11 @@
 #include <migraphx/config.hpp>
 #include <migraphx/value.hpp>
 #include <migraphx/optional.hpp>
-#include <migraphx/hash.hpp>
-#include <migraphx/reflect.hpp>
 #include <migraphx/gpu/export.h>
-#include <cstddef>
+#include <migraphx/gpu/cache_device_key.hpp>
+#include <migraphx/gpu/problem_cache_backend.hpp>
 #include <string>
-#include <unordered_map>
-
-namespace migraphx {
-inline namespace MIGRAPHX_INLINE_NS {
-namespace gpu {
-
-// Identifies the device a problem_cache bucket was populated for.
-struct cache_device_key
-{
-    std::string device_name    = {};
-    std::string gfx_name       = {};
-    std::size_t cu_count       = 0;
-    std::size_t wavefront_size = 0;
-
-    template <class Self, class F>
-    static auto reflect(Self& self, F f)
-    {
-        return pack(f(self.device_name, "device_name"),
-                    f(self.gfx_name, "gfx_name"),
-                    f(self.cu_count, "cu_count"),
-                    f(self.wavefront_size, "wavefront_size"));
-    }
-
-    friend bool operator==(const cache_device_key& a, const cache_device_key& b)
-    {
-        return a.device_name == b.device_name and a.gfx_name == b.gfx_name and
-               a.cu_count == b.cu_count and a.wavefront_size == b.wavefront_size;
-    }
-    friend bool operator!=(const cache_device_key& a, const cache_device_key& b)
-    {
-        return not(a == b);
-    }
-};
-
-} // namespace gpu
-} // namespace MIGRAPHX_INLINE_NS
-} // namespace migraphx
-
-namespace std {
-template <>
-struct hash<migraphx::gpu::cache_device_key>
-{
-    std::size_t operator()(const migraphx::gpu::cache_device_key& k) const noexcept
-    {
-        std::size_t seed = 0;
-        migraphx::hash_combine(seed, k.device_name);
-        migraphx::hash_combine(seed, k.gfx_name);
-        migraphx::hash_combine(seed, k.cu_count);
-        migraphx::hash_combine(seed, k.wavefront_size);
-        return seed;
-    }
-};
-} // namespace std
+#include <vector>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -95,24 +42,46 @@ struct context;
 
 struct MIGRAPHX_GPU_EXPORT problem_cache
 {
+    // Default-constructs with the JSON storage backend.
+    problem_cache();
+
     // Build and store this cache's device key from the owning context.
     void set_device_key(const context& ctx);
+    // Directly set the device key (used by tests and multi-cache setup).
+    void set_device_key(const cache_device_key& key);
     const cache_device_key& get_device_key() const;
 
+    /// Look up a problem. Read-only layers (from load(paths)) are searched in
+    /// priority order first, then the writable cache; the first hit wins.
     bool has(const std::string& name, const value& problem) const;
     void insert(const std::string& name, const value& problem, const value& solution);
     void mark(const std::string& name, const value& problem);
     optional<value> get(const std::string& name, const value& problem) const;
-    void load();
+    /// Load from an explicit file path. An empty path is treated as "no cache"
+    /// (no-op). The path is remembered and reused for the next save().
+    void load(const std::string& path);
+    /// Load a priority list of caches (highest priority first, first hit wins).
+    /// A single path is loaded as the writable cache (same as load(path));
+    /// multiple paths become read-only layers searched before the writable cache.
+    void load(const std::vector<std::string>& paths);
     void save() const;
-    // One {name, problem} -> solution map per device, so a single file can
-    // hold solutions for many GPUs without collisions.
-    std::unordered_map<cache_device_key, std::unordered_map<value, value>> cache;
 
     private:
+    // Pluggable storage backend (JSON by default); e.g. SQLite can be swapped in.
+    // This is the writable cache: new solutions are inserted and saved here.
+    problem_cache_backend backend;
+
+    // Higher-priority read-only layers searched before `backend` (first hit
+    // wins). Populated by load(paths) when multiple files are provided.
+    std::vector<problem_cache_backend> read_only_backends{};
+
     // Device these entries were tuned on; set by the owning context. Empty
     // key = unidentified device, entries land in a single bucket.
     cache_device_key device_key{};
+
+    // File path set by load(path). When non-empty, save() writes here. Empty
+    // means no writable cache is configured.
+    std::string path_override{};
 };
 
 } // namespace gpu

--- a/src/targets/gpu/include/migraphx/gpu/problem_cache_backend.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/problem_cache_backend.hpp
@@ -1,0 +1,424 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+//
+// te.py DSL for migraphx::gpu::problem_cache_backend.
+//
+// The generated header lives at
+// src/targets/gpu/include/migraphx/gpu/problem_cache_backend.hpp; regenerate it
+// with `cd tools && python generate.py` (generate_all routes include/gpu/ inputs
+// into the gpu target tree). Do not edit the generated header by hand.
+//
+// Any type T satisfies the problem_cache_backend concept if it provides the
+// member functions listed below. The wrapper holds T by shared_ptr (small
+// object optimisation is irrelevant -- backends typically own non-trivial
+// resources like file handles or SQLite connections) and forwards each call
+// through a virtual dispatch.
+//
+// Notes:
+//   * cache_device_key is defined in <migraphx/gpu/cache_device_key.hpp>;
+//     the include below pulls in its full definition.
+//   * Backends are NOT expected to be copyable in any meaningful sense
+//     beyond what shared ownership provides; they may freely hold streams,
+//     file handles, etc.
+//   * load() is non-const (mutates internal state); save() is const.
+//
+#ifndef MIGRAPHX_GUARD_GPU_PROBLEM_CACHE_BACKEND_HPP
+#define MIGRAPHX_GUARD_GPU_PROBLEM_CACHE_BACKEND_HPP
+
+#include <cassert>
+#include <string>
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include <migraphx/config.hpp>
+#include <migraphx/value.hpp>
+#include <migraphx/optional.hpp>
+#include <migraphx/gpu/export.h>
+#include <migraphx/gpu/cache_device_key.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
+
+#ifdef DOXYGEN
+
+/// Type-erased interface for problem-cache storage backends.
+///
+/// A backend persists (cache_device_key, key) -> solution entries to some
+/// medium (JSON file, SQLite database, in-memory map for tests, ...). All
+/// lookups and inserts are scoped by the device key so a single backend
+/// instance can hold entries for multiple GPU configurations.
+struct problem_cache_backend
+{
+    /// Load entries from `path` into the backend. Idempotent; calling
+    /// load() twice with the same path leaves the backend in an equivalent
+    /// state. Implementations should treat a missing file as "no entries"
+    /// rather than an error (the typical first-run case).
+    void load(const std::string& path);
+
+    /// Persist all entries to `path`. Const by design: backends that need
+    /// to flush write-behind buffers must do so internally without mutating
+    /// observable state.
+    void save(const std::string& path) const;
+
+    /// Insert (or overwrite) the solution for `key` in the bucket
+    /// identified by `dk`. Precondition: `solution` is not null.
+    void insert(const cache_device_key& dk, const value& key, const value& solution);
+
+    /// Insert a pending sentinel (null value) for `key`, recording that a
+    /// solution for this problem is being tuned. A later lookup that sees the
+    /// sentinel treats the problem as already in progress rather than as a
+    /// real cached solution.
+    void mark(const cache_device_key& dk, const value& key);
+
+    /// Return the stored solution for `key` in the bucket `dk`, or nullopt
+    /// if no entry exists. A present optional with a null value indicates
+    /// a sentinel (set via mark()).
+    optional<value> get(const cache_device_key& dk, const value& key) const;
+
+    /// True iff any entry (real solution or sentinel) exists for `key` in
+    /// the bucket `dk`.
+    bool has(const cache_device_key& dk, const value& key) const;
+};
+
+#else
+
+#ifdef TYPE_ERASED_DECLARATION
+
+// Type-erased interface for:
+struct MIGRAPHX_EXPORT problem_cache_backend
+{
+    //
+    void load(const std::string& path);
+    //
+    void save(const std::string& path) const;
+    //
+    void insert(const cache_device_key& dk, const value& key, const value& solution);
+    //
+    void mark(const cache_device_key& dk, const value& key);
+    //
+    optional<value> get(const cache_device_key& dk, const value& key) const;
+    //
+    bool has(const cache_device_key& dk, const value& key) const;
+};
+
+#else
+// NOLINTBEGIN(performance-unnecessary-value-param)
+struct problem_cache_backend
+{
+    private:
+    template <class PrivateDetailTypeErasedT>
+    struct private_te_unwrap_reference
+    {
+        using type = PrivateDetailTypeErasedT;
+    };
+    template <class PrivateDetailTypeErasedT>
+    struct private_te_unwrap_reference<std::reference_wrapper<PrivateDetailTypeErasedT>>
+    {
+        using type = PrivateDetailTypeErasedT;
+    };
+    template <class PrivateDetailTypeErasedT>
+    using private_te_pure = typename std::remove_cv<
+        typename std::remove_reference<PrivateDetailTypeErasedT>::type>::type;
+
+    template <class PrivateDetailTypeErasedT>
+    using private_te_constraints_impl =
+        decltype(std::declval<PrivateDetailTypeErasedT>().load(std::declval<const std::string&>()),
+                 std::declval<PrivateDetailTypeErasedT>().save(std::declval<const std::string&>()),
+                 std::declval<PrivateDetailTypeErasedT>().insert(
+                     std::declval<const cache_device_key&>(),
+                     std::declval<const value&>(),
+                     std::declval<const value&>()),
+                 std::declval<PrivateDetailTypeErasedT>().mark(
+                     std::declval<const cache_device_key&>(), std::declval<const value&>()),
+                 std::declval<PrivateDetailTypeErasedT>().get(
+                     std::declval<const cache_device_key&>(), std::declval<const value&>()),
+                 std::declval<PrivateDetailTypeErasedT>().has(
+                     std::declval<const cache_device_key&>(), std::declval<const value&>()),
+                 void());
+
+    template <class PrivateDetailTypeErasedT>
+    using private_te_constraints = private_te_constraints_impl<
+        typename private_te_unwrap_reference<private_te_pure<PrivateDetailTypeErasedT>>::type>;
+
+    public:
+    // Constructors
+    problem_cache_backend() = default;
+
+    template <typename PrivateDetailTypeErasedT,
+              typename = private_te_constraints<PrivateDetailTypeErasedT>,
+              typename = typename std::enable_if<
+                  not std::is_same<private_te_pure<PrivateDetailTypeErasedT>,
+                                   problem_cache_backend>{}>::type>
+    problem_cache_backend(PrivateDetailTypeErasedT&& value)
+        : private_detail_te_handle_mem_var(
+              std::make_shared<
+                  private_detail_te_handle_type<private_te_pure<PrivateDetailTypeErasedT>>>(
+                  std::forward<PrivateDetailTypeErasedT>(value)))
+    {
+    }
+
+    // Assignment
+    template <typename PrivateDetailTypeErasedT,
+              typename = private_te_constraints<PrivateDetailTypeErasedT>,
+              typename = typename std::enable_if<
+                  not std::is_same<private_te_pure<PrivateDetailTypeErasedT>,
+                                   problem_cache_backend>{}>::type>
+    problem_cache_backend& operator=(PrivateDetailTypeErasedT && value)
+    {
+        using std::swap;
+        auto* derived = this->any_cast<private_te_pure<PrivateDetailTypeErasedT>>();
+        if(derived and private_detail_te_handle_mem_var.use_count() == 1)
+        {
+            *derived = std::forward<PrivateDetailTypeErasedT>(value);
+        }
+        else
+        {
+            problem_cache_backend rhs(value);
+            swap(private_detail_te_handle_mem_var, rhs.private_detail_te_handle_mem_var);
+        }
+        return *this;
+    }
+
+    // Cast
+    template <typename PrivateDetailTypeErasedT>
+    PrivateDetailTypeErasedT* any_cast()
+    {
+        return this->type_id() == typeid(PrivateDetailTypeErasedT)
+                   ? std::addressof(static_cast<private_detail_te_handle_type<
+                                        typename std::remove_cv<PrivateDetailTypeErasedT>::type>&>(
+                                        private_detail_te_get_handle())
+                                        .private_detail_te_value)
+                   : nullptr;
+    }
+
+    template <typename PrivateDetailTypeErasedT>
+    const typename std::remove_cv<PrivateDetailTypeErasedT>::type* any_cast() const
+    {
+        return this->type_id() == typeid(PrivateDetailTypeErasedT)
+                   ? std::addressof(static_cast<const private_detail_te_handle_type<
+                                        typename std::remove_cv<PrivateDetailTypeErasedT>::type>&>(
+                                        private_detail_te_get_handle())
+                                        .private_detail_te_value)
+                   : nullptr;
+    }
+
+    const std::type_info& type_id() const
+    {
+        if(private_detail_te_handle_empty())
+            return typeid(std::nullptr_t);
+        else
+            return private_detail_te_get_handle().type();
+    }
+
+    void load(const std::string& path)
+    {
+        assert((*this).private_detail_te_handle_mem_var);
+        (*this).private_detail_te_get_handle().load(path);
+    }
+
+    void save(const std::string& path) const
+    {
+        assert((*this).private_detail_te_handle_mem_var);
+        (*this).private_detail_te_get_handle().save(path);
+    }
+
+    void insert(const cache_device_key& dk, const value& key, const value& solution)
+    {
+        assert((*this).private_detail_te_handle_mem_var);
+        (*this).private_detail_te_get_handle().insert(dk, key, solution);
+    }
+
+    void mark(const cache_device_key& dk, const value& key)
+    {
+        assert((*this).private_detail_te_handle_mem_var);
+        (*this).private_detail_te_get_handle().mark(dk, key);
+    }
+
+    optional<value> get(const cache_device_key& dk, const value& key) const
+    {
+        assert((*this).private_detail_te_handle_mem_var);
+        return (*this).private_detail_te_get_handle().get(dk, key);
+    }
+
+    bool has(const cache_device_key& dk, const value& key) const
+    {
+        assert((*this).private_detail_te_handle_mem_var);
+        return (*this).private_detail_te_get_handle().has(dk, key);
+    }
+
+    friend bool is_shared(const problem_cache_backend& private_detail_x,
+                          const problem_cache_backend& private_detail_y)
+    {
+        return private_detail_x.private_detail_te_handle_mem_var ==
+               private_detail_y.private_detail_te_handle_mem_var;
+    }
+
+    private:
+    struct private_detail_te_handle_base_type
+    {
+        virtual ~private_detail_te_handle_base_type() {}
+        virtual std::shared_ptr<private_detail_te_handle_base_type> clone() const = 0;
+        virtual const std::type_info& type() const                                = 0;
+
+        virtual void load(const std::string& path)       = 0;
+        virtual void save(const std::string& path) const = 0;
+        virtual void
+        insert(const cache_device_key& dk, const value& key, const value& solution)     = 0;
+        virtual void mark(const cache_device_key& dk, const value& key)                 = 0;
+        virtual optional<value> get(const cache_device_key& dk, const value& key) const = 0;
+        virtual bool has(const cache_device_key& dk, const value& key) const            = 0;
+    };
+
+    template <typename PrivateDetailTypeErasedT>
+    struct private_detail_te_handle_type : private_detail_te_handle_base_type
+    {
+        template <typename PrivateDetailTypeErasedU = PrivateDetailTypeErasedT>
+        private_detail_te_handle_type(
+            PrivateDetailTypeErasedT value,
+            typename std::enable_if<std::is_reference<PrivateDetailTypeErasedU>{}>::type* = nullptr)
+            : private_detail_te_value(value)
+        {
+        }
+
+        template <typename PrivateDetailTypeErasedU = PrivateDetailTypeErasedT>
+        private_detail_te_handle_type(
+            PrivateDetailTypeErasedT value,
+            typename std::enable_if<not std::is_reference<PrivateDetailTypeErasedU>{}, int>::type* =
+                nullptr) noexcept
+            : private_detail_te_value(std::move(value))
+        {
+        }
+
+        std::shared_ptr<private_detail_te_handle_base_type> clone() const override
+        {
+            return std::make_shared<private_detail_te_handle_type>(private_detail_te_value);
+        }
+
+        const std::type_info& type() const override { return typeid(private_detail_te_value); }
+
+        void load(const std::string& path) override { private_detail_te_value.load(path); }
+
+        void save(const std::string& path) const override { private_detail_te_value.save(path); }
+
+        void insert(const cache_device_key& dk, const value& key, const value& solution) override
+        {
+
+            private_detail_te_value.insert(dk, key, solution);
+        }
+
+        void mark(const cache_device_key& dk, const value& key) override
+        {
+
+            private_detail_te_value.mark(dk, key);
+        }
+
+        optional<value> get(const cache_device_key& dk, const value& key) const override
+        {
+
+            return private_detail_te_value.get(dk, key);
+        }
+
+        bool has(const cache_device_key& dk, const value& key) const override
+        {
+
+            return private_detail_te_value.has(dk, key);
+        }
+
+        PrivateDetailTypeErasedT private_detail_te_value;
+    };
+
+    template <typename PrivateDetailTypeErasedT>
+    struct private_detail_te_handle_type<std::reference_wrapper<PrivateDetailTypeErasedT>>
+        : private_detail_te_handle_type<PrivateDetailTypeErasedT&>
+    {
+        private_detail_te_handle_type(std::reference_wrapper<PrivateDetailTypeErasedT> ref)
+            : private_detail_te_handle_type<PrivateDetailTypeErasedT&>(ref.get())
+        {
+        }
+    };
+
+    bool private_detail_te_handle_empty() const
+    {
+        return private_detail_te_handle_mem_var == nullptr;
+    }
+
+    const private_detail_te_handle_base_type& private_detail_te_get_handle() const
+    {
+        assert(private_detail_te_handle_mem_var != nullptr);
+        return *private_detail_te_handle_mem_var;
+    }
+
+    private_detail_te_handle_base_type& private_detail_te_get_handle()
+    {
+        assert(private_detail_te_handle_mem_var != nullptr);
+        if(private_detail_te_handle_mem_var.use_count() > 1)
+            private_detail_te_handle_mem_var = private_detail_te_handle_mem_var->clone();
+        return *private_detail_te_handle_mem_var;
+    }
+
+    std::shared_ptr<private_detail_te_handle_base_type> private_detail_te_handle_mem_var;
+};
+
+template <typename ValueType>
+inline const ValueType* any_cast(const problem_cache_backend* x)
+{
+    return x->any_cast<ValueType>();
+}
+
+template <typename ValueType>
+inline ValueType* any_cast(problem_cache_backend* x)
+{
+    return x->any_cast<ValueType>();
+}
+
+template <typename ValueType>
+inline ValueType& any_cast(problem_cache_backend& x)
+{
+    auto* y = x.any_cast<typename std::remove_reference<ValueType>::type>();
+    if(y == nullptr)
+        throw std::bad_cast();
+    return *y;
+}
+
+template <typename ValueType>
+inline const ValueType& any_cast(const problem_cache_backend& x)
+{
+    const auto* y = x.any_cast<typename std::remove_reference<ValueType>::type>();
+    if(y == nullptr)
+        throw std::bad_cast();
+    return *y;
+}
+// NOLINTEND(performance-unnecessary-value-param)
+#endif
+
+#endif
+
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+
+#endif // MIGRAPHX_GUARD_GPU_PROBLEM_CACHE_BACKEND_HPP

--- a/src/targets/gpu/include/migraphx/gpu/sqlite_problem_cache.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/sqlite_problem_cache.hpp
@@ -20,55 +20,46 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
+ *
  */
-#ifndef MIGRAPHX_GUARD_RTGLIB_COMPILE_OPTIONS_HPP
-#define MIGRAPHX_GUARD_RTGLIB_COMPILE_OPTIONS_HPP
+#ifndef MIGRAPHX_GUARD_GPU_SQLITE_PROBLEM_CACHE_HPP
+#define MIGRAPHX_GUARD_GPU_SQLITE_PROBLEM_CACHE_HPP
 
 #include <migraphx/config.hpp>
-#include <migraphx/compile_modes.hpp>
-#include <migraphx/tracer.hpp>
 #include <migraphx/value.hpp>
+#include <migraphx/optional.hpp>
+#include <migraphx/gpu/export.h>
+#include <migraphx/gpu/cache_device_key.hpp>
+
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
 
-struct compile_options
+// A problem_cache_backend that stores entries in a SQLite table
+// solutions(device_key, problem_key, solution), keyed by (device_key, problem_key).
+// Store-and-forward like json_problem_cache: load() reads all rows into `cache`,
+// save() rewrites the table in one transaction; insert/mark/get/has are in-memory.
+struct MIGRAPHX_GPU_EXPORT sqlite_problem_cache
 {
-    /**
-     * Have MIGX allocate memory for parameters and add instructions
-     * to copy parameters and output to/from an offload device like a GPU.
-     */
-    bool offload_copy = false;
+    sqlite_problem_cache() = default;
 
-    bool fast_math       = true;
-    bool exhaustive_tune = false;
+    // problem_cache_backend concept members:
+    void load(const std::string& path);
+    void save(const std::string& path) const;
+    void insert(const cache_device_key& dk, const value& key, const value& solution);
+    void mark(const cache_device_key& dk, const value& key);
+    optional<value> get(const cache_device_key& dk, const value& key) const;
+    bool has(const cache_device_key& dk, const value& key) const;
 
-    compile_modes compile_mode = compile_modes::balanced;
-    /**
-     * Backend-specific options keyed by name. Targets can read these to
-     * configure compilation in a way that is opaque to the core engine.
-     */
-    std::unordered_map<std::string, value> backend_options;
-
-    tracer trace{};
+    // Device bucket -> ({name, problem} -> solution).
+    std::unordered_map<cache_device_key, std::unordered_map<value, value>> cache;
 };
 
-/**
- * Merge the backend options from an object value into the compile options.
- * Each top-level key of the object becomes an entry in backend_options.
- */
-inline void set_backend_options(compile_options& options, const value& v)
-{
-    if(not v.is_object())
-        MIGRAPHX_THROW("set_backend_options expects an object value");
-    for(const auto& opt : v)
-        options.backend_options[opt.get_key()] = opt.without_key();
-}
-
+} // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
 
-#endif
+#endif // MIGRAPHX_GUARD_GPU_SQLITE_PROBLEM_CACHE_HPP

--- a/src/targets/gpu/json_problem_cache.cpp
+++ b/src/targets/gpu/json_problem_cache.cpp
@@ -1,0 +1,113 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+#include <migraphx/gpu/json_problem_cache.hpp>
+#include <migraphx/gpu/problem_cache_backend.hpp>
+#include <migraphx/ranges.hpp>
+#include <migraphx/json.hpp>
+#include <migraphx/serialize.hpp>
+#include <migraphx/file_buffer.hpp>
+#include <migraphx/filesystem.hpp>
+#include <migraphx/logger.hpp>
+#include <utility>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
+
+// Compile-time confirmation that json_problem_cache satisfies the backend
+// concept. If a method signature drifts, this assertion fires at the
+// definition site rather than at some far-away usage.
+static_assert(std::is_constructible<problem_cache_backend, json_problem_cache>{},
+              "json_problem_cache must satisfy the problem_cache_backend concept");
+
+void json_problem_cache::load(const std::string& path)
+{
+    if(path.empty())
+        return;
+    if(not fs::exists(path))
+    {
+        // Missing file is not an error: typical first-run case. Caller may
+        // immediately follow with save() to create the file.
+        return;
+    }
+    auto root = from_json_string(read_string(path));
+
+    // The on-disk format is an array of [cache_device_key, inner_map] pairs, as
+    // written by save(). Anything else is an unrecognised or pre-merge file:
+    // skip rather than throw so a stale file does not block first-run.
+    if(not root.is_array())
+    {
+        log::warn() << "json_problem_cache: unrecognised on-disk format at " << path
+                    << ", starting fresh";
+        return;
+    }
+    // Canonicalize keys only (JSON erases value types); solutions verbatim.
+    std::unordered_map<cache_device_key, std::unordered_map<value, value>> raw;
+    from_value(root, raw);
+    for(const auto& dev : raw)
+        for(const auto& entry : dev.second)
+            cache[dev.first][entry.first.normalize()] = entry.second;
+}
+
+void json_problem_cache::save(const std::string& path) const
+{
+    if(path.empty())
+        return;
+    write_string(path, to_pretty_json_string(to_value(cache)));
+}
+
+void json_problem_cache::insert(const cache_device_key& dk, const value& key, const value& solution)
+{
+    assert(not solution.is_null());
+    cache[dk][key.normalize()] = solution;
+}
+
+void json_problem_cache::mark(const cache_device_key& dk, const value& key)
+{
+    cache[dk].insert(std::make_pair(key.normalize(), value{}));
+}
+
+optional<value> json_problem_cache::get(const cache_device_key& dk, const value& key) const
+{
+    auto bucket_it = cache.find(dk);
+    if(bucket_it == cache.end())
+        return nullopt;
+    auto it = bucket_it->second.find(key.normalize());
+    if(it == bucket_it->second.end())
+        return nullopt;
+    return it->second;
+}
+
+bool json_problem_cache::has(const cache_device_key& dk, const value& key) const
+{
+    auto bucket_it = cache.find(dk);
+    if(bucket_it == cache.end())
+        return false;
+    return contains(bucket_it->second, key.normalize());
+}
+
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx

--- a/src/targets/gpu/problem_cache.cpp
+++ b/src/targets/gpu/problem_cache.cpp
@@ -23,22 +23,16 @@
  *
  */
 #include <migraphx/gpu/problem_cache.hpp>
+#include <migraphx/gpu/json_problem_cache.hpp>
 #include <migraphx/gpu/context.hpp>
-#include <migraphx/ranges.hpp>
-#include <migraphx/json.hpp>
-#include <migraphx/env.hpp>
-#include <migraphx/serialize.hpp>
-#include <migraphx/file_buffer.hpp>
-#include <migraphx/logger.hpp>
 #include <algorithm>
-#include <utility>
-#include <vector>
+#include <cassert>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
-MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_PROBLEM_CACHE)
+problem_cache::problem_cache() : backend(json_problem_cache{}) {}
 
 static value create_key(const std::string& name, const value& problem)
 {
@@ -60,98 +54,85 @@ void problem_cache::set_device_key(const context& ctx)
     device_key.wavefront_size = dev.get_wavefront_size();
 }
 
+void problem_cache::set_device_key(const cache_device_key& key) { device_key = key; }
+
 const cache_device_key& problem_cache::get_device_key() const { return device_key; }
 
-void problem_cache::load()
+void problem_cache::load(const std::string& path)
 {
-    auto pc_path = string_value_of(MIGRAPHX_PROBLEM_CACHE{});
-    if(pc_path.empty())
+    if(path.empty())
         return;
-    if(not fs::exists(pc_path))
-    {
-        log::info() << "Problem cache not found. Creating new file.";
-        save();
-        return;
-    }
-    auto root = from_json_string(read_string(pc_path)).normalize();
-
-    // Detect on-disk format. The new device-keyed format serializes the outer
-    // map (unordered_map<cache_device_key, ...>) as a JSON array of
-    // [key_object, inner_map] pairs. The legacy flat format used a JSON
-    // object whose keys were JSON-encoded {name, problem} strings (i.e. they
-    // begin with '{'). Anything else is an unrecognized pre-merge format
-    // (e.g. an earlier prototype that string-keyed by hardware fingerprint);
-    // skip rather than throw, so users with stale files start fresh.
-    if(root.is_array())
-    {
-        from_value(root, cache);
-        return;
-    }
-    if(not root.is_object() or root.empty())
-        return;
-    const auto& first_key = root.begin()->get_key();
-    if(first_key.empty() or first_key.front() != '{')
-    {
-        log::warn() << "Problem cache: unrecognized on-disk format, starting fresh";
-        return;
-    }
-
-    // Legacy flat-object format: migrate entries into the current device's
-    // bucket. Sort by serialized key first so deduplication is deterministic
-    // when multiple entries project to the same {name, problem}.
-    std::unordered_map<value, value> flat;
-    from_value(root, flat);
-    std::vector<std::pair<value, value>> sorted_flat(flat.begin(), flat.end());
-    std::sort(sorted_flat.begin(), sorted_flat.end(), [](const auto& a, const auto& b) {
-        return to_json_string(a.first) < to_json_string(b.first);
-    });
-    auto& bucket = cache[device_key];
-    for(const auto& entry : sorted_flat)
-    {
-        auto projected =
-            create_key(entry.first.at("name").to<std::string>(), entry.first.at("problem"));
-        bucket.emplace(projected, entry.second);
-    }
-    log::info() << "Problem cache: migrated " << flat.size()
-                << " legacy entries into device bucket " << to_json_string(to_value(device_key));
+    // Remember the path so save() writes back here; a missing file loads empty.
+    path_override = path;
+    backend.load(path);
 }
 
 void problem_cache::save() const
 {
-    auto pc_path = string_value_of(MIGRAPHX_PROBLEM_CACHE{});
-    if(pc_path.empty())
+    // No writable path (read-only or unconfigured cache) means save does nothing.
+    if(path_override.empty())
         return;
-    write_string(pc_path, to_pretty_json_string(to_value(cache)));
+    backend.save(path_override);
+}
+
+void problem_cache::load(const std::vector<std::string>& paths)
+{
+    read_only_backends.clear();
+    // Drop any writable path from a prior single-file load so read-only
+    // (multi-file) mode cannot write back through a stale override.
+    path_override.clear();
+    if(paths.empty())
+        return;
+    // A single file is the writable cache (new solutions save back to it).
+    if(paths.size() == 1)
+    {
+        load(paths.front());
+        return;
+    }
+    // Multiple files are a read-only priority list (highest first). Shipped
+    // caches are immutable, so the writable `backend` stays empty and nothing
+    // is written back; persisting to a writable local cache is a future item.
+    for(const auto& path : paths)
+    {
+        problem_cache_backend ro(json_problem_cache{});
+        if(not path.empty())
+            ro.load(path);
+        read_only_backends.push_back(std::move(ro));
+    }
 }
 
 bool problem_cache::has(const std::string& name, const value& problem) const
 {
-    auto bucket_it = cache.find(device_key);
-    if(bucket_it == cache.end())
-        return false;
-    return contains(bucket_it->second, create_key(name, problem));
+    const auto key = create_key(name, problem);
+    // Read-only layers first (highest priority), then the writable cache.
+    return std::any_of(read_only_backends.begin(),
+                       read_only_backends.end(),
+                       [&](const auto& ro) { return ro.has(device_key, key); }) or
+           backend.has(device_key, key);
 }
 
 void problem_cache::insert(const std::string& name, const value& problem, const value& solution)
 {
     assert(not solution.is_null());
-    cache[device_key][create_key(name, problem)] = solution;
+    backend.insert(device_key, create_key(name, problem), solution);
 }
 
 void problem_cache::mark(const std::string& name, const value& problem)
 {
-    cache[device_key].insert(std::make_pair(create_key(name, problem), value{}));
+    backend.mark(device_key, create_key(name, problem));
 }
 
 optional<value> problem_cache::get(const std::string& name, const value& problem) const
 {
-    auto bucket_it = cache.find(device_key);
-    if(bucket_it == cache.end())
-        return nullopt;
-    auto it = bucket_it->second.find(create_key(name, problem));
-    if(it == bucket_it->second.end())
-        return nullopt;
-    return it->second;
+    const auto key = create_key(name, problem);
+    // Read-only layers first (highest priority), then the writable cache.
+    const auto found =
+        std::find_if(read_only_backends.begin(), read_only_backends.end(), [&](const auto& ro) {
+            return ro.get(device_key, key).has_value();
+        });
+    if(found != read_only_backends.end())
+        return found->get(device_key, key);
+    return backend.get(device_key, key);
 }
 
 } // namespace gpu

--- a/src/targets/gpu/sqlite_problem_cache.cpp
+++ b/src/targets/gpu/sqlite_problem_cache.cpp
@@ -1,0 +1,164 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+#include <migraphx/gpu/sqlite_problem_cache.hpp>
+#include <migraphx/gpu/problem_cache_backend.hpp>
+#include <migraphx/sqlite.hpp>
+#include <migraphx/ranges.hpp>
+#include <migraphx/json.hpp>
+#include <migraphx/serialize.hpp>
+#include <migraphx/filesystem.hpp>
+#include <migraphx/errors.hpp>
+#include <migraphx/logger.hpp>
+
+#include <utility>
+#include <vector>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
+
+// Compile-time confirmation that sqlite_problem_cache satisfies the backend
+// concept. If a method signature drifts, this assertion fires at the
+// definition site rather than at some far-away usage.
+static_assert(std::is_constructible<problem_cache_backend, sqlite_problem_cache>{},
+              "sqlite_problem_cache must satisfy the problem_cache_backend concept");
+
+namespace {
+
+constexpr const char* schema_sql = "CREATE TABLE IF NOT EXISTS solutions ("
+                                   "  device_key  TEXT NOT NULL,"
+                                   "  problem_key TEXT NOT NULL,"
+                                   "  solution    TEXT NOT NULL,"
+                                   "  PRIMARY KEY (device_key, problem_key)"
+                                   ") WITHOUT ROWID;";
+
+// Quote a string as a SQL literal, escaping embedded single quotes. Needed
+// because migraphx::sqlite executes raw SQL text (no parameter binding).
+std::string sql_quote(const std::string& s)
+{
+    std::string out;
+    out.reserve(s.size() + 2);
+    out += '\'';
+    for(char c : s)
+    {
+        if(c == '\'')
+            out += "''";
+        else
+            out += c;
+    }
+    out += '\'';
+    return out;
+}
+
+} // namespace
+
+void sqlite_problem_cache::load(const std::string& path)
+{
+    // Missing file is not an error: typical first-run case.
+    if(path.empty() or not fs::exists(path))
+        return;
+
+    auto db = sqlite::read(path);
+    std::vector<std::unordered_map<std::string, std::string>> rows;
+    try
+    {
+        rows = db.execute("SELECT device_key, problem_key, solution FROM solutions;");
+    }
+    catch(const std::exception& e)
+    {
+        log::warn() << "sqlite_problem_cache: cannot read solutions from " << path << ": "
+                    << e.what();
+        return;
+    }
+    for(const auto& row : rows)
+    {
+        cache_device_key dk;
+        from_value(from_json_string(row.at("device_key")), dk);
+        // Normalize keys on load: JSON erases value types, so a serialized key
+        // must be canonicalized to match the normalized runtime lookup key.
+        cache[dk][from_json_string(row.at("problem_key")).normalize()] =
+            from_json_string(row.at("solution"));
+    }
+}
+
+void sqlite_problem_cache::save(const std::string& path) const
+{
+    if(path.empty())
+        return;
+
+    // Rewrite the table in one transaction so the file is deterministic.
+    auto db         = sqlite::write(path);
+    std::string sql = "BEGIN IMMEDIATE;";
+    sql += schema_sql;
+    sql += "DELETE FROM solutions;";
+    for(const auto& bucket : cache)
+    {
+        const std::string dk = to_json_string(to_value(bucket.first));
+        for(const auto& kv : bucket.second)
+        {
+            sql += "INSERT OR REPLACE INTO solutions(device_key, problem_key, solution) VALUES(";
+            sql += sql_quote(dk) + "," + sql_quote(to_json_string(kv.first)) + "," +
+                   sql_quote(to_json_string(kv.second)) + ");";
+        }
+    }
+    sql += "COMMIT;";
+    (void)db.execute(sql);
+}
+
+void sqlite_problem_cache::insert(const cache_device_key& dk,
+                                  const value& key,
+                                  const value& solution)
+{
+    assert(not solution.is_null());
+    cache[dk][key.normalize()] = solution;
+}
+
+void sqlite_problem_cache::mark(const cache_device_key& dk, const value& key)
+{
+    cache[dk].insert(std::make_pair(key.normalize(), value{}));
+}
+
+optional<value> sqlite_problem_cache::get(const cache_device_key& dk, const value& key) const
+{
+    auto bucket_it = cache.find(dk);
+    if(bucket_it == cache.end())
+        return nullopt;
+    auto it = bucket_it->second.find(key.normalize());
+    if(it == bucket_it->second.end())
+        return nullopt;
+    return it->second;
+}
+
+bool sqlite_problem_cache::has(const cache_device_key& dk, const value& key) const
+{
+    auto bucket_it = cache.find(dk);
+    if(bucket_it == cache.end())
+        return false;
+    return contains(bucket_it->second, key.normalize());
+}
+
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -107,11 +107,15 @@ namespace {
 struct backend_options
 {
     std::vector<std::string> mlss_use_specific_ops = {};
+    // Problem cache files, searched in priority order (first hit wins). A single
+    // file is writable (new solutions are saved to it); multiple are read-only.
+    std::vector<std::string> problem_cache_files = {};
 
     template <class Self, class F>
     static auto reflect(Self& self, F f)
     {
-        return pack(f(self.mlss_use_specific_ops, "mlss_use_specific_ops"));
+        return pack(f(self.mlss_use_specific_ops, "mlss_use_specific_ops"),
+                    f(self.problem_cache_files, "problem_cache_files"));
     }
 };
 
@@ -279,12 +283,17 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
 {
     auto& ctx = any_cast<context>(gctx);
     ctx.set_exhaustive_tune_flag(options.exhaustive_tune);
-    ctx.load_problem_cache(); // TODO: update load_problem_cache to include gpu arch
 
     if(options.compile_mode == compile_modes::max)
         ctx.set_exhaustive_tune_flag(true);
 
-    pipeline_factory p{&gctx, options, from_value<backend_options>(value(options.backend_options))};
+    auto backend_opts = from_value<backend_options>(value(options.backend_options));
+
+    // Problem cache files arrive as a GPU backend option, searched in priority
+    // order (first hit wins). A single file is writable; multiple are read-only.
+    ctx.load_problem_caches(backend_opts.problem_cache_files);
+
+    pipeline_factory p{&gctx, options, backend_opts};
 
     std::vector<std::vector<pass>> pipelines;
 

--- a/test/gpu/problem_cache_backend.cpp
+++ b/test/gpu/problem_cache_backend.cpp
@@ -1,0 +1,188 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <migraphx/gpu/problem_cache.hpp>
+#include <migraphx/gpu/problem_cache_backend.hpp>
+#include <migraphx/gpu/json_problem_cache.hpp>
+#include <migraphx/tmp_dir.hpp>
+#include <migraphx/value.hpp>
+
+#include "test.hpp"
+
+namespace {
+
+migraphx::gpu::cache_device_key make_key(const std::string& gfx, std::size_t cu)
+{
+    migraphx::gpu::cache_device_key k;
+    k.device_name    = "test_device_" + gfx;
+    k.gfx_name       = gfx;
+    k.cu_count       = cu;
+    k.wavefront_size = 32;
+    return k;
+}
+
+migraphx::value make_problem(const std::string& name, std::size_t variant)
+{
+    return {{"name", name}, {"problem", migraphx::value{{"variant", variant}}}};
+}
+
+} // namespace
+
+// --------------------------------------------------------------------------
+// Round-trip: write entries, save, load into a fresh instance, verify.
+// --------------------------------------------------------------------------
+TEST_CASE(json_problem_cache_round_trip)
+{
+    migraphx::tmp_dir td{"json_problem_cache_round_trip"};
+    auto path = (td.path / "cache.json").string();
+
+    auto dk1   = make_key("gfx1201", 64);
+    auto dk2   = make_key("gfx1100", 96);
+    auto key_a = make_problem("gemm", 0);
+    auto key_b = make_problem("conv", 1);
+    auto sol_a = migraphx::value{{"block", std::size_t{256}}, {"kernel", "kA"}};
+    auto sol_b = migraphx::value{{"block", std::size_t{128}}, {"kernel", "kB"}};
+
+    migraphx::gpu::json_problem_cache writer;
+    writer.insert(dk1, key_a, sol_a);
+    writer.insert(dk2, key_b, sol_b);
+    writer.mark(dk1, key_b); // sentinel: tried, no solution
+    writer.save(path);
+
+    migraphx::gpu::json_problem_cache reader;
+    reader.load(path);
+
+    EXPECT(reader.has(dk1, key_a));
+    EXPECT(reader.has(dk2, key_b));
+    EXPECT(reader.has(dk1, key_b)); // sentinel still "present"
+
+    auto got_a = reader.get(dk1, key_a);
+    EXPECT(bool(got_a));
+    EXPECT(*got_a == sol_a);
+
+    auto got_b = reader.get(dk2, key_b);
+    EXPECT(bool(got_b));
+    EXPECT(*got_b == sol_b);
+
+    // Sentinel: get() returns a present optional whose value is null.
+    auto sentinel = reader.get(dk1, key_b);
+    EXPECT(bool(sentinel));
+    EXPECT(sentinel->is_null());
+
+    // Miss across buckets: dk2's bucket has no key_a.
+    EXPECT(not reader.has(dk2, key_a));
+    EXPECT(not bool(reader.get(dk2, key_a)));
+}
+
+// --------------------------------------------------------------------------
+// load() from a non-existent path is a no-op (typical first-run case).
+// --------------------------------------------------------------------------
+TEST_CASE(json_problem_cache_missing_file_is_noop)
+{
+    migraphx::tmp_dir td{"json_problem_cache_missing"};
+    auto path = (td.path / "does_not_exist.json").string();
+
+    migraphx::gpu::json_problem_cache c;
+    c.load(path); // must not throw
+    EXPECT(c.cache.empty());
+
+    // Subsequent save() must create the file and round-trip cleanly.
+    auto dk = make_key("gfx1201", 64);
+    c.insert(dk, make_problem("gemm", 0), migraphx::value{{"kernel", "kX"}});
+    c.save(path);
+
+    migraphx::gpu::json_problem_cache c2;
+    c2.load(path);
+    EXPECT(c2.has(dk, make_problem("gemm", 0)));
+}
+
+// --------------------------------------------------------------------------
+// Type-erasure round-trip: wrap json_problem_cache in problem_cache_backend
+// and exercise every concept member. Verifies the te.py-generated wrapper
+// forwards correctly.
+// --------------------------------------------------------------------------
+TEST_CASE(problem_cache_backend_type_erasure)
+{
+    migraphx::tmp_dir td{"problem_cache_backend_te"};
+    auto path = (td.path / "cache.json").string();
+
+    migraphx::gpu::problem_cache_backend backend = migraphx::gpu::json_problem_cache{};
+
+    auto dk   = make_key("gfx1201", 64);
+    auto key  = make_problem("gemm", 7);
+    auto sol  = migraphx::value{{"block", std::size_t{512}}, {"kernel", "kY"}};
+    auto miss = make_problem("never_inserted", 99);
+
+    EXPECT(not backend.has(dk, key));
+    EXPECT(not bool(backend.get(dk, key)));
+
+    backend.insert(dk, key, sol);
+    EXPECT(backend.has(dk, key));
+    auto got = backend.get(dk, key);
+    EXPECT(bool(got));
+    EXPECT(*got == sol);
+
+    backend.mark(dk, miss);
+    auto m = backend.get(dk, miss);
+    EXPECT(bool(m));
+    EXPECT(m->is_null());
+
+    backend.save(path);
+
+    migraphx::gpu::problem_cache_backend reloaded = migraphx::gpu::json_problem_cache{};
+    reloaded.load(path);
+    EXPECT(reloaded.has(dk, key));
+    auto got2 = reloaded.get(dk, key);
+    EXPECT(bool(got2));
+    EXPECT(*got2 == sol);
+}
+
+// --------------------------------------------------------------------------
+// any_cast lets callers recover the concrete backend type. Useful for the
+// future aggregator when it needs backend-specific operations (e.g.,
+// flushing a sqlite WAL) before falling back to the generic interface.
+// --------------------------------------------------------------------------
+TEST_CASE(problem_cache_backend_any_cast)
+{
+    migraphx::gpu::problem_cache_backend backend = migraphx::gpu::json_problem_cache{};
+
+    auto* concrete = backend.any_cast<migraphx::gpu::json_problem_cache>();
+    EXPECT(concrete != nullptr);
+
+    auto dk  = make_key("gfx1201", 64);
+    auto key = make_problem("gemm", 0);
+    backend.insert(dk, key, migraphx::value{{"kernel", "kZ"}});
+
+    // Mutation via the backend is visible to a re-cast of the same instance
+    // (handle is shared until copy-on-write triggers).
+    auto* concrete2 = backend.any_cast<migraphx::gpu::json_problem_cache>();
+    EXPECT(concrete2 != nullptr);
+    EXPECT(concrete2->has(dk, key));
+
+    // Casting to an unrelated type returns nullptr instead of throwing.
+    auto* wrong = backend.any_cast<int>();
+    EXPECT(wrong == nullptr);
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/gpu/problem_cache_path_override.cpp
+++ b/test/gpu/problem_cache_path_override.cpp
@@ -1,0 +1,150 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <migraphx/gpu/problem_cache.hpp>
+#include <migraphx/tmp_dir.hpp>
+#include <migraphx/value.hpp>
+#include <migraphx/file_buffer.hpp>
+
+#include "test.hpp"
+
+namespace {
+
+migraphx::gpu::cache_device_key make_key()
+{
+    migraphx::gpu::cache_device_key k;
+    k.device_name    = "test_device_gfx1201";
+    k.gfx_name       = "gfx1201";
+    k.cu_count       = 64;
+    k.wavefront_size = 32;
+    return k;
+}
+
+migraphx::value make_problem(std::size_t variant) { return migraphx::value{{"variant", variant}}; }
+
+} // namespace
+
+// --------------------------------------------------------------------------
+// load(path) writes to the same path on save() -- the path is "remembered".
+// --------------------------------------------------------------------------
+TEST_CASE(problem_cache_path_override_round_trip)
+{
+    migraphx::tmp_dir td{"problem_cache_path_override"};
+    auto path = (td.path / "explicit.json").string();
+
+    {
+        migraphx::gpu::problem_cache writer;
+        writer.set_device_key(make_key());
+        writer.load(path); // path doesn't exist yet -- no-op load, but path is remembered
+        writer.insert("gemm", make_problem(0), migraphx::value{{"kernel", "kA"}});
+        writer.save(); // must write to `path` because path_override was set
+    }
+
+    EXPECT(migraphx::fs::exists(path));
+
+    {
+        migraphx::gpu::problem_cache reader;
+        reader.set_device_key(make_key());
+        reader.load(path);
+        EXPECT(reader.has("gemm", make_problem(0)));
+        auto v = reader.get("gemm", make_problem(0));
+        EXPECT(bool(v));
+        EXPECT((*v).at("kernel").to<std::string>() == "kA");
+    }
+}
+
+// --------------------------------------------------------------------------
+// load(empty path) is a no-op and leaves the cache empty (no env-var fallback
+// from the path-arg overload).
+// --------------------------------------------------------------------------
+TEST_CASE(problem_cache_path_override_empty_is_noop)
+{
+    migraphx::gpu::problem_cache c;
+    c.set_device_key(make_key());
+    c.load(std::string{});
+    EXPECT(not c.has("gemm", make_problem(7)));
+
+    // Subsequent save() with no path-override and no env var must be a no-op
+    // (no exception, no file written). We can't easily verify the negative
+    // here, but we can verify the cache still works in-memory.
+    c.insert("gemm", make_problem(7), migraphx::value{{"kernel", "kZ"}});
+    EXPECT(c.has("gemm", make_problem(7)));
+}
+
+// --------------------------------------------------------------------------
+// load(paths) with multiple files is a read-only priority list: has()/get()
+// search the layers in order and the first hit wins (highest-priority first).
+// This is the layered search that lives inside problem_cache (not context).
+// --------------------------------------------------------------------------
+TEST_CASE(problem_cache_layered_priority_first_hit_wins)
+{
+    migraphx::tmp_dir td{"problem_cache_layered"};
+    auto high = (td.path / "high.json").string();
+    auto low  = (td.path / "low.json").string();
+
+    // High-priority file: solution kHigh for problem 0.
+    {
+        migraphx::gpu::problem_cache w;
+        w.set_device_key(make_key());
+        w.load(high);
+        w.insert("gemm", make_problem(0), migraphx::value{{"kernel", "kHigh"}});
+        w.save();
+    }
+    // Low-priority file: a *different* solution for problem 0, plus a problem 1
+    // that exists only here.
+    {
+        migraphx::gpu::problem_cache w;
+        w.set_device_key(make_key());
+        w.load(low);
+        w.insert("gemm", make_problem(0), migraphx::value{{"kernel", "kLow"}});
+        w.insert("gemm", make_problem(1), migraphx::value{{"kernel", "kOnlyLow"}});
+        w.save();
+    }
+
+    migraphx::gpu::problem_cache c;
+    c.set_device_key(make_key());
+    c.load(std::vector<std::string>{high, low}); // priority order: high first
+
+    // Problem 0 is in both files -> the higher-priority file wins.
+    EXPECT(c.has("gemm", make_problem(0)));
+    auto s0 = c.get("gemm", make_problem(0));
+    EXPECT(bool(s0));
+    EXPECT((*s0).at("kernel").to<std::string>() == "kHigh");
+
+    // Problem 1 exists only in the lower-priority file -> still found.
+    EXPECT(c.has("gemm", make_problem(1)));
+    auto s1 = c.get("gemm", make_problem(1));
+    EXPECT(bool(s1));
+    EXPECT((*s1).at("kernel").to<std::string>() == "kOnlyLow");
+
+    // A problem in neither file is not found.
+    EXPECT(not c.has("gemm", make_problem(2)));
+    EXPECT(not bool(c.get("gemm", make_problem(2))));
+
+    // Multiple files are a read-only list: save() must be a no-op (no writable
+    // path is configured) and must not throw.
+    c.save();
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/gpu/sqlite_problem_cache.cpp
+++ b/test/gpu/sqlite_problem_cache.cpp
@@ -1,0 +1,211 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <migraphx/gpu/problem_cache.hpp>
+#include <migraphx/gpu/problem_cache_backend.hpp>
+#include <migraphx/gpu/sqlite_problem_cache.hpp>
+#include <migraphx/tmp_dir.hpp>
+#include <migraphx/value.hpp>
+
+#include "test.hpp"
+
+namespace {
+
+migraphx::gpu::cache_device_key make_key(const std::string& gfx, std::size_t cu)
+{
+    migraphx::gpu::cache_device_key k;
+    k.device_name    = "test_device_" + gfx;
+    k.gfx_name       = gfx;
+    k.cu_count       = cu;
+    k.wavefront_size = 32;
+    return k;
+}
+
+migraphx::value make_problem(const std::string& name, std::size_t variant)
+{
+    return {{"name", name}, {"problem", migraphx::value{{"variant", variant}}}};
+}
+
+} // namespace
+
+// --------------------------------------------------------------------------
+// Round-trip: write entries, save, load into a fresh instance, verify.
+// --------------------------------------------------------------------------
+TEST_CASE(sqlite_problem_cache_round_trip)
+{
+    migraphx::tmp_dir td{"sqlite_problem_cache_round_trip"};
+    auto path = (td.path / "cache.db").string();
+
+    auto dk1   = make_key("gfx1201", 64);
+    auto dk2   = make_key("gfx1100", 96);
+    auto key_a = make_problem("gemm", 0);
+    auto key_b = make_problem("conv", 1);
+    auto sol_a = migraphx::value{{"block", std::size_t{256}}, {"kernel", "kA"}};
+    auto sol_b = migraphx::value{{"block", std::size_t{128}}, {"kernel", "kB"}};
+
+    migraphx::gpu::sqlite_problem_cache writer;
+    writer.insert(dk1, key_a, sol_a);
+    writer.insert(dk2, key_b, sol_b);
+    writer.mark(dk1, key_b); // sentinel: tried, no solution
+    writer.save(path);
+
+    migraphx::gpu::sqlite_problem_cache reader;
+    reader.load(path);
+
+    EXPECT(reader.has(dk1, key_a));
+    EXPECT(reader.has(dk2, key_b));
+    EXPECT(reader.has(dk1, key_b)); // sentinel still "present"
+
+    auto got_a = reader.get(dk1, key_a);
+    EXPECT(bool(got_a));
+    EXPECT(*got_a == sol_a);
+
+    auto got_b = reader.get(dk2, key_b);
+    EXPECT(bool(got_b));
+    EXPECT(*got_b == sol_b);
+
+    // Sentinel: get() returns a present optional whose value is null.
+    auto sentinel = reader.get(dk1, key_b);
+    EXPECT(bool(sentinel));
+    EXPECT(sentinel->is_null());
+
+    // Miss across buckets: dk2's bucket has no key_a.
+    EXPECT(not reader.has(dk2, key_a));
+    EXPECT(not bool(reader.get(dk2, key_a)));
+}
+
+// --------------------------------------------------------------------------
+// load() from a non-existent path is a no-op (typical first-run case).
+// --------------------------------------------------------------------------
+TEST_CASE(sqlite_problem_cache_missing_file_is_noop)
+{
+    migraphx::tmp_dir td{"sqlite_problem_cache_missing"};
+    auto path = (td.path / "does_not_exist.db").string();
+
+    migraphx::gpu::sqlite_problem_cache c;
+    c.load(path); // must not throw
+    EXPECT(c.cache.empty());
+
+    // Subsequent save() must create the file and round-trip cleanly.
+    auto dk = make_key("gfx1201", 64);
+    c.insert(dk, make_problem("gemm", 0), migraphx::value{{"kernel", "kX"}});
+    c.save(path);
+
+    migraphx::gpu::sqlite_problem_cache c2;
+    c2.load(path);
+    EXPECT(c2.has(dk, make_problem("gemm", 0)));
+}
+
+// --------------------------------------------------------------------------
+// Save-overwrite: a second save() of a smaller cache must replace the
+// previous file's rows (DELETE FROM solutions semantics), not accumulate.
+// --------------------------------------------------------------------------
+TEST_CASE(sqlite_problem_cache_save_overwrite)
+{
+    migraphx::tmp_dir td{"sqlite_problem_cache_overwrite"};
+    auto path = (td.path / "cache.db").string();
+
+    auto dk    = make_key("gfx1201", 64);
+    auto key_a = make_problem("gemm", 0);
+    auto key_b = make_problem("conv", 1);
+
+    migraphx::gpu::sqlite_problem_cache c;
+    c.insert(dk, key_a, migraphx::value{{"kernel", "kA"}});
+    c.insert(dk, key_b, migraphx::value{{"kernel", "kB"}});
+    c.save(path);
+
+    // Reload, drop one entry, save again.
+    migraphx::gpu::sqlite_problem_cache c2;
+    c2.load(path);
+    EXPECT(c2.has(dk, key_a));
+    EXPECT(c2.has(dk, key_b));
+    // Keys are stored normalized (as insert/load do), so erase by the normalized key.
+    c2.cache[dk].erase(key_b.normalize());
+    c2.save(path);
+
+    // Third instance must see the smaller set.
+    migraphx::gpu::sqlite_problem_cache c3;
+    c3.load(path);
+    EXPECT(c3.has(dk, key_a));
+    EXPECT(not c3.has(dk, key_b));
+}
+
+// --------------------------------------------------------------------------
+// Type-erasure round-trip: wrap sqlite_problem_cache in problem_cache_backend
+// and exercise every concept member. Verifies the te.py-generated wrapper
+// forwards correctly to a *different* concrete backend than json.
+// --------------------------------------------------------------------------
+TEST_CASE(problem_cache_backend_sqlite_type_erasure)
+{
+    migraphx::tmp_dir td{"problem_cache_backend_sqlite_te"};
+    auto path = (td.path / "cache.db").string();
+
+    migraphx::gpu::problem_cache_backend backend = migraphx::gpu::sqlite_problem_cache{};
+
+    auto dk   = make_key("gfx1201", 64);
+    auto key  = make_problem("gemm", 7);
+    auto sol  = migraphx::value{{"block", std::size_t{512}}, {"kernel", "kY"}};
+    auto miss = make_problem("never_inserted", 99);
+
+    EXPECT(not backend.has(dk, key));
+    EXPECT(not bool(backend.get(dk, key)));
+
+    backend.insert(dk, key, sol);
+    EXPECT(backend.has(dk, key));
+    auto got = backend.get(dk, key);
+    EXPECT(bool(got));
+    EXPECT(*got == sol);
+
+    backend.mark(dk, miss);
+    auto m = backend.get(dk, miss);
+    EXPECT(bool(m));
+    EXPECT(m->is_null());
+
+    backend.save(path);
+
+    migraphx::gpu::problem_cache_backend reloaded = migraphx::gpu::sqlite_problem_cache{};
+    reloaded.load(path);
+    EXPECT(reloaded.has(dk, key));
+    auto got2 = reloaded.get(dk, key);
+    EXPECT(bool(got2));
+    EXPECT(*got2 == sol);
+}
+
+// --------------------------------------------------------------------------
+// any_cast lets callers recover the concrete sqlite backend.
+// --------------------------------------------------------------------------
+TEST_CASE(problem_cache_backend_sqlite_any_cast)
+{
+    migraphx::gpu::problem_cache_backend backend = migraphx::gpu::sqlite_problem_cache{};
+
+    auto* concrete = backend.any_cast<migraphx::gpu::sqlite_problem_cache>();
+    EXPECT(concrete != nullptr);
+
+    // Casting to a sibling concrete type returns nullptr (no cross-type
+    // recovery via the type-erased interface).
+    auto* wrong = backend.any_cast<int>();
+    EXPECT(wrong == nullptr);
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/tools/include/gpu/problem_cache_backend.hpp
+++ b/tools/include/gpu/problem_cache_backend.hpp
@@ -1,0 +1,138 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+//
+// te.py DSL for migraphx::gpu::problem_cache_backend.
+//
+// The generated header lives at
+// src/targets/gpu/include/migraphx/gpu/problem_cache_backend.hpp; regenerate it
+// with `cd tools && python generate.py` (generate_all routes include/gpu/ inputs
+// into the gpu target tree). Do not edit the generated header by hand.
+//
+// Any type T satisfies the problem_cache_backend concept if it provides the
+// member functions listed below. The wrapper holds T by shared_ptr (small
+// object optimisation is irrelevant -- backends typically own non-trivial
+// resources like file handles or SQLite connections) and forwards each call
+// through a virtual dispatch.
+//
+// Notes:
+//   * cache_device_key is defined in <migraphx/gpu/cache_device_key.hpp>;
+//     the include below pulls in its full definition.
+//   * Backends are NOT expected to be copyable in any meaningful sense
+//     beyond what shared ownership provides; they may freely hold streams,
+//     file handles, etc.
+//   * load() is non-const (mutates internal state); save() is const.
+//
+#ifndef MIGRAPHX_GUARD_GPU_PROBLEM_CACHE_BACKEND_HPP
+#define MIGRAPHX_GUARD_GPU_PROBLEM_CACHE_BACKEND_HPP
+
+#include <cassert>
+#include <string>
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include <migraphx/config.hpp>
+#include <migraphx/value.hpp>
+#include <migraphx/optional.hpp>
+#include <migraphx/gpu/export.h>
+#include <migraphx/gpu/cache_device_key.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+namespace gpu {
+
+#ifdef DOXYGEN
+
+/// Type-erased interface for problem-cache storage backends.
+///
+/// A backend persists (cache_device_key, key) -> solution entries to some
+/// medium (JSON file, SQLite database, in-memory map for tests, ...). All
+/// lookups and inserts are scoped by the device key so a single backend
+/// instance can hold entries for multiple GPU configurations.
+struct problem_cache_backend
+{
+    /// Load entries from `path` into the backend. Idempotent; calling
+    /// load() twice with the same path leaves the backend in an equivalent
+    /// state. Implementations should treat a missing file as "no entries"
+    /// rather than an error (the typical first-run case).
+    void load(const std::string& path);
+
+    /// Persist all entries to `path`. Const by design: backends that need
+    /// to flush write-behind buffers must do so internally without mutating
+    /// observable state.
+    void save(const std::string& path) const;
+
+    /// Insert (or overwrite) the solution for `key` in the bucket
+    /// identified by `dk`. Precondition: `solution` is not null.
+    void insert(const cache_device_key& dk, const value& key, const value& solution);
+
+    /// Insert a pending sentinel (null value) for `key`, recording that a
+    /// solution for this problem is being tuned. A later lookup that sees the
+    /// sentinel treats the problem as already in progress rather than as a
+    /// real cached solution.
+    void mark(const cache_device_key& dk, const value& key);
+
+    /// Return the stored solution for `key` in the bucket `dk`, or nullopt
+    /// if no entry exists. A present optional with a null value indicates
+    /// a sentinel (set via mark()).
+    optional<value> get(const cache_device_key& dk, const value& key) const;
+
+    /// True iff any entry (real solution or sentinel) exists for `key` in
+    /// the bucket `dk`.
+    bool has(const cache_device_key& dk, const value& key) const;
+};
+
+#else
+
+<%
+    interface(
+        'problem_cache_backend',
+        virtual('load', returns = 'void', path = 'const std::string&'),
+        virtual('save', returns = 'void', path = 'const std::string&', const = True),
+        virtual('insert',
+                returns  = 'void',
+                dk       = 'const cache_device_key&',
+                key      = 'const value&',
+                solution = 'const value&'),
+        virtual('mark', returns = 'void', dk = 'const cache_device_key&', key = 'const value&'),
+        virtual('get',
+                returns = 'optional<value>',
+                dk      = 'const cache_device_key&',
+                key     = 'const value&',
+                const   = True),
+        virtual('has',
+                returns = 'bool',
+                dk      = 'const cache_device_key&',
+                key     = 'const value&',
+                const   = True))
+%>
+
+#endif
+
+} // namespace gpu
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
+
+#endif // MIGRAPHX_GUARD_GPU_PROBLEM_CACHE_BACKEND_HPP


### PR DESCRIPTION
**Release-branch merge - do not review here.** (Reviewed on ROCm/AMDMIGraphX#5117.)

Cherry-pick of the problem-cache follow-on (#5117) onto gpuep-releases/gpuep-rel-2610 so it is available for the next release build.

### Scope: only #5117's changes
- 22 files, +1763/-156: pluggable JSON/SQLite backends, cache_device_key, layered multi-cache priority (app > local > shipped, first-hit-wins), delivered via the `problem_cache_files` GPU backend option.
- Confirmed the diff vs gpuep-rel-2610 contains only #5117's problem-cache files and nothing else.

### Conflict resolutions vs 2610
- `target.cpp`: resolved as the **union** with 2610's compile_mode feature (both kept).
- `tools/generate.py`: **kept 2610's version** (generated header is already committed; #5117's generate.py routing assumes newer develop state and is not needed for the build).

### Validation & caveats
- **Build-verified locally** (gfx1100, RelWithDebInfo): all 12 problem-cache unit tests pass (backend 4/4, path-override 3/3 incl. layered-priority, sqlite 5/5) and the problem-cache GPU sources recompile cleanly. The unrelated MLIR path is stubbed locally for a rocMLIR v5-vs-v6 gap on this box, so release CI remains the authority for a full clean-tree build.
- **#5117 is under active maintainer rework upstream**; this stages the current reviewed state per the release request. The consume path (what a shipped supercache uses) is the validated part (12/12 unit + prior real-GPU E2E).

**Paired with the EP-side release PR:** onnxruntime/onnxruntime-ep-amdgpu#94.