### PR TITLE
Unable to optimize SDXL model pipeline on Amuse App

### DIFF
--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1144,6 +1144,8 @@ static void prepare(module& m) { run_passes(m, {prepare_mlir{}}); }
 
 bool is_module_fusible(const module& m, const context& migraphx_ctx, const value& solution)
 {
+    if(solution.if_string() == nullptr)
+        return true;
     auto mm = m;
     prepare(mm);
     mlir_program mp;


### PR DESCRIPTION
## Motivation
MIGraphX crashes with ACCESS_VIOLATION (0xC0000005) during SDXL Unet optimization on gfx1201/Navi48. is_module_fusible() calls solution.if_string() which returns nullptr when no tuning entry exists for the target architecture, and the result is dereferenced without a null check. This blocks all MIGraphX inference on untuned GPU targets.

## Technical Details
In src/targets/gpu/mlir.cpp, is_module_fusible() assumes solution.if_string() always returns a valid pointer. On GPUs without tuning data (gfx1201), the solution value is not a string type (shows null), so if_string() returns nullptr. The subsequent dereference causes a null pointer access violation in migraphx_gpu!is_module_fusible.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
