### PR TITLE
[AIMIGRAPHX-1279] Skip horizontal fusion if dots are dependent

### DIFF
--- a/src/fuse_horizontal.cpp
+++ b/src/fuse_horizontal.cpp
@@ -486,6 +486,12 @@ struct dot_horizontal_fusion
     std::vector<instruction_ref>
     fuse(module& m, const std::vector<instruction_ref>& dots, instruction_ref insert_pt) const
     {
+        // Skip fusion if any dot is dependent on another
+        if(any_of(dots, [&](auto x) {
+               return any_of(dots, [&](auto y) { return x != y and reaches(x, y); });
+           }))
+            return {};
+
         // Stack input `input_idx` of every dot along a new leading axis.
         auto stack = [&](std::size_t input_idx) {
             std::vector<instruction_ref> unsqueezed(dots.size());

--- a/test/fuse_horizontal_test.cpp
+++ b/test/fuse_horizontal_test.cpp
@@ -1198,6 +1198,45 @@ TEST_CASE(dot_horiz_fusion_basic)
     EXPECT(m1.sort() == m2.sort());
 }
 
+// Two dependent groups of parallel dots must remain topologically ordered after fusion.
+TEST_CASE(dot_horiz_fusion_chained_groups)
+{
+    migraphx::module m;
+    {
+        auto x0 = m.add_parameter("x0", {migraphx::shape::float_type, {2, 4}});
+        auto x1 = m.add_parameter("x1", {migraphx::shape::float_type, {2, 4}});
+        auto x2 = m.add_parameter("x2", {migraphx::shape::float_type, {2, 4}});
+        auto b0 = m.add_parameter("b0", {migraphx::shape::float_type, {2, 4}});
+        auto b1 = m.add_parameter("b1", {migraphx::shape::float_type, {2, 4}});
+        auto b2 = m.add_parameter("b2", {migraphx::shape::float_type, {2, 4}});
+        auto w00 =
+            m.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {4, 4}}, 0));
+        auto w01 =
+            m.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {4, 4}}, 1));
+        auto w02 =
+            m.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {4, 4}}, 2));
+        auto w10 =
+            m.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {4, 4}}, 3));
+        auto w11 =
+            m.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {4, 4}}, 4));
+        auto w12 =
+            m.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {4, 4}}, 5));
+        auto d00 = m.add_instruction(migraphx::make_op("dot"), x0, w00);
+        auto a0  = m.add_instruction(migraphx::make_op("add"), d00, b0);
+        auto d10 = m.add_instruction(migraphx::make_op("dot"), a0, w10);
+        auto d01 = m.add_instruction(migraphx::make_op("dot"), x1, w01);
+        auto a1  = m.add_instruction(migraphx::make_op("add"), d01, b1);
+        auto d11 = m.add_instruction(migraphx::make_op("dot"), a1, w11);
+        auto d02 = m.add_instruction(migraphx::make_op("dot"), x2, w02);
+        auto a2  = m.add_instruction(migraphx::make_op("add"), d02, b2);
+        auto d12 = m.add_instruction(migraphx::make_op("dot"), a2, w12);
+        m.add_return({d10, d11, d12});
+    }
+    run_pass(m);
+
+    EXPECT(m.validate() == m.end());
+}
+
 // Dots whose weights are not compile-time constants are not candidates.
 TEST_CASE(dot_horiz_fusion_non_constant_weight_unchanged)
 {


### PR DESCRIPTION
## Motivation
Currently, when given the following setup:
```mermaid
flowchart LR
    subgraph H0["Head 0"]
        X0["x0 [2×4]"] --> D00["dot d00"]
        W00["w00 [4×4]"] --> D00
        D00 --> A0["add b0"]
        A0 --> D10["dot d10"]
        W10["w10 [4×4]"] --> D10
    end

    subgraph H1["Head 1"]
        X1["x1 [2×4]"] --> D01["dot d01"]
        W01["w01 [4×4]"] --> D01
        D01 --> A1["add b1"]
        A1 --> D11["dot d11"]
        W11["w11 [4×4]"] --> D11
    end

    subgraph H2["Head 2"]
        X2["x2 [2×4]"] --> D02["dot d02"]
        W02["w02 [4×4]"] --> D02
        D02 --> A2["add b2"]
        A2 --> D12["dot d12"]
        W12["w12 [4×4]"] --> D12
    end

    D10 --> R["return"]
    D11 --> R
    D12 --> R
```
The order of the dots are not preserved and instead fused into one large batched dot which results in a cycle:
```mermaid
flowchart LR
    C["concat(x0, x1, a1, x2, a2)"] --> BD["Batched dot<br/>{d00,d01,d11,d02,d12}"]

    BD --> O0["d00 result"]
    BD --> O1["d01 result"]
    BD --> O11["d11 result"]
    BD --> O2["d02 result"]
    BD --> O12["d12 result"]

    O1 --> A1["a1 = add(d01,b1)"]
    A1 --> C

    O2 --> A2["a2 = add(d02,b2)"]
    A2 --> C
```
This seems to be a result of #5087, which enabled fusions for SiLU heads.

## Technical Details
Adds a guard inside `fuse_horizontal.cpp` that checks if any dot is dependent on another, and if so, skips fusing.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
