### PR TITLE
[ROCM-29926] fix non-standard literals causing failures in mlir modules

### DIFF
--- a/src/targets/gpu/prepare_mlir.cpp
+++ b/src/targets/gpu/prepare_mlir.cpp
@@ -129,12 +129,32 @@ struct find_where
     }
 };
 
+// mlir requires literals to be in a standard shape.
+struct find_nonstandard_literal
+{
+    auto matcher() const
+    {
+        return match::name("@literal")(match::not_standard_shape(),
+                                       match::none_of(match::broadcast_shape()));
+    }
+
+    void apply(module& m, const match::matcher_result& r) const
+    {
+        auto ins = r.result;
+        auto arg = ins->get_literal().get_argument();
+        shape s{arg.get_shape().type(), arg.get_shape().lens()};
+        literal result;
+        visit_all(arg)([&](auto x) { result = literal{s, x.to_vector()}; });
+        m.replace_instruction(ins, m.add_literal(result));
+    }
+};
+
 } // namespace
 
 void prepare_mlir::apply(module& m) const
 {
     match::find_matches(m, find_reduce{}, find_leaky_relu{});
-    match::find_matches(m, find_where{});
+    match::find_matches(m, find_where{}, find_nonstandard_literal{});
     run_passes(m, {dead_code_elimination{}});
 }
 

--- a/test/gpu/mlir.cpp
+++ b/test/gpu/mlir.cpp
@@ -25,6 +25,9 @@
 #include <migraphx/gpu/target.hpp>
 #include <migraphx/gpu/context.hpp>
 #include <migraphx/gpu/write_literals.hpp>
+#include <migraphx/gpu/prepare_mlir.hpp>
+#include <migraphx/pass_manager.hpp>
+#include <migraphx/literal.hpp>
 #include <migraphx/register_target.hpp>
 #include <migraphx/env.hpp>
 #include <migraphx/module.hpp>
@@ -852,6 +855,36 @@ module {
         migraphx::interpolate_string(mlir_output, {{"attrs", get_attrs()}});
     CHECK(encode(s) == encode(mlir_output_with_attrs));
     // Don't verify here. Tests with a verify test instead.
+}
+
+// prepare_mlir rewrites a non-standard-strided constant (as folded from a transposed literal) to
+// a standard shape so the emitted MLIR literal is accepted.
+TEST_CASE(dot_nonstandard_literal)
+{
+    std::string mlir_output = R"__migraphx__(
+module {
+  func.func @mlir_dot(%arg0: !migraphx.shaped<1x2x3xf32, 6x3x1>) -> !migraphx.shaped<1x2x2xf32, 4x2x1> attributes ${attrs} {
+    %0 = migraphx.literal(dense<[[[1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00]]]> : tensor<1x3x2xf32>) : <1x3x2xf32, 6x2x1>
+    %1 = migraphx.dot %arg0, %0 : <1x2x3xf32, 6x3x1>, <1x3x2xf32, 6x2x1> -> <1x2x2xf32, 4x2x1>
+    return %1 : !migraphx.shaped<1x2x2xf32, 4x2x1>
+  }
+}
+)__migraphx__";
+    migraphx::module m;
+    auto arg0 = m.add_parameter("arg0", {migraphx::shape::float_type, {1, 2, 3}});
+    migraphx::shape ws{migraphx::shape::float_type, {1, 3, 2}, {6, 1, 3}};
+    auto lit = m.add_literal(migraphx::literal{ws, {1, 2, 3, 4, 5, 6}});
+    auto dot = m.add_instruction(migraphx::make_op("dot"), arg0, lit);
+    m.add_return({dot});
+    migraphx::run_passes(m, {migraphx::gpu::prepare_mlir{}});
+
+    auto s = migraphx::gpu::dump_mlir(m);
+    // Skip test if MLIR is not enabled
+    if(s.empty())
+        return;
+    auto mlir_output_with_attrs =
+        migraphx::interpolate_string(mlir_output, {{"attrs", get_attrs()}});
+    CHECK(encode(s) == encode(mlir_output_with_attrs));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/gpu/prepare_mlir.cpp
+++ b/test/gpu/prepare_mlir.cpp
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <vector>
+#include <migraphx/gpu/prepare_mlir.hpp>
+#include <migraphx/dead_code_elimination.hpp>
+#include <migraphx/pass_manager.hpp>
+#include <migraphx/instruction.hpp>
+#include <migraphx/literal.hpp>
+#include <migraphx/module.hpp>
+#include <migraphx/make_op.hpp>
+#include <test.hpp>
+
+static void run_pass(migraphx::module& m)
+{
+    migraphx::run_passes(m, {migraphx::gpu::prepare_mlir{}, migraphx::dead_code_elimination{}});
+}
+
+// A non-standard-strided literal (as folded from a transposed constant, which mlir rejects) is
+// rewritten to a standard shape, preserving the logical values.
+TEST_CASE(nonstandard_literal_normalized)
+{
+    const auto f = migraphx::shape::float_type;
+
+    migraphx::module m1;
+    {
+        migraphx::shape s{f, {2, 2}, {1, 2}};
+        auto lit = m1.add_literal(migraphx::literal{s, {1, 3, 2, 4}});
+        m1.add_return({lit});
+    }
+    run_pass(m1);
+
+    migraphx::module m2;
+    {
+        auto lit = m2.add_literal(migraphx::literal{migraphx::shape{f, {2, 2}}, {1, 3, 2, 4}});
+        m2.add_return({lit});
+    }
+
+    EXPECT(m1.sort() == m2.sort());
+}
+
+// An already-standard literal is left untouched.
+TEST_CASE(standard_literal_unchanged)
+{
+    const auto f = migraphx::shape::float_type;
+
+    migraphx::module m1;
+    {
+        auto lit = m1.add_literal(migraphx::literal{migraphx::shape{f, {2, 2}}, {1, 2, 3, 4}});
+        m1.add_return({lit});
+    }
+    auto m2 = m1;
+    run_pass(m1);
+
+    EXPECT(m1.sort() == m2.sort());
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
Cherry pick of https://github.com/ROCm/AMDMIGraphX/pull/5070 that addresses non-standard literals.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [x] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
