### PR TITLE
[DO NOT REVIEW] Treat null problem-cache entries as a miss instead of skipping compile (gpuep-rel-2610)

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -342,16 +342,14 @@ struct compile_plan
         if(config.has_value())
         {
             const auto& problem = config->problem;
-            // Priority search (read-only layers first, then writable; first hit
-            // wins) is handled inside problem_cache.
-            if(auto sol = ctx->problem_cache_get(preop.name(), problem))
+            // Priority search (read-only layers first, then writable; first
+            // usable hit wins) is handled inside problem_cache. A null sentinel
+            // is a miss, so compile still generates solutions.
+            if(auto sol = ctx->problem_cache_get(preop.name(), problem);
+               sol.has_value() and not sol->is_null())
             {
-                const auto& solution = sol.value();
-                // No solution yet until benchmarked so skip for now
-                if(solution.is_null())
-                    return;
                 results.resize(1);
-                insert_compiles(compiles, solution, 0);
+                insert_compiles(compiles, *sol, 0);
             }
             else
             {

--- a/src/targets/gpu/include/migraphx/gpu/prepare_mlir.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/prepare_mlir.hpp
@@ -26,6 +26,7 @@
 #define MIGRAPHX_GUARD_GPU_PREPARE_MLIR_HPP
 
 #include <migraphx/config.hpp>
+#include <migraphx/gpu/export.h>
 #include <string>
 
 namespace migraphx {
@@ -35,7 +36,7 @@ struct module;
 
 namespace gpu {
 
-struct prepare_mlir
+struct MIGRAPHX_GPU_EXPORT prepare_mlir
 {
     std::string name() const { return "gpu::prepare_mlir"; }
     void apply(module& m) const;
@@ -44,4 +45,4 @@ struct prepare_mlir
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
-#endif // MIGRAPHX_GUARD_GPU_PREPARE_REDUCE_HPP
+#endif // MIGRAPHX_GUARD_GPU_PREPARE_MLIR_HPP

--- a/src/targets/gpu/include/migraphx/gpu/problem_cache.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/problem_cache.hpp
@@ -52,7 +52,9 @@ struct MIGRAPHX_GPU_EXPORT problem_cache
     const cache_device_key& get_device_key() const;
 
     /// Look up a problem. Read-only layers (from load(paths)) are searched in
-    /// priority order first, then the writable cache; the first hit wins.
+    /// priority order first, then the writable cache; the first *usable* hit
+    /// wins. A `mark()` null sentinel is not a solution and is skipped so a
+    /// later layer (or a miss) can still provide a real perfConfig.
     bool has(const std::string& name, const value& problem) const;
     void insert(const std::string& name, const value& problem, const value& solution);
     void mark(const std::string& name, const value& problem);

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1144,13 +1144,20 @@ static void prepare(module& m) { run_passes(m, {prepare_mlir{}}); }
 
 bool is_module_fusible(const module& m, const context& migraphx_ctx, const value& solution)
 {
+    // rocMLIR needs a perfConfig string. A null/non-string value (empty compile
+    // solution, or a problem-cache mark() sentinel) is not one: do not deref.
+    // Returning true keeps the fused module; compile() still rejects a null
+    // solution. This is crash-hardening, not a substitute for a real solution.
+    const auto* tuning = solution.if_string();
+    if(tuning == nullptr)
+        return true;
     auto mm = m;
     prepare(mm);
     mlir_program mp;
     mp.set_gpu_properties(migraphx_ctx);
     mp.parse(mm);
     mp.run_high_level_pipeline();
-    return mlirIsModuleFusible(mp.mmodule.get(), make_mlir_string_ref(*solution.if_string()));
+    return mlirIsModuleFusible(mp.mmodule.get(), make_mlir_string_ref(*tuning));
 }
 
 void adjust_param_shapes(module& m, const std::vector<shape>& inputs)

--- a/src/targets/gpu/problem_cache.cpp
+++ b/src/targets/gpu/problem_cache.cpp
@@ -125,14 +125,20 @@ void problem_cache::mark(const std::string& name, const value& problem)
 optional<value> problem_cache::get(const std::string& name, const value& problem) const
 {
     const auto key = create_key(name, problem);
-    // Read-only layers first (highest priority), then the writable cache.
-    const auto found =
-        std::find_if(read_only_backends.begin(), read_only_backends.end(), [&](const auto& ro) {
-            return ro.get(device_key, key).has_value();
-        });
+    // A mark() placeholder is stored as null. That is "no tuned solution yet",
+    // not a perfConfig: skip it and keep searching so a shipped cache full of
+    // those sentinels cannot hide a real solution (or force a miss).
+    auto usable = [&](const problem_cache_backend& b) -> optional<value> {
+        if(auto v = b.get(device_key, key); v.has_value() and not v->is_null())
+            return v;
+        return nullopt;
+    };
+    const auto found = std::find_if(read_only_backends.begin(),
+                                    read_only_backends.end(),
+                                    [&](const auto& ro) { return bool(usable(ro)); });
     if(found != read_only_backends.end())
-        return found->get(device_key, key);
-    return backend.get(device_key, key);
+        return usable(*found);
+    return usable(backend);
 }
 
 } // namespace gpu

--- a/test/gpu/problem_cache_path_override.cpp
+++ b/test/gpu/problem_cache_path_override.cpp
@@ -147,4 +147,53 @@ TEST_CASE(problem_cache_layered_priority_first_hit_wins)
     c.save();
 }
 
+TEST_CASE(problem_cache_null_sentinel_is_miss)
+{
+    migraphx::tmp_dir td{"problem_cache_null_sentinel"};
+    auto path = (td.path / "cache.json").string();
+
+    {
+        migraphx::gpu::problem_cache w;
+        w.set_device_key(make_key());
+        w.load(path);
+        w.mark("gpu::mlir_op", make_problem(0));
+        w.save();
+    }
+
+    migraphx::gpu::problem_cache c;
+    c.set_device_key(make_key());
+    c.load(path);
+    EXPECT(not bool(c.get("gpu::mlir_op", make_problem(0))));
+}
+
+TEST_CASE(problem_cache_null_sentinel_does_not_hide_lower_layer)
+{
+    migraphx::tmp_dir td{"problem_cache_null_hidden"};
+    auto high = (td.path / "high.json").string();
+    auto low  = (td.path / "low.json").string();
+
+    {
+        migraphx::gpu::problem_cache w;
+        w.set_device_key(make_key());
+        w.load(high);
+        w.mark("gpu::mlir_op", make_problem(0));
+        w.save();
+    }
+    {
+        migraphx::gpu::problem_cache w;
+        w.set_device_key(make_key());
+        w.load(low);
+        w.insert("gpu::mlir_op", make_problem(0), migraphx::value{{"kernel", "kLow"}});
+        w.save();
+    }
+
+    migraphx::gpu::problem_cache c;
+    c.set_device_key(make_key());
+    c.load(std::vector<std::string>{high, low});
+
+    auto s0 = c.get("gpu::mlir_op", make_problem(0));
+    EXPECT(bool(s0));
+    EXPECT((*s0).at("kernel").to<std::string>() == "kLow");
+}
+
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Problem
On the gpuep-rel-2610 line, a shipped or stale `problem_cache.json` can contain null (`mark()`) sentinels. `get()` returned that null as if it were a real solution, so `compile_ops` skipped compiling and tuning the op and `is_module_fusible` dereferenced a null tuning string. That crashes (0xC0000005) or fails with "no valid tuned compilation for gpu::mlir_op". Seen with the google-bert multilingual pooler on Navi48/gfx1201 (AIRADSW-871); deleting the shipped cache was the only workaround.

## Fix
Treat a null cache entry as a miss, centrally in `problem_cache::get()`, so the op is compiled and tuned instead of skipped. This protects every consumer (mlir `compile_ops`, rocBLAS and hipBLASLt default-solution lookups). Also removes the now-dead null-skip in `compile_ops` and guards `is_module_fusible` against a null or non-string solution.

## Tests
Adds two regression tests: `problem_cache_null_sentinel_is_miss` and `problem_cache_null_sentinel_does_not_hide_lower_layer`.

Fix authored by Uros Petkov and validated on a 2610 setup (co-authored on the commit).
