### PR TITLE
Enable fp16 winograd on gfx1151

### DIFF
--- a/src/targets/gpu/kernels/include/migraphx/kernels/winograd_conv.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/winograd_conv.hpp
@@ -27,6 +27,7 @@
 #include <migraphx/kernels/array.hpp>
 #include <migraphx/kernels/bit_cast.hpp>
 #include <migraphx/kernels/buffer_load.hpp>
+#include <migraphx/kernels/dpp.hpp>
 #include <migraphx/kernels/index.hpp>
 #include <migraphx/kernels/tensor_view.hpp>
 #include <migraphx/kernels/vec.hpp>
@@ -36,6 +37,22 @@
 #include <migraphx/kernels/integral_constant.hpp>
 
 namespace migraphx {
+
+#if defined(__gfx1151__)
+__device__ inline vec<half, 16> pack_wmma_fragment_gfx1151(vec<half, 8> x)
+{
+    auto peer = readlane_xor<16>(x);
+    return __builtin_shufflevector(
+        x, peer, 0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
+}
+
+__device__ inline vec<float, 8>
+wmma_gfx1151(vec<half, 8> a, vec<half, 8> b, vec<float, 8> c)
+{
+    return __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+        pack_wmma_fragment_gfx1151(a), pack_wmma_fragment_gfx1151(b), c);
+}
+#endif
 
 // Quad of WMMAs in a single inline-asm block. Forces the compiler to issue
 // them back-to-back (each is 8-cycle wait state but to a DIFFERENT
@@ -57,12 +74,19 @@ __device__ inline void wmma_quad_asm(vec<half, 8> a0,
                                      vec<float, 8>& m2,
                                      vec<float, 8>& m3)
 {
+#if defined(__gfx1151__)
+    m0 = wmma_gfx1151(a0, b0, m0);
+    m1 = wmma_gfx1151(a1, b1, m1);
+    m2 = wmma_gfx1151(a2, b2, m2);
+    m3 = wmma_gfx1151(a3, b3, m3);
+#else
     asm volatile("v_wmma_f32_16x16x16_f16 %0, %4, %5, %0\n\t"
                  "v_wmma_f32_16x16x16_f16 %1, %6, %7, %1\n\t"
                  "v_wmma_f32_16x16x16_f16 %2, %8, %9, %2\n\t"
                  "v_wmma_f32_16x16x16_f16 %3, %10, %11, %3"
                  : "+v"(m0), "+v"(m1), "+v"(m2), "+v"(m3)
                  : "v"(a0), "v"(b0), "v"(a1), "v"(b1), "v"(a2), "v"(b2), "v"(a3), "v"(b3));
+#endif
 }
 
 // Octet of WMMAs in a single inline-asm block. Costs 8 live fp32 vec<8>
@@ -93,6 +117,16 @@ __device__ inline void wmma_octet_asm(vec<half, 8> a0,
                                       vec<float, 8>& m6,
                                       vec<float, 8>& m7)
 {
+#if defined(__gfx1151__)
+    m0 = wmma_gfx1151(a0, b0, m0);
+    m1 = wmma_gfx1151(a1, b1, m1);
+    m2 = wmma_gfx1151(a2, b2, m2);
+    m3 = wmma_gfx1151(a3, b3, m3);
+    m4 = wmma_gfx1151(a4, b4, m4);
+    m5 = wmma_gfx1151(a5, b5, m5);
+    m6 = wmma_gfx1151(a6, b6, m6);
+    m7 = wmma_gfx1151(a7, b7, m7);
+#else
     asm volatile("v_wmma_f32_16x16x16_f16 %0, %8, %9, %0\n\t"
                  "v_wmma_f32_16x16x16_f16 %1, %10, %11, %1\n\t"
                  "v_wmma_f32_16x16x16_f16 %2, %12, %13, %2\n\t"
@@ -118,6 +152,7 @@ __device__ inline void wmma_octet_asm(vec<half, 8> a0,
                    "v"(b6),
                    "v"(a7),
                    "v"(b7));
+#endif
 }
 
 // F(2x2, 3x3) Winograd transforms used inline by the WMMA path.
@@ -892,7 +927,13 @@ __device__ void winograd_conv_f23_wmma(F f, Output output, Input x, Weights u, I
     // Reuse the per-lane (n_idx, th_idx, tw_idx) computed up at V-load setup.
     // For SK>1 only the wave_sk_part==0 wave of each NT-group has the summed y.
     using out_type               = typename Output::type;
-    const index_int k_row_offset = c_off; // (lane / 16) * 8, same lane mapping
+#if defined(__gfx1151__)
+    const index_int k_row_offset       = lane / 16;
+    constexpr index_int k_row_stride   = 2; // Alternating K rows per lane
+#else
+    const index_int k_row_offset       = c_off;
+    constexpr index_int k_row_stride   = 1;
+#endif
     if(not nt_active)
         return;
     if constexpr(SK > 1)
@@ -935,7 +976,7 @@ __device__ void winograd_conv_f23_wmma(F f, Output output, Input x, Weights u, I
         // fall through to the packed NCHW store below.
         if(sk == 1)
         {
-            const bool k_pack = (out_c % 8 == 0);
+            const bool k_pack = (k_row_stride == 1) and (out_c % 8 == 0);
             repeat_c<KW>([&](auto k_idx_val) {
                 constexpr int k_idx     = k_idx_val;
                 const index_int k_first = k_base + k_idx * bk + k_row_offset;
@@ -976,7 +1017,7 @@ __device__ void winograd_conv_f23_wmma(F f, Output output, Input x, Weights u, I
                         else
                         {
                             repeat_c<8>([&](auto ki) {
-                                const index_int k = k_first + index_int{ki};
+                                const index_int k = k_first + index_int{ki} * k_row_stride;
                                 if(k < out_c)
                                 {
                                     const array<index_int, 4> oid{n_idx, k, h_out, w_out};
@@ -999,10 +1040,11 @@ __device__ void winograd_conv_f23_wmma(F f, Output output, Input x, Weights u, I
                                       (2 * th_idx) * sh + (2 * tw_idx) * sw;
         const bool w_pair_in = (2 * tw_idx + 1 < out_w) and (sw == 1);
         repeat_c<8>([&](auto ki) {
-            const index_int k = k_base + k_idx * bk + k_row_offset + ki;
+            const index_int k =
+                k_base + k_idx * bk + k_row_offset + index_int{ki} * k_row_stride;
             if(k < out_c)
             {
-                const index_int kbase = base_offset + ki * sk;
+                const index_int kbase = base_offset + index_int{ki} * k_row_stride * sk;
                 repeat_c<2>([&](auto i) {
                     const index_int h_out = 2 * th_idx + i;
                     if(h_out < out_h)

--- a/src/targets/gpu/prefuse_ops.cpp
+++ b/src/targets/gpu/prefuse_ops.cpp
@@ -607,8 +607,17 @@ bool winograd_f23_profitable(
     // large-channel regime for NHWC -- this is layout-specific; NCHW still wins
     // it and is unchanged. The override table below is NCHW-derived, so the NHWC
     // gate is applied first.
-    if(nhwc and min_ch >= 224)
-        return false;
+    if(nhwc)
+    {
+        if(min_ch >= 224)
+            return false;
+        if(min_ch >= 128 and spatial >= 48)
+            return false;
+        if(min_ch >= 64 and spatial >= 64)
+            return false;
+        if(max_ch >= 4 * min_ch and spatial >= 32)
+            return false;
+    }
 
     if(const auto* ovr = find_shape_override(winograd_f23_overrides, in_ch, out_ch, height, width))
         return ovr->use_winograd;

--- a/src/targets/gpu/prefuse_ops.cpp
+++ b/src/targets/gpu/prefuse_ops.cpp
@@ -935,7 +935,7 @@ void prefuse_ops::apply(module_pass_manager& mpm) const
     // (after layout_convolution) means winograd inherits the layout that pass
     // chose and replaces the convolution in place via its layout-matching
     // compute_shape.
-    const bool is_gfx12 = starts_with(device_name, "gfx12");
+    const bool supports_winograd = device_name == "gfx1151" or starts_with(device_name, "gfx12");
     if(enabled(MIGRAPHX_ENABLE_LAYERNORM_FUSION{}))
     {
         match::find_matches(mpm.get_module(), find_layernorm{});
@@ -945,7 +945,7 @@ void prefuse_ops::apply(module_pass_manager& mpm) const
     match::find_matches(mpm, find_gemm_softmax_gemm{enable_attention});
     if(is_navi)
         match::find_matches(mpm.get_module(), find_channelwise_convolution{});
-    if(is_gfx12)
+    if(supports_winograd)
     {
         match::find_matches(mpm.get_module(), find_winograd_f23{});
         mpm.run_pass(dead_code_elimination{});


### PR DESCRIPTION
Enable FP16 Winograd convolution support on gfx1151 to improve inference performance for workloads such as YOLO26m.

## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Enable FP16 Winograd convolution on gfx1151 to evaluate its performance against competing solutions.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
gfx1151 WMMA uses a different operand and accumulator layout from gfx12xx. This draft adapts the data packing and output mapping for gfx1151 and enables Winograd prefusion on this architecture.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
