### PR TITLE
Update MIGraphX EP shim to default to the AMD pci vendor ID

### DIFF
--- a/examples/onnxruntime/migraphx_ep.py
+++ b/examples/onnxruntime/migraphx_ep.py
@@ -35,8 +35,10 @@ MIGRAPHX_EP = "MIGraphXExecutionProvider"
 # PCI vendor id ONNX Runtime uses to identify AMD GPU allocators/data-transfers,
 # needed to bind IO to the MIGraphX EP's device explicitly (see
 # bind_migraphx_output() below).
-MIGRAPHX_VENDOR_ID = onnxruntime.OrtDeviceVendorId.AMD
-
+try:
+    MIGRAPHX_VENDOR_ID = onnxruntime.OrtDeviceVendorId.AMD
+except AttributeError:
+    MIGRAPHX_VENDOR_ID = 0x1002  # AMD PCI vendor ID fallback
 
 def _find_migraphx_plugin_lib():
     """Locate the MIGraphX plugin EP shared library.

--- a/examples/onnxruntime/migraphx_ep.py
+++ b/examples/onnxruntime/migraphx_ep.py
@@ -40,6 +40,7 @@ try:
 except AttributeError:
     MIGRAPHX_VENDOR_ID = 0x1002  # AMD PCI vendor ID fallback
 
+
 def _find_migraphx_plugin_lib():
     """Locate the MIGraphX plugin EP shared library.
 


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Update shim python script for using example code with pluggin EP and ROCm 7.14.x builds

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
Original change let us reuse scripts for new EP builds but older ROCm 7.14.x builds of OnnxRT MIGraphX EP don't include the API item for AMD's vendor ID breakout. 

Modifying the script so we just hardcode the vendorID for APIs that don't contain the attribute

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
