### PR TITLE
fix(security): scope CI secrets and pin third-party actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: migraphx
 
+permissions:
+  contents: read
+
 on: 
   pull_request:
   push:
@@ -9,8 +12,6 @@ on:
       - 'release/**'
 
 env:
-  DOCKER_USER: ${{secrets.DOCKERHUB_USERID}}
-  DOCKER_TOKEN: ${{secrets.DOCKERHUB_TOKEN}}
   DOCKER_IMAGE_UBUNTU: "rocm/migraphx-ci-ubuntu"
   DOCKER_IMAGE_SLES: "rocm/migraphx-ci-sles"
 
@@ -71,7 +72,13 @@ jobs:
     name: Build image
     runs-on: ROCM-Ubuntu
     needs: check_image
-    if: ${{ needs.check_image.outputs.imageexists != 'true' }}
+    if: >-
+      ${{ needs.check_image.outputs.imageexists != 'true'
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository) }}
+    env:
+      DOCKER_USER: ${{ secrets.DOCKERHUB_USERID }}
+      DOCKER_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v4.2.2
 
@@ -93,7 +100,13 @@ jobs:
     name: Build SLES image
     runs-on: ROCM-Ubuntu
     needs: check_image
-    if: ${{ needs.check_image.outputs.imageexists_sles != 'true' }}
+    if: >-
+      ${{ needs.check_image.outputs.imageexists_sles != 'true'
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository) }}
+    env:
+      DOCKER_USER: ${{ secrets.DOCKERHUB_USERID }}
+      DOCKER_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v4.2.2
     - name: Build and publish SLES
@@ -231,7 +244,7 @@ jobs:
         fetch-depth: 0
 
     - name: Free space
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@389ec2a768342fb623f912a9654a37885a279847
       continue-on-error: true
       with:
         tool-cache: true
@@ -326,7 +339,7 @@ jobs:
 
     steps:
     - name: Free space
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@389ec2a768342fb623f912a9654a37885a279847
       continue-on-error: true
       with:
         tool-cache: true
@@ -357,7 +370,7 @@ jobs:
 
     steps:
     - name: Free space
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@389ec2a768342fb623f912a9654a37885a279847
       continue-on-error: true
       with:
         tool-cache: true
@@ -400,7 +413,7 @@ jobs:
 
     steps:
     - name: Free space
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@389ec2a768342fb623f912a9654a37885a279847
       continue-on-error: true
       with:
         tool-cache: true
@@ -491,7 +504,7 @@ jobs:
     - name: Upload code coverage
       if: "matrix.configuration == 'codecov'"
       env:
-        CODECOV_TOKEN: "f5d5a10b-3177-4c76-b25f-9b1c2f165e8b"
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
         sudo apt-get update
         sudo apt-get install -y lcov
@@ -526,7 +539,7 @@ jobs:
 
     steps:
     - name: Free space
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@389ec2a768342fb623f912a9654a37885a279847
       continue-on-error: true
       with:
         tool-cache: true


### PR DESCRIPTION
## Summary
- Move DockerHub credentials from workflow-level env to push jobs only
- Replace cleartext Codecov token with CODECOV_TOKEN secret
- Pin jlumbroso/free-disk-space to commit SHA

## JIRA
- ROCM-26618, ROCM-26607, ROCM-26609

## Test plan
- [ ] Verify CI on internal PR

Made with [Cursor](https://cursor.com)