### PR TITLE
Fix unsafe MLIR split boundaries

### DIFF
--- a/src/targets/gpu/jit/mlir.cpp
+++ b/src/targets/gpu/jit/mlir.cpp
@@ -132,29 +132,38 @@ compile_pointwise_module(context& ctx, const std::vector<shape>& inputs, module_
     return co;
 }
 
+static bool is_closed_split(instruction_ref output)
+{
+    std::unordered_set<instruction_ref> inputs;
+    fix<bool>([&](auto self, instruction_ref ins) -> bool {
+        if(not inputs.insert(ins).second)
+            return true;
+        return std::all_of(ins->inputs().begin(), ins->inputs().end(), self);
+    })(output);
+    return std::all_of(inputs.begin(), inputs.end(), [&](instruction_ref ins) {
+        if(ins == output or ins->name() == "@param")
+            return true;
+        return std::all_of(ins->outputs().begin(), ins->outputs().end(), [&](instruction_ref out) {
+            return contains(inputs, out);
+        });
+    });
+}
+
 instruction_ref find_final_split(instruction_ref split_ins)
 {
     auto output_path_range = get_output_path(split_ins);
     std::vector<instruction_ref> output_path(output_path_range.begin(), output_path_range.end());
     if(output_path.empty())
         MIGRAPHX_THROW("find_final_split: empty output path for instruction: " + split_ins->name());
+    if(not is_closed_split(split_ins))
+        MIGRAPHX_THROW("find_final_split: no safe split boundary for instruction: " +
+                       split_ins->name());
     instruction_ref result = split_ins;
     if(output_path.size() < 2)
         return result;
     auto it = std::adjacent_find(
         output_path.begin(), output_path.end(), [&](instruction_ref input, instruction_ref output) {
-            std::unordered_set<instruction_ref> visited;
-            const bool has_closed_inputs = fix<bool>([&](auto self, instruction_ref ins) -> bool {
-                if(not visited.insert(ins).second)
-                    return true;
-                if(ins != output and ins->name() != "@param" and
-                   std::any_of(ins->outputs().begin(),
-                               ins->outputs().end(),
-                               [&](instruction_ref out) { return not reaches(out, output); }))
-                    return false;
-                return std::all_of(ins->inputs().begin(), ins->inputs().end(), self);
-            })(output);
-            if(not has_closed_inputs)
+            if(not is_closed_split(output))
                 return true;
             if(contains({"reshape", "squeeze", "unsqueeze", "transpose"}, output->name()))
                 return false;

--- a/src/targets/gpu/jit/mlir.cpp
+++ b/src/targets/gpu/jit/mlir.cpp
@@ -24,9 +24,11 @@
 
 #include <algorithm>
 #include <iterator>
+#include <unordered_set>
 #include <vector>
 #include <migraphx/builtin.hpp>
 #include <migraphx/errors.hpp>
+#include <migraphx/functional.hpp>
 #include <migraphx/instruction_ref.hpp>
 #include <migraphx/iterator_for.hpp>
 #include <migraphx/make_op.hpp>
@@ -141,6 +143,19 @@ instruction_ref find_final_split(instruction_ref split_ins)
         return result;
     auto it = std::adjacent_find(
         output_path.begin(), output_path.end(), [&](instruction_ref input, instruction_ref output) {
+            std::unordered_set<instruction_ref> visited;
+            const bool has_closed_inputs = fix<bool>([&](auto self, instruction_ref ins) -> bool {
+                if(not visited.insert(ins).second)
+                    return true;
+                if(ins != output and ins->name() != "@param" and
+                   std::any_of(ins->outputs().begin(),
+                               ins->outputs().end(),
+                               [&](instruction_ref out) { return not reaches(out, output); }))
+                    return false;
+                return std::all_of(ins->inputs().begin(), ins->inputs().end(), self);
+            })(output);
+            if(not has_closed_inputs)
+                return true;
             if(contains({"reshape", "squeeze", "unsqueeze", "transpose"}, output->name()))
                 return false;
             if(contains({"add", "mul"}, output->name()))
@@ -245,7 +260,7 @@ struct mlir_compiler : compiler<mlir_compiler>
             input_args.pop_back();
             auto split_ins                               = find_final_split(gemm_like_ins);
             std::array<module_with_inputs, 2> mod_splits = smod->split(input_args, {split_ins});
-            auto dot_mlir_inputs = to_shapes(mod_splits[0].inputs);
+            auto dot_mlir_inputs                         = to_shapes(mod_splits[0].inputs);
             // add alloc for the gemm output
             dot_mlir_inputs.push_back(mod_splits[0].mod.get_output_shapes().front());
             mlir_code_object cop1 = compile_mlir(ctx, mod_splits[0].mod, dot_mlir_inputs, solution);

--- a/test/gpu/mlir_split_fusion.cpp
+++ b/test/gpu/mlir_split_fusion.cpp
@@ -78,6 +78,21 @@ TEST_CASE(find_final_split_with_shared_broadcast)
     EXPECT(migraphx::gpu::find_final_split(graph.dot) == graph.dot);
 }
 
+TEST_CASE(find_final_split_with_shared_gemm_input)
+{
+    migraphx::module m;
+    auto a      = m.add_parameter("a", migraphx::shape{migraphx::shape::float_type, {5, 3}});
+    auto b      = m.add_parameter("b", migraphx::shape{migraphx::shape::float_type, {1, 3, 3}});
+    auto bias   = m.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {1, 5, 3}});
+    auto shared = m.add_instruction(migraphx::make_op("reshape", {{"dims", {1, 5, 3}}}), a);
+    auto dot    = m.add_instruction(migraphx::make_op("dot"), shared, b);
+    auto add    = m.add_instruction(migraphx::make_op("add"), dot, bias);
+    auto mul    = m.add_instruction(migraphx::make_op("mul"), shared, bias);
+    m.add_return({add, mul});
+
+    EXPECT(test::throws([&] { migraphx::gpu::find_final_split(dot); }));
+}
+
 TEST_CASE(find_final_split_without_boundary)
 {
     migraphx::module m;

--- a/test/gpu/mlir_split_fusion.cpp
+++ b/test/gpu/mlir_split_fusion.cpp
@@ -63,6 +63,21 @@ TEST_CASE(find_final_split_with_multiple_outputs)
     EXPECT(migraphx::gpu::find_final_split(graph.dot) == graph.dot);
 }
 
+TEST_CASE(find_final_split_with_shared_broadcast)
+{
+    migraphx::module m;
+    auto graph     = make_dot_graph(m);
+    auto scale     = m.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {3}});
+    auto broadcast = m.add_instruction(
+        migraphx::make_op("broadcast", {{"axis", 2}, {"out_lens", {1, 5, 3}}}), scale);
+    auto add  = m.add_instruction(migraphx::make_op("add"), graph.dot, broadcast);
+    auto tanh = m.add_instruction(migraphx::make_op("tanh"), add);
+    auto mul  = m.add_instruction(migraphx::make_op("mul"), broadcast, graph.bias);
+    m.add_return({tanh, mul});
+
+    EXPECT(migraphx::gpu::find_final_split(graph.dot) == graph.dot);
+}
+
 TEST_CASE(find_final_split_without_boundary)
 {
     migraphx::module m;

--- a/test/gpu/mlir_split_fusion.cpp
+++ b/test/gpu/mlir_split_fusion.cpp
@@ -27,55 +27,50 @@
 #include <migraphx/module.hpp>
 #include <test.hpp>
 
-struct dot_graph
-{
-    migraphx::instruction_ref dot;
-    migraphx::instruction_ref bias;
-};
-
-static dot_graph make_dot_graph(migraphx::module& m)
-{
-    auto a    = m.add_parameter("a", migraphx::shape{migraphx::shape::float_type, {1, 5, 4}});
-    auto b    = m.add_parameter("b", migraphx::shape{migraphx::shape::float_type, {1, 4, 3}});
-    auto bias = m.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {1, 5, 3}});
-    return {m.add_instruction(migraphx::make_op("dot"), a, b), bias};
-}
-
 TEST_CASE(find_final_split_before_pointwise)
 {
     migraphx::module m;
-    auto graph = make_dot_graph(m);
-    auto add   = m.add_instruction(migraphx::make_op("add"), graph.dot, graph.bias);
-    auto tanh  = m.add_instruction(migraphx::make_op("tanh"), add);
+    auto a    = m.add_parameter("a", migraphx::shape{migraphx::shape::float_type, {1, 5, 4}});
+    auto b    = m.add_parameter("b", migraphx::shape{migraphx::shape::float_type, {1, 4, 3}});
+    auto bias = m.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {1, 5, 3}});
+    auto dot  = m.add_instruction(migraphx::make_op("dot"), a, b);
+    auto add  = m.add_instruction(migraphx::make_op("add"), dot, bias);
+    auto tanh = m.add_instruction(migraphx::make_op("tanh"), add);
     m.add_return({tanh});
 
-    EXPECT(migraphx::gpu::find_final_split(graph.dot) == add);
+    EXPECT(migraphx::gpu::find_final_split(dot) == add);
 }
 
 TEST_CASE(find_final_split_with_multiple_outputs)
 {
     migraphx::module m;
-    auto graph = make_dot_graph(m);
-    auto add   = m.add_instruction(migraphx::make_op("add"), graph.dot, graph.bias);
-    auto mul   = m.add_instruction(migraphx::make_op("mul"), graph.dot, graph.bias);
+    auto a    = m.add_parameter("a", migraphx::shape{migraphx::shape::float_type, {1, 5, 4}});
+    auto b    = m.add_parameter("b", migraphx::shape{migraphx::shape::float_type, {1, 4, 3}});
+    auto bias = m.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {1, 5, 3}});
+    auto dot  = m.add_instruction(migraphx::make_op("dot"), a, b);
+    auto add  = m.add_instruction(migraphx::make_op("add"), dot, bias);
+    auto mul  = m.add_instruction(migraphx::make_op("mul"), dot, bias);
     m.add_return({add, mul});
 
-    EXPECT(migraphx::gpu::find_final_split(graph.dot) == graph.dot);
+    EXPECT(migraphx::gpu::find_final_split(dot) == dot);
 }
 
 TEST_CASE(find_final_split_with_shared_broadcast)
 {
     migraphx::module m;
-    auto graph     = make_dot_graph(m);
-    auto scale     = m.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {3}});
+    auto a     = m.add_parameter("a", migraphx::shape{migraphx::shape::float_type, {1, 5, 4}});
+    auto b     = m.add_parameter("b", migraphx::shape{migraphx::shape::float_type, {1, 4, 3}});
+    auto bias  = m.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {1, 5, 3}});
+    auto dot   = m.add_instruction(migraphx::make_op("dot"), a, b);
+    auto scale = m.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {3}});
     auto broadcast = m.add_instruction(
         migraphx::make_op("broadcast", {{"axis", 2}, {"out_lens", {1, 5, 3}}}), scale);
-    auto add  = m.add_instruction(migraphx::make_op("add"), graph.dot, broadcast);
+    auto add  = m.add_instruction(migraphx::make_op("add"), dot, broadcast);
     auto tanh = m.add_instruction(migraphx::make_op("tanh"), add);
-    auto mul  = m.add_instruction(migraphx::make_op("mul"), broadcast, graph.bias);
+    auto mul  = m.add_instruction(migraphx::make_op("mul"), broadcast, bias);
     m.add_return({tanh, mul});
 
-    EXPECT(migraphx::gpu::find_final_split(graph.dot) == graph.dot);
+    EXPECT(migraphx::gpu::find_final_split(dot) == dot);
 }
 
 TEST_CASE(find_final_split_with_shared_gemm_input)
@@ -96,10 +91,12 @@ TEST_CASE(find_final_split_with_shared_gemm_input)
 TEST_CASE(find_final_split_without_boundary)
 {
     migraphx::module m;
-    auto graph   = make_dot_graph(m);
-    auto reshape = m.add_instruction(migraphx::make_op("reshape", {{"dims", {1, 15}}}), graph.dot);
+    auto a       = m.add_parameter("a", migraphx::shape{migraphx::shape::float_type, {1, 5, 4}});
+    auto b       = m.add_parameter("b", migraphx::shape{migraphx::shape::float_type, {1, 4, 3}});
+    auto dot     = m.add_instruction(migraphx::make_op("dot"), a, b);
+    auto reshape = m.add_instruction(migraphx::make_op("reshape", {{"dims", {1, 15}}}), dot);
 
-    EXPECT(migraphx::gpu::find_final_split(graph.dot) == reshape);
+    EXPECT(migraphx::gpu::find_final_split(dot) == reshape);
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation

`test_conv_bn_relu_pooling2<migraphx::shape::float_type>` intermittently failed in a debug build when rocmlirTriton tuning candidates were compiled in parallel. Failures included invalid instruction back-reference assertions, foreign-output assertions, and heap double-free corruption.

The optimized batch-normalization graph contained shared broadcast values:

```text
@10 = mul(@7, @6)       // @6 is convolution
@11 = mul(@8, @10)      // old split point
@12 = mul(@7, x4)
@13 = mul(@8, @12)
@14 = add(@13, @11)
```

The old `find_final_split()` selected `@11`. Its prefix therefore contained `@7` and `@8` as ancestors, while the suffix still needed both values through `@12` and `@13`. Only `@11` was supplied to `module::split()` as a boundary output, so the copied suffix retained direct references to the original module's `@7` and `@8` instructions.

Each tuning candidate had separate temporary split modules, but those foreign references caused their construction and destruction to update the same source instructions' `outputs()` vectors. Concurrent candidate compilation therefore corrupted the shared back-reference bookkeeping. rocmlirTriton's larger candidate set made this latent race reproduce frequently.

## Technical Details

Before accepting a split boundary, `find_final_split()` now collects the proposed output and all of its ancestors. Every non-parameter ancestor must have all direct consumers within that set. This direct membership check avoids the previous nested reachability searches while identifying values that would escape the prefix.

The initial GEMM/convolution boundary is validated as well. If even that boundary has a shared derived input, there is no safe single-output split supported by this path, so that tuning candidate fails cleanly and is skipped instead of constructing modules with foreign references.

For the motivating graph, the split remains at convolution `@6`, so `@7`, `@8`, and all dependent pointwise operations remain together in the suffix. This avoids both foreign instruction references and the need for additional prefix live-outs.

Focused regression tests cover:

- A derived broadcast shared by the proposed prefix and suffix.
- A shared derived GEMM input where no safe split boundary exists.

## Testing

- `clang-format --dry-run --Werror` on both changed files
- `cmake --build build-debug --target tidy -j 384`
- `cmake --build build-debug --target test_gpu_mlir_split_fusion test_verify -j 384`
- `./build-debug/bin/test_gpu_mlir_split_fusion`
- `./build-debug/bin/test_verify 'test_conv_bn_relu_pooling2<migraphx::shape::float_type>'`
- Final revision passed 3 consecutive rocmlirTriton regression runs at full default compilation parallelism

## Changelog Category

- [ ] Added: New functionality.
- [ ] Changed: Changes to existing functionality.
- [ ] Removed: Functionality or support that has been removed.
- [ ] Optimized: Component performance that has been optimized or improved.
- [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- [x] Not Applicable: This PR is not to be included in the changelog.

Assisted-by: Cursor