### PR TITLE
fix: enable Linux build hardening flags and CI checksec gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -490,11 +490,12 @@ jobs:
     - name: Verify binary hardening
       if: matrix.configuration == 'release'
       run: |
-        sudo apt-get update
-        if ! sudo apt-get install -y checksec; then
-          sudo wget -qO /usr/local/bin/checksec https://raw.githubusercontent.com/slimm609/checksec.sh/master/checksec
-          sudo chmod +x /usr/local/bin/checksec
-        fi
+        CHECKSEC_VERSION=3.2.0
+        CHECKSEC_DEB="checksec_${CHECKSEC_VERSION}_amd64.deb"
+        CHECKSEC_SHA512="d15dfa4adb906f9c396cfb30574c91fcb43ee07bfe94108dca073924172469c4be559a9f781afeefbf37655aec399bf010b2669f16cdc01d3eefb1ab4fa32f0c"
+        wget -q "https://github.com/slimm609/checksec/releases/download/${CHECKSEC_VERSION}/${CHECKSEC_DEB}"
+        echo "${CHECKSEC_SHA512}  ${CHECKSEC_DEB}" | sha512sum -c -
+        sudo dpkg -i "${CHECKSEC_DEB}"
         chmod +x tools/checksec.sh
         CHECKSEC_REQUIRED=1 ./tools/checksec.sh
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -487,6 +487,17 @@ jobs:
           -DCTEST_TIMEOUT=${{matrix.configuration == 'release' && '5000' || '10000'}}
         ${{ github.workspace }}/cget/bin/ccache -s
 
+    - name: Verify binary hardening
+      if: matrix.configuration == 'release'
+      run: |
+        sudo apt-get update
+        if ! sudo apt-get install -y checksec; then
+          sudo wget -qO /usr/local/bin/checksec https://raw.githubusercontent.com/slimm609/checksec.sh/master/checksec
+          sudo chmod +x /usr/local/bin/checksec
+        fi
+        chmod +x tools/checksec.sh
+        CHECKSEC_REQUIRED=1 ./tools/checksec.sh
+
     # GH actions can not update existing cache, as a workaround clear cache and then save it
     - name: Clear ccache cache before saving
       continue-on-error: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,9 @@ if(MIGRAPHX_STRIP_SYMBOLS AND NOT WIN32 AND NOT APPLE)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
 endif()
 
+option(MIGRAPHX_ENABLE_HARDENING "Enable Linux exploit-mitigation compiler and linker flags" ON)
+include(Hardening)
+
 if(WIN32) # CK is not yet ported to Windows
 option(MIGRAPHX_USE_COMPOSABLEKERNEL "Enable MIGraphX to use composable kernel JIT library" OFF)
 else()

--- a/cmake/Hardening.cmake
+++ b/cmake/Hardening.cmake
@@ -1,0 +1,42 @@
+#####################################################################################
+# The MIT License (MIT)
+#
+# Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#####################################################################################
+# Linux exploit-mitigation compiler and linker flags (SEC-00802 / SEC-00469)
+
+include(CheckCXXCompilerFlag)
+
+if(NOT WIN32 AND NOT APPLE AND MIGRAPHX_ENABLE_HARDENING)
+    message(STATUS "Linux build hardening enabled")
+    add_compile_options(
+        -fstack-protector-strong
+        -Wformat-security
+        -fstack-clash-protection
+    )
+    add_compile_definitions(_FORTIFY_SOURCE=2)
+    add_link_options(-Wl,-z,relro -Wl,-z,now -pie)
+
+    check_cxx_compiler_flag("-fcf-protection=full" MIGRAPHX_HAS_FCF_PROTECTION)
+    if(MIGRAPHX_HAS_FCF_PROTECTION)
+        add_compile_options(-fcf-protection=full)
+    endif()
+endif()

--- a/cmake/Hardening.cmake
+++ b/cmake/Hardening.cmake
@@ -27,13 +27,26 @@ include(CheckCXXCompilerFlag)
 
 if(NOT WIN32 AND NOT APPLE AND MIGRAPHX_ENABLE_HARDENING)
     message(STATUS "Linux build hardening enabled")
-    add_compile_options(
-        -fstack-protector-strong
-        -Wformat-security
-        -fstack-clash-protection
-    )
+
+    check_cxx_compiler_flag("-fstack-protector-strong" MIGRAPHX_HAS_STACK_PROTECTOR_STRONG)
+    if(MIGRAPHX_HAS_STACK_PROTECTOR_STRONG)
+        add_compile_options(-fstack-protector-strong)
+    endif()
+
+    check_cxx_compiler_flag("-Wformat-security" MIGRAPHX_HAS_FORMAT_SECURITY)
+    if(MIGRAPHX_HAS_FORMAT_SECURITY)
+        add_compile_options(-Wformat-security)
+    endif()
+
+    check_cxx_compiler_flag("-fstack-clash-protection" MIGRAPHX_HAS_STACK_CLASH_PROTECTION)
+    if(MIGRAPHX_HAS_STACK_CLASH_PROTECTION)
+        add_compile_options(-fstack-clash-protection)
+    endif()
+
     add_compile_definitions(_FORTIFY_SOURCE=2)
-    add_link_options(-Wl,-z,relro -Wl,-z,now -pie)
+
+    add_link_options(-Wl,-z,relro -Wl,-z,now)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
 
     check_cxx_compiler_flag("-fcf-protection=full" MIGRAPHX_HAS_FCF_PROTECTION)
     if(MIGRAPHX_HAS_FCF_PROTECTION)

--- a/tools/checksec.sh
+++ b/tools/checksec.sh
@@ -14,31 +14,127 @@ if ! command -v checksec >/dev/null 2>&1; then
     exit 0
 fi
 
+if ! command -v readelf >/dev/null 2>&1; then
+    echo "readelf is required for hardening verification"
+    exit 1
+fi
+
 shopt -s nullglob
 binaries=(
     "${build_dir}/bin/migraphx-driver"
     "${build_dir}/lib/libmigraphx.so"*
 )
 
+run_checksec() {
+    local bin="$1"
+    if checksec file "${bin}" --output json >/dev/null 2>&1; then
+        checksec file "${bin}" --output json
+        return 0
+    fi
+    if checksec --file="${bin}" --output json >/dev/null 2>&1; then
+        checksec --file="${bin}" --output json
+        return 0
+    fi
+    return 1
+}
+
+verify_with_readelf() {
+    local bin="$1"
+    local is_shared="$2"
+    local failed=0
+
+    if ! readelf -s "${bin}" 2>/dev/null | grep -q '__stack_chk_fail'; then
+        echo "Missing stack canary for ${bin}"
+        failed=1
+    fi
+
+    if ! readelf -l "${bin}" 2>/dev/null | grep -q 'GNU_RELRO'; then
+        echo "Missing GNU_RELRO for ${bin}"
+        failed=1
+    elif ! readelf -d "${bin}" 2>/dev/null | grep -q 'BIND_NOW'; then
+        echo "Missing BIND_NOW (full RELRO) for ${bin}"
+        failed=1
+    fi
+
+    local elf_type
+    elf_type="$(readelf -h "${bin}" 2>/dev/null | awk '/Type:/ {print $2}')"
+    if [[ "${elf_type}" != "DYN" ]]; then
+        if [[ "${is_shared}" == "1" ]]; then
+            echo "Expected shared object (Type DYN) for ${bin}, got ${elf_type}"
+        else
+            echo "Missing PIE (Type DYN) for ${bin}, got ${elf_type}"
+        fi
+        failed=1
+    fi
+
+    return "${failed}"
+}
+
+verify_with_checksec_json() {
+    local bin="$1"
+    local is_shared="$2"
+    local json="$3"
+
+    python3 - "${json}" "${is_shared}" "${bin}" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+is_shared = sys.argv[2] == "1"
+path = sys.argv[3]
+
+if isinstance(payload, list):
+    entry = next((item for item in payload if item.get("name") == path), payload[0])
+else:
+    entry = payload
+
+checks = entry.get("checks", entry)
+canary = checks.get("canary", "")
+relro = checks.get("relro", "")
+pie = checks.get("pie", "")
+
+failed = False
+if "Canary Found" not in canary:
+    print(f"Missing stack canary for {path}: {canary!r}")
+    failed = True
+if "Full RELRO" not in relro:
+    print(f"Missing full RELRO for {path}: {relro!r}")
+    failed = True
+if is_shared:
+    if "DSO" not in pie.upper():
+        print(f"Expected DSO for shared library {path}, got {pie!r}")
+        failed = True
+elif "PIE Enabled" not in pie:
+    print(f"Missing PIE for {path}: {pie!r}")
+    failed = True
+
+sys.exit(1 if failed else 0)
+PY
+}
+
 found=0
 failed=0
 for bin in "${binaries[@]}"; do
     [[ -f "${bin}" ]] || continue
     found=1
+
+    is_shared=0
+    if [[ "${bin}" == *.so* ]]; then
+        is_shared=1
+    fi
+
     echo "Checking ${bin}"
-    output="$(checksec --file="${bin}")"
-    echo "${output}"
-    if ! grep -Eq 'Stack:.*(Canary found|canary found)' <<<"${output}"; then
-        echo "Missing stack canary for ${bin}"
-        failed=1
-    fi
-    if ! grep -Eq 'RELRO:.*(Full RELRO|full relro)' <<<"${output}"; then
-        echo "Missing full RELRO for ${bin}"
-        failed=1
-    fi
-    if ! grep -Eq 'PIE:.*(PIE enabled|pie enabled|Yes)' <<<"${output}"; then
-        echo "Missing PIE for ${bin}"
-        failed=1
+    json=""
+    if json="$(run_checksec "${bin}" 2>/dev/null)"; then
+        echo "${json}"
+        if ! verify_with_checksec_json "${bin}" "${is_shared}" "${json}"; then
+            failed=1
+        fi
+    else
+        echo "checksec JSON unavailable; falling back to readelf for ${bin}"
+        if ! verify_with_readelf "${bin}" "${is_shared}"; then
+            failed=1
+        fi
     fi
 done
 

--- a/tools/checksec.sh
+++ b/tools/checksec.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Verify Linux hardening flags on shipped MIGraphX binaries (SEC-00802 / SEC-00469).
+set -euo pipefail
+
+build_dir="${BUILD_DIR:-build}"
+require_checksec="${CHECKSEC_REQUIRED:-0}"
+
+if ! command -v checksec >/dev/null 2>&1; then
+    if [[ "${require_checksec}" == "1" ]]; then
+        echo "checksec is required but not installed"
+        exit 1
+    fi
+    echo "checksec not installed; skipping hardening gate"
+    exit 0
+fi
+
+shopt -s nullglob
+binaries=(
+    "${build_dir}/bin/migraphx-driver"
+    "${build_dir}/lib/libmigraphx.so"*
+)
+
+found=0
+failed=0
+for bin in "${binaries[@]}"; do
+    [[ -f "${bin}" ]] || continue
+    found=1
+    echo "Checking ${bin}"
+    output="$(checksec --file="${bin}")"
+    echo "${output}"
+    if ! grep -Eq 'Stack:.*(Canary found|canary found)' <<<"${output}"; then
+        echo "Missing stack canary for ${bin}"
+        failed=1
+    fi
+    if ! grep -Eq 'RELRO:.*(Full RELRO|full relro)' <<<"${output}"; then
+        echo "Missing full RELRO for ${bin}"
+        failed=1
+    fi
+    if ! grep -Eq 'PIE:.*(PIE enabled|pie enabled|Yes)' <<<"${output}"; then
+        echo "Missing PIE for ${bin}"
+        failed=1
+    fi
+done
+
+if ((found == 0)); then
+    echo "No MIGraphX binaries found under ${build_dir}; skipping"
+    exit 0
+fi
+
+exit "${failed}"


### PR DESCRIPTION
## Summary

- Add `cmake/Hardening.cmake` with Linux exploit-mitigation compiler/linker flags (stack protector, FORTIFY_SOURCE, RELRO/BIND_NOW, PIE, stack-clash, optional CET).
- Gate hardening behind `MIGRAPHX_ENABLE_HARDENING` (default ON).
- Add `tools/checksec.sh` and a release-only CI step to verify `migraphx-driver` and `libmigraphx.so`.

## JIRA

- [ROCM-26641](https://amd-hub.atlassian.net/browse/ROCM-26641) / [SWSPLAT-32802](https://amd.atlassian.net/browse/SWSPLAT-32802)
- [ROCM-26622](https://amd-hub.atlassian.net/browse/ROCM-26622) / [SWSPLAT-32783](https://amd.atlassian.net/browse/SWSPLAT-32783)

## Test plan

- [ ] CI `linux` release matrix passes build + checksec gate
- [ ] Local release build: `./tools/checksec.sh` reports canary, full RELRO, and PIE on shipped binaries
- [ ] Debug/codecov CI configs still build cleanly with hardening enabled

Made with [Cursor](https://cursor.com)

[ROCM-26641]: https://amd-hub.atlassian.net/browse/ROCM-26641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROCM-26622]: https://amd-hub.atlassian.net/browse/ROCM-26622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SWSPLAT-32802]: https://amd.atlassian.net/browse/SWSPLAT-32802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SWSPLAT-32783]: https://amd.atlassian.net/browse/SWSPLAT-32783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ