### PR TITLE
fix(security): pin base image digest and run as jenkins user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@
 #   rbuild build -d depend -B build
 #
 
-FROM ubuntu:24.04
+# Base image pinned to ubuntu:24.04 tag digest (sha256 from tag 24.04 as of 2026-08).
+FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
 
 ARG PREFIX=/usr/local
 # ROCm release version (used in versioned package names, e.g. amdrocm-developer-tools7.13)
@@ -154,4 +155,9 @@ ENV UBSAN_OPTIONS=print_stacktrace=1
 # See: https://github.com/google/sanitizers/issues/1017
 ENV ASAN_OPTIONS=detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
 RUN ln -s /opt/rocm/llvm/bin/llvm-symbolizer /usr/bin/llvm-symbolizer
+
+RUN groupadd -r jenkins && useradd -r -g jenkins -m jenkins && \
+    chown -R jenkins:jenkins /tmp /var/tmp $ONNX_HOME
+
+USER jenkins
 


### PR DESCRIPTION
## Summary
- Pin ubuntu:24.04 to reviewed digest (from tag 24.04)
- Add non-root jenkins user for runtime

## JIRA
- ROCM-26612, ROCM-26613

## Test plan
- [ ] docker build .

Made with [Cursor](https://cursor.com)