### PR TITLE
Release protobuf state on ONNX DLL unload

### DIFF
--- a/src/onnx/dll_main.cpp
+++ b/src/onnx/dll_main.cpp
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+#include <google/protobuf/message_lite.h>
+
+BOOL WINAPI DllMain(HINSTANCE /*instance*/, DWORD reason, LPVOID reserved)
+{
+    // Release this DLL's private static protobuf state only for a real
+    // FreeLibrary unload. The OS reclaims it during process termination.
+    if(reason == DLL_PROCESS_DETACH and reserved == nullptr)
+    {
+        google::protobuf::ShutdownProtobufLibrary();
+    }
+    return TRUE;
+}
+
+#endif // _WIN32

--- a/src/tf/dll_main.cpp
+++ b/src/tf/dll_main.cpp
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+#include <google/protobuf/message_lite.h>
+
+BOOL WINAPI DllMain(HINSTANCE /*instance*/, DWORD reason, LPVOID reserved)
+{
+    // Release this DLL's private static protobuf state only for a real
+    // FreeLibrary unload. The OS reclaims it during process termination.
+    if(reason == DLL_PROCESS_DETACH and reserved == nullptr)
+    {
+        google::protobuf::ShutdownProtobufLibrary();
+    }
+    return TRUE;
+}
+
+#endif // _WIN32


### PR DESCRIPTION
Adds Windows DLL unload cleanup for migraphx_onnx.dll. It releases DLL-local protobuf state during dynamic FreeLibrary unloads, preventing AppVerifier 0x900 heap leak failures.


## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
