### PR TITLE
Marshall exception in simple_par_for

### DIFF
--- a/src/include/migraphx/simple_par_for.hpp
+++ b/src/include/migraphx/simple_par_for.hpp
@@ -27,6 +27,8 @@
 #include <thread>
 #include <cmath>
 #include <algorithm>
+#include <exception>
+#include <mutex>
 #include <vector>
 #include <cassert>
 
@@ -62,15 +64,37 @@ auto thread_invoke(std::size_t i, std::size_t, F f) -> decltype(f(i))
     f(i);
 }
 
+// Runs f over [start, last), capturing the first exception thrown
 template <class F>
-void simple_par_for_impl(std::size_t n, std::size_t threadsize, F f)
+void thread_invoke_range(std::size_t start,
+                         std::size_t last,
+                         std::size_t tid,
+                         F f,
+                         std::exception_ptr& eptr,
+                         std::mutex& eptr_mutex)
 {
-    if(threadsize <= 1)
+    try
     {
-        for(std::size_t i = 0; i < n; i++)
-            thread_invoke(i, 0, f);
+        for(std::size_t i = start; i < last; i++)
+        {
+            thread_invoke(i, tid, f);
+        }
     }
-    else
+    catch(...)
+    {
+        std::lock_guard<std::mutex> lock(eptr_mutex);
+        if(eptr == nullptr)
+            eptr = std::current_exception();
+    }
+}
+
+// Runs f over [0, n) on the given number of threads. An exception thrown on a
+// worker thread is captured and returned after all threads are joined.
+template <class F>
+std::exception_ptr simple_par_for_threads(std::size_t n, std::size_t threadsize, F f)
+{
+    std::exception_ptr eptr;
+    std::mutex eptr_mutex;
     {
         std::vector<joinable_thread> threads(threadsize);
 // Using const here causes gcc 5 to ICE
@@ -81,20 +105,32 @@ void simple_par_for_impl(std::size_t n, std::size_t threadsize, F f)
 
         std::size_t work = 0;
         std::size_t tid  = 0;
-        std::generate(threads.begin(), threads.end(), [=, &work, &tid] {
-            auto result = joinable_thread([=] {
-                std::size_t start = work;
-                std::size_t last  = std::min(n, work + grainsize);
-                for(std::size_t i = start; i < last; i++)
-                {
-                    thread_invoke(i, tid, f);
-                }
+        std::generate(threads.begin(), threads.end(), [=, &work, &tid, &eptr, &eptr_mutex] {
+            auto result = joinable_thread([=, &eptr, &eptr_mutex] {
+                thread_invoke_range(work, std::min(n, work + grainsize), tid, f, eptr, eptr_mutex);
             });
             work += grainsize;
             ++tid;
             return result;
         });
         assert(work >= n);
+    }
+    return eptr;
+}
+
+template <class F>
+void simple_par_for_impl(std::size_t n, std::size_t threadsize, F f)
+{
+    if(threadsize <= 1)
+    {
+        for(std::size_t i = 0; i < n; i++)
+            thread_invoke(i, 0, f);
+    }
+    else
+    {
+        auto eptr = simple_par_for_threads(n, threadsize, f);
+        if(eptr)
+            std::rethrow_exception(eptr);
     }
 }
 

--- a/test/simple_par_for.cpp
+++ b/test/simple_par_for.cpp
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/par_for.hpp>
+#include <migraphx/errors.hpp>
+#include <algorithm>
+#include <atomic>
+#include <vector>
+
+#include <test.hpp>
+
+TEST_CASE(par_for_runs_all)
+{
+    std::vector<int> data(64, 0);
+    migraphx::par_for(data.size(), 1, [&](std::size_t i) { data[i] = 1; });
+    EXPECT(std::all_of(data.begin(), data.end(), [](int x) { return x == 1; }));
+}
+
+TEST_CASE(par_for_exception_propagates)
+{
+    EXPECT(test::throws<migraphx::exception>(
+        [] {
+            migraphx::par_for(64, 1, [](std::size_t i) {
+                if(i % 2 == 0)
+                    MIGRAPHX_THROW("par_for_error");
+            });
+        },
+        "par_for_error"));
+}
+
+TEST_CASE(par_for_exception_propagates_serial)
+{
+    EXPECT(test::throws<migraphx::exception>(
+        [] {
+            migraphx::par_for(4, 100, [](std::size_t i) {
+                if(i == 2)
+                    MIGRAPHX_THROW("par_for_error");
+            });
+        },
+        "par_for_error"));
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
## Motivation
This will help improve error reporting. When an exception is thrown with multiple threads, `std::terminate` is called without the exception message. So this will marshall the exception through so we can get a better error message.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
