### PR TITLE
Fix MLIR benchmark fill for non-packed outputs

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -589,6 +589,7 @@ struct compile_plan
          * and prefill required by the candidate, so split-k is timed end to end.
          */
         auto bench_prog = results[i]->make_program();
+        replace_inserted_device_ops(*ctx, *bench_prog.get_main_module());
         if(trace_level > 2)
             std::cout << bench_prog << std::endl;
         const auto bundle = compute_benchmark_bundle(*bench_prog.get_main_module());

--- a/test/gpu/lower_device_ops.cpp
+++ b/test/gpu/lower_device_ops.cpp
@@ -142,6 +142,27 @@ TEST_CASE(hip_fill_kernel_runs)
     EXPECT(result == migraphx::literal{s, expected}.get_argument());
 }
 
+TEST_CASE(hip_fill_nonpacked_kernel_runs)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 2}, {3, 1}};
+    EXPECT(not s.packed());
+
+    migraphx::gpu::context ctx;
+    auto co = migraphx::gpu::compile_op("hip::fill", ctx, {s}, {{"value", 7}});
+
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    auto y   = mm->add_parameter("output", s);
+    mm->add_instruction(co, y);
+    p.finalize(migraphx::make_target("gpu"));
+
+    auto result =
+        migraphx::gpu::from_gpu(p.eval({{"output", migraphx::gpu::allocate_gpu(s)}}).front());
+
+    std::vector<float> expected(s.elements(), 7.0f);
+    EXPECT(result == migraphx::literal{s, expected}.get_argument());
+}
+
 TEST_CASE(lower_hip_fill_tuple)
 {
     migraphx::shape s{migraphx::shape::float_type, {2, 2}};


### PR DESCRIPTION
## Motivation

MLIR split-K candidates can insert `hip::fill` operations while constructing their benchmark program. Those temporary programs bypass the normal device-op lowering stage, so the raw fill executes through `gpu_fill`, which requires a packed output buffer and fails for fused convolution outputs with non-packed strides. Non-packed output strides occurs from decomposing convolution_backwards

## Technical Details

- Compile device operations inserted into each candidate benchmark program before timing it.
- Add coverage that runs the compiled `hip::fill` kernel on a non-packed buffer.

## Changelog Category

- [ ] Added: New functionality.
- [ ] Changed: Changes to existing functionality.
- [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- [ ] Optimized: Component performance that has been optimized or improved.
- [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- [x] Not Applicable: This PR is not to be included in the changelog.

## Tests

- `python3 tools/format.py origin/develop`
- clang-tidy for `compile_ops.cpp` and `lower_device_ops.cpp`
- `test_gpu_lower_device_ops 'hip_fill*_kernel_runs'`
- `test_verify 'test_convolution_backwards_2x3<migraphx::shape::float_type>'`

Followed the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html).
