### PR TITLE
Have convolution_backwards error on indivisible groups and reference operator accumulate in double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Full documentation for MIGraphX is available at
 * Fixed a GPU compile failure with `redefinition of parameter` when a pointwise fused into a reduce consumed the same tensor at more than one operand slot, which could happen with `--fp16` on models that slice a shared tensor into multiple branches (#5130).
 * Fixed a parse failure in `Softplus` and `Softsign` when an input has a dynamic shape (#5136).
 * Fixed the ONNX and TensorFlow DLLs leaking protobuf state when unloaded with `FreeLibrary` on Windows (#5157).
-* Fixed the reference `convolution_backwards` operator to accumulate in double precision instead of in the tensor type, so fp16 and bf16 results no longer lose several ULPs over the channel and kernel extent.
+* Fixed the reference `convolution_backwards` operator to use type-appropriate accumulator storage: double for floating-point tensors and `int64_t` or `uint64_t` for integral tensors. This prevents repeated fp16 and bf16 rounding without routing 64-bit integers through double. (#5248)
 
 ### Optimized
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Full documentation for MIGraphX is available at
 * Fixed a GPU compile failure with `redefinition of parameter` when a pointwise fused into a reduce consumed the same tensor at more than one operand slot, which could happen with `--fp16` on models that slice a shared tensor into multiple branches (#5130).
 * Fixed a parse failure in `Softplus` and `Softsign` when an input has a dynamic shape (#5136).
 * Fixed the ONNX and TensorFlow DLLs leaking protobuf state when unloaded with `FreeLibrary` on Windows (#5157).
+* Fixed the reference `convolution_backwards` operator to accumulate in double precision instead of in the tensor type, so fp16 and bf16 results no longer lose several ULPs over the channel and kernel extent.
 
 ### Optimized
 

--- a/src/include/migraphx/op/convolution_backwards.hpp
+++ b/src/include/migraphx/op/convolution_backwards.hpp
@@ -31,9 +31,11 @@
 #include <migraphx/config.hpp>
 #include <migraphx/value.hpp>
 #include <migraphx/argument.hpp>
+#include <migraphx/par_dfor.hpp>
 #include <migraphx/par_for.hpp>
 #include <migraphx/shape_for_each.hpp>
 #include <migraphx/dyn_output.hpp>
+#include <migraphx/type_traits.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -65,6 +67,11 @@ struct convolution_backwards
         if(padding.size() != stride.size() or stride.size() != dilation.size())
         {
             MIGRAPHX_THROW("CONVOLUTION_BACKWARDS: inconsistent attribute sizes");
+        }
+
+        if(std::any_of(stride.begin(), stride.end(), [](auto s) { return s == 0; }))
+        {
+            MIGRAPHX_THROW("CONVOLUTION_BACKWARDS: stride must be nonzero");
         }
     }
 
@@ -157,61 +164,79 @@ struct convolution_backwards
     argument compute(const dyn_output& dyn_out, std::vector<argument> args) const
     {
         argument result{dyn_out.computed_shape};
-        const auto num_spatial_dims = this->kdims();
-        const shape& out_shape      = dyn_out.computed_shape;
+        auto num_spatial_dims  = this->kdims();
+        const shape& out_shape = dyn_out.computed_shape;
         visit_all(result, args[0], args[1])([&](auto output, auto input, auto weights) {
-            using type = typename decltype(output)::value_type;
+            using type        = typename decltype(output)::value_type;
+            using accumulator = accumulator_type<type>;
 
-            const auto& in_lens = input.get_shape().lens();
-            const auto& wei     = weights.get_shape().lens();
-            const auto wei_c    = wei[1];
-            // Channels of the input, and so of the weights' first axis, per group.
-            const auto in_per_group = wei[0] / group;
+            // Accumulate narrow floating-point values in double so each term is not rounded to the
+            // output type. Integral values use signedness-matched 64-bit storage instead of double.
+            std::vector<accumulator> scratch(out_shape.element_space(), accumulator{0});
 
-            const shape wei_spatial{out_shape.type(),
-                                    std::vector<std::size_t>(wei.begin() + 2, wei.end())};
+            auto in_lens = input.get_shape().lens();
+            auto in_n    = in_lens[0];
+            auto in_c    = in_lens[1];
 
-            par_for(out_shape.elements(), [&](std::size_t i) {
-                const auto idx_out  = out_shape.multi(i);
-                const auto group_id = idx_out[1] / wei_c;
+            auto wei   = weights.get_shape().lens();
+            auto wei_n = wei[0];
+            auto wei_c = wei[1];
 
-                std::vector<std::size_t> idx_in(num_spatial_dims + 2);
-                std::vector<std::size_t> idx_wei(num_spatial_dims + 2);
-                idx_in[0]  = idx_out[0];
-                idx_wei[1] = idx_out[1] % wei_c;
+            auto out_lens = dyn_out.computed_shape.lens();
 
-                // Sum in double rather than in the output type: a narrow type (fp16/bf16/fp8)
-                // cannot hold the running sum without rounding every term, which loses several
-                // ULPs over the channel/kernel extent. migraphx::convolution states the same
-                // contract for the forward direction.
-                double acc = 0.0;
-                shape_for_each(wei_spatial, [&](const auto& idx_k) {
-                    // The forward direction sends input position q to q * stride - padding +
-                    // k * dilation, so invert that: this weight tap feeds this output position
-                    // only when the inverse lands on an input position that exists.
-                    for(std::size_t n = 0; n < num_spatial_dims; n++)
+            std::vector<std::size_t> win_size{in_c};
+            std::copy(in_lens.begin() + 2, in_lens.end(), std::back_inserter(win_size));
+            std::copy(wei.begin() + 2, wei.end(), std::back_inserter(win_size));
+            shape win_shape{dyn_out.computed_shape.type(), win_size};
+
+            par_dfor(in_n, wei_c)([&](int o, int k) {
+                shape_for_each(win_shape, [&](const auto& idx_win) {
+                    const int w = idx_win[0];
+
+                    auto input_dims_start = idx_win.begin() + 1;
+                    auto wei_dims_start   = idx_win.begin() + num_spatial_dims + 1;
+
+                    std::vector<std::ptrdiff_t> win_start;
+                    win_start.reserve(num_spatial_dims);
+                    for(std::size_t n = 0; n < num_spatial_dims; ++n)
                     {
-                        const auto pos = std::ptrdiff_t(idx_out[n + 2]) +
-                                         std::ptrdiff_t(padding[n]) -
-                                         std::ptrdiff_t(idx_k[n] * dilation[n]);
-                        if(pos < 0 or pos % std::ptrdiff_t(stride[n]) != 0)
-                            return;
-                        const auto q = std::size_t(pos) / stride[n];
-                        if(q >= in_lens[n + 2])
-                            return;
-                        idx_in[n + 2]  = q;
-                        idx_wei[n + 2] = idx_k[n];
+                        win_start.push_back(std::ptrdiff_t(*(input_dims_start + n) * stride[n]) -
+                                            std::ptrdiff_t(padding[n]));
                     }
-                    for(std::size_t w = group_id * in_per_group; w < (group_id + 1) * in_per_group;
-                        w++)
+
+                    const int group_id = w / (wei_n / group);
+                    const int in_ch    = group_id * wei_c + k;
+
+                    std::vector<std::ptrdiff_t> idx_out{o, in_ch};
+
+                    for(size_t n = 0; n < num_spatial_dims; n++)
                     {
-                        idx_in[1]  = w;
-                        idx_wei[0] = w;
-                        acc += static_cast<double>(input(idx_in.begin(), idx_in.end())) *
-                               static_cast<double>(weights(idx_wei.begin(), idx_wei.end()));
+                        idx_out.push_back(win_start[n] + *(wei_dims_start + n) * dilation[n]);
+                    }
+
+                    std::vector<std::ptrdiff_t> idx_wei{w, k};
+                    std::copy(wei_dims_start, idx_win.end(), std::back_inserter(idx_wei));
+
+                    std::vector<std::ptrdiff_t> idx_in{o, w};
+                    std::copy(input_dims_start, wei_dims_start, std::back_inserter(idx_in));
+
+                    if(std::all_of(
+                           idx_out.begin() + 2, idx_out.end(), [&](auto ii) { return ii >= 0; }) and
+                       std::equal(idx_out.begin() + 2,
+                                  idx_out.end(),
+                                  out_lens.begin() + 2,
+                                  out_lens.end(),
+                                  std::less<std::ptrdiff_t>{}))
+                    {
+                        scratch[out_shape.index(idx_out.begin(), idx_out.end())] +=
+                            static_cast<accumulator>(input(idx_in.begin(), idx_in.end())) *
+                            static_cast<accumulator>(weights(idx_wei.begin(), idx_wei.end()));
                     }
                 });
-                output[i] = static_cast<type>(acc);
+            });
+
+            par_for(out_shape.elements(), [&](std::size_t i) {
+                output[i] = static_cast<type>(scratch[out_shape.index(i)]);
             });
         });
         return result;

--- a/src/include/migraphx/op/convolution_backwards.hpp
+++ b/src/include/migraphx/op/convolution_backwards.hpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,7 @@
 #include <migraphx/config.hpp>
 #include <migraphx/value.hpp>
 #include <migraphx/argument.hpp>
-#include <migraphx/par_dfor.hpp>
+#include <migraphx/par_for.hpp>
 #include <migraphx/shape_for_each.hpp>
 #include <migraphx/dyn_output.hpp>
 
@@ -79,10 +79,25 @@ struct convolution_backwards
             MIGRAPHX_THROW("CONVOLUTION_BACKWARDS: input k-dims does not match attribute size");
         }
 
+        if(group < 1)
+        {
+            MIGRAPHX_THROW("CONVOLUTION_BACKWARDS: group (" + to_string(group) +
+                           ") must be positive");
+        }
+
         if(not x_shape.dynamic() and not w_shape.dynamic() and
            x_shape.lens().at(1) != (w_shape.lens().at(0)))
         {
             MIGRAPHX_THROW("CONVOLUTION_BACKWARDS: mismatched channel numbers");
+        }
+
+        // compute() walks a group's input channels as one contiguous block of
+        // weights_channels / group, so an inexact division leaves part of every group unread.
+        if(not w_shape.dynamic() and w_shape.lens().at(0) % group != 0)
+        {
+            MIGRAPHX_THROW("CONVOLUTION_BACKWARDS: input channels (" +
+                           to_string(w_shape.lens().at(0)) + ") is not divisible by group (" +
+                           to_string(group) + ")");
         }
 
         if(x_shape.dynamic() or w_shape.dynamic())
@@ -142,71 +157,61 @@ struct convolution_backwards
     argument compute(const dyn_output& dyn_out, std::vector<argument> args) const
     {
         argument result{dyn_out.computed_shape};
-        auto num_spatial_dims = this->kdims();
+        const auto num_spatial_dims = this->kdims();
+        const shape& out_shape      = dyn_out.computed_shape;
         visit_all(result, args[0], args[1])([&](auto output, auto input, auto weights) {
             using type = typename decltype(output)::value_type;
 
-            std::fill(output.begin(), output.end(), type{0});
+            const auto& in_lens = input.get_shape().lens();
+            const auto& wei     = weights.get_shape().lens();
+            const auto wei_c    = wei[1];
+            // Channels of the input, and so of the weights' first axis, per group.
+            const auto in_per_group = wei[0] / group;
 
-            auto in_lens = input.get_shape().lens();
-            auto in_n    = in_lens[0];
-            auto in_c    = in_lens[1];
+            const shape wei_spatial{out_shape.type(),
+                                    std::vector<std::size_t>(wei.begin() + 2, wei.end())};
 
-            auto wei   = weights.get_shape().lens();
-            auto wei_n = wei[0];
-            auto wei_c = wei[1];
+            par_for(out_shape.elements(), [&](std::size_t i) {
+                const auto idx_out  = out_shape.multi(i);
+                const auto group_id = idx_out[1] / wei_c;
 
-            auto out_lens = dyn_out.computed_shape.lens();
+                std::vector<std::size_t> idx_in(num_spatial_dims + 2);
+                std::vector<std::size_t> idx_wei(num_spatial_dims + 2);
+                idx_in[0]  = idx_out[0];
+                idx_wei[1] = idx_out[1] % wei_c;
 
-            std::vector<std::size_t> win_size{in_c};
-            std::copy(in_lens.begin() + 2, in_lens.end(), std::back_inserter(win_size));
-            std::copy(wei.begin() + 2, wei.end(), std::back_inserter(win_size));
-            shape win_shape{dyn_out.computed_shape.type(), win_size};
-
-            par_dfor(in_n, wei_c)([&](int o, int k) {
-                shape_for_each(win_shape, [&](const auto& idx_win) {
-                    const int w = idx_win[0];
-
-                    auto input_dims_start = idx_win.begin() + 1;
-                    auto wei_dims_start   = idx_win.begin() + num_spatial_dims + 1;
-
-                    std::vector<std::ptrdiff_t> win_start;
-                    win_start.reserve(num_spatial_dims);
-                    for(std::size_t n = 0; n < num_spatial_dims; ++n)
+                // Sum in double rather than in the output type: a narrow type (fp16/bf16/fp8)
+                // cannot hold the running sum without rounding every term, which loses several
+                // ULPs over the channel/kernel extent. migraphx::convolution states the same
+                // contract for the forward direction.
+                double acc = 0.0;
+                shape_for_each(wei_spatial, [&](const auto& idx_k) {
+                    // The forward direction sends input position q to q * stride - padding +
+                    // k * dilation, so invert that: this weight tap feeds this output position
+                    // only when the inverse lands on an input position that exists.
+                    for(std::size_t n = 0; n < num_spatial_dims; n++)
                     {
-                        win_start.push_back(std::ptrdiff_t(*(input_dims_start + n) * stride[n]) -
-                                            std::ptrdiff_t(padding[n]));
+                        const auto pos = std::ptrdiff_t(idx_out[n + 2]) +
+                                         std::ptrdiff_t(padding[n]) -
+                                         std::ptrdiff_t(idx_k[n] * dilation[n]);
+                        if(pos < 0 or pos % std::ptrdiff_t(stride[n]) != 0)
+                            return;
+                        const auto q = std::size_t(pos) / stride[n];
+                        if(q >= in_lens[n + 2])
+                            return;
+                        idx_in[n + 2]  = q;
+                        idx_wei[n + 2] = idx_k[n];
                     }
-
-                    const int group_id = w / (wei_n / group);
-                    const int in_ch    = group_id * wei_c + k;
-
-                    std::vector<std::ptrdiff_t> idx_out{o, in_ch};
-
-                    for(size_t n = 0; n < num_spatial_dims; n++)
+                    for(std::size_t w = group_id * in_per_group; w < (group_id + 1) * in_per_group;
+                        w++)
                     {
-                        idx_out.push_back(win_start[n] + *(wei_dims_start + n) * dilation[n]);
-                    }
-
-                    std::vector<std::ptrdiff_t> idx_wei{w, k};
-                    std::copy(wei_dims_start, idx_win.end(), std::back_inserter(idx_wei));
-
-                    std::vector<std::ptrdiff_t> idx_in{o, w};
-                    std::copy(input_dims_start, wei_dims_start, std::back_inserter(idx_in));
-
-                    if(std::all_of(
-                           idx_out.begin() + 2, idx_out.end(), [&](auto ii) { return ii >= 0; }) and
-                       std::equal(idx_out.begin() + 2,
-                                  idx_out.end(),
-                                  out_lens.begin() + 2,
-                                  out_lens.end(),
-                                  std::less<std::ptrdiff_t>{}))
-                    {
-                        output(idx_out.begin(), idx_out.end()) +=
-                            input(idx_in.begin(), idx_in.end()) *
-                            weights(idx_wei.begin(), idx_wei.end());
+                        idx_in[1]  = w;
+                        idx_wei[0] = w;
+                        acc += static_cast<double>(input(idx_in.begin(), idx_in.end())) *
+                               static_cast<double>(weights(idx_wei.begin(), idx_wei.end()));
                     }
                 });
+                output[i] = static_cast<type>(acc);
             });
         });
         return result;

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -949,6 +949,13 @@ TEST_CASE(convolution_backwards_2stride)
                  weights);
 }
 
+TEST_CASE(convolution_backwards_stride_zero)
+{
+    migraphx::shape input{migraphx::shape::float_type, {1, 1, 2, 2}};
+    migraphx::shape weights{migraphx::shape::float_type, {1, 1, 2, 2}};
+    throws_shape(migraphx::make_op("convolution_backwards", {{"stride", {0, 1}}}), input, weights);
+}
+
 TEST_CASE(convolution_backwards_2dilation)
 {
     migraphx::shape input{migraphx::shape::float_type, {4, 4, 4, 4}};

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -994,6 +994,22 @@ TEST_CASE(convolution_backwards_channel_mismatch)
     throws_shape(migraphx::make_op("convolution_backwards"), input, weights);
 }
 
+// compute() splits the input channels into equal per-group blocks, so a group that does not
+// divide them would leave part of every group unread.
+TEST_CASE(convolution_backwards_group_indivisible)
+{
+    migraphx::shape input{migraphx::shape::float_type, {1, 5, 4, 4}};
+    migraphx::shape weights{migraphx::shape::float_type, {5, 3, 3, 3}};
+    throws_shape(migraphx::make_op("convolution_backwards", {{"group", 2}}), input, weights);
+}
+
+TEST_CASE(convolution_backwards_group_not_positive)
+{
+    migraphx::shape input{migraphx::shape::float_type, {1, 4, 4, 4}};
+    migraphx::shape weights{migraphx::shape::float_type, {4, 2, 3, 3}};
+    throws_shape(migraphx::make_op("convolution_backwards", {{"group", 0}}), input, weights);
+}
+
 TEST_CASE(convolution_backwards_dyn_batch_2d)
 {
     migraphx::shape input{migraphx::shape::float_type, {{1, 4}, {4, 4}, {1, 1}, {1, 1}}};

--- a/test/ref/convolution_backwards.cpp
+++ b/test/ref/convolution_backwards.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -320,4 +320,46 @@ TEST_CASE(convolution_backwards_dyn_batch2)
     std::vector<float> results_vector;
     result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
     EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+}
+
+// A 1x1 kernel over a 1x1 input makes the single output element one dot product over the input
+// channels, which is the shortest way to observe the accumulator's precision.
+static std::vector<float> conv_backwards_channel_dot(migraphx::shape::type_t type, float small)
+{
+    migraphx::shape xs{type, {1, 5, 1, 1}};
+    migraphx::shape ws{type, {5, 1, 1, 1}};
+    std::vector<float> x_data{1.0f, small, small, small, small};
+    std::vector<float> w_data(x_data.size(), 1.0f);
+
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    auto x   = mm->add_literal(migraphx::literal{xs, x_data});
+    auto w   = mm->add_literal(migraphx::literal{ws, w_data});
+    mm->add_instruction(migraphx::make_op("convolution_backwards"), x, w);
+    p.compile(migraphx::make_target("ref"));
+
+    std::vector<float> results_vector;
+    p.eval({}).back().visit(
+        [&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    return results_vector;
+}
+
+// The reference sums in double whatever the element type is. Each small term below sits exactly on
+// the tie one half-ULP under the running total, so an accumulator in the tensor type rounds every
+// one of them away and returns a bare 1.0; the double sum keeps all four. Both the terms and the
+// expected total are exactly representable, so the check is exact rather than tolerance-bounded.
+TEST_CASE(convolution_backwards_half_accumulate)
+{
+    // 1/2048 is half an ULP of half at 1.0, and the four of them total 1/512.
+    auto results = conv_backwards_channel_dot(migraphx::shape::half_type, 1.0f / 2048.0f);
+    EXPECT(results.size() == 1);
+    EXPECT(migraphx::float_equal(results.front(), 1.0f + 1.0f / 512.0f));
+}
+
+TEST_CASE(convolution_backwards_bf16_accumulate)
+{
+    // 1/256 is half an ULP of bf16 at 1.0, and the four of them total 1/64.
+    auto results = conv_backwards_channel_dot(migraphx::shape::bf16_type, 1.0f / 256.0f);
+    EXPECT(results.size() == 1);
+    EXPECT(migraphx::float_equal(results.front(), 1.0f + 1.0f / 64.0f));
 }

--- a/test/ref/convolution_backwards.cpp
+++ b/test/ref/convolution_backwards.cpp
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <cstdint>
 #include <migraphx/instruction.hpp>
 #include <migraphx/literal.hpp>
 #include <migraphx/make_op.hpp>
@@ -253,6 +254,27 @@ TEST_CASE(convolution_backwards_2d_group)
     EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
 }
 
+TEST_CASE(convolution_backwards_2d_group_multiple_input_channels)
+{
+    migraphx::shape input_shape{migraphx::shape::float_type, {1, 4, 1, 1}};
+    migraphx::shape weights_shape{migraphx::shape::float_type, {4, 1, 1, 1}};
+    std::vector<float> input_data{1.0f, 2.0f, 4.0f, 8.0f};
+    std::vector<float> weights_data(4, 1.0f);
+    std::vector<float> gold{3.0f, 12.0f};
+
+    migraphx::program p;
+    auto* mm     = p.get_main_module();
+    auto input   = mm->add_literal(migraphx::literal{input_shape, input_data});
+    auto weights = mm->add_literal(migraphx::literal{weights_shape, weights_data});
+    mm->add_instruction(migraphx::make_op("convolution_backwards", {{"group", 2}}), input, weights);
+    p.compile(migraphx::make_target("ref"));
+
+    std::vector<float> results_vector;
+    p.eval({}).back().visit(
+        [&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(migraphx::verify::verify_rms_range(results_vector, gold));
+}
+
 TEST_CASE(convolution_backwards_dyn_batch1)
 {
     migraphx::program p;
@@ -344,10 +366,10 @@ static std::vector<float> conv_backwards_channel_dot(migraphx::shape::type_t typ
     return results_vector;
 }
 
-// The reference sums in double whatever the element type is. Each small term below sits exactly on
-// the tie one half-ULP under the running total, so an accumulator in the tensor type rounds every
-// one of them away and returns a bare 1.0; the double sum keeps all four. Both the terms and the
-// expected total are exactly representable, so the check is exact rather than tolerance-bounded.
+// The reference sums floating-point values in double. Each small term below sits exactly on the tie
+// one half-ULP under the running total, so an accumulator in the tensor type rounds every one of
+// them away and returns a bare 1.0; the double sum keeps all four. Both the terms and the expected
+// total are exactly representable, so the check is exact rather than tolerance-bounded.
 TEST_CASE(convolution_backwards_half_accumulate)
 {
     // 1/2048 is half an ULP of half at 1.0, and the four of them total 1/512.
@@ -362,4 +384,38 @@ TEST_CASE(convolution_backwards_bf16_accumulate)
     auto results = conv_backwards_channel_dot(migraphx::shape::bf16_type, 1.0f / 256.0f);
     EXPECT(results.size() == 1);
     EXPECT(migraphx::float_equal(results.front(), 1.0f + 1.0f / 64.0f));
+}
+
+TEST_CASE(convolution_backwards_int64_accumulate)
+{
+    constexpr std::int64_t value = -9007199254740993LL;
+    migraphx::shape s{migraphx::shape::int64_type, {1, 1, 1, 1}};
+    auto input_data   = std::vector<std::int64_t>{value};
+    auto weights_data = std::vector<std::int64_t>{1};
+
+    migraphx::program p;
+    auto* mm     = p.get_main_module();
+    auto input   = mm->add_literal(migraphx::literal{s, input_data});
+    auto weights = mm->add_literal(migraphx::literal{s, weights_data});
+    mm->add_instruction(migraphx::make_op("convolution_backwards"), input, weights);
+    p.compile(migraphx::make_target("ref"));
+
+    EXPECT(p.eval({}).back().at<std::int64_t>() == value);
+}
+
+TEST_CASE(convolution_backwards_uint64_accumulate)
+{
+    constexpr std::uint64_t value = 9007199254740993ULL;
+    migraphx::shape s{migraphx::shape::uint64_type, {1, 1, 1, 1}};
+    auto input_data   = std::vector<std::uint64_t>{value};
+    auto weights_data = std::vector<std::uint64_t>{1};
+
+    migraphx::program p;
+    auto* mm     = p.get_main_module();
+    auto input   = mm->add_literal(migraphx::literal{s, input_data});
+    auto weights = mm->add_literal(migraphx::literal{s, weights_data});
+    mm->add_instruction(migraphx::make_op("convolution_backwards"), input, weights);
+    p.compile(migraphx::make_target("ref"));
+
+    EXPECT(p.eval({}).back().at<std::uint64_t>() == value);
 }


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
* `convolution_backwards` was hitting accuracy errors with allclose due to reference accumulator inaccuracy. It was accumulating in the low precision types on the reference side.
* Also fixed correctness for `convolution_backwards` for invalid `groups` settings.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
* Change accumulator to use double type on reference `convolution_backwards`.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
