### PR TITLE
Add executable path flags and --all option to tools/format.py

### DIFF
--- a/tools/format.py
+++ b/tools/format.py
@@ -27,7 +27,7 @@ import argparse
 import subprocess
 from git_tools import get_all_files, get_changed_files, get_merge_base, get_top, run
 
-DEFAULT_CLANG_FORMAT = '/opt/rocm/llvm/bin/clang-format'
+DEFAULT_CLANG_FORMAT = 'clang-format'
 
 EXCLUDE_FILES = ['requirements.in', 'onnx.proto']
 

--- a/tools/format.py
+++ b/tools/format.py
@@ -90,7 +90,8 @@ def main():
     parser.add_argument('--yapf-path',
                         default='yapf',
                         help='Path to the yapf executable')
-    parser.add_argument('--exit-zero', action='store_true',
+    parser.add_argument('--exit-zero',
+                        action='store_true',
                         help='Exit 0 even when formatting differs')
     args = parser.parse_args()
     try:

--- a/tools/format.py
+++ b/tools/format.py
@@ -25,7 +25,7 @@ import os
 import shutil
 import argparse
 import subprocess
-from git_tools import get_changed_files, get_merge_base, get_top, run
+from git_tools import get_all_files, get_changed_files, get_merge_base, get_top, run
 
 DEFAULT_CLANG_FORMAT = '/opt/rocm/llvm/bin/clang-format'
 
@@ -40,10 +40,23 @@ def is_excluded(f):
     return base in EXCLUDE_FILES
 
 
-def clang_format(against, apply=False, clang_format=DEFAULT_CLANG_FORMAT):
-    base = get_merge_base(against)
+def clang_format(against,
+                 apply=False,
+                 all_files=False,
+                 clang_format=DEFAULT_CLANG_FORMAT):
     if not shutil.which(clang_format):
         print(f"{clang_format} not installed. Skipping format.")
+        return
+    files = get_all_files() if all_files else get_changed_files(against)
+    files = [
+        f for f in files if f.endswith(CLANG_EXTENSIONS) and not is_excluded(f)
+    ]
+    if not files:
+        print("No modified cpp files to format")
+        return
+    if all_files:
+        mode_flags = ['-i'] if apply else ['--dry-run', '-Werror']
+        run([clang_format] + mode_flags + files, cwd=get_top(), verbose=True)
         return
     git_clang_format = os.path.join(os.path.dirname(clang_format),
                                     'git-clang-format')
@@ -51,27 +64,21 @@ def clang_format(against, apply=False, clang_format=DEFAULT_CLANG_FORMAT):
         print(f"{git_clang_format} not installed. Skipping format.")
         return
     diff_flag = [] if apply else ["--diff"]
-    files = get_changed_files(base)
-    files = [
-        f for f in files if f.endswith(CLANG_EXTENSIONS) and not is_excluded(f)
-    ]
-    if files:
-        run([git_clang_format, '--binary', clang_format] + diff_flag + [base] +
-            files,
-            cwd=get_top(),
-            verbose=True)
-    else:
-        print("No modified cpp files to format")
+    base = get_merge_base(against)
+    run([git_clang_format, '--binary', clang_format] + diff_flag + [base] +
+        files,
+        cwd=get_top(),
+        verbose=True)
 
 
-def yapf_format(against, apply=False, yapf='yapf'):
+def yapf_format(against, apply=False, all_files=False, yapf='yapf'):
     if not shutil.which(yapf):
         print(f"{yapf} not installed. Skipping format.")
         return
     diff_flag = "--in-place" if apply else "--diff"
+    files = get_all_files() if all_files else get_changed_files(against)
     files = [
-        f for f in get_changed_files(against)
-        if f.endswith(YAPF_EXTENSIONS) and not is_excluded(f)
+        f for f in files if f.endswith(YAPF_EXTENSIONS) and not is_excluded(f)
     ]
     if files:
         run([yapf, diff_flag, '-p'] + files, cwd=get_top(), verbose=True)
@@ -84,6 +91,10 @@ def main():
     parser.add_argument('against', default='develop', nargs='?')
     parser.add_argument('-i', '--in-place', action='store_true')
     parser.add_argument('-q', '--quiet', action='store_true')
+    parser.add_argument('-a',
+                        '--all',
+                        action='store_true',
+                        help='Format all tracked files, not just changed ones')
     parser.add_argument('--clang-format-path',
                         default=DEFAULT_CLANG_FORMAT,
                         help='Path to the clang-format executable')
@@ -97,8 +108,12 @@ def main():
     try:
         clang_format(args.against,
                      apply=args.in_place,
+                     all_files=args.all,
                      clang_format=args.clang_format_path)
-        yapf_format(args.against, apply=args.in_place, yapf=args.yapf_path)
+        yapf_format(args.against,
+                    apply=args.in_place,
+                    all_files=args.all,
+                    yapf=args.yapf_path)
     except subprocess.CalledProcessError as ex:
         if ex.stdout:
             print(ex.stdout)

--- a/tools/format.py
+++ b/tools/format.py
@@ -27,7 +27,7 @@ import argparse
 import subprocess
 from git_tools import get_changed_files, get_merge_base, get_top, run
 
-CLANG_FORMAT_PATH = '/opt/rocm/llvm/bin'
+DEFAULT_CLANG_FORMAT = '/opt/rocm/llvm/bin/clang-format'
 
 EXCLUDE_FILES = ['requirements.in', 'onnx.proto']
 
@@ -40,14 +40,14 @@ def is_excluded(f):
     return base in EXCLUDE_FILES
 
 
-def clang_format(against, apply=False, path=CLANG_FORMAT_PATH):
+def clang_format(against, apply=False, clang_format=DEFAULT_CLANG_FORMAT):
     base = get_merge_base(against)
-    clang_format = os.path.join(path, 'clang-format')
-    if not os.path.exists(clang_format):
+    if not shutil.which(clang_format):
         print(f"{clang_format} not installed. Skipping format.")
         return
-    git_clang_format = os.path.join(path, 'git-clang-format')
-    if not os.path.exists(git_clang_format):
+    git_clang_format = os.path.join(os.path.dirname(clang_format),
+                                    'git-clang-format')
+    if not shutil.which(git_clang_format):
         print(f"{git_clang_format} not installed. Skipping format.")
         return
     diff_flag = [] if apply else ["--diff"]
@@ -64,17 +64,17 @@ def clang_format(against, apply=False, path=CLANG_FORMAT_PATH):
         print("No modified cpp files to format")
 
 
-def yapf_format(against, apply=False):
-    if not shutil.which('yapf'):
-        print("yapf not installed. Skipping format.")
+def yapf_format(against, apply=False, yapf='yapf'):
+    if not shutil.which(yapf):
+        print(f"{yapf} not installed. Skipping format.")
         return
     diff_flag = "--in-place" if apply else "--diff"
-    files = ' '.join(get_changed_files(against))
     files = [
-        f for f in files if f.endswith(YAPF_EXTENSIONS) and not is_excluded(f)
+        f for f in get_changed_files(against)
+        if f.endswith(YAPF_EXTENSIONS) and not is_excluded(f)
     ]
     if files:
-        run(f"yapf {diff_flag} -p {files}", cwd=get_top(), verbose=True)
+        run([yapf, diff_flag, '-p'] + files, cwd=get_top(), verbose=True)
     else:
         print("No modified python files to format")
 
@@ -84,12 +84,20 @@ def main():
     parser.add_argument('against', default='develop', nargs='?')
     parser.add_argument('-i', '--in-place', action='store_true')
     parser.add_argument('-q', '--quiet', action='store_true')
+    parser.add_argument('--clang-format-path',
+                        default=DEFAULT_CLANG_FORMAT,
+                        help='Path to the clang-format executable')
+    parser.add_argument('--yapf-path',
+                        default='yapf',
+                        help='Path to the yapf executable')
     parser.add_argument('--exit-zero', action='store_true',
                         help='Exit 0 even when formatting differs')
     args = parser.parse_args()
     try:
-        clang_format(args.against, apply=args.in_place)
-        yapf_format(args.against, apply=args.in_place)
+        clang_format(args.against,
+                     apply=args.in_place,
+                     clang_format=args.clang_format_path)
+        yapf_format(args.against, apply=args.in_place, yapf=args.yapf_path)
     except subprocess.CalledProcessError as ex:
         if ex.stdout:
             print(ex.stdout)


### PR DESCRIPTION
## Motivation

The format script hardcoded the ROCm clang-format location and the `yapf` name, so it could not be used in environments where these tools live elsewhere (local installs, CI images without `/opt/rocm`). The newer rocm images no longer have clang-format in /opt/rocm/llvm, so we werent checking any formatting in the CI.

The script only formatted files changed against a base branch, with no way to format or check the whole repository.

Additionally, the yapf path had a bug that prevented it from ever formatting any files.

## Technical Details

- Added `--clang-format-path` and `--yapf-path` flags that take the executable to use. Both default to resolving `clang-format`/`yapf` from `PATH`; `git-clang-format` is looked up next to the given clang-format binary (or from `PATH` when a bare name is used).
- Added `-a`/`--all` to run on all tracked files (`git ls-files`) instead of the changeset. Since `git-clang-format` only operates on diffs, this mode invokes `clang-format` directly: `-i` with `--in-place`, otherwise `--dry-run -Werror` so it still fails on formatting differences.
- Fixed a bug in `yapf_format`: the changed-file list was joined into a single string and then filtered character-by-character, so the filter always produced an empty list and yapf never ran. Files are now filtered as a list and passed to `run` as an argument list, which also handles filenames with spaces.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
