### PR TITLE
fix(security): harden Python driver/codegen tools

### DIFF
--- a/tools/api.py
+++ b/tools/api.py
@@ -26,6 +26,7 @@ import string
 import sys
 import re
 import runpy
+import ast
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from pathlib import Path
@@ -1289,10 +1290,47 @@ def template_eval(template, **kwargs):
     end = '%>'
     escaped = (re.escape(start), re.escape(end))
     mark = re.compile('%s(.*?)%s' % escaped, re.DOTALL)
-    for key in kwargs:
-        exec('%s = %s' % (key, kwargs[key]))
+    namespace = dict(kwargs)
+    allowed_nodes = {
+        ast.Expression,
+        ast.Constant,
+        ast.Name,
+        ast.Load,
+        ast.BinOp,
+        ast.UnaryOp,
+        ast.Compare,
+        ast.BoolOp,
+        ast.Add,
+        ast.Sub,
+        ast.Mult,
+        ast.Div,
+        ast.Mod,
+        ast.Pow,
+        ast.And,
+        ast.Or,
+        ast.Not,
+        ast.Eq,
+        ast.NotEq,
+        ast.Lt,
+        ast.LtE,
+        ast.Gt,
+        ast.GtE,
+        ast.List,
+        ast.Tuple,
+        ast.Subscript,
+        ast.Slice,
+        ast.Call,
+        ast.Attribute,
+        ast.keyword,
+    }
     for item in mark.findall(template):
-        e = eval(item.strip())
+        tree = ast.parse(item.strip(), mode='eval')
+        for node in ast.walk(tree):
+            if type(node) not in allowed_nodes:
+                raise ValueError(
+                    f"Disallowed expression in template: {type(node).__name__}")
+        e = eval(compile(tree, '<template>', 'eval'),
+                 {"__builtins__": {}}, namespace)
         template = template.replace(start + item + end, str(e))
     return template
 

--- a/tools/generate.py
+++ b/tools/generate.py
@@ -37,9 +37,8 @@ optional_components = ['enable_onnx', 'enable_tensorflow']
 
 
 def clang_format(buffer, **kwargs):
-    return subprocess.run(f'{clang_format_path} -style=file',
+    return subprocess.run([str(clang_format_path), '-style=file'],
                           capture_output=True,
-                          shell=True,
                           check=True,
                           input=buffer.encode('utf-8'),
                           cwd=work_dir,

--- a/tools/roctx.py
+++ b/tools/roctx.py
@@ -27,6 +27,8 @@
 import json
 import argparse
 import os
+import subprocess
+import shlex
 from sys import argv as sysargs
 from sys import version_info as python_version
 from sys import exit as sys_exit
@@ -220,7 +222,7 @@ def run():
     executable = f"/opt/rocm/bin/migraphx-driver roctx {run_args}"
     process_args = configs + ' ' + output_dir + ' ' + executable
     for i in range(repeat_count):
-        os.system('rocprof ' + process_args)
+        subprocess.run(shlex.split('rocprof ' + process_args), check=True)
     print("RUN COMPLETE.")
 
 
@@ -254,12 +256,16 @@ def main():
         rpd_path = '/tmp/rocm-profile-data/rocmProfileData/'
         if not os.path.exists(rpd_path):
             print("rocmProfileData DOES NOT EXIST. CLONING...")
-            os.system(
-                f"git clone https://github.com/ROCmSoftwarePlatform/rocmProfileData.git {rpd_path}"
-            )
+            subprocess.run([
+                'git', 'clone',
+                'https://github.com/ROCmSoftwarePlatform/rocmProfileData.git',
+                rpd_path
+            ],
+                         check=True)
         os.chdir(rpd_path + "rocpd_python/")
-        os.system(python_bin + ' -m pip install --upgrade pip')
-        os.system(python_bin + ' setup.py install')
+        subprocess.run([python_bin, '-m', 'pip', 'install', '--upgrade', 'pip'],
+                       check=True)
+        subprocess.run([python_bin, 'setup.py', 'install'], check=True)
         os.chdir(curr)
         run()
         os.chdir(curr + f"/{args.out}/")

--- a/tools/te.py
+++ b/tools/te.py
@@ -21,7 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #####################################################################################
-import string, sys, re
+import string, sys, re, ast
 
 trivial = [
     'std::size_t', 'instruction_ref', 'support_metric', 'const_module_ref',
@@ -473,11 +473,48 @@ def template_eval(template, **kwargs):
     end = '%>'
     escaped = (re.escape(start), re.escape(end))
     mark = re.compile('%s(.*?)%s' % escaped, re.DOTALL)
-    for key in kwargs:
-        exec('%s = %s' % (key, kwargs[key]))
+    namespace = dict(kwargs)
+    allowed_nodes = {
+        ast.Expression,
+        ast.Constant,
+        ast.Name,
+        ast.Load,
+        ast.BinOp,
+        ast.UnaryOp,
+        ast.Compare,
+        ast.BoolOp,
+        ast.Add,
+        ast.Sub,
+        ast.Mult,
+        ast.Div,
+        ast.Mod,
+        ast.Pow,
+        ast.And,
+        ast.Or,
+        ast.Not,
+        ast.Eq,
+        ast.NotEq,
+        ast.Lt,
+        ast.LtE,
+        ast.Gt,
+        ast.GtE,
+        ast.List,
+        ast.Tuple,
+        ast.Subscript,
+        ast.Slice,
+        ast.Call,
+        ast.Attribute,
+        ast.keyword,
+    }
     for item in mark.findall(template):
-        template = template.replace(start + item + end,
-                                    str(eval(item.strip())))
+        tree = ast.parse(item.strip(), mode='eval')
+        for node in ast.walk(tree):
+            if type(node) not in allowed_nodes:
+                raise ValueError(
+                    f"Disallowed expression in template: {type(node).__name__}")
+        value = eval(compile(tree, '<template>', 'eval'),
+                     {"__builtins__": {}}, namespace)
+        template = template.replace(start + item + end, str(value))
     return template
 
 


### PR DESCRIPTION
## Summary
- Remove shell=True/os.system from driver tools; restrict template eval with AST allowlist

## JIRA
- ROCM-26621, ROCM-26353

## Test plan
- [ ] Run make generate
- [ ] Run tools/te.py on template inputs

Made with [Cursor](https://cursor.com)