### PR TITLE
Jenkins: delete build dir and clean workspace after each stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -272,15 +272,19 @@ def rocmtest = { Map conf = [:], Closure body ->
         }
 
         stage("build ${variant}") {
-            withDockerContainer(image: "${image}:${imageTag}", args: docker_opts + docker_args) {
-                timeout(time: 4, unit: 'HOURS') {
-                    sh """
-                        mkdir -p ${ccache} ${comgr_cache}
-                        ls -l /workspaces/
-                        ls -l /workspaces/.cache/
-                    """
-                    body()
+            try {
+                withDockerContainer(image: "${image}:${imageTag}", args: docker_opts + docker_args) {
+                    timeout(time: 4, unit: 'HOURS') {
+                        sh """
+                            mkdir -p ${ccache} ${comgr_cache}
+                            ls -l /workspaces/
+                            ls -l /workspaces/.cache/
+                        """
+                        body()
+                    }
                 }
+            } finally {
+                sh 'rm -rf build'
             }
         }
     }
@@ -562,6 +566,12 @@ pipeline {
                     }
                 }
             }
+        }
+    }
+
+    post {
+        always {
+            cleanWs()
         }
     }
 }


### PR DESCRIPTION
## Motivation
Some jobs create 130GB of data and can fill up drive space unnecessarily 

## Technical Details
Delete the build/ directory in a finally block after each slave's Docker container exits, and call cleanWs() in a top-level post { always } block to wipe the primary agent checkout. Stash and archiveArtifacts for HIP Clang Release still run inside body() before cleanup, so .deb artifacts are preserved.