### PR TITLE
CI: report.yaml Generate Performance Report workflow

### DIFF
--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -15,14 +15,23 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'ROCm/AMDMIGraphX' && github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: Generate a token
-        id: generate-token
+      - name: Generate token for ROCm org
+        id: generate-token-rocm
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          client-id: ${{ vars.GH_APP_MIGRAPHX_BOT_PR_WRITE_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_MIGRAPHX_BOT_PR_WRITE_PRIVATE_KEY }}
+          owner: ROCm
+          repositories: AMDMIGraphX
+
+      - name: Generate token for AMD-ROCm-Internal org
+        id: generate-token-internal
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
         with:
           client-id: ${{ vars.GH_APP_MIGRAPHX_BOT_PR_WRITE_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_MIGRAPHX_BOT_PR_WRITE_PRIVATE_KEY }}
           owner: AMD-ROCm-Internal
-          repositories: AMDMIGraphX,migraphx-reports,migraphx-benchmark-utils
+          repositories: migraphx-reports,migraphx-benchmark-utils
 
       - name: Download artifacts
         id: dl_art
@@ -31,7 +40,7 @@ jobs:
         with:
           name: performance-run-data
           path: test-results
-          github-token: ${{ steps.generate-token.outputs.token }}
+          github-token: ${{ steps.generate-token-rocm.outputs.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Extract context safely
@@ -60,7 +69,7 @@ jobs:
         with:
           repository: AMD-ROCm-Internal/${{ env.REPORTS_DIR }}
           path: ${{ env.REPORTS_DIR }}
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.generate-token-internal.outputs.token }}
           fetch-depth: 0
 
       - name: Checkout utils repo
@@ -69,7 +78,7 @@ jobs:
         with:
           repository: AMD-ROCm-Internal/migraphx-benchmark-utils
           path: benchmark-utils
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.generate-token-internal.outputs.token }}
 
       - name: Setup Python
         if: steps.dl_art.outcome == 'success'
@@ -122,10 +131,9 @@ jobs:
           && env.PR_NUMBER
           && env.GIT_SHA
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.generate-token-rocm.outputs.token }}
         run: |
           python3 benchmark-utils/scripts/perf_compare.py -f "$REPOFILEPATH/results.csv"
           if [ -n "$ACCURACY_DIR" ] && [ -f "$REPOFILEPATH/accuracy_logs/results.md" ]; then
             python3 benchmark-utils/scripts/accuracy_comment.py -f "$REPOFILEPATH/accuracy_logs/results.md" -p "$PR_NUMBER"
           fi
-


### PR DESCRIPTION
## Summary

- Fixes the failing [Generate Performance Report](https://github.com/ROCm/AMDMIGraphX/actions/runs/33092321192/job/98588120014) workflow introduced by #5159
- Splits the single `actions/create-github-app-token` step into two org-scoped token steps, addressing the Copilot review feedback that was not actioned before merge

## Root Cause

`actions/create-github-app-token` installation tokens are scoped to **one org per token**. PR #5159 set `owner: AMD-ROCm-Internal` but included `AMDMIGraphX` in `repositories:`, causing the action to look up `AMD-ROCm-Internal/AMDMIGraphX` — a repo that does not exist. The resulting 404 aborted the entire job before any artifact download or report push could occur.

Copilot flagged this exact issue three times during review of #5159.

## Fix

Two token steps replace the single broken one:

| Step ID | `owner` | `repositories` | Used by |
|---|---|---|---|
| `generate-token-rocm` | `ROCm` | `AMDMIGraphX` | Artifact download, PR comment publishing |
| `generate-token-internal` | `AMD-ROCm-Internal` | `migraphx-reports,migraphx-benchmark-utils` | Checkout + push to internal repos |

## Prerequisite

The GitHub App (`GH_APP_MIGRAPHX_BOT_PR_WRITE`) must be installed in the `AMD-ROCm-Internal` org with access to `migraphx-reports` and `migraphx-benchmark-utils`. If that installation does not yet exist, it must be configured in the org settings before this workflow will succeed.

## Test plan

- [ ] Verify the GitHub App is installed in `AMD-ROCm-Internal` org with access to `migraphx-reports` and `migraphx-benchmark-utils`
- [ ] Re-run the failing workflow after merge and confirm both token generation steps succeed
- [ ] Confirm artifact download completes using the ROCm-scoped token
- [ ] Confirm report push to `AMD-ROCm-Internal/migraphx-reports` succeeds using the internal token
- [ ] Confirm PR comment is posted back to `ROCm/AMDMIGraphX` using the ROCm-scoped token

🤖 Generated with [Claude Code](https://claude.com/claude-code)