### PR TITLE
windows-gpu: free disk space before ROCm install

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -99,6 +99,21 @@ jobs:
       ROCM_VERSION: "7.13"
 
     steps:
+    - name: Free disk space
+      shell: pwsh
+      run: |
+        Get-PSDrive C | Select-Object @{Name="Used (GB)"; Expression={$_.Used / 1GB}}, @{Name="Free (GB)"; Expression={$_.Free / 1GB}}
+        if (Test-Path 'C:\Android') { Remove-Item -Recurse -Force 'C:\Android' }
+        if (Test-Path 'C:\ghcup') { Remove-Item -Recurse -Force 'C:\ghcup' }
+        if (Test-Path 'C:\tools\stack') { Remove-Item -Recurse -Force 'C:\tools\stack' }
+        Get-ChildItem 'C:\hostedtoolcache\windows' -Filter 'Java_*' -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force
+        Get-ChildItem 'C:\hostedtoolcache\windows' -Filter 'swift*' -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force
+        if (Test-Path 'C:\Ruby*') { Get-Item 'C:\Ruby*' | Remove-Item -Recurse -Force }
+        if (Test-Path 'C:\hostedtoolcache\windows\go') { Remove-Item -Recurse -Force 'C:\hostedtoolcache\windows\go' }
+        Get-PSDrive C | Select-Object @{Name="Used (GB)"; Expression={$_.Used / 1GB}}, @{Name="Free (GB)"; Expression={$_.Free / 1GB}}
+
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Set up Python

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -103,15 +103,15 @@ jobs:
       shell: pwsh
       run: |
         Get-PSDrive C | Select-Object @{Name="Used (GB)"; Expression={$_.Used / 1GB}}, @{Name="Free (GB)"; Expression={$_.Free / 1GB}}
-        if (Test-Path 'C:\Android') { Remove-Item -Recurse -Force 'C:\Android' }
-        if (Test-Path 'C:\ghcup') { Remove-Item -Recurse -Force 'C:\ghcup' }
-        if (Test-Path 'C:\tools\stack') { Remove-Item -Recurse -Force 'C:\tools\stack' }
+        if (Test-Path 'C:\Android') { Remove-Item -Recurse -Force -ErrorAction SilentlyContinue 'C:\Android' }
+        if (Test-Path 'C:\ghcup') { Remove-Item -Recurse -Force -ErrorAction SilentlyContinue 'C:\ghcup' }
+        if (Test-Path 'C:\tools\stack') { Remove-Item -Recurse -Force -ErrorAction SilentlyContinue 'C:\tools\stack' }
         Get-ChildItem 'C:\hostedtoolcache\windows' -Filter 'Java_*' -ErrorAction SilentlyContinue |
-            Remove-Item -Recurse -Force
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
         Get-ChildItem 'C:\hostedtoolcache\windows' -Filter 'swift*' -ErrorAction SilentlyContinue |
-            Remove-Item -Recurse -Force
-        if (Test-Path 'C:\Ruby*') { Get-Item 'C:\Ruby*' | Remove-Item -Recurse -Force }
-        if (Test-Path 'C:\hostedtoolcache\windows\go') { Remove-Item -Recurse -Force 'C:\hostedtoolcache\windows\go' }
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+        if (Test-Path 'C:\Ruby*') { Get-Item 'C:\Ruby*' | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue }
+        if (Test-Path 'C:\hostedtoolcache\windows\go') { Remove-Item -Recurse -Force -ErrorAction SilentlyContinue 'C:\hostedtoolcache\windows\go' }
         Get-PSDrive C | Select-Object @{Name="Used (GB)"; Expression={$_.Used / 1GB}}, @{Name="Free (GB)"; Expression={$_.Free / 1GB}}
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2


### PR DESCRIPTION
## Summary

- The `windows-gpu` job was failing with `OSError: [Errno 28] No space left on device` while extracting the ROCm TheRock wheel ([run 32733329319](https://github.com/ROCm/AMDMIGraphX/actions/runs/32733329319/job/97450330743))
- The `windows-2025` runner image (`windows-2025-vs2026/20260818.207`) consumes >50 GB before any workflow step runs — Android SDK, Java JDKs, Haskell GHC, Swift, Ruby, Go — leaving insufficient headroom for the ROCm install (~10–15 GB)
- Adds a `Free disk space` PowerShell step as the **first** step in `windows-gpu` that removes toolchains the GPU job does not use, reclaiming ~20 GB; reports `Used (GB)` / `Free (GB)` before and after for visibility

## Test plan

- [ ] Verify `windows-gpu` job passes the "Install ROCm from TheRock python wheels" step without disk space error
- [ ] Confirm before/after disk usage is logged in the "Free disk space" step output
- [ ] Confirm `windows-cpu` jobs are unaffected (change is scoped to `windows-gpu` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)