### PR TITLE
Jenkins: create ccache dirs on host before container launch to fix root ownership

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -273,10 +273,10 @@ def rocmtest = { Map conf = [:], Closure body ->
 
         stage("build ${variant}") {
             try {
+                sh "mkdir -p '${env.WORKSPACE}/../.cache/ccache' '${env.WORKSPACE}/../.cache/comgr_cache'"
                 withDockerContainer(image: "${image}:${imageTag}", args: docker_opts + docker_args) {
                     timeout(time: 4, unit: 'HOURS') {
                         sh """
-                            mkdir -p ${ccache} ${comgr_cache}
                             ls -l /workspaces/
                             ls -l /workspaces/.cache/
                         """


### PR DESCRIPTION
## Summary

- Moves `mkdir -p` for the ccache and comgr_cache directories out of the Docker container and onto the host, running before `withDockerContainer`
- Uses `${env.WORKSPACE}/../.cache/ccache` (host path) instead of `/workspaces/.cache/ccache` (container path) — these resolve to the same location on disk
- No hardcoded paths; works on any node regardless of where Jenkins' workspace root lives

## Root cause

The ORT stage passes `docker_args: '-u root'`, which causes the container to run as root. The `mkdir -p /workspaces/.cache/ccache` inside that container created the cache directories owned by `root:root` with mode `drwxr-xr-x`. Subsequent build stages on the same node (running as the Jenkins user) then failed because ccache could not create a `tmp/` subdirectory — `Permission denied`.

This was confirmed in PR-5144's Jenkins log: the ORT stage ran at 06:05 creating the dirs as root, and a later build stage on the same node at 17:27 observed the root-owned directories and hit ccache errors throughout the compile.

## Test plan

- [ ] Trigger a Jenkins build and confirm `ls -l /workspaces/.cache/` shows the cache dirs owned by the Jenkins user (uid 1001), not root
- [ ] Confirm ccache operates without permission errors in all build stages
- [ ] Confirm the ORT stage still passes (the `-u root` directive is unchanged; only the mkdir was moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)