### PR TITLE
Treat null problem-cache entries as a miss instead of skipping compile

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -344,12 +344,10 @@ struct compile_plan
             const auto& problem = config->problem;
             if(auto sol = ctx->get_problem_cache().get(preop.name(), problem))
             {
-                const auto& solution = sol.value();
-                // No solution yet until benchmarked so skip for now
-                if(solution.is_null())
-                    return;
+                // get() never returns a null sentinel (a null cache entry is
+                // treated as a miss), so a value here is always a real solution.
                 results.resize(1);
-                insert_compiles(compiles, solution, 0);
+                insert_compiles(compiles, sol.value(), 0);
             }
             else
             {

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1144,13 +1144,19 @@ static void prepare(module& m) { run_passes(m, {prepare_mlir{}}); }
 
 bool is_module_fusible(const module& m, const context& migraphx_ctx, const value& solution)
 {
+    // Without a string tuning solution (e.g. a null cache sentinel or a
+    // malformed entry) there is nothing to hand to MLIR, so treat the module as
+    // fusible rather than dereferencing a null string.
+    const auto* tuning = solution.if_string();
+    if(tuning == nullptr)
+        return true;
     auto mm = m;
     prepare(mm);
     mlir_program mp;
     mp.set_gpu_properties(migraphx_ctx);
     mp.parse(mm);
     mp.run_high_level_pipeline();
-    return mlirIsModuleFusible(mp.mmodule.get(), make_mlir_string_ref(*solution.if_string()));
+    return mlirIsModuleFusible(mp.mmodule.get(), make_mlir_string_ref(*tuning));
 }
 
 void adjust_param_shapes(module& m, const std::vector<shape>& inputs)

--- a/src/targets/gpu/problem_cache.cpp
+++ b/src/targets/gpu/problem_cache.cpp
@@ -140,14 +140,22 @@ void problem_cache::mark(const std::string& name, const value& problem)
 optional<value> problem_cache::get(const std::string& name, const value& problem) const
 {
     const auto key = create_key(name, problem);
+    // A null value is a mark() sentinel (benchmark started, no tuned solution
+    // yet), not a real solution: treat it as a miss so the op is compiled and
+    // tuned instead of skipped. This also stops a stale/shipped null entry from
+    // hiding a real solution in a lower-priority layer.
+    const auto usable = [&](const problem_cache_backend& b) -> optional<value> {
+        if(auto sol = b.get(device_key, key); sol.has_value() and not sol->is_null())
+            return sol;
+        return {};
+    };
     // Writable caches first (a locally tuned solution wins), then the read-only
-    // layers in priority order (first hit wins among them).
+    // layers in priority order (first usable hit wins among them).
     const auto search = [&](const std::vector<problem_cache_backend>& backends) -> optional<value> {
-        const auto it = std::find_if(backends.begin(), backends.end(), [&](const auto& b) {
-            return b.get(device_key, key).has_value();
-        });
+        const auto it = std::find_if(
+            backends.begin(), backends.end(), [&](const auto& b) { return bool(usable(b)); });
         if(it != backends.end())
-            return it->get(device_key, key);
+            return usable(*it);
         return {};
     };
     if(auto sol = search(writable_backends))

--- a/test/gpu/problem_cache_path_override.cpp
+++ b/test/gpu/problem_cache_path_override.cpp
@@ -269,4 +269,62 @@ TEST_CASE(problem_cache_no_cache_config_is_noop)
     c.save(); // no writable cache -> no-op, must not throw
 }
 
+// --------------------------------------------------------------------------
+// A null cache entry (a mark() sentinel: benchmark started, no tuned solution
+// yet) is treated as a miss by get(), so the op is compiled and tuned instead
+// of being handed a null "solution". has() still reports the marked key as
+// present; only get() filters the sentinel out.
+// --------------------------------------------------------------------------
+TEST_CASE(problem_cache_null_sentinel_is_miss)
+{
+    migraphx::gpu::problem_cache c;
+    c.set_device_key(make_key());
+    c.load(std::vector<std::string>{}, std::vector<std::string>{});
+
+    // mark() records a null sentinel for the problem.
+    c.mark("gemm", make_problem(0));
+    EXPECT(c.has("gemm", make_problem(0)));
+    // get() reports the null sentinel as a miss, not a solution.
+    EXPECT(not bool(c.get("gemm", make_problem(0))));
+
+    // A real solution inserted afterwards replaces the sentinel and is returned.
+    c.insert("gemm", make_problem(0), migraphx::value{{"kernel", "kReal"}});
+    auto s = c.get("gemm", make_problem(0));
+    EXPECT(bool(s));
+    EXPECT((*s).at("kernel").to<std::string>() == "kReal");
+}
+
+// --------------------------------------------------------------------------
+// A null sentinel in a higher-priority (writable) layer must not hide a real
+// solution in a lower-priority (read-only) layer: get() skips the null and
+// keeps searching, returning the real solution from the read-only cache.
+// --------------------------------------------------------------------------
+TEST_CASE(problem_cache_null_sentinel_does_not_hide_lower_layer)
+{
+    migraphx::tmp_dir td{"problem_cache_null_lower"};
+    auto ro = (td.path / "read_only.json").string();
+
+    // Read-only layer holds a real solution for problem 0.
+    {
+        migraphx::gpu::problem_cache w;
+        w.set_device_key(make_key());
+        w.load(std::vector<std::string>{}, std::vector<std::string>{ro});
+        w.insert("gemm", make_problem(0), migraphx::value{{"kernel", "kReadOnly"}});
+        w.save();
+    }
+
+    migraphx::gpu::problem_cache c;
+    c.set_device_key(make_key());
+    c.load(std::vector<std::string>{ro}, std::vector<std::string>{});
+
+    // Mark problem 0 in the writable (in-memory) layer: a null sentinel that is
+    // searched before the read-only layer.
+    c.mark("gemm", make_problem(0));
+
+    // The writable null is skipped, so the real read-only solution still wins.
+    auto s = c.get("gemm", make_problem(0));
+    EXPECT(bool(s));
+    EXPECT((*s).at("kernel").to<std::string>() == "kReadOnly");
+}
+
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Problem
A shipped or stale `problem_cache.json` can contain null (`mark()`) sentinels. `problem_cache::get()` returned that null as if it were a real solution, so `compile_ops` skipped compiling and tuning the op and `is_module_fusible` dereferenced a null tuning string via `if_string()`. That crashes (0xC0000005) or fails with "no valid tuned compilation for gpu::mlir_op". Seen with the google-bert multilingual pooler on Navi48/gfx1201 (AIRADSW-871).

## Fix
Treat a null cache entry as a miss, centrally in `problem_cache::get()`, so the op is compiled and tuned instead of skipped. Because the fix lives in `get()`, it protects every consumer: mlir `compile_ops`, and the rocBLAS and hipBLASLt default-solution lookups. Also removes the now-dead null-skip in `compile_ops` and guards `is_module_fusible` against a null or non-string solution.

## Tests
Adds two regression tests (`problem_cache_null_sentinel_is_miss`, `problem_cache_null_sentinel_does_not_hide_lower_layer`). Built with MLIR off on gfx1100; the full problem-cache test suite passes.
