### PR TITLE
[DO NOT REVIEW] Drop null problem-cache sentinels on load, keep in-run dedup (gpuep-rel-2610)

### DIFF
--- a/src/targets/gpu/include/migraphx/gpu/prepare_mlir.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/prepare_mlir.hpp
@@ -26,6 +26,7 @@
 #define MIGRAPHX_GUARD_GPU_PREPARE_MLIR_HPP
 
 #include <migraphx/config.hpp>
+#include <migraphx/gpu/export.h>
 #include <string>
 
 namespace migraphx {
@@ -35,7 +36,7 @@ struct module;
 
 namespace gpu {
 
-struct prepare_mlir
+struct MIGRAPHX_GPU_EXPORT prepare_mlir
 {
     std::string name() const { return "gpu::prepare_mlir"; }
     void apply(module& m) const;
@@ -44,4 +45,4 @@ struct prepare_mlir
 } // namespace gpu
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
-#endif // MIGRAPHX_GUARD_GPU_PREPARE_REDUCE_HPP
+#endif // MIGRAPHX_GUARD_GPU_PREPARE_MLIR_HPP

--- a/src/targets/gpu/json_problem_cache.cpp
+++ b/src/targets/gpu/json_problem_cache.cpp
@@ -66,9 +66,13 @@ void json_problem_cache::load(const std::string& path)
     // Canonicalize keys only (JSON erases value types); solutions verbatim.
     std::unordered_map<cache_device_key, std::unordered_map<value, value>> raw;
     from_value(root, raw);
+    // Drop persisted null mark() sentinels: they are transient "benchmark in
+    // progress" markers, not real solutions, so a stale/shipped null is a miss
+    // and the problem is compiled and tuned fresh.
     for(const auto& dev : raw)
         for(const auto& entry : dev.second)
-            cache[dev.first][entry.first.normalize()] = entry.second;
+            if(not entry.second.is_null())
+                cache[dev.first][entry.first.normalize()] = entry.second;
 }
 
 void json_problem_cache::save(const std::string& path) const

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -1144,13 +1144,20 @@ static void prepare(module& m) { run_passes(m, {prepare_mlir{}}); }
 
 bool is_module_fusible(const module& m, const context& migraphx_ctx, const value& solution)
 {
+    // rocMLIR needs a perfConfig string. A null/non-string value (empty compile
+    // solution, or a problem-cache mark() sentinel) is not one: do not deref.
+    // Returning true keeps the fused module; compile() still rejects a null
+    // solution. This is crash-hardening, not a substitute for a real solution.
+    const auto* tuning = solution.if_string();
+    if(tuning == nullptr)
+        return true;
     auto mm = m;
     prepare(mm);
     mlir_program mp;
     mp.set_gpu_properties(migraphx_ctx);
     mp.parse(mm);
     mp.run_high_level_pipeline();
-    return mlirIsModuleFusible(mp.mmodule.get(), make_mlir_string_ref(*solution.if_string()));
+    return mlirIsModuleFusible(mp.mmodule.get(), make_mlir_string_ref(*tuning));
 }
 
 void adjust_param_shapes(module& m, const std::vector<shape>& inputs)

--- a/src/targets/gpu/sqlite_problem_cache.cpp
+++ b/src/targets/gpu/sqlite_problem_cache.cpp
@@ -94,12 +94,15 @@ void sqlite_problem_cache::load(const std::string& path)
     }
     for(const auto& row : rows)
     {
+        // Drop persisted null mark() sentinels (see json_problem_cache::load).
+        auto solution = from_json_string(row.at("solution"));
+        if(solution.is_null())
+            continue;
         cache_device_key dk;
         from_value(from_json_string(row.at("device_key")), dk);
         // Normalize keys on load: JSON erases value types, so a serialized key
         // must be canonicalized to match the normalized runtime lookup key.
-        cache[dk][from_json_string(row.at("problem_key")).normalize()] =
-            from_json_string(row.at("solution"));
+        cache[dk][from_json_string(row.at("problem_key")).normalize()] = solution;
     }
 }
 

--- a/test/gpu/problem_cache_backend.cpp
+++ b/test/gpu/problem_cache_backend.cpp
@@ -75,7 +75,9 @@ TEST_CASE(json_problem_cache_round_trip)
 
     EXPECT(reader.has(dk1, key_a));
     EXPECT(reader.has(dk2, key_b));
-    EXPECT(reader.has(dk1, key_b)); // sentinel still "present"
+    // The null mark() sentinel is transient and dropped on load, so the real
+    // solutions round-trip but the sentinel does not.
+    EXPECT(not reader.has(dk1, key_b));
 
     auto got_a = reader.get(dk1, key_a);
     EXPECT(bool(got_a));
@@ -85,10 +87,8 @@ TEST_CASE(json_problem_cache_round_trip)
     EXPECT(bool(got_b));
     EXPECT(*got_b == sol_b);
 
-    // Sentinel: get() returns a present optional whose value is null.
-    auto sentinel = reader.get(dk1, key_b);
-    EXPECT(bool(sentinel));
-    EXPECT(sentinel->is_null());
+    // Sentinel dropped on load: a persisted null is a miss.
+    EXPECT(not bool(reader.get(dk1, key_b)));
 
     // Miss across buckets: dk2's bucket has no key_a.
     EXPECT(not reader.has(dk2, key_a));

--- a/test/gpu/sqlite_problem_cache.cpp
+++ b/test/gpu/sqlite_problem_cache.cpp
@@ -75,7 +75,9 @@ TEST_CASE(sqlite_problem_cache_round_trip)
 
     EXPECT(reader.has(dk1, key_a));
     EXPECT(reader.has(dk2, key_b));
-    EXPECT(reader.has(dk1, key_b)); // sentinel still "present"
+    // The null mark() sentinel is transient and dropped on load, so the real
+    // solutions round-trip but the sentinel does not.
+    EXPECT(not reader.has(dk1, key_b));
 
     auto got_a = reader.get(dk1, key_a);
     EXPECT(bool(got_a));
@@ -85,10 +87,8 @@ TEST_CASE(sqlite_problem_cache_round_trip)
     EXPECT(bool(got_b));
     EXPECT(*got_b == sol_b);
 
-    // Sentinel: get() returns a present optional whose value is null.
-    auto sentinel = reader.get(dk1, key_b);
-    EXPECT(bool(sentinel));
-    EXPECT(sentinel->is_null());
+    // Sentinel dropped on load: a persisted null is a miss.
+    EXPECT(not bool(reader.get(dk1, key_b)));
 
     // Miss across buckets: dk2's bucket has no key_a.
     EXPECT(not reader.has(dk2, key_a));


### PR DESCRIPTION
## Problem
A null `mark()` entry in the problem cache is a transient, in-run "benchmark in progress" sentinel. It was stored in the same map that is persisted to disk, so a null that never got overwritten (a failed or interrupted benchmark) could be persisted, shipped, and re-loaded. On the next run `get()` returned that stale null and the op was skipped forever, leaving it unresolved → `0xC0000005` / "No valid tuned compilation" (AIRADSW-871, BERT pooler on Navi48/gfx1201). Deleting `problem_cache.json` cleared the nulls and worked around it.

## Fix
Drop null sentinels at the load boundary in the json and sqlite backends, so a persisted or shipped null can never come back. The in-run dedup is unchanged: `get()` still returns the in-memory `mark()`, and `compile_ops` skips on a null so a repeated problem is benchmarked once, not once per instruction. Also guards `is_module_fusible` against a null or non-string solution.

This is the `gpuep-rel-2610` counterpart of develop PR #5204. It supersedes #5201, which treated a null as a cache **miss** — that fixed the crash but removed the in-run dedup and re-benchmarked a repeated problem once per instruction (raised in review).

## Tests
Backend round-trip tests updated: a null sentinel no longer survives save/load (real solutions still do).

Note: not built on this box (the 2610 build needs MIOpen, not installed here). The identical change is build- and test-verified on develop **#5204** — reduced MLIR-off gfx1100 build, all four problem-cache test binaries pass — and CI validates here.
