### PR TITLE
Symbolic and dynamic shape Cpp & Python printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Full documentation for MIGraphX is available at
 
 ### Added
 
-* Added `migraphx::shape::from_json` and the matching `migraphx.shape.from_json` Python binding, which rebuild a shape from the json form of its value representation, preserving the symbolic dimension expressions, bounds, and optimals that no constructor argument can spell.
+* Added `migraphx::shape::from_json` and the matching `migraphx.shape.from_json` Python binding, which rebuild a shape from the json form of its value representation, preserving the symbolic dimension expressions, bounds, and optimals that no constructor argument can spell (#5205).
 * Added `ArrayFeatureExtractor` ONNX operator support (#4742).
 * Added support for building against ROCm 7.13 and newer using TheRock (#4952)
 * Added YOLO26 object detection example notebook.
@@ -92,7 +92,7 @@ Full documentation for MIGraphX is available at
 * Fixed a GPU compile failure with `redefinition of parameter` when a pointwise fused into a reduce consumed the same tensor at more than one operand slot, which could happen with `--fp16` on models that slice a shared tensor into multiple branches (#5130).
 * Fixed validation to report a clear error when splitting `gpu::mlir_op` produces a pointwise module containing unsupported non-pointwise instructions.
 * Fixed a parse failure in `Softplus` and `Softsign` when an input has a dynamic shape (#5136).
-* Fixed the `--py` and `--cpp` program printers throwing `SHAPE: lens() called on a dynamic shape` for any program holding a dynamic shape. A range-based dynamic dimension is now printed as its bounds, and a symbolic one is printed as the json form of its value representation via the new `migraphx::shape::from_json` and `migraphx.shape.from_json`, so the generated code rebuilds the symbolic expression, its bounds and optimals, and any symbolic strides exactly.
+* Fixed the `--py` and `--cpp` program printers throwing `SHAPE: lens() called on a dynamic shape` for any program holding a dynamic shape. A range-based dynamic dimension is now printed as its bounds, and a symbolic one is printed as the json form of its value representation via the new `migraphx::shape::from_json` and `migraphx.shape.from_json`, so the generated code rebuilds the symbolic expression, its bounds and optimals, and any symbolic strides exactly (#5205).
 
 ### Optimized
 * Optimized flash decoding recombination in `fuse_attention` to use the exp-normalize form (#5090).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Full documentation for MIGraphX is available at
 * Fixed a GPU compile failure with `redefinition of parameter` when a pointwise fused into a reduce consumed the same tensor at more than one operand slot, which could happen with `--fp16` on models that slice a shared tensor into multiple branches (#5130).
 * Fixed validation to report a clear error when splitting `gpu::mlir_op` produces a pointwise module containing unsupported non-pointwise instructions.
 * Fixed a parse failure in `Softplus` and `Softsign` when an input has a dynamic shape (#5136).
+* Fixed the `--py` and `--cpp` program printers throwing `SHAPE: lens() called on a dynamic shape` for any program holding a dynamic shape. A range-based dynamic dimension is now printed as its bounds, and a symbolic one is printed as the json form of its value representation via the new `migraphx::make_json_shape` and `migraphx.shape.from_json`, so the generated code rebuilds the symbolic expression, its bounds and optimals, and any symbolic strides exactly.
 
 ### Optimized
 * Optimized flash decoding recombination in `fuse_attention` to use the exp-normalize form (#5090).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ Full documentation for MIGraphX is available at
 * Fixed a GPU compile failure with `redefinition of parameter` when a pointwise fused into a reduce consumed the same tensor at more than one operand slot, which could happen with `--fp16` on models that slice a shared tensor into multiple branches (#5130).
 * Fixed validation to report a clear error when splitting `gpu::mlir_op` produces a pointwise module containing unsupported non-pointwise instructions.
 * Fixed a parse failure in `Softplus` and `Softsign` when an input has a dynamic shape (#5136).
-* Fixed the `--py` and `--cpp` program printers throwing `SHAPE: lens() called on a dynamic shape` for any program holding a dynamic shape. A range-based dynamic dimension is now printed as its bounds, and a symbolic one is printed as the json form of its value representation via the new `migraphx::make_json_shape` and `migraphx.shape.from_json`, so the generated code rebuilds the symbolic expression, its bounds and optimals, and any symbolic strides exactly.
+* Fixed the `--py` and `--cpp` program printers throwing `SHAPE: lens() called on a dynamic shape` for any program holding a dynamic shape. A range-based dynamic dimension is now printed as its bounds, and a symbolic one is printed as the json form of its value representation via the new `migraphx::shape::from_json` and `migraphx.shape.from_json`, so the generated code rebuilds the symbolic expression, its bounds and optimals, and any symbolic strides exactly.
 
 ### Optimized
 * Optimized flash decoding recombination in `fuse_attention` to use the exp-normalize form (#5090).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Full documentation for MIGraphX is available at
 
 ### Added
 
+* Added `migraphx::shape::from_json` and the matching `migraphx.shape.from_json` Python binding, which rebuild a shape from the json form of its value representation, preserving the symbolic dimension expressions, bounds, and optimals that no constructor argument can spell.
 * Added `ArrayFeatureExtractor` ONNX operator support (#4742).
 * Added support for building against ROCm 7.13 and newer using TheRock (#4952)
 * Added YOLO26 object detection example notebook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ Full documentation for MIGraphX is available at
 
 ### Added
 
-* Added `migraphx::shape::from_json` and the matching `migraphx.shape.from_json` Python binding, which rebuild a shape from the json form of its value representation, preserving the symbolic dimension expressions, bounds, and optimals that no constructor argument can spell (#5205).
+* Added symbolic shapes to the Python API: dimensions as expression strings with a `symbols` table and optional `dyn_strides`, plus `shape.dyn_strides()`, `shape.symbolic()`, `shape.symbol_table()` and `dynamic_dimension.expression` (#5205).
+* Added `migraphx::shape::make_symbolic_shape` and `migraphx::shape::symbol_table` for building and reading symbolic shapes (#5205).
+* Added `migraphx_shape_create_symbolic` and the `migraphx_symbol_table` handle to the C API, with a matching `migraphx::shape` constructor in `migraphx.hpp` (#5205).
+* Added `migraphx::sym::find_variable_bounds` and an overload of `migraphx::sym::var` taking a list of intervals (#5205).
 * Added `ArrayFeatureExtractor` ONNX operator support (#4742).
 * Added support for building against ROCm 7.13 and newer using TheRock (#4952)
 * Added YOLO26 object detection example notebook.
@@ -49,6 +52,7 @@ Full documentation for MIGraphX is available at
 
 ### Changed
 
+* Symbol names in symbolic shapes must now be valid identifiers; names taken from an ONNX model are rewritten to fit, so an input named `0` yields `_0_d0` and a `dim_param` of `batch.size` yields `batch_size` (#5205).
 * Converted `nonzero` operator from device implementation to JIT compilation (#4720).
 * Converted `prefix_scan_sum` operator from device implementation to JIT compilation (#4720).
 * Converted `reverse` operator from device implementation to JIT compilation (#4645).
@@ -70,6 +74,7 @@ Full documentation for MIGraphX is available at
 
 ### Resolved issues
 
+* Fixed `migraphx::sym::expr::to_string` rounding double literals to six significant digits, so they could not be parsed back (#5205).
 * Fixed the reference `nonzero` operator to handle non-standard input layouts such as transposed or broadcasted tensors.
 * Restored support for the documented flat {min,max,optimals} JSON format in migraphx-driver's --default-dyn-dim and --dyn-input-dim flags (#4926).
 * Fixed ONNX `Where` parsing for dynamic-shape inputs that require broadcasting (including mixed static and dynamic inputs), which previously threw `same_dims: where: Dimensions do not match` (#4925).
@@ -92,7 +97,7 @@ Full documentation for MIGraphX is available at
 * Fixed a GPU compile failure with `redefinition of parameter` when a pointwise fused into a reduce consumed the same tensor at more than one operand slot, which could happen with `--fp16` on models that slice a shared tensor into multiple branches (#5130).
 * Fixed validation to report a clear error when splitting `gpu::mlir_op` produces a pointwise module containing unsupported non-pointwise instructions.
 * Fixed a parse failure in `Softplus` and `Softsign` when an input has a dynamic shape (#5136).
-* Fixed the `--py` and `--cpp` program printers throwing `SHAPE: lens() called on a dynamic shape` for any program holding a dynamic shape. A range-based dynamic dimension is now printed as its bounds, and a symbolic one is printed as the json form of its value representation via the new `migraphx::shape::from_json` and `migraphx.shape.from_json`, so the generated code rebuilds the symbolic expression, its bounds and optimals, and any symbolic strides exactly (#5205).
+* Fixed the `--py` and `--cpp` program printers throwing `SHAPE: lens() called on a dynamic shape` for any program holding a dynamic shape (#5205).
 
 ### Optimized
 * Optimized flash decoding recombination in `fuse_attention` to use the exp-normalize form (#5090).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ Full documentation for MIGraphX is available at
 
 ### Added
 
-* Added symbolic shapes to the Python API: dimensions as expression strings with a `symbols` table and optional `dyn_strides`, plus `shape.dyn_strides()`, `shape.symbolic()`, `shape.symbol_table()` and `dynamic_dimension.expression` (#5205).
-* Added `migraphx::shape::make_symbolic_shape` and `migraphx::shape::symbol_table` for building and reading symbolic shapes (#5205).
-* Added `migraphx_shape_create_symbolic` and the `migraphx_symbol_table` handle to the C API, with a matching `migraphx::shape` constructor in `migraphx.hpp` (#5205).
-* Added `migraphx::sym::find_variable_bounds` and an overload of `migraphx::sym::var` taking a list of intervals (#5205).
+* Added symbolic shapes to the Python API: dimensions as self-contained expression strings with optional `dyn_strides`, plus `shape.dyn_strides()`, `shape.symbolic()` and `dynamic_dimension.expression` (#5205).
+* Added `migraphx::shape::make_symbolic_shape` and `migraphx_shape_create_symbolic` for building symbolic shapes from self-contained dimension and stride expressions, with a matching `migraphx::shape` constructor in `migraphx.hpp` (#5205).
+* Added constraints and optimals to the symbolic variable text format, plus an overload of `migraphx::sym::var` taking a list of intervals (#5205).
 * Added `ArrayFeatureExtractor` ONNX operator support (#4742).
 * Added support for building against ROCm 7.13 and newer using TheRock (#4952)
 * Added YOLO26 object detection example notebook.

--- a/docs/reference/MIGraphX-py.rst
+++ b/docs/reference/MIGraphX-py.rst
@@ -101,15 +101,27 @@ shape
 
     :rtype: bool
 
-.. py:staticmethod:: from_json(s)
+.. py:method:: symbolic()
 
-    Rebuilds a shape from the json form of its value representation, which is the spelling
-    :py:meth:`program.to_py` emits for a shape carrying a symbolic dimension. Unlike the
-    constructor this preserves symbolic dimension expressions, their bounds and optimals, and
-    symbolic strides.
+    Returns true if every dimension of the shape is symbolic.
 
-    :param str s: The json form of a shape's value representation.
-    :rtype: shape
+    :rtype: bool
+
+.. py:method:: dyn_strides()
+
+    The symbolic strides of the shape, as expression strings. Empty unless
+    :py:meth:`shape.symbolic` is true.
+
+    :rtype: list[str]
+
+.. py:method:: symbol_table()
+
+    The bounds each symbol of the shape stands for, in the form the ``symbols`` argument takes,
+    so a symbolic shape can be rebuilt from what can be read of it. Empty for a range-based or
+    static shape. A symbol always maps to a list here, even where the constructor also accepts a
+    bare :py:class:`dynamic_dimension`.
+
+    :rtype: dict[str, list[dynamic_dimension]]
 
 dynamic_dimension
 -----------------
@@ -118,11 +130,83 @@ dynamic_dimension
 
     Constructs a `dynamic_dimension` from a minimum, a maximum, and optionally a set of optimals.
 
+.. py:class:: dynamic_dimension(expression, symbols)
+    :no-index:
+
+    Constructs a symbolic `dynamic_dimension` by parsing an expression string and binding each
+    named symbol to the bounds and optimals of a range `dynamic_dimension`.
+
+    :param str expression: The expression to parse, such as ``"n * 3 + 1"``.
+    :param dict[str, dynamic_dimension] symbols: The bounds to bind each name to.
+
 .. py:method:: is_fixed()
     
     Returns true if the `dynamic_dimension` is fixed.
 
     :rtype : int
+
+.. py:method:: is_symbolic()
+
+    Returns true if the `dynamic_dimension` carries a symbolic expression.
+
+    :rtype: bool
+
+.. py:attribute:: min
+
+    The smallest size the dimension can take.
+
+.. py:attribute:: max
+
+    The largest size the dimension can take.
+
+.. py:attribute:: optimals
+
+    The set of sizes to optimize the dimension for.
+
+.. py:attribute:: expression
+
+    The expression giving the size of the dimension, or ``None`` when the dimension is
+    range-based.
+
+symbolic shapes
+---------------
+
+A dynamic dimension can be a symbolic expression rather than a plain range. Expressions are
+written as strings and the symbols they name are given bounds through a ``symbols`` table, which
+is also the spelling :py:meth:`program.to_py` emits::
+
+    s = migraphx.shape(type="float_type",
+                       dyn_dims=["n", "3"],
+                       symbols={"n": migraphx.shape.dynamic_dimension(1, 8, {2, 4})})
+
+A symbol name has to be a valid identifier, that is a letter or an underscore followed by
+letters, digits or underscores, because the expression has to survive being parsed back. Names
+taken from an ONNX model are rewritten to fit, so an input named ``0`` yields the symbol
+``_0_d0`` and a ``dim_param`` of ``batch.size`` yields ``batch_size``.
+
+Give a list of bounds when a symbol asserts more than one interval, which is what adding two
+differently bounded uses of the same name produces::
+
+    symbols={"n": [migraphx.shape.dynamic_dimension(1, 20),
+                   migraphx.shape.dynamic_dimension(2, 10, {4})]}
+
+Pass ``dyn_strides`` for a transposed or broadcasted layout; without it an all-symbolic shape is
+given packed standard strides. Stride expressions resolve through the same ``symbols`` table, so
+they share the dimensions' symbols::
+
+    s = migraphx.shape(type="float_type",
+                       dyn_dims=["n", "3"],
+                       dyn_strides=["1", "n"],
+                       symbols={"n": migraphx.shape.dynamic_dimension(1, 8)})
+
+A shape that mixes symbolic and range-based dimensions is built dimension by dimension instead,
+with :py:class:`dynamic_dimension` taking the expression and its symbols directly.
+
+:py:meth:`shape.symbol_table` is the inverse of the ``symbols`` argument, so a symbolic shape
+round trips through its own API::
+
+    migraphx.shape(type="float_type", dyn_dims=["n", "3"], symbols=s.symbol_table()) == s
+
 
 argument
 --------

--- a/docs/reference/MIGraphX-py.rst
+++ b/docs/reference/MIGraphX-py.rst
@@ -101,6 +101,16 @@ shape
 
     :rtype: bool
 
+.. py:staticmethod:: from_json(s)
+
+    Rebuilds a shape from the json form of its value representation, which is the spelling
+    :py:meth:`program.to_py` emits for a shape carrying a symbolic dimension. Unlike the
+    constructor this preserves symbolic dimension expressions, their bounds and optimals, and
+    symbolic strides.
+
+    :param str s: The json form of a shape's value representation.
+    :rtype: shape
+
 dynamic_dimension
 -----------------
 

--- a/docs/reference/MIGraphX-py.rst
+++ b/docs/reference/MIGraphX-py.rst
@@ -114,15 +114,6 @@ shape
 
     :rtype: list[str]
 
-.. py:method:: symbol_table()
-
-    The bounds each symbol of the shape stands for, in the form the ``symbols`` argument takes,
-    so a symbolic shape can be rebuilt from what can be read of it. Empty for a range-based or
-    static shape. A symbol always maps to a list here, even where the constructor also accepts a
-    bare :py:class:`dynamic_dimension`.
-
-    :rtype: dict[str, list[dynamic_dimension]]
-
 dynamic_dimension
 -----------------
 
@@ -130,13 +121,15 @@ dynamic_dimension
 
     Constructs a `dynamic_dimension` from a minimum, a maximum, and optionally a set of optimals.
 
-.. py:class:: dynamic_dimension(expression, symbols)
+.. py:class:: dynamic_dimension(expression, symbols={})
     :no-index:
 
-    Constructs a symbolic `dynamic_dimension` by parsing an expression string and binding each
-    named symbol to the bounds and optimals of a range `dynamic_dimension`.
+    Constructs a symbolic `dynamic_dimension` by parsing an expression string. Constraints and
+    optimals can be written directly on each variable. The optional ``symbols`` map can still bind
+    bounds to bare variable names.
 
-    :param str expression: The expression to parse, such as ``"n * 3 + 1"``.
+    :param str expression: The expression to parse, such as
+                          ``"n(constraints={[1..8]}) * 3 + 1"``.
     :param dict[str, dynamic_dimension] symbols: The bounds to bind each name to.
 
 .. py:method:: is_fixed()
@@ -172,46 +165,31 @@ symbolic shapes
 ---------------
 
 A dynamic dimension can be a symbolic expression rather than a plain range. Expressions are
-written as strings and the symbols they name are given bounds through a ``symbols`` table, which
-is also the spelling :py:meth:`program.to_py` emits::
+written as strings, with each variable carrying its constraints and optimals inline. This is also
+the spelling :py:meth:`program.to_py` emits::
 
     s = migraphx.shape(type="float_type",
-                       dyn_dims=["n", "3"],
-                       symbols={"n": migraphx.shape.dynamic_dimension(1, 8, {2, 4})})
+                       dyn_dims=["n(constraints={[1..8]}, optimals={2, 4})", "3"])
 
 A symbol name has to be a valid identifier, that is a letter or an underscore followed by
 letters, digits or underscores, because the expression has to survive being parsed back. Names
 taken from an ONNX model are rewritten to fit, so an input named ``0`` yields the symbol
 ``_0_d0`` and a ``dim_param`` of ``batch.size`` yields ``batch_size``.
 
-Give a list of bounds when a symbol asserts more than one interval, which is what adding two
-differently bounded uses of the same name produces::
+List each interval in ``constraints`` when a symbol asserts more than one, which is what adding
+two differently bounded uses of the same name produces::
 
-    symbols={"n": [migraphx.shape.dynamic_dimension(1, 20),
-                   migraphx.shape.dynamic_dimension(2, 10, {4})]}
+    "n(constraints={[1..20], [2..10]}, optimals={4})"
 
 Pass ``dyn_strides`` for a transposed or broadcasted layout; without it an all-symbolic shape is
-given packed standard strides. Stride expressions resolve through the same ``symbols`` table, so
-they share the dimensions' symbols::
+given packed standard strides. Each stride is also a self-contained symbolic expression::
 
     s = migraphx.shape(type="float_type",
-                       dyn_dims=["n", "3"],
-                       dyn_strides=["1", "n"],
-                       symbols={"n": migraphx.shape.dynamic_dimension(1, 8)})
+                       dyn_dims=["n(constraints={[1..8]})", "3"],
+                       dyn_strides=["1", "n(constraints={[1..8]})"])
 
 A shape that mixes symbolic and range-based dimensions is built dimension by dimension instead,
-with :py:class:`dynamic_dimension` taking the expression and its symbols directly.
-
-:py:meth:`shape.symbol_table` is the inverse of the ``symbols`` argument, so a symbolic shape
-round trips through its own API::
-
-    s = migraphx.shape(type="float_type",
-                       dyn_dims=["n", "3"],
-                       symbols={"n": migraphx.shape.dynamic_dimension(1, 8, {2, 4})})
-    migraphx.shape(type="float_type", dyn_dims=["n", "3"], symbols=s.symbol_table()) == s
-
-A shape carrying explicit strides needs ``dyn_strides=s.dyn_strides()`` as well, since rebuilding
-without them gives packed standard strides.
+with :py:class:`dynamic_dimension` taking the self-contained expression directly.
 
 
 argument

--- a/docs/reference/MIGraphX-py.rst
+++ b/docs/reference/MIGraphX-py.rst
@@ -205,7 +205,13 @@ with :py:class:`dynamic_dimension` taking the expression and its symbols directl
 :py:meth:`shape.symbol_table` is the inverse of the ``symbols`` argument, so a symbolic shape
 round trips through its own API::
 
+    s = migraphx.shape(type="float_type",
+                       dyn_dims=["n", "3"],
+                       symbols={"n": migraphx.shape.dynamic_dimension(1, 8, {2, 4})})
     migraphx.shape(type="float_type", dyn_dims=["n", "3"], symbols=s.symbol_table()) == s
+
+A shape carrying explicit strides needs ``dyn_strides=s.dyn_strides()`` as well, since rebuilding
+without them gives packed standard strides.
 
 
 argument

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -220,6 +220,24 @@ static shape::dynamic_dimension make_symbolic_dynamic_dimension(
     return shape::make_symbolic_dynamic_dimension(expression, symbols);
 }
 
+// Build a symbolic shape from expression strings. The expressions arrive as C arrays rather than
+// through a handle, because std::vector<std::string> is already claimed by
+// migraphx_quantize_op_names and registering it twice would silently rebind that handle's
+// parameters.
+static shape
+create_symbolic_shape(shape::type_t t,
+                      const char* const* dims,
+                      std::size_t ndims,
+                      const char* const* strides,
+                      std::size_t nstrides,
+                      const std::map<std::string, std::vector<shape::dynamic_dimension>>& symbols)
+{
+    return shape::make_symbolic_shape(t,
+                                      std::vector<std::string>(dims, dims + ndims),
+                                      std::vector<std::string>(strides, strides + nstrides),
+                                      symbols);
+}
+
 #ifdef MIGRAPHX_ENABLE_ONNX
 
 static void set_default_dim_value(onnx_options& options, size_t value)
@@ -609,6 +627,17 @@ struct migraphx_symbol_bounds
     {
     }
     std::unordered_map<std::string, migraphx::shape::dynamic_dimension> object;
+};
+
+extern "C" struct migraphx_symbol_table;
+struct migraphx_symbol_table
+{
+    template <class... Ts>
+    migraphx_symbol_table(Ts&&... xs)
+        : object(std::forward<Ts>(xs)...) // NOLINT(readability-redundant-member-init)
+    {
+    }
+    std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>> object;
 };
 
 extern "C" struct migraphx_dynamic_dimension;
@@ -1041,6 +1070,42 @@ extern "C" migraphx_status migraphx_symbol_bounds_add(migraphx_symbol_bounds_t s
     return api_error_result;
 }
 
+extern "C" migraphx_status migraphx_symbol_table_destroy(migraphx_symbol_table_t symbol_table)
+{
+    auto api_error_result = migraphx::try_([&] { destroy((symbol_table)); });
+    return api_error_result;
+}
+
+extern "C" migraphx_status migraphx_symbol_table_assign_to(migraphx_symbol_table_t output,
+                                                           const_migraphx_symbol_table_t input)
+{
+    auto api_error_result = migraphx::try_([&] { *output = *input; });
+    return api_error_result;
+}
+
+extern "C" migraphx_status migraphx_symbol_table_create(migraphx_symbol_table_t* symbol_table)
+{
+    auto api_error_result = migraphx::try_([&] {
+        *symbol_table = object_cast<migraphx_symbol_table_t>(
+            allocate<std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>>>());
+    });
+    return api_error_result;
+}
+
+extern "C" migraphx_status migraphx_symbol_table_add(migraphx_symbol_table_t symbol_table,
+                                                     const char* name,
+                                                     const_migraphx_dynamic_dimensions_t bounds)
+{
+    auto api_error_result = migraphx::try_([&] {
+        if(symbol_table == nullptr)
+            MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter symbol_table: Null pointer");
+        if(bounds == nullptr)
+            MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter bounds: Null pointer");
+        (symbol_table->object)[(name)] = (bounds->object);
+    });
+    return api_error_result;
+}
+
 extern "C" migraphx_status
 migraphx_dynamic_dimension_destroy(migraphx_dynamic_dimension_t dynamic_dimension)
 {
@@ -1259,6 +1324,28 @@ extern "C" migraphx_status migraphx_shape_create_dynamic(migraphx_shape_t* shape
             MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter dims: Null pointer");
         *shape = object_cast<migraphx_shape_t>(
             allocate<migraphx::shape>((migraphx::to_shape_type(type)), (dims->object)));
+    });
+    return api_error_result;
+}
+
+extern "C" migraphx_status migraphx_shape_create_symbolic(migraphx_shape_t* shape,
+                                                          migraphx_shape_datatype_t type,
+                                                          const char* const* dims,
+                                                          size_t ndims,
+                                                          const char* const* strides,
+                                                          size_t nstrides,
+                                                          const_migraphx_symbol_table_t symbols)
+{
+    auto api_error_result = migraphx::try_([&] {
+        if(symbols == nullptr)
+            MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter symbols: Null pointer");
+        *shape = object_cast<migraphx_shape_t>(allocate<migraphx::shape>(
+            migraphx::create_symbolic_shape((migraphx::to_shape_type(type)),
+                                            (dims),
+                                            (ndims),
+                                            (strides),
+                                            (nstrides),
+                                            (symbols->object))));
     });
     return api_error_result;
 }

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -220,22 +220,32 @@ static shape::dynamic_dimension make_symbolic_dynamic_dimension(
     return shape::make_symbolic_dynamic_dimension(expression, symbols);
 }
 
-// Build a symbolic shape from expression strings. The expressions arrive as C arrays rather than
-// through a handle, because std::vector<std::string> is already claimed by
+// Build a symbolic shape from self-contained expression strings. The expressions arrive as C
+// arrays rather than through a handle, because std::vector<std::string> is already claimed by
 // migraphx_quantize_op_names and registering it twice would silently rebind that handle's
 // parameters.
-static shape
-create_symbolic_shape(shape::type_t t,
-                      const char* const* dims,
-                      std::size_t ndims,
-                      const char* const* strides,
-                      std::size_t nstrides,
-                      const std::map<std::string, std::vector<shape::dynamic_dimension>>& symbols)
+static std::vector<std::string>
+make_expression_strings(const char* const* expressions, std::size_t size, const std::string& name)
+{
+    if(size == 0)
+        return {};
+    if(expressions == nullptr or
+       std::any_of(expressions, expressions + size, [](const char* expression) {
+           return expression == nullptr;
+       }))
+        MIGRAPHX_THROW("CREATE_SYMBOLIC_SHAPE: Null " + name + " expression");
+    return {expressions, expressions + size};
+}
+
+static shape create_symbolic_shape(shape::type_t t,
+                                   const char* const* dims,
+                                   std::size_t ndims,
+                                   const char* const* strides,
+                                   std::size_t nstrides)
 {
     return shape::make_symbolic_shape(t,
-                                      std::vector<std::string>(dims, dims + ndims),
-                                      std::vector<std::string>(strides, strides + nstrides),
-                                      symbols);
+                                      make_expression_strings(dims, ndims, "dimension"),
+                                      make_expression_strings(strides, nstrides, "stride"));
 }
 
 #ifdef MIGRAPHX_ENABLE_ONNX
@@ -627,17 +637,6 @@ struct migraphx_symbol_bounds
     {
     }
     std::unordered_map<std::string, migraphx::shape::dynamic_dimension> object;
-};
-
-extern "C" struct migraphx_symbol_table;
-struct migraphx_symbol_table
-{
-    template <class... Ts>
-    migraphx_symbol_table(Ts&&... xs)
-        : object(std::forward<Ts>(xs)...) // NOLINT(readability-redundant-member-init)
-    {
-    }
-    std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>> object;
 };
 
 extern "C" struct migraphx_dynamic_dimension;
@@ -1070,42 +1069,6 @@ extern "C" migraphx_status migraphx_symbol_bounds_add(migraphx_symbol_bounds_t s
     return api_error_result;
 }
 
-extern "C" migraphx_status migraphx_symbol_table_destroy(migraphx_symbol_table_t symbol_table)
-{
-    auto api_error_result = migraphx::try_([&] { destroy((symbol_table)); });
-    return api_error_result;
-}
-
-extern "C" migraphx_status migraphx_symbol_table_assign_to(migraphx_symbol_table_t output,
-                                                           const_migraphx_symbol_table_t input)
-{
-    auto api_error_result = migraphx::try_([&] { *output = *input; });
-    return api_error_result;
-}
-
-extern "C" migraphx_status migraphx_symbol_table_create(migraphx_symbol_table_t* symbol_table)
-{
-    auto api_error_result = migraphx::try_([&] {
-        *symbol_table = object_cast<migraphx_symbol_table_t>(
-            allocate<std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>>>());
-    });
-    return api_error_result;
-}
-
-extern "C" migraphx_status migraphx_symbol_table_add(migraphx_symbol_table_t symbol_table,
-                                                     const char* name,
-                                                     const_migraphx_dynamic_dimensions_t bounds)
-{
-    auto api_error_result = migraphx::try_([&] {
-        if(symbol_table == nullptr)
-            MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter symbol_table: Null pointer");
-        if(bounds == nullptr)
-            MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter bounds: Null pointer");
-        (symbol_table->object)[(name)] = (bounds->object);
-    });
-    return api_error_result;
-}
-
 extern "C" migraphx_status
 migraphx_dynamic_dimension_destroy(migraphx_dynamic_dimension_t dynamic_dimension)
 {
@@ -1333,19 +1296,12 @@ extern "C" migraphx_status migraphx_shape_create_symbolic(migraphx_shape_t* shap
                                                           const char* const* dims,
                                                           size_t ndims,
                                                           const char* const* strides,
-                                                          size_t nstrides,
-                                                          const_migraphx_symbol_table_t symbols)
+                                                          size_t nstrides)
 {
     auto api_error_result = migraphx::try_([&] {
-        if(symbols == nullptr)
-            MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter symbols: Null pointer");
-        *shape = object_cast<migraphx_shape_t>(allocate<migraphx::shape>(
-            migraphx::create_symbolic_shape((migraphx::to_shape_type(type)),
-                                            (dims),
-                                            (ndims),
-                                            (strides),
-                                            (nstrides),
-                                            (symbols->object))));
+        *shape =
+            object_cast<migraphx_shape_t>(allocate<migraphx::shape>(migraphx::create_symbolic_shape(
+                (migraphx::to_shape_type(type)), (dims), (ndims), (strides), (nstrides))));
     });
     return api_error_result;
 }

--- a/src/api/include/migraphx/migraphx.h
+++ b/src/api/include/migraphx/migraphx.h
@@ -91,6 +91,9 @@ typedef const struct migraphx_optimals* const_migraphx_optimals_t;
 typedef struct migraphx_symbol_bounds* migraphx_symbol_bounds_t;
 typedef const struct migraphx_symbol_bounds* const_migraphx_symbol_bounds_t;
 
+typedef struct migraphx_symbol_table* migraphx_symbol_table_t;
+typedef const struct migraphx_symbol_table* const_migraphx_symbol_table_t;
+
 typedef struct migraphx_dynamic_dimension* migraphx_dynamic_dimension_t;
 typedef const struct migraphx_dynamic_dimension* const_migraphx_dynamic_dimension_t;
 
@@ -219,6 +222,20 @@ MIGRAPHX_C_EXPORT migraphx_status migraphx_symbol_bounds_add(migraphx_symbol_bou
                                                              const_migraphx_dynamic_dimension_t dd);
 
 MIGRAPHX_C_EXPORT migraphx_status
+migraphx_symbol_table_destroy(migraphx_symbol_table_t symbol_table);
+
+MIGRAPHX_C_EXPORT migraphx_status migraphx_symbol_table_assign_to(
+    migraphx_symbol_table_t output, const_migraphx_symbol_table_t input);
+
+MIGRAPHX_C_EXPORT migraphx_status
+migraphx_symbol_table_create(migraphx_symbol_table_t* symbol_table);
+
+MIGRAPHX_C_EXPORT migraphx_status
+migraphx_symbol_table_add(migraphx_symbol_table_t symbol_table,
+                          const char* name,
+                          const_migraphx_dynamic_dimensions_t bounds);
+
+MIGRAPHX_C_EXPORT migraphx_status
 migraphx_dynamic_dimension_destroy(migraphx_dynamic_dimension_t dynamic_dimension);
 
 MIGRAPHX_C_EXPORT migraphx_status migraphx_dynamic_dimension_assign_to(
@@ -291,6 +308,15 @@ MIGRAPHX_C_EXPORT migraphx_status migraphx_shape_create_scalar(migraphx_shape_t*
 MIGRAPHX_C_EXPORT migraphx_status migraphx_shape_create_dynamic(migraphx_shape_t* shape,
                                                                 migraphx_shape_datatype_t type,
                                                                 migraphx_dynamic_dimensions_t dims);
+
+MIGRAPHX_C_EXPORT migraphx_status
+migraphx_shape_create_symbolic(migraphx_shape_t* shape,
+                               migraphx_shape_datatype_t type,
+                               const char* const* dims,
+                               size_t ndims,
+                               const char* const* strides,
+                               size_t nstrides,
+                               const_migraphx_symbol_table_t symbols);
 
 MIGRAPHX_C_EXPORT migraphx_status migraphx_shape_lengths(const size_t** out,
                                                          size_t* out_size,

--- a/src/api/include/migraphx/migraphx.h
+++ b/src/api/include/migraphx/migraphx.h
@@ -91,9 +91,6 @@ typedef const struct migraphx_optimals* const_migraphx_optimals_t;
 typedef struct migraphx_symbol_bounds* migraphx_symbol_bounds_t;
 typedef const struct migraphx_symbol_bounds* const_migraphx_symbol_bounds_t;
 
-typedef struct migraphx_symbol_table* migraphx_symbol_table_t;
-typedef const struct migraphx_symbol_table* const_migraphx_symbol_table_t;
-
 typedef struct migraphx_dynamic_dimension* migraphx_dynamic_dimension_t;
 typedef const struct migraphx_dynamic_dimension* const_migraphx_dynamic_dimension_t;
 
@@ -222,20 +219,6 @@ MIGRAPHX_C_EXPORT migraphx_status migraphx_symbol_bounds_add(migraphx_symbol_bou
                                                              const_migraphx_dynamic_dimension_t dd);
 
 MIGRAPHX_C_EXPORT migraphx_status
-migraphx_symbol_table_destroy(migraphx_symbol_table_t symbol_table);
-
-MIGRAPHX_C_EXPORT migraphx_status migraphx_symbol_table_assign_to(
-    migraphx_symbol_table_t output, const_migraphx_symbol_table_t input);
-
-MIGRAPHX_C_EXPORT migraphx_status
-migraphx_symbol_table_create(migraphx_symbol_table_t* symbol_table);
-
-MIGRAPHX_C_EXPORT migraphx_status
-migraphx_symbol_table_add(migraphx_symbol_table_t symbol_table,
-                          const char* name,
-                          const_migraphx_dynamic_dimensions_t bounds);
-
-MIGRAPHX_C_EXPORT migraphx_status
 migraphx_dynamic_dimension_destroy(migraphx_dynamic_dimension_t dynamic_dimension);
 
 MIGRAPHX_C_EXPORT migraphx_status migraphx_dynamic_dimension_assign_to(
@@ -309,14 +292,12 @@ MIGRAPHX_C_EXPORT migraphx_status migraphx_shape_create_dynamic(migraphx_shape_t
                                                                 migraphx_shape_datatype_t type,
                                                                 migraphx_dynamic_dimensions_t dims);
 
-MIGRAPHX_C_EXPORT migraphx_status
-migraphx_shape_create_symbolic(migraphx_shape_t* shape,
-                               migraphx_shape_datatype_t type,
-                               const char* const* dims,
-                               size_t ndims,
-                               const char* const* strides,
-                               size_t nstrides,
-                               const_migraphx_symbol_table_t symbols);
+MIGRAPHX_C_EXPORT migraphx_status migraphx_shape_create_symbolic(migraphx_shape_t* shape,
+                                                                 migraphx_shape_datatype_t type,
+                                                                 const char* const* dims,
+                                                                 size_t ndims,
+                                                                 const char* const* strides,
+                                                                 size_t nstrides);
 
 MIGRAPHX_C_EXPORT migraphx_status migraphx_shape_lengths(const size_t** out,
                                                          size_t* out_size,

--- a/src/api/include/migraphx/migraphx.hpp
+++ b/src/api/include/migraphx/migraphx.hpp
@@ -712,6 +712,29 @@ struct dynamic_dimensions : MIGRAPHX_HANDLE_BASE(dynamic_dimensions)
     }
 };
 
+/// The bounds each named symbol of a symbolic shape stands for. Several bounds for one name
+/// assert several intervals, which is what a variable merged from differently bounded
+/// same-named ones carries.
+struct symbol_table : MIGRAPHX_HANDLE_BASE(symbol_table)
+{
+    MIGRAPHX_HANDLE_CONSTRUCTOR(symbol_table)
+
+    symbol_table() { this->make_handle(&migraphx_symbol_table_create); }
+
+    void add(const std::string& name, const dynamic_dimensions& bounds)
+    {
+        call(&migraphx_symbol_table_add,
+             this->get_handle_ptr(),
+             name.c_str(),
+             bounds.get_handle_ptr());
+    }
+
+    void add(const std::string& name, const dynamic_dimension& bound)
+    {
+        this->add(name, dynamic_dimensions{bound});
+    }
+};
+
 /**
  * @brief Describe shape of tensor
  * @details A shape consists of a data type, lengths of multi-dimension tensor, and strides
@@ -760,6 +783,41 @@ struct shape : MIGRAPHX_CONST_HANDLE_BASE(shape)
     shape(migraphx_shape_datatype_t type, const dynamic_dimensions& dyn_dims)
     {
         this->make_handle(&migraphx_shape_create_dynamic, type, dyn_dims.get_handle_ptr());
+    }
+
+    /// Construct a symbolic shape from expression strings, binding each named symbol to the
+    /// bounds carried by its entry in the table. The strides are packed standard.
+    shape(migraphx_shape_datatype_t type,
+          const std::vector<std::string>& dims,
+          const symbol_table& symbols)
+        : shape(type, dims, {}, symbols)
+    {
+    }
+
+    /// As above, for a transposed or broadcasted layout. Strides resolve through the same table,
+    /// so they share the dimensions' symbols.
+    shape(migraphx_shape_datatype_t type,
+          const std::vector<std::string>& dims,
+          const std::vector<std::string>& strides,
+          const symbol_table& symbols)
+    {
+        auto to_c = [](const std::vector<std::string>& xs) {
+            std::vector<const char*> result;
+            std::transform(xs.begin(),
+                           xs.end(),
+                           std::back_inserter(result),
+                           [](const std::string& x) { return x.c_str(); });
+            return result;
+        };
+        auto cdims    = to_c(dims);
+        auto cstrides = to_c(strides);
+        this->make_handle(&migraphx_shape_create_symbolic,
+                          type,
+                          cdims.data(),
+                          cdims.size(),
+                          cstrides.data(),
+                          cstrides.size(),
+                          symbols.get_handle_ptr());
     }
 
     std::vector<size_t> lengths() const

--- a/src/api/include/migraphx/migraphx.hpp
+++ b/src/api/include/migraphx/migraphx.hpp
@@ -624,10 +624,10 @@ struct dynamic_dimension : MIGRAPHX_CONST_HANDLE_BASE(dynamic_dimension)
             &migraphx_dynamic_dimension_create_min_max_optimals, min, max, opts.get_handle_ptr());
     }
 
-    /// Build a symbolic dimension by parsing an expression string and binding each named
-    /// symbol to the bounds/optimals supplied as range dynamic_dimensions.
+    /// Build a symbolic dimension by parsing an expression string. Variables can carry metadata
+    /// inline; the optional map binds bounds/optimals to bare variable names.
     dynamic_dimension(const std::string& expression,
-                      const std::unordered_map<std::string, dynamic_dimension>& symbols);
+                      const std::unordered_map<std::string, dynamic_dimension>& symbols = {});
 
     bool is_fixed() const
     {
@@ -712,29 +712,6 @@ struct dynamic_dimensions : MIGRAPHX_HANDLE_BASE(dynamic_dimensions)
     }
 };
 
-/// The bounds each named symbol of a symbolic shape stands for. Several bounds for one name
-/// assert several intervals, which is what a variable merged from differently bounded
-/// same-named ones carries.
-struct symbol_table : MIGRAPHX_HANDLE_BASE(symbol_table)
-{
-    MIGRAPHX_HANDLE_CONSTRUCTOR(symbol_table)
-
-    symbol_table() { this->make_handle(&migraphx_symbol_table_create); }
-
-    void add(const std::string& name, const dynamic_dimensions& bounds)
-    {
-        call(&migraphx_symbol_table_add,
-             this->get_handle_ptr(),
-             name.c_str(),
-             bounds.get_handle_ptr());
-    }
-
-    void add(const std::string& name, const dynamic_dimension& bound)
-    {
-        this->add(name, dynamic_dimensions{bound});
-    }
-};
-
 /**
  * @brief Describe shape of tensor
  * @details A shape consists of a data type, lengths of multi-dimension tensor, and strides
@@ -785,21 +762,22 @@ struct shape : MIGRAPHX_CONST_HANDLE_BASE(shape)
         this->make_handle(&migraphx_shape_create_dynamic, type, dyn_dims.get_handle_ptr());
     }
 
-    /// Construct a symbolic shape from expression strings, binding each named symbol to the
-    /// bounds carried by its entry in the table. The strides are packed standard.
-    shape(migraphx_shape_datatype_t type,
-          const std::vector<std::string>& dims,
-          const symbol_table& symbols)
-        : shape(type, dims, {}, symbols)
+    /// Construct a symbolic shape from self-contained expression strings. The strides are packed
+    /// standard.
+    shape(migraphx_shape_datatype_t type, const std::vector<std::string>& dims)
+        : shape(type, dims, {})
     {
     }
 
-    /// As above, for a transposed or broadcasted layout. Strides resolve through the same table,
-    /// so they share the dimensions' symbols.
+    shape(migraphx_shape_datatype_t type, std::initializer_list<std::string> dims)
+        : shape(type, std::vector<std::string>(dims))
+    {
+    }
+
+    /// As above, for a transposed or broadcasted layout.
     shape(migraphx_shape_datatype_t type,
           const std::vector<std::string>& dims,
-          const std::vector<std::string>& strides,
-          const symbol_table& symbols)
+          const std::vector<std::string>& strides)
     {
         auto to_c = [](const std::vector<std::string>& xs) {
             std::vector<const char*> result;
@@ -816,8 +794,14 @@ struct shape : MIGRAPHX_CONST_HANDLE_BASE(shape)
                           cdims.data(),
                           cdims.size(),
                           cstrides.data(),
-                          cstrides.size(),
-                          symbols.get_handle_ptr());
+                          cstrides.size());
+    }
+
+    shape(migraphx_shape_datatype_t type,
+          std::initializer_list<std::string> dims,
+          std::initializer_list<std::string> strides)
+        : shape(type, std::vector<std::string>(dims), std::vector<std::string>(strides))
+    {
     }
 
     std::vector<size_t> lengths() const

--- a/src/api/migraphx.py
+++ b/src/api/migraphx.py
@@ -71,6 +71,21 @@ def symbol_bounds(h):
              invoke='${symbol_bounds}[${name}] = ${dd}')
 
 
+@api.handle(
+    'migraphx_symbol_table',
+    'std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>>')
+def symbol_table(h):
+    h.constructor('create')
+    # Several bounds assert several intervals, which is what a variable merged from
+    # differently bounded same-named ones carries.
+    h.method(
+        'add',
+        api.params(
+            name='const char*',
+            bounds='const std::vector<migraphx::shape::dynamic_dimension>&'),
+        invoke='${symbol_table}[${name}] = ${bounds}')
+
+
 @api.handle('migraphx_dynamic_dimension', 'migraphx::shape::dynamic_dimension')
 def dynamic_dimension(h):
     h.constructor('create_min_max', api.params(min='size_t', max='size_t'))
@@ -126,6 +141,17 @@ def shape(h):
         'create_dynamic',
         api.params(type='migraphx::shape::type_t',
                    dims='std::vector<migraphx::shape::dynamic_dimension>'))
+    h.constructor(
+        'create_symbolic',
+        api.params(
+            type='migraphx::shape::type_t',
+            dims='const char* const*',
+            ndims='size_t',
+            strides='const char* const*',
+            nstrides='size_t',
+            symbols=
+            'const std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>>&'),
+        fname='migraphx::create_symbolic_shape')
     h.method('lengths',
              fname='lens',
              returns='const std::vector<size_t>&',

--- a/src/api/migraphx.py
+++ b/src/api/migraphx.py
@@ -71,21 +71,6 @@ def symbol_bounds(h):
              invoke='${symbol_bounds}[${name}] = ${dd}')
 
 
-@api.handle(
-    'migraphx_symbol_table',
-    'std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>>')
-def symbol_table(h):
-    h.constructor('create')
-    # Several bounds assert several intervals, which is what a variable merged from
-    # differently bounded same-named ones carries.
-    h.method(
-        'add',
-        api.params(
-            name='const char*',
-            bounds='const std::vector<migraphx::shape::dynamic_dimension>&'),
-        invoke='${symbol_table}[${name}] = ${bounds}')
-
-
 @api.handle('migraphx_dynamic_dimension', 'migraphx::shape::dynamic_dimension')
 def dynamic_dimension(h):
     h.constructor('create_min_max', api.params(min='size_t', max='size_t'))
@@ -141,17 +126,13 @@ def shape(h):
         'create_dynamic',
         api.params(type='migraphx::shape::type_t',
                    dims='std::vector<migraphx::shape::dynamic_dimension>'))
-    h.constructor(
-        'create_symbolic',
-        api.params(
-            type='migraphx::shape::type_t',
-            dims='const char* const*',
-            ndims='size_t',
-            strides='const char* const*',
-            nstrides='size_t',
-            symbols=
-            'const std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>>&'),
-        fname='migraphx::create_symbolic_shape')
+    h.constructor('create_symbolic',
+                  api.params(type='migraphx::shape::type_t',
+                             dims='const char* const*',
+                             ndims='size_t',
+                             strides='const char* const*',
+                             nstrides='size_t'),
+                  fname='migraphx::create_symbolic_shape')
     h.method('lengths',
              fname='lens',
              returns='const std::vector<size_t>&',

--- a/src/include/migraphx/shape.hpp
+++ b/src/include/migraphx/shape.hpp
@@ -27,6 +27,7 @@
 #include <array>
 #include <vector>
 #include <cassert>
+#include <map>
 #include <ostream>
 #include <numeric>
 #include <memory>
@@ -294,11 +295,6 @@ struct MIGRAPHX_EXPORT shape
                                   const std::vector<dynamic_dimension>& dds,
                                   const std::vector<int64_t>& perm);
 
-    /// Rebuild a shape from `to_json_string(migraphx::to_value(s))`. Unlike the constructors this
-    /// restores symbolic dimension expressions, their bounds and optimals, and symbolic strides
-    /// exactly, which is why the --cpp and --py printers emit this spelling.
-    static shape from_json(const std::string& s);
-
     type_t type() const;
     const std::vector<std::size_t>& lens() const;
     const std::vector<std::size_t>& strides() const;
@@ -495,6 +491,28 @@ struct MIGRAPHX_EXPORT shape
     static dynamic_dimension make_symbolic_dynamic_dimension(
         const std::string& expression,
         const std::unordered_map<std::string, dynamic_dimension>& symbols);
+
+    /// Build a symbolic shape from expression strings. Each free symbol is bound to the bounds
+    /// and optimals of its entry in `symbols`; several entries assert several intervals, which
+    /// is what a variable merged from differently bounded ones carries. This is the spelling the
+    /// --cpp and --py printers emit.
+    static shape
+    make_symbolic_shape(type_t t,
+                        const std::vector<std::string>& dims,
+                        const std::map<std::string, std::vector<dynamic_dimension>>& symbols);
+
+    /// As above, for a transposed or broadcasted layout. Strides resolve through the same table,
+    /// so they share the dimensions' variables; without them the strides are packed standard.
+    static shape
+    make_symbolic_shape(type_t t,
+                        const std::vector<std::string>& dims,
+                        const std::vector<std::string>& strides,
+                        const std::map<std::string, std::vector<dynamic_dimension>>& symbols);
+
+    /// The symbols this shape's dimensions and strides use, in the form make_symbolic_shape
+    /// takes, so a symbolic shape round trips through its own API. Each interval a symbol
+    /// asserts becomes one dynamic_dimension, and its optimals ride on the first.
+    std::map<std::string, std::vector<dynamic_dimension>> symbol_table() const;
 
     MIGRAPHX_EXPORT friend bool operator==(const shape& x, const shape& y);
     MIGRAPHX_EXPORT friend bool operator!=(const shape& x, const shape& y);

--- a/src/include/migraphx/shape.hpp
+++ b/src/include/migraphx/shape.hpp
@@ -294,7 +294,9 @@ struct MIGRAPHX_EXPORT shape
                                   const std::vector<dynamic_dimension>& dds,
                                   const std::vector<int64_t>& perm);
 
-    /// Rebuild a shape from the json form of its value representation.
+    /// Rebuild a shape from `to_json_string(migraphx::to_value(s))`. Unlike the constructors this
+    /// restores symbolic dimension expressions, their bounds and optimals, and symbolic strides
+    /// exactly, which is why the --cpp and --py printers emit this spelling.
     static shape from_json(const std::string& s);
 
     type_t type() const;

--- a/src/include/migraphx/shape.hpp
+++ b/src/include/migraphx/shape.hpp
@@ -640,6 +640,11 @@ MIGRAPHX_EXPORT std::vector<shape> flatten_tuple_shapes(const std::vector<shape>
 MIGRAPHX_EXPORT void migraphx_to_value(value& v, const shape& s);
 MIGRAPHX_EXPORT void migraphx_from_value(const value& v, shape& s);
 
+/// Rebuild a shape from the json form of its value representation. Unlike the
+/// constructors, this preserves symbolic dimensions exactly, so it is the
+/// spelling used by the generated-code printers.
+MIGRAPHX_EXPORT shape make_json_shape(const std::string& s);
+
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx
 

--- a/src/include/migraphx/shape.hpp
+++ b/src/include/migraphx/shape.hpp
@@ -294,6 +294,9 @@ struct MIGRAPHX_EXPORT shape
                                   const std::vector<dynamic_dimension>& dds,
                                   const std::vector<int64_t>& perm);
 
+    /// Rebuild a shape from the json form of its value representation.
+    static shape from_json(const std::string& s);
+
     type_t type() const;
     const std::vector<std::size_t>& lens() const;
     const std::vector<std::size_t>& strides() const;
@@ -639,11 +642,6 @@ MIGRAPHX_EXPORT std::vector<shape> flatten_tuple_shapes(const std::vector<shape>
 
 MIGRAPHX_EXPORT void migraphx_to_value(value& v, const shape& s);
 MIGRAPHX_EXPORT void migraphx_from_value(const value& v, shape& s);
-
-/// Rebuild a shape from the json form of its value representation. Unlike the
-/// constructors, this preserves symbolic dimensions exactly, so it is the
-/// spelling used by the generated-code printers.
-MIGRAPHX_EXPORT shape make_json_shape(const std::string& s);
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/include/migraphx/shape.hpp
+++ b/src/include/migraphx/shape.hpp
@@ -27,7 +27,6 @@
 #include <array>
 #include <vector>
 #include <cassert>
-#include <map>
 #include <ostream>
 #include <numeric>
 #include <memory>
@@ -485,34 +484,23 @@ struct MIGRAPHX_EXPORT shape
     shape to_static(std::size_t x) const;
     shape to_static(const std::unordered_map<sym::expr, std::size_t>& symbol_map = {}) const;
 
-    // Build a symbolic dynamic_dimension by parsing an expression string and binding each
-    // named symbol to the interval/optimals carried by its (range) dynamic_dimension.
-    // Throws if the expression is empty.
+    // Build a symbolic dynamic_dimension by parsing an expression string. Variable constraints
+    // and optimals can be carried inline by the expression; the optional symbols map binds
+    // metadata to bare variable names for compatibility with existing callers.
     static dynamic_dimension make_symbolic_dynamic_dimension(
         const std::string& expression,
-        const std::unordered_map<std::string, dynamic_dimension>& symbols);
+        const std::unordered_map<std::string, dynamic_dimension>& symbols = {});
 
-    /// Build a symbolic shape from expression strings. Each free symbol is bound to the bounds
-    /// and optimals of its entry in `symbols`; several entries assert several intervals, which
-    /// is what a variable merged from differently bounded ones carries. This is the spelling the
-    /// --cpp and --py printers emit.
-    static shape
-    make_symbolic_shape(type_t t,
-                        const std::vector<std::string>& dims,
-                        const std::map<std::string, std::vector<dynamic_dimension>>& symbols);
+    /// Build a symbolic shape from expression strings. Variable constraints and optimals are
+    /// parsed from the expressions themselves. This is the spelling the --cpp and --py printers
+    /// emit.
+    static shape make_symbolic_shape(type_t t, const std::vector<std::string>& dims);
 
-    /// As above, for a transposed or broadcasted layout. Strides resolve through the same table,
-    /// so they share the dimensions' variables; without them the strides are packed standard.
-    static shape
-    make_symbolic_shape(type_t t,
-                        const std::vector<std::string>& dims,
-                        const std::vector<std::string>& strides,
-                        const std::map<std::string, std::vector<dynamic_dimension>>& symbols);
-
-    /// The symbols this shape's dimensions and strides use, in the form make_symbolic_shape
-    /// takes, so a symbolic shape round trips through its own API. Each interval a symbol
-    /// asserts becomes one dynamic_dimension, and its optimals ride on the first.
-    std::map<std::string, std::vector<dynamic_dimension>> symbol_table() const;
+    /// As above, for a transposed or broadcasted layout. Without explicit symbolic strides the
+    /// shape is packed standard.
+    static shape make_symbolic_shape(type_t t,
+                                     const std::vector<std::string>& dims,
+                                     const std::vector<std::string>& strides);
 
     MIGRAPHX_EXPORT friend bool operator==(const shape& x, const shape& y);
     MIGRAPHX_EXPORT friend bool operator!=(const shape& x, const shape& y);

--- a/src/include/migraphx/sym.hpp
+++ b/src/include/migraphx/sym.hpp
@@ -32,6 +32,7 @@
 #include <memory>
 #include <optional>
 #include <ostream>
+#include <map>
 #include <set>
 #include <string>
 #include <string_view>
@@ -246,6 +247,13 @@ class MIGRAPHX_EXPORT expr
 
 MIGRAPHX_EXPORT expr var(std::string name);
 MIGRAPHX_EXPORT expr var(std::string name, interval constraint, std::set<scalar> optimals = {});
+// A variable can end up asserting more than one interval: adding two same-named
+// variables merges their metadata by unioning the constraint sets. This overload
+// is what spells that result, so every variable the library can produce is also
+// constructible.
+MIGRAPHX_EXPORT expr var(std::string name,
+                         std::vector<interval> constraints,
+                         std::set<scalar> optimals = {});
 
 // Project an expr onto its structural symbol form, stripping all variable
 // metadata (constraints, optimals). `same_symbol(a, b)` is true when a and b
@@ -257,6 +265,17 @@ MIGRAPHX_EXPORT bool same_symbol(const expr& a, const expr& b);
 
 // Find distinct variables as metadata-free symbols.
 MIGRAPHX_EXPORT std::unordered_set<expr> find_variables(const expr& e);
+
+// The bounds and optimals a variable asserts, which find_variables strips.
+struct variable_bounds
+{
+    std::vector<interval> constraints;
+    std::set<scalar> optimals;
+};
+
+// Find distinct variables keyed by name, keeping the metadata find_variables strips. Variables
+// sharing a name are merged as combining them into one expression would.
+MIGRAPHX_EXPORT std::map<std::string, variable_bounds> find_variable_bounds(const expr& e);
 // Whether dividend is evenly divisible by divisor (integral operands only).
 MIGRAPHX_EXPORT bool is_divisible(const expr& dividend, const expr& divisor);
 
@@ -304,6 +323,8 @@ auto call(std::string name, Eval eval)
 }
 
 MIGRAPHX_EXPORT std::string to_string(const expr& e);
+// The shortest spelling of a scalar that parses back to the same value.
+MIGRAPHX_EXPORT std::string to_string(const scalar& v);
 
 MIGRAPHX_EXPORT expr parse(const std::string& str);
 

--- a/src/include/migraphx/sym.hpp
+++ b/src/include/migraphx/sym.hpp
@@ -32,7 +32,6 @@
 #include <memory>
 #include <optional>
 #include <ostream>
-#include <map>
 #include <set>
 #include <string>
 #include <string_view>
@@ -266,20 +265,6 @@ MIGRAPHX_EXPORT bool same_symbol(const expr& a, const expr& b);
 // Find distinct variables as metadata-free symbols.
 MIGRAPHX_EXPORT std::unordered_set<expr> find_variables(const expr& e);
 
-// The bounds and optimals a variable asserts, which find_variables strips.
-struct variable_bounds
-{
-    std::vector<interval> constraints;
-    std::set<scalar> optimals;
-};
-
-// Find distinct variables keyed by name, keeping the metadata find_variables strips. Variables
-// sharing a name are merged as combining them into one expression would.
-MIGRAPHX_EXPORT std::map<std::string, variable_bounds> find_variable_bounds(const expr& e);
-// The same across several expressions, so a name appearing in more than one is merged rather
-// than reported from whichever was visited first.
-MIGRAPHX_EXPORT std::map<std::string, variable_bounds>
-find_variable_bounds(const std::vector<expr>& es);
 // Whether dividend is evenly divisible by divisor (integral operands only).
 MIGRAPHX_EXPORT bool is_divisible(const expr& dividend, const expr& divisor);
 

--- a/src/include/migraphx/sym.hpp
+++ b/src/include/migraphx/sym.hpp
@@ -276,6 +276,10 @@ struct variable_bounds
 // Find distinct variables keyed by name, keeping the metadata find_variables strips. Variables
 // sharing a name are merged as combining them into one expression would.
 MIGRAPHX_EXPORT std::map<std::string, variable_bounds> find_variable_bounds(const expr& e);
+// The same across several expressions, so a name appearing in more than one is merged rather
+// than reported from whichever was visited first.
+MIGRAPHX_EXPORT std::map<std::string, variable_bounds>
+find_variable_bounds(const std::vector<expr>& es);
 // Whether dividend is evenly divisible by divisor (integral operands only).
 MIGRAPHX_EXPORT bool is_divisible(const expr& dividend, const expr& divisor);
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -43,7 +43,7 @@
 #include <migraphx/fp8_types.hpp>
 #include <migraphx/logger.hpp>
 #include <iostream>
-#include <sstream>
+#include <map>
 #include <algorithm>
 #include <array>
 #include <set>
@@ -1629,51 +1629,153 @@ static void print_make_op(std::ostream& os, const operation& op)
     os << ")";
 }
 
-// A range-based dynamic dimension is printed from its bounds and optimals, which is everything a
-// constructor takes. A symbolic one is not: see print_json_shape.
-static std::string
-dyn_dims_string(const migraphx::shape& s, const std::string& open, const std::string& close)
+// A double has to survive the round trip through the generated source, so it is printed with
+// enough digits to recover it exactly; the stream default would round to six significant digits,
+// which is also why the expression strings below do not come from sym::expr::to_string.
+// The bounds a symbol asserts, as the "min, max" arguments of a dynamic_dimension. The optimals
+// already ride on the first bound, which is where symbol_table put them.
+static std::vector<std::string>
+symbol_bounds(const std::vector<migraphx::shape::dynamic_dimension>& bounds)
 {
+    std::vector<std::string> result;
+    std::transform(bounds.begin(), bounds.end(), std::back_inserter(result), [](const auto& bound) {
+        auto i        = bound.get_interval();
+        auto spelling = std::to_string(i.min) + ", " + std::to_string(i.max);
+        if(bound.has_optimal())
+            spelling += ", {" + to_string_range(bound.get_optimals()) + "}";
+        return spelling;
+    });
+    return result;
+}
+
+static std::string expr_string(const migraphx::sym::expr& e) { return enclose_name(e.to_string()); }
+
+template <class Range>
+static std::string expr_list_string(const Range& exprs)
+{
+    std::vector<std::string> strings;
+    std::transform(exprs.begin(), exprs.end(), std::back_inserter(strings), [](const auto& e) {
+        return expr_string(e);
+    });
+    return join_strings(strings, ", ");
+}
+
+static std::string sym_dims_string(const migraphx::shape& s)
+{
+    std::vector<std::string> dims;
+    std::transform(s.dyn_dims().begin(),
+                   s.dyn_dims().end(),
+                   std::back_inserter(dims),
+                   [](const auto& d) { return expr_string(d.sym_expr); });
+    return join_strings(dims, ", ");
+}
+
+// Strides are only carried by an all-symbolic shape, and make_symbolic recomputes packed
+// standard ones when none are given, so they are needed only for another layout.
+static bool needs_dyn_strides(const migraphx::shape& s)
+{
+    return s.symbolic() and not s.standard();
+}
+
+using symbol_table = std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>>;
+
+static std::string cpp_symbols_string(const symbol_table& symbols)
+{
+    std::vector<std::string> entries;
+    std::transform(
+        symbols.begin(), symbols.end(), std::back_inserter(entries), [](const auto& symbol) {
+            auto bounds = symbol_bounds(symbol.second);
+            std::vector<std::string> dims;
+            std::transform(
+                bounds.begin(), bounds.end(), std::back_inserter(dims), [](const auto& b) {
+                    return "migraphx::shape::dynamic_dimension{" + b + "}";
+                });
+            return "{" + enclose_name(symbol.first) + ", {" + join_strings(dims, ", ") + "}}";
+        });
+    return "{" + join_strings(entries, ", ") + "}";
+}
+
+static std::string py_symbols_string(const symbol_table& symbols)
+{
+    std::vector<std::string> entries;
+    std::transform(
+        symbols.begin(), symbols.end(), std::back_inserter(entries), [](const auto& symbol) {
+            auto bounds = symbol_bounds(symbol.second);
+            std::vector<std::string> dims;
+            std::transform(
+                bounds.begin(), bounds.end(), std::back_inserter(dims), [](const auto& b) {
+                    return "migraphx.shape.dynamic_dimension(" + b + ")";
+                });
+            auto value = dims.size() == 1 ? dims.front() : "[" + join_strings(dims, ", ") + "]";
+            return enclose_name(symbol.first) + ": " + value;
+        });
+    return "{" + join_strings(entries, ", ") + "}";
+}
+
+// The entries of a shape's table that one expression actually uses, which is what the
+// per-dimension spelling below needs.
+static symbol_table symbols_for(const migraphx::sym::expr& e, const symbol_table& symbols)
+{
+    auto used = migraphx::sym::find_variable_bounds(e);
+    symbol_table result;
+    std::transform(
+        used.begin(), used.end(), std::inserter(result, result.end()), [&](const auto& variable) {
+            return std::pair<std::string, std::vector<migraphx::shape::dynamic_dimension>>{
+                variable.first, symbols.at(variable.first)};
+        });
+    return result;
+}
+
+// A range-based dynamic dimension is printed from its bounds and optimals, a symbolic one from
+// its expression and the symbols that expression needs. This is the mixed-shape spelling;
+// make_symbolic cannot express a range dimension, so those shapes go dimension by dimension.
+static std::string dyn_dims_string(const migraphx::shape& s, bool cpp)
+{
+    auto table = s.symbol_table();
     std::vector<std::string> dims;
     std::transform(
         s.dyn_dims().begin(), s.dyn_dims().end(), std::back_inserter(dims), [&](const auto& d) {
-            auto i      = d.get_interval();
-            auto result = open + std::to_string(i.min) + ", " + std::to_string(i.max);
-            if(d.has_optimal())
-                result += ", {" + to_string_range(d.get_optimals()) + "}";
-            return result + close;
+            if(not d.is_symbolic())
+            {
+                auto i      = d.get_interval();
+                auto result = std::to_string(i.min) + ", " + std::to_string(i.max);
+                if(d.has_optimal())
+                    result += ", {" + to_string_range(d.get_optimals()) + "}";
+                return cpp ? "migraphx::shape::dynamic_dimension{" + result + "}"
+                           : "migraphx.shape.dynamic_dimension(" + result + ")";
+            }
+            auto symbols = symbols_for(d.sym_expr, table);
+            // make_symbolic_dynamic_dimension binds one interval per symbol, so a variable
+            // asserting several has no spelling here. It cannot reach a mixed shape.
+            if(std::any_of(symbols.begin(), symbols.end(), [](const auto& symbol) {
+                   return symbol.second.size() > 1;
+               }))
+                MIGRAPHX_THROW("PRINT_SHAPE: A symbol asserting several intervals cannot be "
+                               "printed in a partly symbolic shape");
+            auto args = expr_string(d.sym_expr) + ", ";
+            if(cpp)
+                return "migraphx::shape::make_symbolic_dynamic_dimension(" + args +
+                       cpp_symbols_string(symbols) + ")";
+            return "migraphx.shape.dynamic_dimension(" + args + py_symbols_string(symbols) + ")";
         });
     return join_strings(dims, ", ");
 }
 
-// Not shape::symbolic(), which requires every dimension to be symbolic: one symbolic dimension
-// among range ones is already enough to make the bounds spelling lossy.
-static bool has_symbolic_dim(const migraphx::shape& s)
-{
-    return s.dynamic() and std::any_of(s.dyn_dims().begin(), s.dyn_dims().end(), [](const auto& d) {
-               return d.is_symbolic();
-           });
-}
-
-// A symbolic dimension carries an expression that no constructor argument can spell, so the shape
-// is emitted as the json of its value representation for from_json to rebuild. enclose_name turns
-// that json into a valid string literal in the generated source.
-static void print_json_shape(std::ostream& os, const std::string& factory, const migraphx::shape& s)
-{
-    os << factory << "(" << enclose_name(to_json_string(migraphx::to_value(s))) << ")";
-}
-
 static void print_py_shape(std::ostream& os, const migraphx::shape& s)
 {
-    if(has_symbolic_dim(s))
+    if(s.symbolic())
     {
-        print_json_shape(os, "migraphx.shape.from_json", s);
+        os << "migraphx.shape(type=" << to_json_string(s.type_string()) << ", dyn_dims=["
+           << sym_dims_string(s) << "]";
+        if(needs_dyn_strides(s))
+            os << ", dyn_strides=[" << expr_list_string(s.dyn_strides()) << "]";
+        os << ", symbols=" << py_symbols_string(s.symbol_table()) << ")";
         return;
     }
     os << "migraphx.shape(type=" << to_json_string(s.type_string());
     if(s.dynamic())
     {
-        os << ", dyn_dims=[" << dyn_dims_string(s, "migraphx.shape.dynamic_dimension(", ")") << "]";
+        os << ", dyn_dims=[" << dyn_dims_string(s, false) << "]";
     }
     else
     {
@@ -1686,15 +1788,19 @@ static void print_py_shape(std::ostream& os, const migraphx::shape& s)
 
 static void print_cpp_shape(std::ostream& os, const migraphx::shape& s)
 {
-    if(has_symbolic_dim(s))
+    if(s.symbolic())
     {
-        print_json_shape(os, "migraphx::shape::from_json", s);
+        os << "migraphx::shape::make_symbolic_shape(migraphx::shape::" << s.type_string() << ", {"
+           << sym_dims_string(s) << "}";
+        if(needs_dyn_strides(s))
+            os << ", {" << expr_list_string(s.dyn_strides()) << "}";
+        os << ", " << cpp_symbols_string(s.symbol_table()) << ")";
         return;
     }
     os << "migraphx::shape{migraphx::shape::" << s.type_string();
     if(s.dynamic())
     {
-        os << ", {" << dyn_dims_string(s, "migraphx::shape::dynamic_dimension{", "}") << "}";
+        os << ", {" << dyn_dims_string(s, true) << "}";
     }
     else
     {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1694,7 +1694,7 @@ static void print_cpp_shape(std::ostream& os, const migraphx::shape& s)
     os << "migraphx::shape{migraphx::shape::" << s.type_string();
     if(s.dynamic())
     {
-        os << ", {" << dyn_dims_string(s, "{", "}") << "}";
+        os << ", {" << dyn_dims_string(s, "migraphx::shape::dynamic_dimension{", "}") << "}";
     }
     else
     {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1629,20 +1629,25 @@ static void print_make_op(std::ostream& os, const operation& op)
     os << ")";
 }
 
-// A range-based dynamic dimension is fully described by its bounds, so it is printed as those
-// bounds.
+// A range-based dynamic dimension is printed from its bounds and optimals, which is everything a
+// constructor takes. A symbolic one is not: see print_json_shape.
 static std::string
 dyn_dims_string(const migraphx::shape& s, const std::string& open, const std::string& close)
 {
     std::vector<std::string> dims;
     std::transform(
         s.dyn_dims().begin(), s.dyn_dims().end(), std::back_inserter(dims), [&](const auto& d) {
-            auto i = d.get_interval();
-            return open + std::to_string(i.min) + ", " + std::to_string(i.max) + close;
+            auto i      = d.get_interval();
+            auto result = open + std::to_string(i.min) + ", " + std::to_string(i.max);
+            if(d.has_optimal())
+                result += ", {" + to_string_range(d.get_optimals()) + "}";
+            return result + close;
         });
     return join_strings(dims, ", ");
 }
 
+// Not shape::symbolic(), which requires every dimension to be symbolic: one symbolic dimension
+// among range ones is already enough to make the bounds spelling lossy.
 static bool has_symbolic_dim(const migraphx::shape& s)
 {
     return s.dynamic() and std::any_of(s.dyn_dims().begin(), s.dyn_dims().end(), [](const auto& d) {
@@ -1650,7 +1655,9 @@ static bool has_symbolic_dim(const migraphx::shape& s)
            });
 }
 
-// Use enclose_name to make sure symbolic variable name is preserved.
+// A symbolic dimension carries an expression that no constructor argument can spell, so the shape
+// is emitted as the json of its value representation for from_json to rebuild. enclose_name turns
+// that json into a valid string literal in the generated source.
 static void print_json_shape(std::ostream& os, const std::string& factory, const migraphx::shape& s)
 {
     os << factory << "(" << enclose_name(to_json_string(migraphx::to_value(s))) << ")";
@@ -1779,10 +1786,9 @@ module::print_py(std::ostream& os,
                 os << mname << ".add_instruction(";
                 print_py_op(os, ins->get_operator());
                 os << ", [" << join_strings(input_vars, ", ") << "]";
-                // A comment does not have to be constructible, so use the readable shape form
-                // rather than the json a symbolic shape would otherwise print as.
-                os << ") # " << ins->get_shape();
-                os << std::endl;
+                // The trailing shape is only a comment in the generated code, so it need not be
+                // constructible: print the readable form, not the json a symbolic shape would emit.
+                os << ") # " << ins->get_shape() << std::endl;
             }
         },
         names);

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1670,7 +1670,7 @@ static std::string sym_dims_string(const migraphx::shape& s)
     return join_strings(dims, ", ");
 }
 
-// Strides are only carried by an all-symbolic shape, and make_symbolic recomputes packed
+// Strides are only carried by an all-symbolic shape, and make_symbolic_shape recomputes packed
 // standard ones when none are given, so they are needed only for another layout.
 static bool needs_dyn_strides(const migraphx::shape& s)
 {
@@ -1728,7 +1728,7 @@ static symbol_table symbols_for(const migraphx::sym::expr& e, const symbol_table
 
 // A range-based dynamic dimension is printed from its bounds and optimals, a symbolic one from
 // its expression and the symbols that expression needs. This is the mixed-shape spelling;
-// make_symbolic cannot express a range dimension, so those shapes go dimension by dimension.
+// make_symbolic_shape cannot express a range dimension, so those shapes go dimension by dimension.
 static std::string dyn_dims_string(const migraphx::shape& s, bool cpp)
 {
     auto table = s.symbol_table();

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1629,21 +1629,75 @@ static void print_make_op(std::ostream& os, const operation& op)
     os << ")";
 }
 
+// A range-based dynamic dimension is fully described by its bounds, so it is printed as those
+// bounds. A symbolic dimension is not: see print_json_shape.
+static std::string
+dyn_dims_string(const migraphx::shape& s, const std::string& open, const std::string& close)
+{
+    std::vector<std::string> dims;
+    std::transform(
+        s.dyn_dims().begin(), s.dyn_dims().end(), std::back_inserter(dims), [&](const auto& d) {
+            auto i = d.get_interval();
+            return open + std::to_string(i.min) + ", " + std::to_string(i.max) + close;
+        });
+    return join_strings(dims, ", ");
+}
+
+static bool has_symbolic_dim(const migraphx::shape& s)
+{
+    return s.dynamic() and std::any_of(s.dyn_dims().begin(), s.dyn_dims().end(), [](const auto& d) {
+               return d.is_symbolic();
+           });
+}
+
+// A symbolic dimension carries an expression that no constructor argument can spell, so the shape
+// is instead rebuilt from the json form of its value representation. That is the same codec used
+// for serialization, so the expression, its per-variable bounds and optimals, and any symbolic
+// strides all survive the round trip.
+static void print_json_shape(std::ostream& os, const std::string& factory, const migraphx::shape& s)
+{
+    os << factory << "(" << enclose_name(to_json_string(migraphx::to_value(s))) << ")";
+}
+
 static void print_py_shape(std::ostream& os, const migraphx::shape& s)
 {
-    os << "migraphx.shape(type=" << to_json_string(s.type_string()) << ", lens=["
-       << to_string_range(s.lens()) << "]";
-    if(not s.standard())
-        os << ", strides=[" << to_string_range(s.strides()) << "]";
+    if(has_symbolic_dim(s))
+    {
+        print_json_shape(os, "migraphx.shape.from_json", s);
+        return;
+    }
+    os << "migraphx.shape(type=" << to_json_string(s.type_string());
+    if(s.dynamic())
+    {
+        os << ", dyn_dims=[" << dyn_dims_string(s, "migraphx.shape.dynamic_dimension(", ")") << "]";
+    }
+    else
+    {
+        os << ", lens=[" << to_string_range(s.lens()) << "]";
+        if(not s.standard())
+            os << ", strides=[" << to_string_range(s.strides()) << "]";
+    }
     os << ")";
 }
 
 static void print_cpp_shape(std::ostream& os, const migraphx::shape& s)
 {
+    if(has_symbolic_dim(s))
+    {
+        print_json_shape(os, "migraphx::make_json_shape", s);
+        return;
+    }
     os << "migraphx::shape{migraphx::shape::" << s.type_string();
-    os << ", {" << to_string_range(s.lens()) << "}";
-    if(not s.standard())
-        os << ", {" << to_string_range(s.strides()) << "}";
+    if(s.dynamic())
+    {
+        os << ", {" << dyn_dims_string(s, "{", "}") << "}";
+    }
+    else
+    {
+        os << ", {" << to_string_range(s.lens()) << "}";
+        if(not s.standard())
+            os << ", {" << to_string_range(s.strides()) << "}";
+    }
     os << "}";
 }
 
@@ -1728,8 +1782,9 @@ module::print_py(std::ostream& os,
                 os << mname << ".add_instruction(";
                 print_py_op(os, ins->get_operator());
                 os << ", [" << join_strings(input_vars, ", ") << "]";
-                os << ") # ";
-                print_py_shape(os, ins->get_shape());
+                // A comment does not have to be constructible, so use the readable shape form
+                // rather than the json a symbolic shape would otherwise print as.
+                os << ") # " << ins->get_shape();
                 os << std::endl;
             }
         },

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1630,7 +1630,7 @@ static void print_make_op(std::ostream& os, const operation& op)
 }
 
 // A range-based dynamic dimension is fully described by its bounds, so it is printed as those
-// bounds. A symbolic dimension is not: see print_json_shape.
+// bounds.
 static std::string
 dyn_dims_string(const migraphx::shape& s, const std::string& open, const std::string& close)
 {
@@ -1650,10 +1650,7 @@ static bool has_symbolic_dim(const migraphx::shape& s)
            });
 }
 
-// A symbolic dimension carries an expression that no constructor argument can spell, so the shape
-// is instead rebuilt from the json form of its value representation. That is the same codec used
-// for serialization, so the expression, its per-variable bounds and optimals, and any symbolic
-// strides all survive the round trip.
+// Use enclose_name to make sure symbolic variable name is preserved.
 static void print_json_shape(std::ostream& os, const std::string& factory, const migraphx::shape& s)
 {
     os << factory << "(" << enclose_name(to_json_string(migraphx::to_value(s))) << ")";
@@ -1684,7 +1681,7 @@ static void print_cpp_shape(std::ostream& os, const migraphx::shape& s)
 {
     if(has_symbolic_dim(s))
     {
-        print_json_shape(os, "migraphx::make_json_shape", s);
+        print_json_shape(os, "migraphx::shape::from_json", s);
         return;
     }
     os << "migraphx::shape{migraphx::shape::" << s.type_string();

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -43,7 +43,6 @@
 #include <migraphx/fp8_types.hpp>
 #include <migraphx/logger.hpp>
 #include <iostream>
-#include <map>
 #include <algorithm>
 #include <array>
 #include <set>
@@ -1629,22 +1628,6 @@ static void print_make_op(std::ostream& os, const operation& op)
     os << ")";
 }
 
-// The bounds a symbol asserts, as the "min, max" arguments of a dynamic_dimension. The optimals
-// already ride on the first bound, which is where symbol_table put them.
-static std::vector<std::string>
-symbol_bounds(const std::vector<migraphx::shape::dynamic_dimension>& bounds)
-{
-    std::vector<std::string> result;
-    std::transform(bounds.begin(), bounds.end(), std::back_inserter(result), [](const auto& bound) {
-        auto i        = bound.get_interval();
-        auto spelling = std::to_string(i.min) + ", " + std::to_string(i.max);
-        if(bound.has_optimal())
-            spelling += ", {" + to_string_range(bound.get_optimals()) + "}";
-        return spelling;
-    });
-    return result;
-}
-
 static std::string expr_string(const migraphx::sym::expr& e) { return enclose_name(e.to_string()); }
 
 template <class Range>
@@ -1674,61 +1657,11 @@ static bool needs_dyn_strides(const migraphx::shape& s)
     return s.symbolic() and not s.standard();
 }
 
-using symbol_table = std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>>;
-
-static std::string cpp_symbols_string(const symbol_table& symbols)
-{
-    std::vector<std::string> entries;
-    std::transform(
-        symbols.begin(), symbols.end(), std::back_inserter(entries), [](const auto& symbol) {
-            auto bounds = symbol_bounds(symbol.second);
-            std::vector<std::string> dims;
-            std::transform(
-                bounds.begin(), bounds.end(), std::back_inserter(dims), [](const auto& b) {
-                    return "migraphx::shape::dynamic_dimension{" + b + "}";
-                });
-            return "{" + enclose_name(symbol.first) + ", {" + join_strings(dims, ", ") + "}}";
-        });
-    return "{" + join_strings(entries, ", ") + "}";
-}
-
-static std::string py_symbols_string(const symbol_table& symbols)
-{
-    std::vector<std::string> entries;
-    std::transform(
-        symbols.begin(), symbols.end(), std::back_inserter(entries), [](const auto& symbol) {
-            auto bounds = symbol_bounds(symbol.second);
-            std::vector<std::string> dims;
-            std::transform(
-                bounds.begin(), bounds.end(), std::back_inserter(dims), [](const auto& b) {
-                    return "migraphx.shape.dynamic_dimension(" + b + ")";
-                });
-            auto value = dims.size() == 1 ? dims.front() : "[" + join_strings(dims, ", ") + "]";
-            return enclose_name(symbol.first) + ": " + value;
-        });
-    return "{" + join_strings(entries, ", ") + "}";
-}
-
-// The entries of a shape's table that one expression actually uses, which is what the
-// per-dimension spelling below needs.
-static symbol_table symbols_for(const migraphx::sym::expr& e, const symbol_table& symbols)
-{
-    auto used = migraphx::sym::find_variable_bounds(e);
-    symbol_table result;
-    std::transform(
-        used.begin(), used.end(), std::inserter(result, result.end()), [&](const auto& variable) {
-            return std::pair<std::string, std::vector<migraphx::shape::dynamic_dimension>>{
-                variable.first, symbols.at(variable.first)};
-        });
-    return result;
-}
-
 // A range-based dynamic dimension is printed from its bounds and optimals, a symbolic one from
-// its expression and the symbols that expression needs. make_symbolic_shape cannot express a
-// range dimension, so any shape holding one is spelled dimension by dimension instead.
+// its self-contained expression. make_symbolic_shape cannot express a range dimension, so any
+// shape holding one is spelled dimension by dimension instead.
 static std::string dyn_dims_string(const migraphx::shape& s, bool cpp)
 {
-    auto table = s.symbol_table();
     std::vector<std::string> dims;
     std::transform(
         s.dyn_dims().begin(), s.dyn_dims().end(), std::back_inserter(dims), [&](const auto& d) {
@@ -1741,19 +1674,10 @@ static std::string dyn_dims_string(const migraphx::shape& s, bool cpp)
                 return cpp ? "migraphx::shape::dynamic_dimension{" + result + "}"
                            : "migraphx.shape.dynamic_dimension(" + result + ")";
             }
-            auto symbols = symbols_for(d.sym_expr, table);
-            // make_symbolic_dynamic_dimension binds one interval per symbol, so a variable
-            // asserting several has no spelling in a partly symbolic shape.
-            if(std::any_of(symbols.begin(), symbols.end(), [](const auto& symbol) {
-                   return symbol.second.size() > 1;
-               }))
-                MIGRAPHX_THROW("PRINT_SHAPE: A symbol asserting several intervals cannot be "
-                               "printed in a partly symbolic shape");
-            auto args = expr_string(d.sym_expr) + ", ";
             if(cpp)
-                return "migraphx::shape::make_symbolic_dynamic_dimension(" + args +
-                       cpp_symbols_string(symbols) + ")";
-            return "migraphx.shape.dynamic_dimension(" + args + py_symbols_string(symbols) + ")";
+                return "migraphx::shape::make_symbolic_dynamic_dimension(" +
+                       expr_string(d.sym_expr) + ")";
+            return "migraphx.shape.dynamic_dimension(" + expr_string(d.sym_expr) + ")";
         });
     return join_strings(dims, ", ");
 }
@@ -1766,7 +1690,7 @@ static void print_py_shape(std::ostream& os, const migraphx::shape& s)
            << sym_dims_string(s) << "]";
         if(needs_dyn_strides(s))
             os << ", dyn_strides=[" << expr_list_string(s.dyn_strides()) << "]";
-        os << ", symbols=" << py_symbols_string(s.symbol_table()) << ")";
+        os << ")";
         return;
     }
     os << "migraphx.shape(type=" << to_json_string(s.type_string());
@@ -1791,7 +1715,7 @@ static void print_cpp_shape(std::ostream& os, const migraphx::shape& s)
            << sym_dims_string(s) << "}";
         if(needs_dyn_strides(s))
             os << ", {" << expr_list_string(s.dyn_strides()) << "}";
-        os << ", " << cpp_symbols_string(s.symbol_table()) << ")";
+        os << ")";
         return;
     }
     os << "migraphx::shape{migraphx::shape::" << s.type_string();

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1629,9 +1629,6 @@ static void print_make_op(std::ostream& os, const operation& op)
     os << ")";
 }
 
-// A double has to survive the round trip through the generated source, so it is printed with
-// enough digits to recover it exactly; the stream default would round to six significant digits,
-// which is also why the expression strings below do not come from sym::expr::to_string.
 // The bounds a symbol asserts, as the "min, max" arguments of a dynamic_dimension. The optimals
 // already ride on the first bound, which is where symbol_table put them.
 static std::vector<std::string>
@@ -1727,8 +1724,8 @@ static symbol_table symbols_for(const migraphx::sym::expr& e, const symbol_table
 }
 
 // A range-based dynamic dimension is printed from its bounds and optimals, a symbolic one from
-// its expression and the symbols that expression needs. This is the mixed-shape spelling;
-// make_symbolic_shape cannot express a range dimension, so those shapes go dimension by dimension.
+// its expression and the symbols that expression needs. make_symbolic_shape cannot express a
+// range dimension, so any shape holding one is spelled dimension by dimension instead.
 static std::string dyn_dims_string(const migraphx::shape& s, bool cpp)
 {
     auto table = s.symbol_table();
@@ -1746,7 +1743,7 @@ static std::string dyn_dims_string(const migraphx::shape& s, bool cpp)
             }
             auto symbols = symbols_for(d.sym_expr, table);
             // make_symbolic_dynamic_dimension binds one interval per symbol, so a variable
-            // asserting several has no spelling here. It cannot reach a mixed shape.
+            // asserting several has no spelling in a partly symbolic shape.
             if(std::any_of(symbols.begin(), symbols.end(), [](const auto& symbol) {
                    return symbol.second.size() > 1;
                }))
@@ -1893,7 +1890,7 @@ module::print_py(std::ostream& os,
                 print_py_op(os, ins->get_operator());
                 os << ", [" << join_strings(input_vars, ", ") << "]";
                 // The trailing shape is only a comment in the generated code, so it need not be
-                // constructible: print the readable form, not the json a symbolic shape would emit.
+                // constructible: print the readable form rather than the constructor spelling.
                 os << ") # " << ins->get_shape() << std::endl;
             }
         },

--- a/src/onnx/include/migraphx/onnx/onnx_parser.hpp
+++ b/src/onnx/include/migraphx/onnx/onnx_parser.hpp
@@ -110,6 +110,11 @@ struct onnx_parser
     int64_t limit_max_iterations = std::numeric_limits<uint16_t>::max();
     int64_t opset_version        = 13;
 
+    // ONNX names are arbitrary strings but a symbol name has to be an identifier, so each one
+    // is rewritten once and remembered, which is what keeps two names that sanitize alike
+    // distinct. Mutable because the parse_type chain that reaches it is const.
+    mutable std::unordered_map<std::string, std::string> symbol_names;
+
     std::unordered_map<std::string, op_func> ops;
 
     onnx_parser();

--- a/src/onnx/onnx_parser.cpp
+++ b/src/onnx/onnx_parser.cpp
@@ -41,7 +41,10 @@
 #include <migraphx/env.hpp>
 #include <migraphx/logger.hpp>
 #include <onnx.pb.h>
+#include <algorithm>
+#include <cctype>
 #include <iomanip>
+#include <iterator>
 #include <set>
 #include <sstream>
 
@@ -904,11 +907,47 @@ literal onnx_parser::parse_tensor(const onnx::TensorProto& t) const
     MIGRAPHX_THROW("PARSE_TENSOR: Invalid tensor type");
 }
 
-static shape::dynamic_dimension make_symbol(const std::string& sym_name,
+// Rewrite an ONNX name into an identifier, which is what sym::var accepts and what lets a
+// symbolic shape be spelled as an expression string. Anything outside [A-Za-z0-9_] becomes an
+// underscore and a leading digit gains one, so "input.1" and "0" become "input_1" and "_0".
+static std::string sanitize_symbol_name(const std::string& name)
+{
+    std::string result;
+    result.reserve(name.size() + 1);
+    if(name.empty() or std::isdigit(static_cast<unsigned char>(name.front())) != 0)
+        result += '_';
+    std::transform(name.begin(), name.end(), std::back_inserter(result), [](unsigned char c) {
+        return std::isalnum(c) != 0 ? static_cast<char>(c) : '_';
+    });
+    return result;
+}
+
+// Sanitizing is many-to-one, so a name that lands on one already taken by a different original
+// gains a counter. The mapping is remembered so the same ONNX name always yields the same symbol.
+static const std::string& symbol_name_for(const onnx_parser& parser, const std::string& name)
+{
+    auto it = parser.symbol_names.find(name);
+    if(it != parser.symbol_names.end())
+        return it->second;
+    auto base      = sanitize_symbol_name(name);
+    auto candidate = base;
+    auto taken     = [&](const std::string& s) {
+        return std::any_of(parser.symbol_names.begin(),
+                           parser.symbol_names.end(),
+                           [&](const auto& kv) { return kv.second == s; });
+    };
+    for(std::size_t i = 2; taken(candidate); i++)
+        candidate = base + "_" + std::to_string(i);
+    return parser.symbol_names.emplace(name, std::move(candidate)).first->second;
+}
+
+static shape::dynamic_dimension make_symbol(const onnx_parser& parser,
+                                            const std::string& sym_name,
                                             const shape::dynamic_dimension& bounds)
 {
     auto iv = bounds.get_interval();
-    return shape::dynamic_dimension{sym::var(sym_name, {iv.min, iv.max}, sym_optimals(bounds))};
+    return shape::dynamic_dimension{
+        sym::var(symbol_name_for(parser, sym_name), {iv.min, iv.max}, sym_optimals(bounds))};
 }
 
 static shape::dynamic_dimension resolve_dim(const onnx_parser& parser,
@@ -923,7 +962,7 @@ static shape::dynamic_dimension resolve_dim(const onnx_parser& parser,
         return shape::dynamic_dimension{sym::lit(bounds.get_interval().min)};
     // A ranged bound becomes a per-axis symbol "<input>_d<axis>" (onnxruntime's scheme
     // for unnamed dims).
-    return make_symbol(name + "_d" + std::to_string(axis), bounds);
+    return make_symbol(parser, name + "_d" + std::to_string(axis), bounds);
 }
 
 static shape::dynamic_dimension
@@ -956,7 +995,8 @@ static shape::dynamic_dimension map_dyn_dim(const onnx_parser& parser,
     {
         const auto& dim_param = model_dim->dim_param();
         if(parser.use_symbolic_shapes)
-            return make_symbol(dim_param, dim_param_bounds(parser, dim_param, override_dim));
+            return make_symbol(
+                parser, dim_param, dim_param_bounds(parser, dim_param, override_dim));
         if(override_dim != nullptr)
             return *override_dim;
         if(contains(parser.dim_params, dim_param))

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -309,6 +309,37 @@ py::object to_py_object(const migraphx::value& val)
     return result;
 }
 
+// The `symbols` argument of a symbolic shape: a name maps either to one dynamic_dimension or,
+// for a symbol asserting several intervals, to a list of them.
+std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>>
+to_symbol_table(const migraphx::value& v)
+{
+    std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>> symbols;
+    if(not v.contains("symbols"))
+        return symbols;
+    const auto& entries = v.at("symbols");
+    std::transform(
+        entries.begin(), entries.end(), std::inserter(symbols, symbols.end()), [](const auto& e) {
+            using bounds_type = std::vector<migraphx::shape::dynamic_dimension>;
+            auto bounds       = e.without_key();
+            return std::pair<std::string, bounds_type>{
+                e.get_key(),
+                bounds.is_object()
+                    ? bounds_type{migraphx::from_value<migraphx::shape::dynamic_dimension>(bounds)}
+                    : migraphx::from_value<bounds_type>(bounds)};
+        });
+    return symbols;
+}
+
+std::vector<std::string> to_expression_strings(const std::vector<migraphx::sym::expr>& exprs)
+{
+    std::vector<std::string> strings;
+    std::transform(exprs.begin(), exprs.end(), std::back_inserter(strings), [](const auto& e) {
+        return e.to_string();
+    });
+    return strings;
+}
+
 migraphx::shape to_shape(const py::buffer_info& info)
 {
     migraphx::shape::type_t t;
@@ -373,10 +404,20 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             auto t = migraphx::shape::parse_type(v.get("type", "float"));
             if(v.contains("dyn_dims"))
             {
-                auto dyn_dims =
-                    migraphx::from_value<std::vector<migraphx::shape::dynamic_dimension>>(
-                        v.at("dyn_dims"));
-                return migraphx::shape(t, dyn_dims);
+                const auto& dims = v.at("dyn_dims");
+                // Expression strings name symbols that `symbols` supplies the bounds for; the
+                // dynamic_dimension form carries its own. Strides are only needed for a
+                // transposed or broadcasted layout, since make_symbolic_shape computes packed
+                // standard ones otherwise.
+                if(not dims.empty() and dims.front().if_string() != nullptr)
+                    return migraphx::shape::make_symbolic_shape(
+                        t,
+                        dims.to_vector<std::string>(),
+                        v.contains("dyn_strides") ? v.at("dyn_strides").to_vector<std::string>()
+                                                  : std::vector<std::string>{},
+                        to_symbol_table(v));
+                return migraphx::shape(
+                    t, migraphx::from_value<std::vector<migraphx::shape::dynamic_dimension>>(dims));
             }
             auto lens = v.get<std::size_t>("lens", {1});
             if(v.contains("strides"))
@@ -387,7 +428,6 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             else
                 return migraphx::shape(t, lens);
         }))
-        .def_static("from_json", &migraphx::shape::from_json, py::arg("s"))
         .def("type", &migraphx::shape::type)
         .def("lens", &migraphx::shape::lens)
         .def("strides", &migraphx::shape::strides)
@@ -397,6 +437,12 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         .def("type_string", &migraphx::shape::type_string)
         .def("type_size", &migraphx::shape::type_size)
         .def("dyn_dims", &migraphx::shape::dyn_dims)
+        .def("dyn_strides",
+             [](const migraphx::shape& s) { return to_expression_strings(s.dyn_strides()); })
+        // The bounds each symbol stands for, in the form the symbols argument takes, so a
+        // symbolic shape can be rebuilt from what Python can read of it. A symbol always maps
+        // to a list here, even where the constructor also accepts a bare dynamic_dimension.
+        .def("symbol_table", &migraphx::shape::symbol_table)
         .def("sub_shapes", &migraphx::shape::sub_shapes)
         .def("packed", &migraphx::shape::packed)
         .def("transposed", &migraphx::shape::transposed)
@@ -404,6 +450,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         .def("standard", &migraphx::shape::standard)
         .def("scalar", &migraphx::shape::scalar)
         .def("dynamic", &migraphx::shape::dynamic)
+        .def("symbolic", &migraphx::shape::symbolic)
         .def("__eq__", std::equal_to<migraphx::shape>{})
         .def("__ne__", std::not_equal_to<migraphx::shape>{})
         .def("__repr__", [](const migraphx::shape& s) { return migraphx::to_string(s); });
@@ -422,6 +469,12 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
              }),
              py::arg("expression"),
              py::arg("symbols"))
+        .def_property_readonly("expression",
+                               [](const migraphx::shape::dynamic_dimension& d) -> py::object {
+                                   if(not d.is_symbolic())
+                                       return py::none();
+                                   return py::cast(d.sym_expr.to_string());
+                               })
         .def_property_readonly(
             "min", [](const migraphx::shape::dynamic_dimension& d) { return d.get_interval().min; })
         .def_property_readonly(

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -387,7 +387,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             else
                 return migraphx::shape(t, lens);
         }))
-        .def_static("from_json", &migraphx::make_json_shape, py::arg("s"))
+        .def_static("from_json", &migraphx::shape::from_json, py::arg("s"))
         .def("type", &migraphx::shape::type)
         .def("lens", &migraphx::shape::lens)
         .def("strides", &migraphx::shape::strides)

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -387,6 +387,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             else
                 return migraphx::shape(t, lens);
         }))
+        .def_static("from_json", &migraphx::make_json_shape, py::arg("s"))
         .def("type", &migraphx::shape::type)
         .def("lens", &migraphx::shape::lens)
         .def("strides", &migraphx::shape::strides)

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -309,28 +309,6 @@ py::object to_py_object(const migraphx::value& val)
     return result;
 }
 
-// The `symbols` argument of a symbolic shape: a name maps either to one dynamic_dimension or,
-// for a symbol asserting several intervals, to a list of them.
-std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>>
-to_symbol_table(const migraphx::value& v)
-{
-    std::map<std::string, std::vector<migraphx::shape::dynamic_dimension>> symbols;
-    if(not v.contains("symbols"))
-        return symbols;
-    const auto& entries = v.at("symbols");
-    std::transform(
-        entries.begin(), entries.end(), std::inserter(symbols, symbols.end()), [](const auto& e) {
-            using bounds_type = std::vector<migraphx::shape::dynamic_dimension>;
-            auto bounds       = e.without_key();
-            return std::pair<std::string, bounds_type>{
-                e.get_key(),
-                bounds.is_object()
-                    ? bounds_type{migraphx::from_value<migraphx::shape::dynamic_dimension>(bounds)}
-                    : migraphx::from_value<bounds_type>(bounds)};
-        });
-    return symbols;
-}
-
 std::vector<std::string> to_expression_strings(const std::vector<migraphx::sym::expr>& exprs)
 {
     std::vector<std::string> strings;
@@ -405,17 +383,15 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             if(v.contains("dyn_dims"))
             {
                 const auto& dims = v.at("dyn_dims");
-                // Expression strings name symbols that `symbols` supplies the bounds for; the
-                // dynamic_dimension form carries its own. Strides are only needed for a
-                // transposed or broadcasted layout, since make_symbolic_shape computes packed
-                // standard ones otherwise.
+                // Expression strings carry their variable metadata inline. Strides are only
+                // needed for a transposed or broadcasted layout, since make_symbolic_shape
+                // computes packed standard ones otherwise.
                 if(not dims.empty() and dims.front().if_string() != nullptr)
                     return migraphx::shape::make_symbolic_shape(
                         t,
                         dims.to_vector<std::string>(),
                         v.contains("dyn_strides") ? v.at("dyn_strides").to_vector<std::string>()
-                                                  : std::vector<std::string>{},
-                        to_symbol_table(v));
+                                                  : std::vector<std::string>{});
                 return migraphx::shape(
                     t, migraphx::from_value<std::vector<migraphx::shape::dynamic_dimension>>(dims));
             }
@@ -439,7 +415,6 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         .def("dyn_dims", &migraphx::shape::dyn_dims)
         .def("dyn_strides",
              [](const migraphx::shape& s) { return to_expression_strings(s.dyn_strides()); })
-        .def("symbol_table", &migraphx::shape::symbol_table)
         .def("sub_shapes", &migraphx::shape::sub_shapes)
         .def("packed", &migraphx::shape::packed)
         .def("transposed", &migraphx::shape::transposed)
@@ -465,7 +440,8 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
                  return migraphx::shape::make_symbolic_dynamic_dimension(expression, symbols);
              }),
              py::arg("expression"),
-             py::arg("symbols"))
+             py::arg("symbols") =
+                 std::unordered_map<std::string, migraphx::shape::dynamic_dimension>{})
         .def_property_readonly("expression",
                                [](const migraphx::shape::dynamic_dimension& d) -> py::object {
                                    if(not d.is_symbolic())

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -439,9 +439,6 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
         .def("dyn_dims", &migraphx::shape::dyn_dims)
         .def("dyn_strides",
              [](const migraphx::shape& s) { return to_expression_strings(s.dyn_strides()); })
-        // The bounds each symbol stands for, in the form the symbols argument takes, so a
-        // symbolic shape can be rebuilt from what Python can read of it. A symbol always maps
-        // to a list here, even where the constructor also accepts a bare dynamic_dimension.
         .def("symbol_table", &migraphx::shape::symbol_table)
         .def("sub_shapes", &migraphx::shape::sub_shapes)
         .def("packed", &migraphx::shape::packed)

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -27,7 +27,6 @@
 #include <migraphx/stringutils.hpp>
 #include <migraphx/serialize.hpp>
 #include <migraphx/json.hpp>
-#include <migraphx/convert_to_json.hpp>
 #include <migraphx/permutation.hpp>
 #include <migraphx/ranges.hpp>
 #include <numeric>
@@ -1497,10 +1496,7 @@ void migraphx_from_value(const value& v, shape& s)
     }
 }
 
-shape shape::from_json(const std::string& s)
-{
-    return from_value<shape>(from_json_string(convert_to_json(s)));
-}
+shape shape::from_json(const std::string& s) { return from_value<shape>(from_json_string(s)); }
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -26,7 +26,6 @@
 #include <migraphx/sym.hpp>
 #include <migraphx/stringutils.hpp>
 #include <migraphx/serialize.hpp>
-#include <migraphx/json.hpp>
 #include <migraphx/permutation.hpp>
 #include <migraphx/ranges.hpp>
 #include <numeric>
@@ -895,26 +894,148 @@ shape shape::to_dynamic() const
     return {type(), lens(), lens(), {}};
 }
 
-shape::dynamic_dimension shape::make_symbolic_dynamic_dimension(
-    const std::string& expression,
-    const std::unordered_map<std::string, dynamic_dimension>& symbols)
+// Build the variable a symbol name stands for. Several bounds assert several intervals, which is
+// what a variable merged from differently bounded same-named ones carries, and their optimals are
+// unioned the same way that merge does.
+static sym::expr make_symbol(const std::string& name,
+                             const std::vector<shape::dynamic_dimension>& bounds)
 {
-    auto e = sym::parse(expression);
-    if(e.empty())
-        MIGRAPHX_THROW("MAKE_SYMBOLIC_DYNAMIC_DIMENSION: symbolic expression is empty");
+    std::vector<sym::interval> constraints;
+    std::set<sym::scalar> optimals;
+    std::transform(bounds.begin(),
+                   bounds.end(),
+                   std::back_inserter(constraints),
+                   [&](const shape::dynamic_dimension& dd) {
+                       auto opts = dd.get_optimals();
+                       optimals.insert(opts.begin(), opts.end());
+                       auto iv = dd.get_interval();
+                       return sym::interval{iv.min, iv.max};
+                   });
+    return sym::var(name, std::move(constraints), std::move(optimals));
+}
+
+template <class Symbols, class F>
+static std::unordered_map<sym::expr, sym::expr> make_bindings(const Symbols& symbols, F to_symbol)
+{
     std::unordered_map<sym::expr, sym::expr> bindings;
     std::transform(symbols.begin(),
                    symbols.end(),
                    std::inserter(bindings, bindings.end()),
-                   [](const auto& kv) {
-                       const auto& [name, dd] = kv;
-                       auto iv                = dd.get_interval();
-                       auto opts              = dd.get_optimals();
-                       std::set<sym::scalar> optimals(opts.begin(), opts.end());
-                       return std::pair<sym::expr, sym::expr>{
-                           sym::parse(name), sym::var(name, {iv.min, iv.max}, std::move(optimals))};
+                   [&](const auto& kv) {
+                       return std::pair<sym::expr, sym::expr>{sym::parse(kv.first),
+                                                              to_symbol(kv.first, kv.second)};
                    });
-    return dynamic_dimension{e.subs(bindings)};
+    return bindings;
+}
+
+static sym::expr parse_bound(const std::string& expression,
+                             const std::unordered_map<sym::expr, sym::expr>& bindings,
+                             const std::string& what)
+{
+    auto e = sym::parse(expression);
+    if(e.empty())
+        MIGRAPHX_THROW("SHAPE: " + what + " expression is empty");
+    return e.subs(bindings);
+}
+
+shape::dynamic_dimension shape::make_symbolic_dynamic_dimension(
+    const std::string& expression,
+    const std::unordered_map<std::string, dynamic_dimension>& symbols)
+{
+    auto bindings =
+        make_bindings(symbols, [](const std::string& name, const dynamic_dimension& dd) {
+            return make_symbol(name, {dd});
+        });
+    return dynamic_dimension{
+        parse_bound(expression, bindings, "MAKE_SYMBOLIC_DYNAMIC_DIMENSION: symbolic")};
+}
+
+shape shape::make_symbolic_shape(
+    type_t t,
+    const std::vector<std::string>& dims,
+    const std::map<std::string, std::vector<dynamic_dimension>>& symbols)
+{
+    return make_symbolic_shape(t, dims, {}, symbols);
+}
+
+shape shape::make_symbolic_shape(
+    type_t t,
+    const std::vector<std::string>& dims,
+    const std::vector<std::string>& strides,
+    const std::map<std::string, std::vector<dynamic_dimension>>& symbols)
+{
+    auto bindings = make_bindings(symbols, &make_symbol);
+    std::vector<dynamic_dimension> dyn_dims;
+    std::transform(
+        dims.begin(), dims.end(), std::back_inserter(dyn_dims), [&](const std::string& d) {
+            return dynamic_dimension{parse_bound(d, bindings, "MAKE_SYMBOLIC_SHAPE: dimension")};
+        });
+    if(strides.empty())
+        return {t, std::move(dyn_dims)};
+    if(strides.size() != dims.size())
+        MIGRAPHX_THROW(
+            "MAKE_SYMBOLIC_SHAPE: number of strides does not match number of dimensions");
+    // A stride is a product of the dimensions, so it resolves through the same table and ends up
+    // sharing their variables.
+    std::vector<sym::expr> dyn_strides;
+    std::transform(
+        strides.begin(), strides.end(), std::back_inserter(dyn_strides), [&](const std::string& s) {
+            return parse_bound(s, bindings, "MAKE_SYMBOLIC_SHAPE: stride");
+        });
+    return {t, std::move(dyn_dims), std::move(dyn_strides)};
+}
+
+// The inverse of make_symbol: each interval a symbol asserts becomes one dynamic_dimension, and
+// the optimals, which belong to the symbol rather than to any one interval, ride on the first.
+static std::vector<shape::dynamic_dimension> make_bounds(const sym::variable_bounds& v)
+{
+    std::vector<shape::dynamic_dimension> bounds;
+    std::transform(v.constraints.begin(),
+                   v.constraints.end(),
+                   std::back_inserter(bounds),
+                   [](const sym::interval& i) {
+                       return shape::dynamic_dimension{sym::to<std::size_t>(i.min),
+                                                       sym::to<std::size_t>(i.max)};
+                   });
+    if(bounds.empty())
+        MIGRAPHX_THROW("SYMBOL_TABLE: a symbol without bounds has no dimension");
+    std::set<std::size_t> optimals;
+    std::transform(v.optimals.begin(),
+                   v.optimals.end(),
+                   std::inserter(optimals, optimals.end()),
+                   [](const sym::scalar& s) { return sym::to<std::size_t>(s); });
+    if(not optimals.empty())
+    {
+        auto front     = bounds.front().get_interval();
+        bounds.front() = shape::dynamic_dimension{front.min, front.max, std::move(optimals)};
+    }
+    return bounds;
+}
+
+std::map<std::string, std::vector<shape::dynamic_dimension>> shape::symbol_table() const
+{
+    // A static or tuple shape names no symbols, and dyn_dims() would throw on one.
+    if(not dynamic())
+        return {};
+    std::map<std::string, sym::variable_bounds> variables;
+    auto collect = [&](const sym::expr& e) {
+        for(auto&& [name, bounds] : sym::find_variable_bounds(e))
+            variables.emplace(name, std::move(bounds));
+    };
+    for(const auto& d : dyn_dims())
+    {
+        if(d.is_symbolic())
+            collect(d.sym_expr);
+    }
+    for(const auto& e : dyn_strides())
+        collect(e);
+    std::map<std::string, std::vector<dynamic_dimension>> result;
+    std::transform(
+        variables.begin(), variables.end(), std::inserter(result, result.end()), [](const auto& v) {
+            return std::pair<std::string, std::vector<dynamic_dimension>>{v.first,
+                                                                          make_bounds(v.second)};
+        });
+    return result;
 }
 
 static bool any_non_sym_dynamic(const shape& s)
@@ -1495,8 +1616,6 @@ void migraphx_from_value(const value& v, shape& s)
         }
     }
 }
-
-shape shape::from_json(const std::string& s) { return from_value<shape>(from_json_string(s)); }
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -26,6 +26,8 @@
 #include <migraphx/sym.hpp>
 #include <migraphx/stringutils.hpp>
 #include <migraphx/serialize.hpp>
+#include <migraphx/json.hpp>
+#include <migraphx/convert_to_json.hpp>
 #include <migraphx/permutation.hpp>
 #include <migraphx/ranges.hpp>
 #include <numeric>
@@ -1493,6 +1495,11 @@ void migraphx_from_value(const value& v, shape& s)
             }
         }
     }
+}
+
+shape make_json_shape(const std::string& s)
+{
+    return from_value<shape>(from_json_string(convert_to_json(s)));
 }
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -1497,7 +1497,7 @@ void migraphx_from_value(const value& v, shape& s)
     }
 }
 
-shape make_json_shape(const std::string& s)
+shape shape::from_json(const std::string& s)
 {
     return from_value<shape>(from_json_string(convert_to_json(s)));
 }

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -894,81 +894,58 @@ shape shape::to_dynamic() const
     return {type(), lens(), lens(), {}};
 }
 
-// Build the variable a symbol name stands for. Several bounds assert several intervals, which is
-// what a variable merged from differently bounded same-named ones carries, and their optimals are
-// unioned the same way that merge does.
-static sym::expr make_symbol(const std::string& name,
-                             const std::vector<shape::dynamic_dimension>& bounds)
+// Build the variable a symbol name stands for in the compatibility binding map.
+static sym::expr make_symbol(const std::string& name, const shape::dynamic_dimension& bound)
 {
-    std::vector<sym::interval> constraints;
-    std::set<sym::scalar> optimals;
-    std::transform(bounds.begin(),
-                   bounds.end(),
-                   std::back_inserter(constraints),
-                   [&](const shape::dynamic_dimension& dd) {
-                       auto opts = dd.get_optimals();
-                       optimals.insert(opts.begin(), opts.end());
-                       auto iv = dd.get_interval();
-                       return sym::interval{iv.min, iv.max};
-                   });
-    return sym::var(name, std::move(constraints), std::move(optimals));
+    auto opts = bound.get_optimals();
+    std::set<sym::scalar> optimals(opts.begin(), opts.end());
+    auto iv = bound.get_interval();
+    return sym::var(name, {iv.min, iv.max}, std::move(optimals));
 }
 
-template <class Symbols, class F>
-static std::unordered_map<sym::expr, sym::expr> make_bindings(const Symbols& symbols, F to_symbol)
+static std::unordered_map<sym::expr, sym::expr>
+make_bindings(const std::unordered_map<std::string, shape::dynamic_dimension>& symbols)
 {
     std::unordered_map<sym::expr, sym::expr> bindings;
     std::transform(symbols.begin(),
                    symbols.end(),
                    std::inserter(bindings, bindings.end()),
-                   [&](const auto& kv) {
+                   [](const auto& kv) {
                        return std::pair<sym::expr, sym::expr>{sym::parse(kv.first),
-                                                              to_symbol(kv.first, kv.second)};
+                                                              make_symbol(kv.first, kv.second)};
                    });
     return bindings;
 }
 
-static sym::expr parse_bound(const std::string& expression,
-                             const std::unordered_map<sym::expr, sym::expr>& bindings,
-                             const std::string& what)
+static sym::expr parse_bound(const std::string& expression, const std::string& what)
 {
     auto e = sym::parse(expression);
     if(e.empty())
         MIGRAPHX_THROW("SHAPE: " + what + " expression is empty");
-    return e.subs(bindings);
+    return e;
 }
 
 shape::dynamic_dimension shape::make_symbolic_dynamic_dimension(
     const std::string& expression,
     const std::unordered_map<std::string, dynamic_dimension>& symbols)
 {
-    auto bindings =
-        make_bindings(symbols, [](const std::string& name, const dynamic_dimension& dd) {
-            return make_symbol(name, {dd});
-        });
-    return dynamic_dimension{
-        parse_bound(expression, bindings, "MAKE_SYMBOLIC_DYNAMIC_DIMENSION: symbolic")};
+    auto e = parse_bound(expression, "MAKE_SYMBOLIC_DYNAMIC_DIMENSION: symbolic");
+    return dynamic_dimension{e.subs(make_bindings(symbols))};
 }
 
-shape shape::make_symbolic_shape(
-    type_t t,
-    const std::vector<std::string>& dims,
-    const std::map<std::string, std::vector<dynamic_dimension>>& symbols)
+shape shape::make_symbolic_shape(type_t t, const std::vector<std::string>& dims)
 {
-    return make_symbolic_shape(t, dims, {}, symbols);
+    return make_symbolic_shape(t, dims, {});
 }
 
-shape shape::make_symbolic_shape(
-    type_t t,
-    const std::vector<std::string>& dims,
-    const std::vector<std::string>& strides,
-    const std::map<std::string, std::vector<dynamic_dimension>>& symbols)
+shape shape::make_symbolic_shape(type_t t,
+                                 const std::vector<std::string>& dims,
+                                 const std::vector<std::string>& strides)
 {
-    auto bindings = make_bindings(symbols, &make_symbol);
     std::vector<dynamic_dimension> dyn_dims;
     std::transform(
         dims.begin(), dims.end(), std::back_inserter(dyn_dims), [&](const std::string& d) {
-            return dynamic_dimension{parse_bound(d, bindings, "MAKE_SYMBOLIC_SHAPE: dimension")};
+            return dynamic_dimension{parse_bound(d, "MAKE_SYMBOLIC_SHAPE: dimension")};
         });
     if(strides.empty())
         return {t, std::move(dyn_dims)};
@@ -979,61 +956,9 @@ shape shape::make_symbolic_shape(
     std::vector<sym::expr> dyn_strides;
     std::transform(
         strides.begin(), strides.end(), std::back_inserter(dyn_strides), [&](const std::string& s) {
-            return parse_bound(s, bindings, "MAKE_SYMBOLIC_SHAPE: stride");
+            return parse_bound(s, "MAKE_SYMBOLIC_SHAPE: stride");
         });
     return {t, std::move(dyn_dims), std::move(dyn_strides)};
-}
-
-// The inverse of make_symbol: each interval a symbol asserts becomes one dynamic_dimension, and
-// the optimals, which belong to the symbol rather than to any one interval, ride on the first.
-static std::vector<shape::dynamic_dimension> make_bounds(const sym::variable_bounds& v)
-{
-    std::vector<shape::dynamic_dimension> bounds;
-    std::transform(v.constraints.begin(),
-                   v.constraints.end(),
-                   std::back_inserter(bounds),
-                   [](const sym::interval& i) {
-                       return shape::dynamic_dimension{sym::to<std::size_t>(i.min),
-                                                       sym::to<std::size_t>(i.max)};
-                   });
-    if(bounds.empty())
-        MIGRAPHX_THROW("SYMBOL_TABLE: a symbol without bounds has no dimension");
-    std::set<std::size_t> optimals;
-    std::transform(v.optimals.begin(),
-                   v.optimals.end(),
-                   std::inserter(optimals, optimals.end()),
-                   [](const sym::scalar& s) { return sym::to<std::size_t>(s); });
-    if(not optimals.empty())
-    {
-        auto front     = bounds.front().get_interval();
-        bounds.front() = shape::dynamic_dimension{front.min, front.max, std::move(optimals)};
-    }
-    return bounds;
-}
-
-std::map<std::string, std::vector<shape::dynamic_dimension>> shape::symbol_table() const
-{
-    // A static or tuple shape names no symbols, and dyn_dims() would throw on one.
-    if(not dynamic())
-        return {};
-    // A name can appear in several dimensions or strides, so they are merged together rather
-    // than one expression at a time.
-    std::vector<sym::expr> exprs;
-    for(const auto& d : dyn_dims())
-    {
-        if(d.is_symbolic())
-            exprs.push_back(d.sym_expr);
-    }
-    const auto& strides = dyn_strides();
-    exprs.insert(exprs.end(), strides.begin(), strides.end());
-    auto variables = sym::find_variable_bounds(exprs);
-    std::map<std::string, std::vector<dynamic_dimension>> result;
-    std::transform(
-        variables.begin(), variables.end(), std::inserter(result, result.end()), [](const auto& v) {
-            return std::pair<std::string, std::vector<dynamic_dimension>>{v.first,
-                                                                          make_bounds(v.second)};
-        });
-    return result;
 }
 
 static bool any_non_sym_dynamic(const shape& s)

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -975,8 +975,7 @@ shape shape::make_symbolic_shape(
     if(strides.size() != dims.size())
         MIGRAPHX_THROW(
             "MAKE_SYMBOLIC_SHAPE: number of strides does not match number of dimensions");
-    // A stride is a product of the dimensions, so it resolves through the same table and ends up
-    // sharing their variables.
+    // Strides parse with the same bindings, so they share the dimensions' variables.
     std::vector<sym::expr> dyn_strides;
     std::transform(
         strides.begin(), strides.end(), std::back_inserter(dyn_strides), [&](const std::string& s) {
@@ -1017,18 +1016,17 @@ std::map<std::string, std::vector<shape::dynamic_dimension>> shape::symbol_table
     // A static or tuple shape names no symbols, and dyn_dims() would throw on one.
     if(not dynamic())
         return {};
-    std::map<std::string, sym::variable_bounds> variables;
-    auto collect = [&](const sym::expr& e) {
-        for(auto&& [name, bounds] : sym::find_variable_bounds(e))
-            variables.emplace(name, std::move(bounds));
-    };
+    // A name can appear in several dimensions or strides, so they are merged together rather
+    // than one expression at a time.
+    std::vector<sym::expr> exprs;
     for(const auto& d : dyn_dims())
     {
         if(d.is_symbolic())
-            collect(d.sym_expr);
+            exprs.push_back(d.sym_expr);
     }
-    for(const auto& e : dyn_strides())
-        collect(e);
+    const auto& strides = dyn_strides();
+    exprs.insert(exprs.end(), strides.begin(), strides.end());
+    auto variables = sym::find_variable_bounds(exprs);
     std::map<std::string, std::vector<dynamic_dimension>> result;
     std::transform(
         variables.begin(), variables.end(), std::inserter(result, result.end()), [](const auto& v) {

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -34,6 +34,9 @@
 #include <migraphx/sat_ops.hpp>
 
 #include <algorithm>
+#include <array>
+#include <cctype>
+#include <charconv>
 #include <cstdint>
 #include <iterator>
 #include <functional>
@@ -451,20 +454,45 @@ template std::shared_ptr<const expr::impl> expr::make_impl(op_node, std::vector<
 
 expr lit(scalar v) { return expr(literal_node{v}); }
 
-expr var(std::string name)
+static void normalize_constraints(std::vector<interval>& cs);
+
+// A symbolic shape is spelled in generated code as an expression string, so every symbol has to
+// survive a round trip through parse. That means a name must be an identifier by the same rule
+// parse_func_or_var accepts.
+static void check_var_name(const std::string& name)
 {
     if(name.empty())
         MIGRAPHX_THROW("Variable name must not be empty");
+    auto first = static_cast<unsigned char>(name.front());
+    if(std::isalpha(first) == 0 and first != '_')
+        MIGRAPHX_THROW("Variable name must start with a letter or an underscore: " + name);
+    if(not std::all_of(name.begin(), name.end(), [](unsigned char c) {
+           return std::isalnum(c) != 0 or c == '_';
+       }))
+        MIGRAPHX_THROW("Variable name must only contain letters, digits and underscores: " + name);
+}
+
+expr var(std::string name)
+{
+    check_var_name(name);
     return expr(variable_node{std::move(name), {}, {}});
 }
 
 expr var(std::string name, interval constraint, std::set<scalar> optimals)
 {
-    if(name.empty())
-        MIGRAPHX_THROW("Variable name must not be empty");
-    if(not constraint.valid())
+    return var(std::move(name), std::vector<interval>{constraint}, std::move(optimals));
+}
+
+expr var(std::string name, std::vector<interval> constraints, std::set<scalar> optimals)
+{
+    check_var_name(name);
+    if(std::any_of(
+           constraints.begin(), constraints.end(), [](const interval& c) { return not c.valid(); }))
         MIGRAPHX_THROW("Invalid interval");
-    return expr(variable_node{std::move(name), {constraint}, std::move(optimals)});
+    // Canonicalize here as well as on merge, so a variable built from a constraint
+    // set compares equal to the same one obtained by merging or deserializing.
+    normalize_constraints(constraints);
+    return expr(variable_node{std::move(name), std::move(constraints), std::move(optimals)});
 }
 
 expr arg(expr x) { return x; }
@@ -1665,6 +1693,30 @@ std::unordered_set<expr> find_variables(const expr& e)
     return result;
 }
 
+std::map<std::string, variable_bounds> find_variable_bounds(const expr& e)
+{
+    std::unordered_set<expr> visited;
+    std::map<std::string, variable_bounds> result;
+    fix([&](auto self, const expr& x) {
+        if(x.empty() or not visited.insert(x).second)
+            return;
+        if(const auto* v = std::get_if<variable_node>(&get_node(x)))
+        {
+            // Two nodes sharing a name but not their metadata are distinct exprs, so merge them
+            // the same way combining them into one expression would.
+            auto& bounds = result[v->name];
+            bounds.constraints.insert(
+                bounds.constraints.end(), v->constraints.begin(), v->constraints.end());
+            normalize_constraints(bounds.constraints);
+            bounds.optimals.insert(v->optimals.begin(), v->optimals.end());
+            return;
+        }
+        for(const auto& c : x.children())
+            self(c);
+    })(e);
+    return result;
+}
+
 [[maybe_unused]] static bool has_float_literal(const expr& e)
 {
     if(e.empty())
@@ -1955,13 +2007,25 @@ std::set<std::size_t> expr::eval_optimals_uint() const
     return result;
 }
 
-static std::string scalar_to_string(const scalar& v)
+// A scalar has to survive the round trip through to_string and parse, so a double gets the
+// shortest representation that reads back exactly. A stream would round to six significant
+// digits, which is lossy for any literal that is not a simple decimal.
+std::string to_string(const scalar& v)
 {
     return visit(
         [](auto x) -> std::string {
-            std::ostringstream ss;
-            ss << x;
-            return ss.str();
+            if constexpr(std::is_floating_point<decltype(x)>{})
+            {
+                std::array<char, 32> buffer{};
+                auto result = std::to_chars(buffer.data(), buffer.data() + buffer.size(), x);
+                if(result.ec != std::errc{})
+                    MIGRAPHX_THROW("Failed to format scalar");
+                return std::string(buffer.data(), result.ptr);
+            }
+            else
+            {
+                return std::to_string(x);
+            }
         },
         v);
 }
@@ -1999,7 +2063,7 @@ std::string expr::to_string() const
                        return string_prec{};
                    return std::visit(
                        overloaded{[](const literal_node& n) -> std::optional<string_prec> {
-                                      return string_prec{scalar_to_string(n.val)};
+                                      return string_prec{sym::to_string(n.val)};
                                   },
                                   [](const variable_node& n) -> std::optional<string_prec> {
                                       return string_prec{n.name};
@@ -2186,11 +2250,26 @@ static expr parse_number(sym_parser& p)
 {
     if((std::isdigit(p.peek_char()) == 0) and p.peek_char() != '.')
         return {};
-    auto token    = p.parse_while([](unsigned char c) { return std::isdigit(c) or c == '.'; });
-    bool is_float = token.find('.') != std::string_view::npos;
-    if(is_float)
-        return lit(std::stod(std::string(token)));
-    return lit(std::stoll(std::string(token)));
+    std::string token{p.parse_while([](unsigned char c) { return std::isdigit(c) or c == '.'; })};
+    // An exponent only counts when digits actually follow it, so a variable beginning with e is
+    // not mistaken for one. to_string emits this form for very large and very small doubles, and
+    // without it those cannot be read back.
+    auto tail = p.peek();
+    if(not tail.empty() and (tail.front() == 'e' or tail.front() == 'E'))
+    {
+        std::size_t n = 1;
+        if(n < tail.size() and (tail[n] == '+' or tail[n] == '-'))
+            n++;
+        if(n < tail.size() and std::isdigit(static_cast<unsigned char>(tail[n])) != 0)
+        {
+            token += std::string{tail.substr(0, n)};
+            p.advance(n);
+            token += std::string{p.parse_while([](unsigned char c) { return std::isdigit(c); })};
+        }
+    }
+    if(token.find_first_of(".eE") != std::string::npos)
+        return lit(std::stod(token));
+    return lit(std::stoll(token));
 }
 
 static expr parse_func_or_var(sym_parser& p)

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -1693,44 +1693,6 @@ std::unordered_set<expr> find_variables(const expr& e)
     return result;
 }
 
-// Accumulate one expression's variables without canonicalizing, so that merging several
-// expressions sorts each constraint set once rather than once per occurrence.
-static void collect_variable_bounds(const expr& e, std::map<std::string, variable_bounds>& result)
-{
-    std::unordered_set<expr> visited;
-    fix([&](auto self, const expr& x) {
-        if(x.empty() or not visited.insert(x).second)
-            return;
-        if(const auto* v = std::get_if<variable_node>(&get_node(x)))
-        {
-            auto& bounds = result[v->name];
-            bounds.constraints.insert(
-                bounds.constraints.end(), v->constraints.begin(), v->constraints.end());
-            bounds.optimals.insert(v->optimals.begin(), v->optimals.end());
-            return;
-        }
-        for(const auto& c : x.children())
-            self(c);
-    })(e);
-}
-
-std::map<std::string, variable_bounds> find_variable_bounds(const expr& e)
-{
-    return find_variable_bounds(std::vector<expr>{e});
-}
-
-std::map<std::string, variable_bounds> find_variable_bounds(const std::vector<expr>& es)
-{
-    std::map<std::string, variable_bounds> result;
-    for(const auto& e : es)
-        collect_variable_bounds(e, result);
-    // Nodes sharing a name but not their metadata are distinct exprs, so merge them the same way
-    // combining them into one expression would.
-    for(auto& entry : result)
-        normalize_constraints(entry.second.constraints);
-    return result;
-}
-
 [[maybe_unused]] static bool has_float_literal(const expr& e)
 {
     if(e.empty())
@@ -2044,6 +2006,37 @@ std::string to_string(const scalar& v)
         v);
 }
 
+static std::string constraint_to_string(const interval& constraint)
+{
+    return "[" + sym::to_string(constraint.min) + ".." + sym::to_string(constraint.max) + "]";
+}
+
+static std::string variable_to_string(const variable_node& variable)
+{
+    std::vector<std::string> attributes;
+    if(not variable.constraints.empty())
+    {
+        std::vector<std::string> constraints;
+        std::transform(variable.constraints.begin(),
+                       variable.constraints.end(),
+                       std::back_inserter(constraints),
+                       &constraint_to_string);
+        attributes.push_back("constraints={" + join_strings(constraints, ", ") + "}");
+    }
+    if(not variable.optimals.empty())
+    {
+        std::vector<std::string> optimals;
+        std::transform(variable.optimals.begin(),
+                       variable.optimals.end(),
+                       std::back_inserter(optimals),
+                       [](const scalar& optimal) { return sym::to_string(optimal); });
+        attributes.push_back("optimals={" + join_strings(optimals, ", ") + "}");
+    }
+    if(attributes.empty())
+        return variable.name;
+    return variable.name + "(" + join_strings(attributes, ", ") + ")";
+}
+
 struct string_prec
 {
     std::string str;
@@ -2080,7 +2073,7 @@ std::string expr::to_string() const
                                       return string_prec{sym::to_string(n.val)};
                                   },
                                   [](const variable_node& n) -> std::optional<string_prec> {
-                                      return string_prec{n.name};
+                                      return string_prec{variable_to_string(n)};
                                   },
                                   [](const op_node&) -> std::optional<string_prec> {
                                       return std::nullopt;
@@ -2260,42 +2253,163 @@ static expr call_function(const std::string& name, const std::vector<expr>& args
     return it->second(args);
 }
 
-static expr parse_number(sym_parser& p)
+static std::optional<scalar> parse_scalar(sym_parser& p, bool allow_sign = false)
 {
-    if((std::isdigit(p.peek_char()) == 0) and p.peek_char() != '.')
-        return {};
-    std::string token{p.parse_while([](unsigned char c) { return std::isdigit(c) or c == '.'; })};
-    // An exponent only counts when digits actually follow it, so a variable beginning with e is
-    // not mistaken for one. to_string emits this form for very large and very small doubles, and
-    // without it those cannot be read back.
-    auto tail = p.peek();
-    if(not tail.empty() and (tail.front() == 'e' or tail.front() == 'E'))
+    auto q = p;
+    std::string token;
+    if(allow_sign and (q.peek_char() == '-' or q.peek_char() == '+'))
     {
-        std::size_t n = 1;
-        if(n < tail.size() and (tail[n] == '+' or tail[n] == '-'))
-            n++;
-        if(n < tail.size() and std::isdigit(static_cast<unsigned char>(tail[n])) != 0)
+        token += q.peek_char();
+        q.advance(1);
+    }
+
+    auto whole = q.parse_while([](unsigned char c) { return std::isdigit(c) != 0; });
+    token += std::string{whole};
+    bool has_digits = not whole.empty();
+
+    // Do not consume the first dot of an interval delimiter such as "1..4".
+    if(q.peek_char() == '.' and not q.starts_with(std::string_view{".."}))
+    {
+        token += '.';
+        q.advance(1);
+        auto fraction = q.parse_while([](unsigned char c) { return std::isdigit(c) != 0; });
+        token += std::string{fraction};
+        has_digits = has_digits or not fraction.empty();
+    }
+    if(not has_digits)
+        return std::nullopt;
+
+    // An exponent only counts when digits actually follow it. to_string emits this form for very
+    // large and very small doubles, and without it those cannot be read back.
+    if(q.peek_char() == 'e' or q.peek_char() == 'E')
+    {
+        auto exponent_parser = q;
+        std::string exponent{exponent_parser.peek_char()};
+        exponent_parser.advance(1);
+        if(exponent_parser.peek_char() == '+' or exponent_parser.peek_char() == '-')
         {
-            token += std::string{tail.substr(0, n)};
-            p.advance(n);
-            token += std::string{p.parse_while([](unsigned char c) { return std::isdigit(c); })};
+            exponent += exponent_parser.peek_char();
+            exponent_parser.advance(1);
+        }
+        auto digits =
+            exponent_parser.parse_while([](unsigned char c) { return std::isdigit(c) != 0; });
+        if(not digits.empty())
+        {
+            exponent += std::string{digits};
+            token += exponent;
+            q = exponent_parser;
         }
     }
+
+    p = q;
     if(token.find_first_of(".eE") != std::string::npos)
-        return lit(std::stod(token));
-    return lit(std::stoll(token));
+        return scalar{std::stod(token)};
+    return scalar{std::stoll(token)};
+}
+
+static expr parse_number(sym_parser& p)
+{
+    auto value = parse_scalar(p);
+    if(not value.has_value())
+        return {};
+    return lit(*value);
+}
+
+static scalar parse_variable_scalar(sym_parser& p)
+{
+    auto value = parse_scalar(p, true);
+    if(not value.has_value())
+        MIGRAPHX_THROW(p.error_message("number"));
+    return *value;
+}
+
+static interval parse_constraint(sym_parser& p)
+{
+    p.expect(std::string_view{"["});
+    auto min = parse_variable_scalar(p);
+    p.expect(std::string_view{".."});
+    auto max = parse_variable_scalar(p);
+    p.expect(std::string_view{"]"});
+    return {std::move(min), std::move(max)};
+}
+
+template <class F>
+static auto parse_braced_list(sym_parser& p, F parse_element)
+{
+    using value_type = decltype(parse_element(p));
+    std::vector<value_type> result;
+    p.expect(std::string_view{"{"});
+    if(p.match(std::string_view{"}"}))
+        return result;
+    result.push_back(parse_element(p));
+    while(p.match(std::string_view{","}))
+        result.push_back(parse_element(p));
+    p.expect(std::string_view{"}"});
+    return result;
+}
+
+static std::string_view parse_identifier(sym_parser& p)
+{
+    char c = p.peek_char();
+    if((std::isalpha(static_cast<unsigned char>(c)) == 0) and c != '_')
+        return {};
+    return p.parse_while([](unsigned char ch) { return std::isalnum(ch) != 0 or ch == '_'; });
+}
+
+static bool starts_variable_attributes(sym_parser p)
+{
+    auto attribute = parse_identifier(p);
+    return not attribute.empty() and p.match(std::string_view{"="});
+}
+
+static expr parse_variable_attributes(sym_parser& p, std::string name)
+{
+    std::optional<std::vector<interval>> constraints;
+    std::optional<std::set<scalar>> optimals;
+    auto parse_attribute = [&] {
+        auto attribute = parse_identifier(p);
+        if(attribute.empty())
+            MIGRAPHX_THROW(p.error_message("variable attribute"));
+        p.expect(std::string_view{"="});
+        if(attribute == "constraints")
+        {
+            if(constraints.has_value())
+                MIGRAPHX_THROW("Duplicate variable attribute: constraints");
+            constraints = parse_braced_list(p, &parse_constraint);
+        }
+        else if(attribute == "optimals")
+        {
+            if(optimals.has_value())
+                MIGRAPHX_THROW("Duplicate variable attribute: optimals");
+            auto values = parse_braced_list(p, &parse_variable_scalar);
+            optimals    = std::set<scalar>{values.begin(), values.end()};
+        }
+        else
+        {
+            MIGRAPHX_THROW("Unknown variable attribute: " + std::string{attribute});
+        }
+    };
+
+    parse_attribute();
+    while(p.match(std::string_view{","}))
+        parse_attribute();
+    p.expect(std::string_view{")"});
+    return var(std::move(name),
+               constraints.value_or(std::vector<interval>{}),
+               optimals.value_or(std::set<scalar>{}));
 }
 
 static expr parse_func_or_var(sym_parser& p)
 {
-    char c = p.peek_char();
-    if((std::isalpha(c) == 0) and c != '_')
+    auto name = parse_identifier(p);
+    if(name.empty())
         return {};
-    auto name = p.parse_while([](unsigned char ch) { return std::isalnum(ch) or ch == '_'; });
     std::string sname(name);
     if(p.peek_char() != '(')
         return var(sname);
     p.advance(1);
+    if(starts_variable_attributes(p))
+        return parse_variable_attributes(p, std::move(sname));
     std::vector<expr> args;
     if(p.peek_char() != ')')
     {

--- a/src/sym.cpp
+++ b/src/sym.cpp
@@ -1693,27 +1693,41 @@ std::unordered_set<expr> find_variables(const expr& e)
     return result;
 }
 
-std::map<std::string, variable_bounds> find_variable_bounds(const expr& e)
+// Accumulate one expression's variables without canonicalizing, so that merging several
+// expressions sorts each constraint set once rather than once per occurrence.
+static void collect_variable_bounds(const expr& e, std::map<std::string, variable_bounds>& result)
 {
     std::unordered_set<expr> visited;
-    std::map<std::string, variable_bounds> result;
     fix([&](auto self, const expr& x) {
         if(x.empty() or not visited.insert(x).second)
             return;
         if(const auto* v = std::get_if<variable_node>(&get_node(x)))
         {
-            // Two nodes sharing a name but not their metadata are distinct exprs, so merge them
-            // the same way combining them into one expression would.
             auto& bounds = result[v->name];
             bounds.constraints.insert(
                 bounds.constraints.end(), v->constraints.begin(), v->constraints.end());
-            normalize_constraints(bounds.constraints);
             bounds.optimals.insert(v->optimals.begin(), v->optimals.end());
             return;
         }
         for(const auto& c : x.children())
             self(c);
     })(e);
+}
+
+std::map<std::string, variable_bounds> find_variable_bounds(const expr& e)
+{
+    return find_variable_bounds(std::vector<expr>{e});
+}
+
+std::map<std::string, variable_bounds> find_variable_bounds(const std::vector<expr>& es)
+{
+    std::map<std::string, variable_bounds> result;
+    for(const auto& e : es)
+        collect_variable_bounds(e, result);
+    // Nodes sharing a name but not their metadata are distinct exprs, so merge them the same way
+    // combining them into one expression would.
+    for(auto& entry : result)
+        normalize_constraints(entry.second.constraints);
     return result;
 }
 

--- a/test/api/test_symbolic_shape.cpp
+++ b/test/api/test_symbolic_shape.cpp
@@ -61,6 +61,48 @@ TEST_CASE(create_symbolic_dynamic_shape)
     EXPECT(not s.dyn_dims()[1].is_symbolic());
 }
 
+TEST_CASE(make_symbolic_shape)
+{
+    migraphx::symbol_table symbols;
+    symbols.add("n", migraphx::dynamic_dimension{1, 8, migraphx::optimals{2, 4}});
+    migraphx::shape s{migraphx_shape_float_type, {"n", "3"}, symbols};
+
+    EXPECT(s.dynamic());
+    EXPECT(s.dyn_dims()[0].is_symbolic());
+    EXPECT(s.dyn_dims()[1].is_symbolic());
+    EXPECT(s.standard());
+
+    // The same shape built one dimension at a time.
+    migraphx::dynamic_dimensions dyn_dims(
+        migraphx::dynamic_dimension{
+            "n", {{"n", migraphx::dynamic_dimension{1, 8, migraphx::optimals{2, 4}}}}},
+        migraphx::dynamic_dimension{"3", {}});
+    EXPECT(s == (migraphx::shape{migraphx_shape_float_type, dyn_dims}));
+}
+
+// Strides resolve through the same table, so they share the dimensions' symbols.
+TEST_CASE(make_symbolic_shape_with_strides)
+{
+    migraphx::symbol_table symbols;
+    symbols.add("n", migraphx::dynamic_dimension{1, 8});
+    migraphx::shape s{migraphx_shape_float_type, {"n", "3"}, {"1", "n"}, symbols};
+    EXPECT(s.dynamic());
+    EXPECT(not s.standard());
+}
+
+// Several bounds for one name assert several intervals, which is what merging two differently
+// bounded same-named variables produces.
+TEST_CASE(make_symbolic_shape_multiple_constraints)
+{
+    migraphx::symbol_table symbols;
+    symbols.add("n",
+                migraphx::dynamic_dimensions(migraphx::dynamic_dimension{1, 20},
+                                             migraphx::dynamic_dimension{2, 10}));
+    migraphx::shape s{migraphx_shape_float_type, {"n"}, symbols};
+    EXPECT(s.dynamic());
+    EXPECT(s.dyn_dims()[0].is_symbolic());
+}
+
 TEST_CASE(parse_onnx_symbolic_dyn_input)
 {
     migraphx::onnx_options options;

--- a/test/api/test_symbolic_shape.cpp
+++ b/test/api/test_symbolic_shape.cpp
@@ -63,9 +63,7 @@ TEST_CASE(create_symbolic_dynamic_shape)
 
 TEST_CASE(make_symbolic_shape)
 {
-    migraphx::symbol_table symbols;
-    symbols.add("n", migraphx::dynamic_dimension{1, 8, migraphx::optimals{2, 4}});
-    migraphx::shape s{migraphx_shape_float_type, {"n", "3"}, symbols};
+    migraphx::shape s{migraphx_shape_float_type, {"n(constraints={[1..8]}, optimals={2, 4})", "3"}};
 
     EXPECT(s.dynamic());
     EXPECT(s.dyn_dims()[0].is_symbolic());
@@ -74,31 +72,24 @@ TEST_CASE(make_symbolic_shape)
 
     // The same shape built one dimension at a time.
     migraphx::dynamic_dimensions dyn_dims(
-        migraphx::dynamic_dimension{
-            "n", {{"n", migraphx::dynamic_dimension{1, 8, migraphx::optimals{2, 4}}}}},
-        migraphx::dynamic_dimension{"3", {}});
+        migraphx::dynamic_dimension{"n(constraints={[1..8]}, optimals={2, 4})"},
+        migraphx::dynamic_dimension{"3"});
     EXPECT(s == (migraphx::shape{migraphx_shape_float_type, dyn_dims}));
 }
 
-// Strides resolve through the same table, so they share the dimensions' symbols.
 TEST_CASE(make_symbolic_shape_with_strides)
 {
-    migraphx::symbol_table symbols;
-    symbols.add("n", migraphx::dynamic_dimension{1, 8});
-    migraphx::shape s{migraphx_shape_float_type, {"n", "3"}, {"1", "n"}, symbols};
+    migraphx::shape s{migraphx_shape_float_type,
+                      {"n(constraints={[1..8]})", "3"},
+                      {"1", "n(constraints={[1..8]})"}};
     EXPECT(s.dynamic());
     EXPECT(not s.standard());
 }
 
-// Several bounds for one name assert several intervals, which is what merging two differently
-// bounded same-named variables produces.
 TEST_CASE(make_symbolic_shape_multiple_constraints)
 {
-    migraphx::symbol_table symbols;
-    symbols.add("n",
-                migraphx::dynamic_dimensions(migraphx::dynamic_dimension{1, 20},
-                                             migraphx::dynamic_dimension{2, 10}));
-    migraphx::shape s{migraphx_shape_float_type, {"n"}, symbols};
+    migraphx::shape s{migraphx_shape_float_type,
+                      {"n(constraints={[1..20], [2..10]}, optimals={4})"}};
     EXPECT(s.dynamic());
     EXPECT(s.dyn_dims()[0].is_symbolic());
 }

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -2308,31 +2308,39 @@ TEST_CASE(module_assign_clears_previous_foreign_outputs)
     EXPECT(x->outputs().empty());
 }
 
-// The printers emit factory("<json with escaped quotes>"). Recover that json and rebuild the shape,
-// so the tests exercise the round trip rather than recomputing the printer's own escaping. Every
-// quote in the payload is escaped, so the last ") on the line is the closing one.
-static migraphx::shape rebuild_printed_shape(const std::string& text, const std::string& factory)
+static std::string printed_cpp(const migraphx::shape& s)
 {
-    auto call  = text.find(factory + "(\"");
-    auto start = call + factory.size() + 2;
-    auto line  = text.find('\n', start);
-    auto end   = text.rfind("\")", line);
-    return migraphx::shape::from_json(
-        migraphx::replace_string(text.substr(start, end - start), "\\\"", "\""));
+    migraphx::module m;
+    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
+    std::stringstream ss;
+    m.print_cpp(ss);
+    return ss.str();
 }
 
+static std::string printed_py(const migraphx::shape& s)
+{
+    migraphx::module m;
+    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
+    std::stringstream ss;
+    m.print_py(ss);
+    return ss.str();
+}
+
+// Each of these pins the emitted spelling and then compiles that same spelling to confirm it
+// rebuilds the shape, so a printer change that stays syntactically valid but loses the
+// expression still fails.
 TEST_CASE(module_print_symbolic_shape_cpp)
 {
     migraphx::shape s{migraphx::shape::float_type,
                       {migraphx::shape::dynamic_dimension{migraphx::sym::var("n", {1, 8})},
                        migraphx::shape::dynamic_dimension{migraphx::sym::lit(3)}}};
-    migraphx::module m;
-    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
-
-    std::stringstream ss;
-    m.print_cpp(ss);
-    EXPECT(migraphx::contains(ss.str(), "migraphx::shape::from_json("));
-    EXPECT(rebuild_printed_shape(ss.str(), "migraphx::shape::from_json") == s);
+    EXPECT(migraphx::contains(
+        printed_cpp(s),
+        R"(migraphx::shape::make_symbolic_shape(migraphx::shape::float_type, {"n", "3"}, {{"n", {migraphx::shape::dynamic_dimension{1, 8}}}}))"));
+    EXPECT(migraphx::shape::make_symbolic_shape(
+               migraphx::shape::float_type,
+               {"n", "3"},
+               {{"n", {migraphx::shape::dynamic_dimension{1, 8}}}}) == s);
 }
 
 TEST_CASE(module_print_symbolic_shape_py)
@@ -2340,62 +2348,123 @@ TEST_CASE(module_print_symbolic_shape_py)
     migraphx::shape s{migraphx::shape::float_type,
                       {migraphx::shape::dynamic_dimension{migraphx::sym::var("n", {1, 8})},
                        migraphx::shape::dynamic_dimension{migraphx::sym::lit(3)}}};
-    migraphx::module m;
-    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
-
-    std::stringstream ss;
-    m.print_py(ss);
-    EXPECT(migraphx::contains(ss.str(), "migraphx.shape.from_json("));
-    EXPECT(rebuild_printed_shape(ss.str(), "migraphx.shape.from_json") == s);
+    EXPECT(migraphx::contains(
+        printed_py(s),
+        R"(migraphx.shape(type="float_type", dyn_dims=["n", "3"], symbols={"n": migraphx.shape.dynamic_dimension(1, 8)}))"));
 }
 
-// A symbol name that sym::parse would reject still survives the printers, because the name travels
-// inside the json instead of as an expression to be reparsed.
-TEST_CASE(module_print_symbolic_shape_name_not_an_identifier)
+TEST_CASE(module_print_symbolic_shape_compound_expression)
 {
-    migraphx::shape s{
-        migraphx::shape::float_type,
-        {migraphx::shape::dynamic_dimension{migraphx::sym::var("input.1_d0", {1, 8})}}};
-    migraphx::module m;
-    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
-
-    std::stringstream ss;
-    m.print_cpp(ss);
-    EXPECT(migraphx::contains(ss.str(), "migraphx::shape::from_json("));
-    EXPECT(rebuild_printed_shape(ss.str(), "migraphx::shape::from_json") == s);
+    auto n = migraphx::sym::var("n", {1, 8});
+    migraphx::shape s{migraphx::shape::float_type, {migraphx::shape::dynamic_dimension{n * 3 + 1}}};
+    EXPECT(migraphx::contains(printed_cpp(s), R"({"3*n + 1"})"));
+    EXPECT(migraphx::contains(printed_py(s), R"(dyn_dims=["3*n + 1"])"));
+    EXPECT(migraphx::shape::make_symbolic_shape(
+               migraphx::shape::float_type,
+               {"3*n + 1"},
+               {{"n", {migraphx::shape::dynamic_dimension{1, 8}}}}) == s);
 }
 
-// Only symbolic dimensions need the json form; a range-based dynamic shape keeps the readable one.
+// Optimals belong to the symbol rather than to any one interval, so they ride on its first bound.
+TEST_CASE(module_print_symbolic_shape_optimals)
+{
+    migraphx::shape s{migraphx::shape::float_type,
+                      {migraphx::shape::dynamic_dimension{
+                          migraphx::sym::var("n", {2, 16}, {std::int64_t{4}, std::int64_t{8}})}}};
+    EXPECT(migraphx::contains(printed_cpp(s),
+                              R"({{"n", {migraphx::shape::dynamic_dimension{2, 16, {4, 8}}}}})"));
+    EXPECT(migraphx::contains(printed_py(s),
+                              R"(symbols={"n": migraphx.shape.dynamic_dimension(2, 16, {4, 8})})"));
+    EXPECT(migraphx::shape::make_symbolic_shape(
+               migraphx::shape::float_type,
+               {"n"},
+               {{"n", {migraphx::shape::dynamic_dimension{2, 16, {4, 8}}}}}) == s);
+}
+
+// A symbol asserting more than one interval takes a list of bounds.
+TEST_CASE(module_print_symbolic_shape_multiple_constraints)
+{
+    migraphx::shape s{migraphx::shape::float_type,
+                      {migraphx::shape::dynamic_dimension{
+                          migraphx::sym::var("n", {{1, 20}, {2, 10}}, {std::int64_t{4}})}}};
+    EXPECT(migraphx::contains(
+        printed_cpp(s),
+        R"({{"n", {migraphx::shape::dynamic_dimension{1, 20, {4}}, migraphx::shape::dynamic_dimension{2, 10}}}})"));
+    EXPECT(migraphx::contains(
+        printed_py(s),
+        R"(symbols={"n": [migraphx.shape.dynamic_dimension(1, 20, {4}), migraphx.shape.dynamic_dimension(2, 10)]})"));
+    EXPECT(migraphx::shape::make_symbolic_shape(migraphx::shape::float_type,
+                                                {"n"},
+                                                {{"n",
+                                                  {migraphx::shape::dynamic_dimension{1, 20, {4}},
+                                                   migraphx::shape::dynamic_dimension{2, 10}}}}) ==
+           s);
+}
+
+// make_symbolic_shape recomputes packed standard strides when none are given.
+TEST_CASE(module_print_symbolic_shape_standard_omits_strides)
+{
+    migraphx::shape s{migraphx::shape::float_type,
+                      {migraphx::shape::dynamic_dimension{migraphx::sym::var("n", {1, 8})},
+                       migraphx::shape::dynamic_dimension{migraphx::sym::lit(3)}}};
+    EXPECT(s.standard());
+    EXPECT(not migraphx::contains(printed_cpp(s), R"({"3", "1"})"));
+    EXPECT(not migraphx::contains(printed_py(s), "dyn_strides"));
+}
+
+// A stride resolves through the same symbol table, so it shares the dimensions' variables.
+TEST_CASE(module_print_symbolic_shape_strides)
+{
+    auto n = migraphx::sym::var("n", {1, 8});
+    migraphx::shape s{migraphx::shape::float_type,
+                      {migraphx::shape::dynamic_dimension{n},
+                       migraphx::shape::dynamic_dimension{migraphx::sym::lit(3)}},
+                      {migraphx::sym::lit(1), n}};
+    EXPECT(not s.standard());
+    EXPECT(migraphx::contains(printed_cpp(s), R"(, {"1", "n"}, {{"n", )"));
+    EXPECT(migraphx::contains(printed_py(s), R"(, dyn_strides=["1", "n"], symbols=)"));
+    EXPECT(migraphx::shape::make_symbolic_shape(
+               migraphx::shape::float_type,
+               {"n", "3"},
+               {"1", "n"},
+               {{"n", {migraphx::shape::dynamic_dimension{1, 8}}}}) == s);
+}
+
+// A partly symbolic shape is not symbolic(), and make_symbolic_shape cannot express a range
+// dimension, so it is spelled dimension by dimension instead.
+TEST_CASE(module_print_symbolic_shape_mixed_with_range)
+{
+    migraphx::shape s{migraphx::shape::float_type,
+                      {migraphx::shape::dynamic_dimension{migraphx::sym::var("n", {1, 8})},
+                       migraphx::shape::dynamic_dimension{3, 5}}};
+    EXPECT(not s.symbolic());
+    EXPECT(migraphx::contains(
+        printed_cpp(s),
+        R"({migraphx::shape::make_symbolic_dynamic_dimension("n", {{"n", {migraphx::shape::dynamic_dimension{1, 8}}}}), migraphx::shape::dynamic_dimension{3, 5}})"));
+    EXPECT(migraphx::contains(
+        printed_py(s),
+        R"(dyn_dims=[migraphx.shape.dynamic_dimension("n", {"n": migraphx.shape.dynamic_dimension(1, 8)}), migraphx.shape.dynamic_dimension(3, 5)])"));
+    EXPECT((migraphx::shape{migraphx::shape::float_type,
+                            {migraphx::shape::make_symbolic_dynamic_dimension(
+                                 "n", {{"n", migraphx::shape::dynamic_dimension{1, 8}}}),
+                             migraphx::shape::dynamic_dimension{3, 5}}}) == s);
+}
+
+// A range-based dynamic shape has no expression, so it keeps the bounds spelling.
 TEST_CASE(module_print_dyn_range_shape_stays_readable)
 {
     migraphx::shape s{migraphx::shape::float_type, {{1, 4}, {3, 3}}};
-    migraphx::module m;
-    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
-
-    std::stringstream ss_cpp;
-    m.print_cpp(ss_cpp);
-    EXPECT(migraphx::contains(ss_cpp.str(), "migraphx::shape{migraphx::shape::float_type"));
-    EXPECT(not migraphx::contains(ss_cpp.str(), "from_json"));
-
-    std::stringstream ss_py;
-    m.print_py(ss_py);
-    EXPECT(migraphx::contains(ss_py.str(), "migraphx.shape.dynamic_dimension(1, 4)"));
-    EXPECT(not migraphx::contains(ss_py.str(), "from_json"));
+    EXPECT(migraphx::contains(printed_cpp(s), "migraphx::shape{migraphx::shape::float_type"));
+    EXPECT(not migraphx::contains(printed_cpp(s), "migraphx::sym::"));
+    EXPECT(migraphx::contains(printed_py(s), "migraphx.shape.dynamic_dimension(1, 4)"));
+    EXPECT(not migraphx::contains(printed_py(s), "migraphx.sym."));
 }
 
 TEST_CASE(module_print_dyn_dim_optimals)
 {
     migraphx::shape s{migraphx::shape::float_type, {{1, 4, {2, 4}}, {3, 3}}};
-    migraphx::module m;
-    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
-
-    std::stringstream ss_cpp;
-    m.print_cpp(ss_cpp);
-    EXPECT(migraphx::contains(ss_cpp.str(), "migraphx::shape::dynamic_dimension{1, 4, {2, 4}}"));
-
-    std::stringstream ss_py;
-    m.print_py(ss_py);
-    EXPECT(migraphx::contains(ss_py.str(), "migraphx.shape.dynamic_dimension(1, 4, {2, 4})"));
+    EXPECT(migraphx::contains(printed_cpp(s), "migraphx::shape::dynamic_dimension{1, 4, {2, 4}}"));
+    EXPECT(migraphx::contains(printed_py(s), "migraphx.shape.dynamic_dimension(1, 4, {2, 4})"));
 }
 
 // A single dimension is the case where a bare brace pair would be an ambiguous constructor call,
@@ -2403,12 +2472,16 @@ TEST_CASE(module_print_dyn_dim_optimals)
 TEST_CASE(module_print_dyn_range_shape_single_dim)
 {
     migraphx::shape s{migraphx::shape::float_type, {migraphx::shape::dynamic_dimension{1, 4}}};
-    migraphx::module m;
-    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
+    EXPECT(migraphx::contains(printed_cpp(s), "{migraphx::shape::dynamic_dimension{1, 4}}"));
+}
 
-    std::stringstream ss;
-    m.print_cpp(ss);
-    EXPECT(migraphx::contains(ss.str(), "{migraphx::shape::dynamic_dimension{1, 4}}"));
+TEST_CASE(module_print_static_shape)
+{
+    migraphx::shape s{migraphx::shape::float_type, {2, 3, 4}, {1, 8, 2}};
+    EXPECT(migraphx::contains(
+        printed_cpp(s), "migraphx::shape{migraphx::shape::float_type, {2, 3, 4}, {1, 8, 2}}"));
+    EXPECT(migraphx::contains(
+        printed_py(s), R"(migraphx.shape(type="float_type", lens=[2, 3, 4], strides=[1, 8, 2]))"));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -28,6 +28,9 @@
 #include <migraphx/register_target.hpp>
 #include <migraphx/ranges.hpp>
 #include <migraphx/make_op.hpp>
+#include <migraphx/json.hpp>
+#include <migraphx/stringutils.hpp>
+#include <migraphx/sym.hpp>
 #include <random>
 #include <sstream>
 
@@ -2304,6 +2307,74 @@ TEST_CASE(module_assign_clears_previous_foreign_outputs)
     // Assigning over a drops the instruction that referenced x.
     a = migraphx::module{};
     EXPECT(x->outputs().empty());
+}
+
+// The printers spell a shape carrying a symbolic dimension as its json value form, so build the
+// expected call the same way the printers do and check it appears verbatim.
+static std::string json_shape_call(const std::string& factory, const migraphx::shape& s)
+{
+    auto json = migraphx::to_json_string(migraphx::to_value(s));
+    return factory + "(\"" + migraphx::replace_string(json, "\"", "\\\"") + "\")";
+}
+
+static migraphx::module symbolic_param_module(const migraphx::shape& s)
+{
+    migraphx::module m;
+    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
+    return m;
+}
+
+TEST_CASE(module_print_symbolic_shape_cpp)
+{
+    migraphx::shape s{migraphx::shape::float_type,
+                      {migraphx::shape::dynamic_dimension{migraphx::sym::var("n", {1, 8})},
+                       migraphx::shape::dynamic_dimension{migraphx::sym::lit(3)}}};
+    auto m = symbolic_param_module(s);
+
+    std::stringstream ss;
+    m.print_cpp(ss);
+    EXPECT(migraphx::contains(ss.str(), json_shape_call("migraphx::make_json_shape", s)));
+}
+
+TEST_CASE(module_print_symbolic_shape_py)
+{
+    migraphx::shape s{migraphx::shape::float_type,
+                      {migraphx::shape::dynamic_dimension{migraphx::sym::var("n", {1, 8})},
+                       migraphx::shape::dynamic_dimension{migraphx::sym::lit(3)}}};
+    auto m = symbolic_param_module(s);
+
+    std::stringstream ss;
+    m.print_py(ss);
+    EXPECT(migraphx::contains(ss.str(), json_shape_call("migraphx.shape.from_json", s)));
+}
+
+// A symbol name that sym::parse would reject must not need any escaping beyond the json quoting.
+TEST_CASE(module_print_symbolic_shape_name_not_an_identifier)
+{
+    migraphx::shape s{
+        migraphx::shape::float_type,
+        {migraphx::shape::dynamic_dimension{migraphx::sym::var("input.1_d0", {1, 8})}}};
+    auto m = symbolic_param_module(s);
+
+    std::stringstream ss;
+    m.print_cpp(ss);
+    EXPECT(migraphx::contains(ss.str(), json_shape_call("migraphx::make_json_shape", s)));
+}
+
+// Only symbolic dimensions need the json form; a range-based dynamic shape keeps the readable one.
+TEST_CASE(module_print_dyn_range_shape_stays_readable)
+{
+    auto m = symbolic_param_module({migraphx::shape::float_type, {{1, 4}, {3, 3}}});
+
+    std::stringstream ss_cpp;
+    m.print_cpp(ss_cpp);
+    EXPECT(migraphx::contains(ss_cpp.str(), "migraphx::shape{migraphx::shape::float_type"));
+    EXPECT(not migraphx::contains(ss_cpp.str(), "make_json_shape"));
+
+    std::stringstream ss_py;
+    m.print_py(ss_py);
+    EXPECT(migraphx::contains(ss_py.str(), "migraphx.shape.dynamic_dimension(1, 4)"));
+    EXPECT(not migraphx::contains(ss_py.str(), "from_json"));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -2309,8 +2309,7 @@ TEST_CASE(module_assign_clears_previous_foreign_outputs)
     EXPECT(x->outputs().empty());
 }
 
-// The printers spell a shape carrying a symbolic dimension as its json value form, so build the
-// expected call the same way the printers do and check it appears verbatim.
+// Builds the from_json call the printers are expected to emit for a shape with a symbolic dim.
 static std::string json_shape_call(const std::string& factory, const migraphx::shape& s)
 {
     auto json = migraphx::to_json_string(migraphx::to_value(s));
@@ -2343,7 +2342,8 @@ TEST_CASE(module_print_symbolic_shape_py)
     EXPECT(migraphx::contains(ss.str(), json_shape_call("migraphx.shape.from_json", s)));
 }
 
-// A symbol name that sym::parse would reject must not need any escaping beyond the json quoting.
+// A symbol name that sym::parse would reject still survives the printers, because the name travels
+// inside the json instead of as an expression to be reparsed.
 TEST_CASE(module_print_symbolic_shape_name_not_an_identifier)
 {
     migraphx::shape s{
@@ -2373,6 +2373,21 @@ TEST_CASE(module_print_dyn_range_shape_stays_readable)
     m.print_py(ss_py);
     EXPECT(migraphx::contains(ss_py.str(), "migraphx.shape.dynamic_dimension(1, 4)"));
     EXPECT(not migraphx::contains(ss_py.str(), "from_json"));
+}
+
+TEST_CASE(module_print_dyn_dim_optimals)
+{
+    migraphx::shape s{migraphx::shape::float_type, {{1, 4, {2, 4}}, {3, 3}}};
+    migraphx::module m;
+    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
+
+    std::stringstream ss_cpp;
+    m.print_cpp(ss_cpp);
+    EXPECT(migraphx::contains(ss_cpp.str(), "{1, 4, {2, 4}}"));
+
+    std::stringstream ss_py;
+    m.print_py(ss_py);
+    EXPECT(migraphx::contains(ss_py.str(), "migraphx.shape.dynamic_dimension(1, 4, {2, 4})"));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -2317,19 +2317,13 @@ static std::string json_shape_call(const std::string& factory, const migraphx::s
     return factory + "(\"" + migraphx::replace_string(json, "\"", "\\\"") + "\")";
 }
 
-static migraphx::module symbolic_param_module(const migraphx::shape& s)
-{
-    migraphx::module m;
-    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
-    return m;
-}
-
 TEST_CASE(module_print_symbolic_shape_cpp)
 {
     migraphx::shape s{migraphx::shape::float_type,
                       {migraphx::shape::dynamic_dimension{migraphx::sym::var("n", {1, 8})},
                        migraphx::shape::dynamic_dimension{migraphx::sym::lit(3)}}};
-    auto m = symbolic_param_module(s);
+    migraphx::module m;
+    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
 
     std::stringstream ss;
     m.print_cpp(ss);
@@ -2341,7 +2335,8 @@ TEST_CASE(module_print_symbolic_shape_py)
     migraphx::shape s{migraphx::shape::float_type,
                       {migraphx::shape::dynamic_dimension{migraphx::sym::var("n", {1, 8})},
                        migraphx::shape::dynamic_dimension{migraphx::sym::lit(3)}}};
-    auto m = symbolic_param_module(s);
+    migraphx::module m;
+    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
 
     std::stringstream ss;
     m.print_py(ss);
@@ -2354,7 +2349,8 @@ TEST_CASE(module_print_symbolic_shape_name_not_an_identifier)
     migraphx::shape s{
         migraphx::shape::float_type,
         {migraphx::shape::dynamic_dimension{migraphx::sym::var("input.1_d0", {1, 8})}}};
-    auto m = symbolic_param_module(s);
+    migraphx::module m;
+    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
 
     std::stringstream ss;
     m.print_cpp(ss);
@@ -2364,7 +2360,9 @@ TEST_CASE(module_print_symbolic_shape_name_not_an_identifier)
 // Only symbolic dimensions need the json form; a range-based dynamic shape keeps the readable one.
 TEST_CASE(module_print_dyn_range_shape_stays_readable)
 {
-    auto m = symbolic_param_module({migraphx::shape::float_type, {{1, 4}, {3, 3}}});
+    migraphx::shape s{migraphx::shape::float_type, {{1, 4}, {3, 3}}};
+    migraphx::module m;
+    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
 
     std::stringstream ss_cpp;
     m.print_cpp(ss_cpp);

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -2327,7 +2327,7 @@ TEST_CASE(module_print_symbolic_shape_cpp)
 
     std::stringstream ss;
     m.print_cpp(ss);
-    EXPECT(migraphx::contains(ss.str(), json_shape_call("migraphx::make_json_shape", s)));
+    EXPECT(migraphx::contains(ss.str(), json_shape_call("migraphx::shape::from_json", s)));
 }
 
 TEST_CASE(module_print_symbolic_shape_py)
@@ -2354,7 +2354,7 @@ TEST_CASE(module_print_symbolic_shape_name_not_an_identifier)
 
     std::stringstream ss;
     m.print_cpp(ss);
-    EXPECT(migraphx::contains(ss.str(), json_shape_call("migraphx::make_json_shape", s)));
+    EXPECT(migraphx::contains(ss.str(), json_shape_call("migraphx::shape::from_json", s)));
 }
 
 // Only symbolic dimensions need the json form; a range-based dynamic shape keeps the readable one.
@@ -2367,7 +2367,7 @@ TEST_CASE(module_print_dyn_range_shape_stays_readable)
     std::stringstream ss_cpp;
     m.print_cpp(ss_cpp);
     EXPECT(migraphx::contains(ss_cpp.str(), "migraphx::shape{migraphx::shape::float_type"));
-    EXPECT(not migraphx::contains(ss_cpp.str(), "make_json_shape"));
+    EXPECT(not migraphx::contains(ss_cpp.str(), "from_json"));
 
     std::stringstream ss_py;
     m.print_py(ss_py);

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -28,7 +28,6 @@
 #include <migraphx/register_target.hpp>
 #include <migraphx/ranges.hpp>
 #include <migraphx/make_op.hpp>
-#include <migraphx/json.hpp>
 #include <migraphx/stringutils.hpp>
 #include <migraphx/sym.hpp>
 #include <random>
@@ -2309,11 +2308,17 @@ TEST_CASE(module_assign_clears_previous_foreign_outputs)
     EXPECT(x->outputs().empty());
 }
 
-// Builds the from_json call the printers are expected to emit for a shape with a symbolic dim.
-static std::string json_shape_call(const std::string& factory, const migraphx::shape& s)
+// The printers emit factory("<json with escaped quotes>"). Recover that json and rebuild the shape,
+// so the tests exercise the round trip rather than recomputing the printer's own escaping. Every
+// quote in the payload is escaped, so the last ") on the line is the closing one.
+static migraphx::shape rebuild_printed_shape(const std::string& text, const std::string& factory)
 {
-    auto json = migraphx::to_json_string(migraphx::to_value(s));
-    return factory + "(\"" + migraphx::replace_string(json, "\"", "\\\"") + "\")";
+    auto call  = text.find(factory + "(\"");
+    auto start = call + factory.size() + 2;
+    auto line  = text.find('\n', start);
+    auto end   = text.rfind("\")", line);
+    return migraphx::shape::from_json(
+        migraphx::replace_string(text.substr(start, end - start), "\\\"", "\""));
 }
 
 TEST_CASE(module_print_symbolic_shape_cpp)
@@ -2326,7 +2331,8 @@ TEST_CASE(module_print_symbolic_shape_cpp)
 
     std::stringstream ss;
     m.print_cpp(ss);
-    EXPECT(migraphx::contains(ss.str(), json_shape_call("migraphx::shape::from_json", s)));
+    EXPECT(migraphx::contains(ss.str(), "migraphx::shape::from_json("));
+    EXPECT(rebuild_printed_shape(ss.str(), "migraphx::shape::from_json") == s);
 }
 
 TEST_CASE(module_print_symbolic_shape_py)
@@ -2339,7 +2345,8 @@ TEST_CASE(module_print_symbolic_shape_py)
 
     std::stringstream ss;
     m.print_py(ss);
-    EXPECT(migraphx::contains(ss.str(), json_shape_call("migraphx.shape.from_json", s)));
+    EXPECT(migraphx::contains(ss.str(), "migraphx.shape.from_json("));
+    EXPECT(rebuild_printed_shape(ss.str(), "migraphx.shape.from_json") == s);
 }
 
 // A symbol name that sym::parse would reject still survives the printers, because the name travels
@@ -2354,7 +2361,8 @@ TEST_CASE(module_print_symbolic_shape_name_not_an_identifier)
 
     std::stringstream ss;
     m.print_cpp(ss);
-    EXPECT(migraphx::contains(ss.str(), json_shape_call("migraphx::shape::from_json", s)));
+    EXPECT(migraphx::contains(ss.str(), "migraphx::shape::from_json("));
+    EXPECT(rebuild_printed_shape(ss.str(), "migraphx::shape::from_json") == s);
 }
 
 // Only symbolic dimensions need the json form; a range-based dynamic shape keeps the readable one.
@@ -2383,11 +2391,24 @@ TEST_CASE(module_print_dyn_dim_optimals)
 
     std::stringstream ss_cpp;
     m.print_cpp(ss_cpp);
-    EXPECT(migraphx::contains(ss_cpp.str(), "{1, 4, {2, 4}}"));
+    EXPECT(migraphx::contains(ss_cpp.str(), "migraphx::shape::dynamic_dimension{1, 4, {2, 4}}"));
 
     std::stringstream ss_py;
     m.print_py(ss_py);
     EXPECT(migraphx::contains(ss_py.str(), "migraphx.shape.dynamic_dimension(1, 4, {2, 4})"));
+}
+
+// A single dimension is the case where a bare brace pair would be an ambiguous constructor call,
+// because it is also viable as the lens vector.
+TEST_CASE(module_print_dyn_range_shape_single_dim)
+{
+    migraphx::shape s{migraphx::shape::float_type, {migraphx::shape::dynamic_dimension{1, 4}}};
+    migraphx::module m;
+    m.add_return({m.add_instruction(migraphx::make_op("neg"), m.add_parameter("x", s))});
+
+    std::stringstream ss;
+    m.print_cpp(ss);
+    EXPECT(migraphx::contains(ss.str(), "{migraphx::shape::dynamic_dimension{1, 4}}"));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -2326,9 +2326,8 @@ static std::string printed_py(const migraphx::shape& s)
     return ss.str();
 }
 
-// Each of these pins the emitted spelling and then compiles that same spelling to confirm it
-// rebuilds the shape, so a printer change that stays syntactically valid but loses the
-// expression still fails.
+// These pin the emitted spelling; the C++ cases also build a shape from that same spelling, so a
+// printer change that stays syntactically valid but loses the expression still fails.
 TEST_CASE(module_print_symbolic_shape_cpp)
 {
     migraphx::shape s{migraphx::shape::float_type,

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -2335,11 +2335,9 @@ TEST_CASE(module_print_symbolic_shape_cpp)
                        migraphx::shape::dynamic_dimension{migraphx::sym::lit(3)}}};
     EXPECT(migraphx::contains(
         printed_cpp(s),
-        R"(migraphx::shape::make_symbolic_shape(migraphx::shape::float_type, {"n", "3"}, {{"n", {migraphx::shape::dynamic_dimension{1, 8}}}}))"));
-    EXPECT(migraphx::shape::make_symbolic_shape(
-               migraphx::shape::float_type,
-               {"n", "3"},
-               {{"n", {migraphx::shape::dynamic_dimension{1, 8}}}}) == s);
+        R"code(migraphx::shape::make_symbolic_shape(migraphx::shape::float_type, {"n(constraints={[1..8]})", "3"}))code"));
+    EXPECT(migraphx::shape::make_symbolic_shape(migraphx::shape::float_type,
+                                                {"n(constraints={[1..8]})", "3"}) == s);
 }
 
 TEST_CASE(module_print_symbolic_shape_py)
@@ -2349,54 +2347,44 @@ TEST_CASE(module_print_symbolic_shape_py)
                        migraphx::shape::dynamic_dimension{migraphx::sym::lit(3)}}};
     EXPECT(migraphx::contains(
         printed_py(s),
-        R"(migraphx.shape(type="float_type", dyn_dims=["n", "3"], symbols={"n": migraphx.shape.dynamic_dimension(1, 8)}))"));
+        R"code(migraphx.shape(type="float_type", dyn_dims=["n(constraints={[1..8]})", "3"]))code"));
 }
 
 TEST_CASE(module_print_symbolic_shape_compound_expression)
 {
     auto n = migraphx::sym::var("n", {1, 8});
     migraphx::shape s{migraphx::shape::float_type, {migraphx::shape::dynamic_dimension{n * 3 + 1}}};
-    EXPECT(migraphx::contains(printed_cpp(s), R"({"3*n + 1"})"));
-    EXPECT(migraphx::contains(printed_py(s), R"(dyn_dims=["3*n + 1"])"));
-    EXPECT(migraphx::shape::make_symbolic_shape(
-               migraphx::shape::float_type,
-               {"3*n + 1"},
-               {{"n", {migraphx::shape::dynamic_dimension{1, 8}}}}) == s);
+    EXPECT(migraphx::contains(printed_cpp(s), R"code({"3*n(constraints={[1..8]}) + 1"})code"));
+    EXPECT(
+        migraphx::contains(printed_py(s), R"code(dyn_dims=["3*n(constraints={[1..8]}) + 1"])code"));
+    EXPECT(migraphx::shape::make_symbolic_shape(migraphx::shape::float_type,
+                                                {"3*n(constraints={[1..8]}) + 1"}) == s);
 }
 
-// Optimals belong to the symbol rather than to any one interval, so they ride on its first bound.
 TEST_CASE(module_print_symbolic_shape_optimals)
 {
     migraphx::shape s{migraphx::shape::float_type,
                       {migraphx::shape::dynamic_dimension{
                           migraphx::sym::var("n", {2, 16}, {std::int64_t{4}, std::int64_t{8}})}}};
     EXPECT(migraphx::contains(printed_cpp(s),
-                              R"({{"n", {migraphx::shape::dynamic_dimension{2, 16, {4, 8}}}}})"));
+                              R"code("n(constraints={[2..16]}, optimals={4, 8})")code"));
     EXPECT(migraphx::contains(printed_py(s),
-                              R"(symbols={"n": migraphx.shape.dynamic_dimension(2, 16, {4, 8})})"));
+                              R"code("n(constraints={[2..16]}, optimals={4, 8})")code"));
     EXPECT(migraphx::shape::make_symbolic_shape(
-               migraphx::shape::float_type,
-               {"n"},
-               {{"n", {migraphx::shape::dynamic_dimension{2, 16, {4, 8}}}}}) == s);
+               migraphx::shape::float_type, {"n(constraints={[2..16]}, optimals={4, 8})"}) == s);
 }
 
-// A symbol asserting more than one interval takes a list of bounds.
 TEST_CASE(module_print_symbolic_shape_multiple_constraints)
 {
     migraphx::shape s{migraphx::shape::float_type,
                       {migraphx::shape::dynamic_dimension{
                           migraphx::sym::var("n", {{1, 20}, {2, 10}}, {std::int64_t{4}})}}};
-    EXPECT(migraphx::contains(
-        printed_cpp(s),
-        R"({{"n", {migraphx::shape::dynamic_dimension{1, 20, {4}}, migraphx::shape::dynamic_dimension{2, 10}}}})"));
-    EXPECT(migraphx::contains(
-        printed_py(s),
-        R"(symbols={"n": [migraphx.shape.dynamic_dimension(1, 20, {4}), migraphx.shape.dynamic_dimension(2, 10)]})"));
-    EXPECT(migraphx::shape::make_symbolic_shape(migraphx::shape::float_type,
-                                                {"n"},
-                                                {{"n",
-                                                  {migraphx::shape::dynamic_dimension{1, 20, {4}},
-                                                   migraphx::shape::dynamic_dimension{2, 10}}}}) ==
+    EXPECT(migraphx::contains(printed_cpp(s),
+                              R"code("n(constraints={[1..20], [2..10]}, optimals={4})")code"));
+    EXPECT(migraphx::contains(printed_py(s),
+                              R"code("n(constraints={[1..20], [2..10]}, optimals={4})")code"));
+    EXPECT(migraphx::shape::make_symbolic_shape(
+               migraphx::shape::float_type, {"n(constraints={[1..20], [2..10]}, optimals={4})"}) ==
            s);
 }
 
@@ -2411,7 +2399,7 @@ TEST_CASE(module_print_symbolic_shape_standard_omits_strides)
     EXPECT(not migraphx::contains(printed_py(s), "dyn_strides"));
 }
 
-// A stride resolves through the same symbol table, so it shares the dimensions' variables.
+// A stride carries the same self-contained symbolic variable as the dimension.
 TEST_CASE(module_print_symbolic_shape_strides)
 {
     auto n = migraphx::sym::var("n", {1, 8});
@@ -2420,13 +2408,12 @@ TEST_CASE(module_print_symbolic_shape_strides)
                        migraphx::shape::dynamic_dimension{migraphx::sym::lit(3)}},
                       {migraphx::sym::lit(1), n}};
     EXPECT(not s.standard());
-    EXPECT(migraphx::contains(printed_cpp(s), R"(, {"1", "n"}, {{"n", )"));
-    EXPECT(migraphx::contains(printed_py(s), R"(, dyn_strides=["1", "n"], symbols=)"));
-    EXPECT(migraphx::shape::make_symbolic_shape(
-               migraphx::shape::float_type,
-               {"n", "3"},
-               {"1", "n"},
-               {{"n", {migraphx::shape::dynamic_dimension{1, 8}}}}) == s);
+    EXPECT(migraphx::contains(printed_cpp(s), R"code(, {"1", "n(constraints={[1..8]})"})code"));
+    EXPECT(migraphx::contains(printed_py(s),
+                              R"code(, dyn_strides=["1", "n(constraints={[1..8]})"])code"));
+    EXPECT(migraphx::shape::make_symbolic_shape(migraphx::shape::float_type,
+                                                {"n(constraints={[1..8]})", "3"},
+                                                {"1", "n(constraints={[1..8]})"}) == s);
 }
 
 // A partly symbolic shape is not symbolic(), and make_symbolic_shape cannot express a range
@@ -2439,14 +2426,28 @@ TEST_CASE(module_print_symbolic_shape_mixed_with_range)
     EXPECT(not s.symbolic());
     EXPECT(migraphx::contains(
         printed_cpp(s),
-        R"({migraphx::shape::make_symbolic_dynamic_dimension("n", {{"n", {migraphx::shape::dynamic_dimension{1, 8}}}}), migraphx::shape::dynamic_dimension{3, 5}})"));
+        R"code({migraphx::shape::make_symbolic_dynamic_dimension("n(constraints={[1..8]})"), migraphx::shape::dynamic_dimension{3, 5}})code"));
     EXPECT(migraphx::contains(
         printed_py(s),
-        R"(dyn_dims=[migraphx.shape.dynamic_dimension("n", {"n": migraphx.shape.dynamic_dimension(1, 8)}), migraphx.shape.dynamic_dimension(3, 5)])"));
-    EXPECT((migraphx::shape{migraphx::shape::float_type,
-                            {migraphx::shape::make_symbolic_dynamic_dimension(
-                                 "n", {{"n", migraphx::shape::dynamic_dimension{1, 8}}}),
-                             migraphx::shape::dynamic_dimension{3, 5}}}) == s);
+        R"code(dyn_dims=[migraphx.shape.dynamic_dimension("n(constraints={[1..8]})"), migraphx.shape.dynamic_dimension(3, 5)])code"));
+    EXPECT((migraphx::shape{
+               migraphx::shape::float_type,
+               {migraphx::shape::make_symbolic_dynamic_dimension("n(constraints={[1..8]})"),
+                migraphx::shape::dynamic_dimension{3, 5}}}) == s);
+}
+
+TEST_CASE(module_print_symbolic_shape_multiple_constraints_mixed_with_range)
+{
+    auto n = migraphx::sym::var("n", {{1, 20}, {2, 10}}, {std::int64_t{4}});
+    migraphx::shape s{
+        migraphx::shape::float_type,
+        {migraphx::shape::dynamic_dimension{n}, migraphx::shape::dynamic_dimension{3, 5}}};
+    EXPECT(migraphx::contains(
+        printed_cpp(s),
+        R"code(migraphx::shape::make_symbolic_dynamic_dimension("n(constraints={[1..20], [2..10]}, optimals={4})"))code"));
+    EXPECT(migraphx::contains(
+        printed_py(s),
+        R"code(migraphx.shape.dynamic_dimension("n(constraints={[1..20], [2..10]}, optimals={4})"))code"));
 }
 
 // A range-based dynamic shape has no expression, so it keeps the bounds spelling.

--- a/test/onnx/dim_param_odd_names_test.onnx
+++ b/test/onnx/dim_param_odd_names_test.onnx
@@ -1,0 +1,15 @@
+	dim_param_odd_names_test:xdim_param_odd_names_testZ-
+0(
+&"
+
+batch.size
+
+batch_size
+2db-
+0(
+&"
+
+batch.size
+
+batch_size
+2dB

--- a/test/onnx/gen_onnx.py
+++ b/test/onnx/gen_onnx.py
@@ -3196,6 +3196,16 @@ def dim_param_test():
 
 
 @onnx_test()
+def dim_param_odd_names_test():
+    # A dim_param is an arbitrary string, but a symbol name has to be an identifier. The first
+    # two only differ where sanitizing rewrites them, so they also cover collision handling.
+    x = helper.make_tensor_value_info('0', TensorProto.FLOAT,
+                                      ["batch.size", "batch_size", "2d"])
+
+    return ([], [x], [x])
+
+
+@onnx_test()
 def dropout_test():
     x = helper.make_tensor_value_info('0', TensorProto.FLOAT, [1, 3, 2, 2])
     y = helper.make_tensor_value_info('1', TensorProto.FLOAT, [1, 3, 2, 2])

--- a/test/onnx/parse/dim_param_test.cpp
+++ b/test/onnx/parse/dim_param_test.cpp
@@ -114,6 +114,28 @@ TEST_CASE(dim_param_symbolic_map_dyn_input_optimals_test)
     EXPECT(p == prog);
 }
 
+// A dim_param is an arbitrary string but a symbol name has to be an identifier, so the parser
+// rewrites it. "batch.size" and "batch_size" sanitize alike, so the second to be seen gains a
+// counter rather than silently sharing the first one's symbol.
+TEST_CASE(dim_param_symbolic_odd_names_test)
+{
+    using migraphx::sym::var;
+    migraphx::program p;
+    auto* mm   = p.get_main_module();
+    auto input = mm->add_parameter("0",
+                                   migraphx::shape{migraphx::shape::float_type,
+                                                   sym_dims({var("batch_size", {1, 4}),
+                                                             var("batch_size_2", {1, 4}),
+                                                             var("_2d", {1, 4})})});
+    mm->add_return({input});
+
+    migraphx::onnx_options opt;
+    opt.use_symbolic_shapes   = true;
+    opt.default_dyn_dim_value = {1, 4};
+    auto prog                 = read_onnx("dim_param_odd_names_test.onnx", opt);
+    EXPECT(p == prog);
+}
+
 TEST_CASE(dim_param_symbolic_map_dyn_input_explicit_sym_test)
 {
     using migraphx::sym::var;

--- a/test/onnx/parse/variable_batch_test.cpp
+++ b/test/onnx/parse/variable_batch_test.cpp
@@ -127,12 +127,13 @@ TEST_CASE(variable_batch_symbolic_test)
     using migraphx::sym::var;
     migraphx::program p;
     auto* mm = p.get_main_module();
-    // The unnamed batch dim has no map_dyn_input_dims override, so parse_type synthesizes the
-    // symbol "0_d0" from the ranged default_dyn_dim_value; the fixed dims become literals.
+    // The unnamed batch dim has no map_dyn_input_dims override, so parse_type synthesizes a
+    // symbol from the input name and axis; the fixed dims become literals. The input is named
+    // "0", and a symbol name has to be an identifier, so it is sanitized to "_0_d0".
     auto l0 = mm->add_parameter(
         "0",
         migraphx::shape{migraphx::shape::float_type,
-                        sym_dims({var("0_d0", {1, 4}), lit(3), lit(16), lit(16)})});
+                        sym_dims({var("_0_d0", {1, 4}), lit(3), lit(16), lit(16)})});
     auto r = mm->add_instruction(migraphx::make_op("identity"), l0);
     mm->add_return({r});
 

--- a/test/py/test_symbolic_shape.py
+++ b/test/py/test_symbolic_shape.py
@@ -62,7 +62,7 @@ def test_create_symbolic_dyn_shape():
     assert not s.dyn_dims()[1].is_symbolic()
 
 
-def _symbolic_program():
+def test_to_py_preserves_symbolic_expression():
     p = migraphx.program()
     m = p.get_main_module()
     s = migraphx.shape(type='float',
@@ -74,17 +74,14 @@ def _symbolic_program():
                        ])
     m.add_return(
         [m.add_instruction(migraphx.op("neg"), [m.add_parameter("x", s)])])
-    return p
 
+    code = p.to_py()
+    assert "migraphx.shape.from_json" in code
 
-def test_to_py_preserves_symbolic_expression():
-    p = _symbolic_program()
-    assert "migraphx.shape.from_json" in p.to_py()
-
-    # The generated code has to rebuild an equal program, expression included. Sorting first
-    # because to_py does not preserve the declaration order of parameters.
+    # The generated code has to rebuild an equal program, expression included. sort() normalizes
+    # instruction order, which to_py only perturbs once a module has more than one parameter.
     scope = {"migraphx": migraphx}
-    exec(p.to_py(), scope)
+    exec(code, scope)
     assert scope["p"].sort() == p.sort()
 
 

--- a/test/py/test_symbolic_shape.py
+++ b/test/py/test_symbolic_shape.py
@@ -62,6 +62,119 @@ def test_create_symbolic_dyn_shape():
     assert not s.dyn_dims()[1].is_symbolic()
 
 
+def test_create_symbolic_shape_from_strings():
+    dd = migraphx.shape.dynamic_dimension
+    s = migraphx.shape(type='float',
+                       dyn_dims=["n", "3"],
+                       symbols={"n": dd(1, 8, {2, 4})})
+    assert s.symbolic()
+    assert s.dyn_dims()[0].expression == "n"
+    assert s.dyn_dims()[0].min == 1
+    assert s.dyn_dims()[0].max == 8
+    assert s.dyn_dims()[0].optimals == {2, 4}
+    # An all-symbolic shape gets packed standard strides when none are given.
+    assert s.standard()
+    assert s.dyn_strides() == ["3", "1"]
+
+    # A range-based dimension carries no expression.
+    r = migraphx.shape(type='float', dyn_dims=[dd(1, 4)])
+    assert r.dyn_dims()[0].expression is None
+
+
+def test_create_symbolic_shape_compound_expression():
+    dd = migraphx.shape.dynamic_dimension
+    s = migraphx.shape(type='float',
+                       dyn_dims=["3*n + 1"],
+                       symbols={"n": dd(1, 8)})
+    assert s.dyn_dims()[0].expression == "3*n + 1"
+    assert (s.dyn_dims()[0].min, s.dyn_dims()[0].max) == (4, 25)
+
+
+def test_create_symbolic_shape_with_strides():
+    dd = migraphx.shape.dynamic_dimension
+    s = migraphx.shape(type='float',
+                       dyn_dims=["n", "3"],
+                       symbols={"n": dd(1, 8)},
+                       dyn_strides=["1", "n"])
+    assert not s.standard()
+    assert s.dyn_strides() == ["1", "n"]
+
+
+def test_create_symbolic_shape_multiple_constraints():
+    dd = migraphx.shape.dynamic_dimension
+    # A list of bounds asserts several intervals, which is what merging two differently bounded
+    # same-named variables produces.
+    s = migraphx.shape(type='float',
+                       dyn_dims=["n"],
+                       symbols={"n": [dd(1, 20), dd(2, 10, {4})]})
+    assert s.dyn_dims()[0].is_symbolic()
+    assert s.dyn_dims()[0].optimals == {4}
+
+
+def test_symbol_table_round_trip():
+    dd = migraphx.shape.dynamic_dimension
+    s = migraphx.shape(type='float',
+                       dyn_dims=["3*n + 1", "m"],
+                       symbols={
+                           "n": dd(1, 8, {2, 4}),
+                           "m": dd(2, 16)
+                       })
+    table = s.symbol_table()
+    # A symbol always maps to a list here, even where the constructor also takes a bare
+    # dynamic_dimension.
+    assert sorted(table) == ["m", "n"]
+    assert len(table["n"]) == 1
+    assert (table["n"][0].min, table["n"][0].max) == (1, 8)
+    assert table["n"][0].optimals == {2, 4}
+    # The table is what the constructor takes, so a shape rebuilds from what can be read of it.
+    assert migraphx.shape(type='float',
+                          dyn_dims=["3*n + 1", "m"],
+                          symbols=table) == s
+
+
+def test_symbol_table_strides_and_multiple_constraints():
+    dd = migraphx.shape.dynamic_dimension
+    # A stride shares the dimensions' symbols, so the table does not grow for it.
+    s = migraphx.shape(type='float',
+                       dyn_dims=["n", "3"],
+                       symbols={"n": dd(1, 8)},
+                       dyn_strides=["1", "n"])
+    assert list(s.symbol_table()) == ["n"]
+    assert migraphx.shape(type='float',
+                          dyn_dims=["n", "3"],
+                          symbols=s.symbol_table(),
+                          dyn_strides=s.dyn_strides()) == s
+
+    m = migraphx.shape(type='float',
+                       dyn_dims=["n"],
+                       symbols={"n": [dd(1, 20), dd(2, 10, {4})]})
+    assert len(m.symbol_table()["n"]) == 2
+    assert migraphx.shape(type='float',
+                          dyn_dims=["n"],
+                          symbols=m.symbol_table()) == m
+
+
+# A range-based or static shape names no symbols.
+def test_symbol_table_empty_without_symbols():
+    dd = migraphx.shape.dynamic_dimension
+    assert migraphx.shape(type='float', dyn_dims=[dd(1,
+                                                     4)]).symbol_table() == {}
+    assert migraphx.shape(type='float', lens=[2, 3]).symbol_table() == {}
+
+
+def test_symbol_name_must_be_an_identifier():
+    dd = migraphx.shape.dynamic_dimension
+    # A symbolic shape is spelled as an expression string, so a name has to survive parsing.
+    try:
+        migraphx.shape(type='float',
+                       dyn_dims=["input.1"],
+                       symbols={"input.1": dd(1, 8)})
+    except RuntimeError:
+        pass
+    else:
+        assert False, "expected a non-identifier symbol name to be rejected"
+
+
 def test_to_py_preserves_symbolic_expression():
     p = migraphx.program()
     m = p.get_main_module()
@@ -76,7 +189,9 @@ def test_to_py_preserves_symbolic_expression():
         [m.add_instruction(migraphx.op("neg"), [m.add_parameter("x", s)])])
 
     code = p.to_py()
-    assert "migraphx.shape.from_json" in code
+    # The second dimension is range-based, so this is the per-dimension spelling.
+    assert not s.symbolic()
+    assert '"3*n + 1"' in code
 
     # The generated code has to rebuild an equal program, expression included. sort() normalizes
     # instruction order, which to_py only perturbs once a module has more than one parameter.
@@ -86,6 +201,44 @@ def test_to_py_preserves_symbolic_expression():
 
     # Program equality compares printed IR, which renders neither optimals nor symbolic strides,
     # so the expression is only really pinned by comparing the shape itself.
+    assert scope["p"].get_parameter_shapes()["x"] == s
+
+
+def test_to_py_preserves_symbolic_strides():
+    p = migraphx.program()
+    m = p.get_main_module()
+    s = migraphx.shape(type='float',
+                       dyn_dims=["n", "3"],
+                       symbols={"n": migraphx.shape.dynamic_dimension(1, 8)},
+                       dyn_strides=["1", "n"])
+    m.add_return(
+        [m.add_instruction(migraphx.op("neg"), [m.add_parameter("x", s)])])
+
+    code = p.to_py()
+    assert "dyn_strides" in code
+    scope = {"migraphx": migraphx}
+    exec(code, scope)
+    assert scope["p"].get_parameter_shapes()["x"] == s
+
+
+# make_symbolic_shape cannot express a range dimension, so a partly symbolic shape is printed
+# dimension by dimension instead.
+def test_to_py_mixed_symbolic_and_range():
+    p = migraphx.program()
+    m = p.get_main_module()
+    s = migraphx.shape(type='float',
+                       dyn_dims=[
+                           migraphx.shape.dynamic_dimension(
+                               "n",
+                               {"n": migraphx.shape.dynamic_dimension(1, 8)}),
+                           migraphx.shape.dynamic_dimension(3, 5)
+                       ])
+    m.add_return(
+        [m.add_instruction(migraphx.op("neg"), [m.add_parameter("x", s)])])
+
+    assert not s.symbolic()
+    scope = {"migraphx": migraphx}
+    exec(p.to_py(), scope)
     assert scope["p"].get_parameter_shapes()["x"] == s
 
 
@@ -127,6 +280,16 @@ if __name__ == "__main__":
     test_create_symbolic_dyn_dims()
     test_create_symbolic_compound_expr()
     test_create_symbolic_dyn_shape()
+    test_create_symbolic_shape_from_strings()
+    test_create_symbolic_shape_compound_expression()
+    test_create_symbolic_shape_with_strides()
+    test_create_symbolic_shape_multiple_constraints()
+    test_symbol_table_round_trip()
+    test_symbol_table_strides_and_multiple_constraints()
+    test_symbol_table_empty_without_symbols()
+    test_symbol_name_must_be_an_identifier()
     test_to_py_preserves_symbolic_expression()
+    test_to_py_preserves_symbolic_strides()
+    test_to_py_mixed_symbolic_and_range()
     test_to_py_preserves_dyn_dim_optimals()
     test_parse_onnx_symbolic_dyn_input()

--- a/test/py/test_symbolic_shape.py
+++ b/test/py/test_symbolic_shape.py
@@ -62,6 +62,32 @@ def test_create_symbolic_dyn_shape():
     assert not s.dyn_dims()[1].is_symbolic()
 
 
+def _symbolic_program():
+    p = migraphx.program()
+    m = p.get_main_module()
+    s = migraphx.shape(type='float',
+                       dyn_dims=[
+                           migraphx.shape.dynamic_dimension(
+                               "n * 3 + 1",
+                               {"n": migraphx.shape.dynamic_dimension(1, 8)}),
+                           migraphx.shape.dynamic_dimension(3, 3)
+                       ])
+    m.add_return(
+        [m.add_instruction(migraphx.op("neg"), [m.add_parameter("x", s)])])
+    return p
+
+
+def test_to_py_preserves_symbolic_expression():
+    p = _symbolic_program()
+    assert "migraphx.shape.from_json" in p.to_py()
+
+    # The generated code has to rebuild an equal program, expression included. Sorting first
+    # because to_py does not preserve the declaration order of parameters.
+    scope = {"migraphx": migraphx}
+    exec(p.to_py(), scope)
+    assert scope["p"].sort() == p.sort()
+
+
 def test_parse_onnx_symbolic_dyn_input():
     p = migraphx.parse_onnx(
         "dim_param_test.onnx",
@@ -84,4 +110,5 @@ if __name__ == "__main__":
     test_create_symbolic_dyn_dims()
     test_create_symbolic_compound_expr()
     test_create_symbolic_dyn_shape()
+    test_to_py_preserves_symbolic_expression()
     test_parse_onnx_symbolic_dyn_input()

--- a/test/py/test_symbolic_shape.py
+++ b/test/py/test_symbolic_shape.py
@@ -84,6 +84,26 @@ def test_to_py_preserves_symbolic_expression():
     exec(code, scope)
     assert scope["p"].sort() == p.sort()
 
+    # Program equality compares printed IR, which renders neither optimals nor symbolic strides,
+    # so the expression is only really pinned by comparing the shape itself.
+    assert scope["p"].get_parameter_shapes()["x"] == s
+
+
+def test_to_py_preserves_dyn_dim_optimals():
+    p = migraphx.program()
+    m = p.get_main_module()
+    s = migraphx.shape(type='float',
+                       dyn_dims=[
+                           migraphx.shape.dynamic_dimension(1, 4, {2, 4}),
+                           migraphx.shape.dynamic_dimension(3, 3)
+                       ])
+    m.add_return(
+        [m.add_instruction(migraphx.op("neg"), [m.add_parameter("x", s)])])
+
+    scope = {"migraphx": migraphx}
+    exec(p.to_py(), scope)
+    assert scope["p"].get_parameter_shapes()["x"] == s
+
 
 def test_parse_onnx_symbolic_dyn_input():
     p = migraphx.parse_onnx(
@@ -108,4 +128,5 @@ if __name__ == "__main__":
     test_create_symbolic_compound_expr()
     test_create_symbolic_dyn_shape()
     test_to_py_preserves_symbolic_expression()
+    test_to_py_preserves_dyn_dim_optimals()
     test_parse_onnx_symbolic_dyn_input()

--- a/test/py/test_symbolic_shape.py
+++ b/test/py/test_symbolic_shape.py
@@ -193,14 +193,13 @@ def test_to_py_preserves_symbolic_expression():
     assert not s.symbolic()
     assert '"3*n + 1"' in code
 
-    # The generated code has to rebuild an equal program, expression included. sort() normalizes
-    # instruction order, which to_py only perturbs once a module has more than one parameter.
+    # The generated code has to rebuild an equal program, expression included; sort() normalizes
+    # instruction order.
     scope = {"migraphx": migraphx}
     exec(code, scope)
     assert scope["p"].sort() == p.sort()
 
-    # Program equality compares printed IR, which renders neither optimals nor symbolic strides,
-    # so the expression is only really pinned by comparing the shape itself.
+    # Printed IR leaves out a dimension's optimals, so compare the shape itself as well.
     assert scope["p"].get_parameter_shapes()["x"] == s
 
 

--- a/test/py/test_symbolic_shape.py
+++ b/test/py/test_symbolic_shape.py
@@ -64,14 +64,15 @@ def test_create_symbolic_dyn_shape():
 
 def test_create_symbolic_shape_from_strings():
     dd = migraphx.shape.dynamic_dimension
-    s = migraphx.shape(type='float',
-                       dyn_dims=["n", "3"],
-                       symbols={"n": dd(1, 8, {2, 4})})
+    s = migraphx.shape(
+        type='float',
+        dyn_dims=["n(constraints={[1..8]}, optimals={2, 4})", "3"])
     assert s.symbolic()
-    assert s.dyn_dims()[0].expression == "n"
-    assert s.dyn_dims()[0].min == 1
-    assert s.dyn_dims()[0].max == 8
-    assert s.dyn_dims()[0].optimals == {2, 4}
+    dims = s.dyn_dims()
+    assert dims[0].expression == "n(constraints={[1..8]}, optimals={2, 4})"
+    assert dims[0].min == 1
+    assert dims[0].max == 8
+    assert dims[0].optimals == {2, 4}
     # An all-symbolic shape gets packed standard strides when none are given.
     assert s.standard()
     assert s.dyn_strides() == ["3", "1"]
@@ -82,93 +83,51 @@ def test_create_symbolic_shape_from_strings():
 
 
 def test_create_symbolic_shape_compound_expression():
-    dd = migraphx.shape.dynamic_dimension
     s = migraphx.shape(type='float',
-                       dyn_dims=["3*n + 1"],
-                       symbols={"n": dd(1, 8)})
-    assert s.dyn_dims()[0].expression == "3*n + 1"
+                       dyn_dims=["3*n(constraints={[1..8]}) + 1"])
+    assert s.dyn_dims()[0].expression == "3*n(constraints={[1..8]}) + 1"
     assert (s.dyn_dims()[0].min, s.dyn_dims()[0].max) == (4, 25)
 
 
 def test_create_symbolic_shape_with_strides():
-    dd = migraphx.shape.dynamic_dimension
     s = migraphx.shape(type='float',
-                       dyn_dims=["n", "3"],
-                       symbols={"n": dd(1, 8)},
-                       dyn_strides=["1", "n"])
+                       dyn_dims=["n(constraints={[1..8]})", "3"],
+                       dyn_strides=["1", "n(constraints={[1..8]})"])
     assert not s.standard()
-    assert s.dyn_strides() == ["1", "n"]
+    assert s.dyn_strides() == ["1", "n(constraints={[1..8]})"]
 
 
 def test_create_symbolic_shape_multiple_constraints():
-    dd = migraphx.shape.dynamic_dimension
-    # A list of bounds asserts several intervals, which is what merging two differently bounded
-    # same-named variables produces.
-    s = migraphx.shape(type='float',
-                       dyn_dims=["n"],
-                       symbols={"n": [dd(1, 20), dd(2, 10, {4})]})
+    s = migraphx.shape(
+        type='float',
+        dyn_dims=["n(constraints={[1..20], [2..10]}, optimals={4})"])
     assert s.dyn_dims()[0].is_symbolic()
     assert s.dyn_dims()[0].optimals == {4}
 
 
-def test_symbol_table_round_trip():
-    dd = migraphx.shape.dynamic_dimension
+def test_expression_strings_round_trip():
     s = migraphx.shape(type='float',
-                       dyn_dims=["3*n + 1", "m"],
-                       symbols={
-                           "n": dd(1, 8, {2, 4}),
-                           "m": dd(2, 16)
-                       })
-    table = s.symbol_table()
-    # A symbol always maps to a list here, even where the constructor also takes a bare
-    # dynamic_dimension.
-    assert sorted(table) == ["m", "n"]
-    assert len(table["n"]) == 1
-    assert (table["n"][0].min, table["n"][0].max) == (1, 8)
-    assert table["n"][0].optimals == {2, 4}
-    # The table is what the constructor takes, so a shape rebuilds from what can be read of it.
+                       dyn_dims=[
+                           "3*n(constraints={[1..8]}, optimals={2, 4}) + 1",
+                           "m(constraints={[2..16]})"
+                       ])
+    dims = [d.expression for d in s.dyn_dims()]
+    assert migraphx.shape(type='float', dyn_dims=dims) == s
+
+    strided = migraphx.shape(type='float',
+                             dyn_dims=["n(constraints={[1..8]})", "3"],
+                             dyn_strides=["1", "n(constraints={[1..8]})"])
+    dims = [d.expression for d in strided.dyn_dims()]
     assert migraphx.shape(type='float',
-                          dyn_dims=["3*n + 1", "m"],
-                          symbols=table) == s
-
-
-def test_symbol_table_strides_and_multiple_constraints():
-    dd = migraphx.shape.dynamic_dimension
-    # A stride shares the dimensions' symbols, so the table does not grow for it.
-    s = migraphx.shape(type='float',
-                       dyn_dims=["n", "3"],
-                       symbols={"n": dd(1, 8)},
-                       dyn_strides=["1", "n"])
-    assert list(s.symbol_table()) == ["n"]
-    assert migraphx.shape(type='float',
-                          dyn_dims=["n", "3"],
-                          symbols=s.symbol_table(),
-                          dyn_strides=s.dyn_strides()) == s
-
-    m = migraphx.shape(type='float',
-                       dyn_dims=["n"],
-                       symbols={"n": [dd(1, 20), dd(2, 10, {4})]})
-    assert len(m.symbol_table()["n"]) == 2
-    assert migraphx.shape(type='float',
-                          dyn_dims=["n"],
-                          symbols=m.symbol_table()) == m
-
-
-# A range-based or static shape names no symbols.
-def test_symbol_table_empty_without_symbols():
-    dd = migraphx.shape.dynamic_dimension
-    assert migraphx.shape(type='float', dyn_dims=[dd(1,
-                                                     4)]).symbol_table() == {}
-    assert migraphx.shape(type='float', lens=[2, 3]).symbol_table() == {}
+                          dyn_dims=dims,
+                          dyn_strides=strided.dyn_strides()) == strided
 
 
 def test_symbol_name_must_be_an_identifier():
-    dd = migraphx.shape.dynamic_dimension
     # A symbolic shape is spelled as an expression string, so a name has to survive parsing.
     try:
         migraphx.shape(type='float',
-                       dyn_dims=["input.1"],
-                       symbols={"input.1": dd(1, 8)})
+                       dyn_dims=["input.1(constraints={[1..8]})"])
     except RuntimeError:
         pass
     else:
@@ -181,8 +140,7 @@ def test_to_py_preserves_symbolic_expression():
     s = migraphx.shape(type='float',
                        dyn_dims=[
                            migraphx.shape.dynamic_dimension(
-                               "n * 3 + 1",
-                               {"n": migraphx.shape.dynamic_dimension(1, 8)}),
+                               "n(constraints={[1..8]}) * 3 + 1"),
                            migraphx.shape.dynamic_dimension(3, 3)
                        ])
     m.add_return(
@@ -191,7 +149,7 @@ def test_to_py_preserves_symbolic_expression():
     code = p.to_py()
     # The second dimension is range-based, so this is the per-dimension spelling.
     assert not s.symbolic()
-    assert '"3*n + 1"' in code
+    assert '"3*n(constraints={[1..8]}) + 1"' in code
 
     # The generated code has to rebuild an equal program, expression included; sort() normalizes
     # instruction order.
@@ -199,7 +157,7 @@ def test_to_py_preserves_symbolic_expression():
     exec(code, scope)
     assert scope["p"].sort() == p.sort()
 
-    # Printed IR leaves out a dimension's optimals, so compare the shape itself as well.
+    # Explicitly guard the complete symbolic shape, including variable metadata.
     assert scope["p"].get_parameter_shapes()["x"] == s
 
 
@@ -207,9 +165,8 @@ def test_to_py_preserves_symbolic_strides():
     p = migraphx.program()
     m = p.get_main_module()
     s = migraphx.shape(type='float',
-                       dyn_dims=["n", "3"],
-                       symbols={"n": migraphx.shape.dynamic_dimension(1, 8)},
-                       dyn_strides=["1", "n"])
+                       dyn_dims=["n(constraints={[1..8]})", "3"],
+                       dyn_strides=["1", "n(constraints={[1..8]})"])
     m.add_return(
         [m.add_instruction(migraphx.op("neg"), [m.add_parameter("x", s)])])
 
@@ -225,13 +182,13 @@ def test_to_py_preserves_symbolic_strides():
 def test_to_py_mixed_symbolic_and_range():
     p = migraphx.program()
     m = p.get_main_module()
-    s = migraphx.shape(type='float',
-                       dyn_dims=[
-                           migraphx.shape.dynamic_dimension(
-                               "n",
-                               {"n": migraphx.shape.dynamic_dimension(1, 8)}),
-                           migraphx.shape.dynamic_dimension(3, 5)
-                       ])
+    s = migraphx.shape(
+        type='float',
+        dyn_dims=[
+            migraphx.shape.dynamic_dimension(
+                "n(constraints={[1..20], [2..10]}, optimals={4})"),
+            migraphx.shape.dynamic_dimension(3, 5)
+        ])
     m.add_return(
         [m.add_instruction(migraphx.op("neg"), [m.add_parameter("x", s)])])
 
@@ -283,9 +240,7 @@ if __name__ == "__main__":
     test_create_symbolic_shape_compound_expression()
     test_create_symbolic_shape_with_strides()
     test_create_symbolic_shape_multiple_constraints()
-    test_symbol_table_round_trip()
-    test_symbol_table_strides_and_multiple_constraints()
-    test_symbol_table_empty_without_symbols()
+    test_expression_strings_round_trip()
     test_symbol_name_must_be_an_identifier()
     test_to_py_preserves_symbolic_expression()
     test_to_py_preserves_symbolic_strides()

--- a/test/shape_test.cpp
+++ b/test/shape_test.cpp
@@ -26,7 +26,6 @@
 #include <migraphx/sym.hpp>
 #include <migraphx/common.hpp>
 #include <migraphx/serialize.hpp>
-#include <migraphx/json.hpp>
 #include <migraphx/ranges.hpp>
 #include <migraphx/permutation.hpp>
 #include <migraphx/stringutils.hpp>
@@ -2518,66 +2517,172 @@ TEST_CASE(to_symbolic_range_based_throws)
     EXPECT(test::throws([&] { s.to_symbolic(); }));
 }
 
-static bool json_shape_roundtrips(const migraphx::shape& s)
+static bool value_shape_roundtrips(const migraphx::shape& s)
 {
-    return migraphx::shape::from_json(migraphx::to_json_string(migraphx::to_value(s))) == s;
+    return migraphx::from_value<migraphx::shape>(migraphx::to_value(s)) == s;
 }
 
-TEST_CASE(from_json_static)
+TEST_CASE(value_roundtrip_static)
 {
-    EXPECT(json_shape_roundtrips({migraphx::shape::float_type, {2, 3, 4}}));
+    EXPECT(value_shape_roundtrips({migraphx::shape::float_type, {2, 3, 4}}));
 }
 
-TEST_CASE(from_json_static_non_standard_strides)
+TEST_CASE(value_roundtrip_static_non_standard_strides)
 {
-    EXPECT(json_shape_roundtrips({migraphx::shape::float_type, {2, 3, 4}, {0, 4, 1}}));
+    EXPECT(value_shape_roundtrips({migraphx::shape::float_type, {2, 3, 4}, {0, 4, 1}}));
 }
 
-TEST_CASE(from_json_dyn_range)
+TEST_CASE(value_roundtrip_dyn_range)
 {
-    EXPECT(json_shape_roundtrips({migraphx::shape::float_type, {{1, 4, {2, 4}}, {3, 3}}}));
+    EXPECT(value_shape_roundtrips({migraphx::shape::float_type, {{1, 4, {2, 4}}, {3, 3}}}));
 }
 
-TEST_CASE(from_json_symbolic)
+TEST_CASE(value_roundtrip_symbolic)
 {
     auto n = var("n", {1, 8});
     migraphx::shape s{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}};
     EXPECT(s.symbolic());
     EXPECT(not s.dyn_strides().empty());
-    EXPECT(json_shape_roundtrips(s));
+    EXPECT(value_shape_roundtrips(s));
 }
 
-TEST_CASE(from_json_symbolic_compound_expr)
+TEST_CASE(value_roundtrip_symbolic_compound_expr)
 {
     auto n = var("n", {1, 8});
     auto m = var("m", {2, 16}, {4, 8});
-    EXPECT(json_shape_roundtrips({migraphx::shape::float_type, {dd{n * 3 + 1}, dd{m}}}));
+    EXPECT(value_shape_roundtrips({migraphx::shape::float_type, {dd{n * 3 + 1}, dd{m}}}));
+}
+
+TEST_CASE(value_roundtrip_symbolic_non_standard_strides)
+{
+    auto n = var("n", {1, 8});
+    migraphx::shape s{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}, {lit(1), n}};
+    EXPECT(not s.standard());
+    EXPECT(value_shape_roundtrips(s));
 }
 
 // A partly symbolic shape is not symbolic(), so it decodes with no dyn_strides while still
 // carrying a symbolic dimension.
-TEST_CASE(from_json_symbolic_mixed_with_range)
+TEST_CASE(value_roundtrip_symbolic_mixed_with_range)
 {
     auto n = var("n", {1, 8});
     migraphx::shape s{migraphx::shape::float_type, {dd{n}, dd{3, 5}}};
     EXPECT(not s.symbolic());
-    EXPECT(json_shape_roundtrips(s));
+    EXPECT(value_shape_roundtrips(s));
 }
 
-// The json codec is structural, so a symbol name that sym::parse would reject still round trips.
-TEST_CASE(from_json_symbolic_name_not_an_identifier)
+TEST_CASE(make_symbolic_shape_dims)
 {
-    auto n = var("input.1_d0", {1, 8});
-    migraphx::shape s{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}};
-    EXPECT(json_shape_roundtrips(s));
+    auto s = migraphx::shape::make_symbolic_shape(
+        migraphx::shape::float_type, {"n", "3"}, {{"n", {{1, 8, {2, 4}}}}});
+    EXPECT(s == (migraphx::shape{
+                    migraphx::shape::float_type,
+                    {dd{var("n", {1, 8}, {std::int64_t{2}, std::int64_t{4}})}, dd{lit(3)}}}));
+    EXPECT(s.standard());
 }
 
-TEST_CASE(from_json_tuple_of_symbolic)
+TEST_CASE(make_symbolic_shape_compound_expression)
+{
+    auto n = var("n", {1, 8});
+    EXPECT(migraphx::shape::make_symbolic_shape(
+               migraphx::shape::float_type, {"3*n + 1"}, {{"n", {{1, 8}}}}) ==
+           (migraphx::shape{migraphx::shape::float_type, {dd{n * 3 + 1}}}));
+}
+
+// A stride resolves through the same table, so it shares the dimensions' variables.
+TEST_CASE(make_symbolic_shape_strides)
+{
+    auto n = var("n", {1, 8});
+    auto s = migraphx::shape::make_symbolic_shape(
+        migraphx::shape::float_type, {"n", "3"}, {"1", "n"}, {{"n", {{1, 8}}}});
+    EXPECT(s == (migraphx::shape{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}, {lit(1), n}}));
+    EXPECT(not s.standard());
+}
+
+// Several bounds for one name assert several intervals, which is what merging two differently
+// bounded same-named variables produces.
+TEST_CASE(make_symbolic_shape_multiple_constraints)
+{
+    auto s = migraphx::shape::make_symbolic_shape(
+        migraphx::shape::float_type, {"n"}, {{"n", {{1, 20}, {2, 10}}}});
+    EXPECT(s.dyn_dims().front() ==
+           dd{var("n", std::vector<migraphx::sym::interval>{{1, 20}, {2, 10}})});
+}
+
+// symbol_table is the inverse of make_symbolic_shape, so a symbolic shape rebuilds from its own
+// table.
+static bool symbol_table_roundtrips(const migraphx::shape& s, const std::vector<std::string>& dims)
+{
+    std::vector<std::string> strides;
+    std::transform(s.dyn_strides().begin(),
+                   s.dyn_strides().end(),
+                   std::back_inserter(strides),
+                   [](const auto& e) { return e.to_string(); });
+    if(s.standard())
+        strides.clear();
+    return migraphx::shape::make_symbolic_shape(s.type(), dims, strides, s.symbol_table()) == s;
+}
+
+TEST_CASE(symbol_table_dims)
+{
+    auto s = migraphx::shape::make_symbolic_shape(
+        migraphx::shape::float_type, {"n", "3"}, {{"n", {{1, 8, {2, 4}}}}});
+    auto table = s.symbol_table();
+    EXPECT(table.size() == 1);
+    EXPECT(table.at("n") == std::vector<dd>{{1, 8, {2, 4}}});
+    EXPECT(symbol_table_roundtrips(s, {"n", "3"}));
+}
+
+TEST_CASE(symbol_table_compound_expression)
+{
+    auto s = migraphx::shape::make_symbolic_shape(
+        migraphx::shape::float_type, {"3*n + 1", "m"}, {{"n", {{1, 8}}}, {"m", {{2, 4}}}});
+    EXPECT(symbol_table_roundtrips(s, {"3*n + 1", "m"}));
+}
+
+// A stride's symbols are the dimensions' own, so the table covers them without duplication.
+TEST_CASE(symbol_table_strides)
+{
+    auto s = migraphx::shape::make_symbolic_shape(
+        migraphx::shape::float_type, {"n", "3"}, {"1", "n"}, {{"n", {{1, 8}}}});
+    EXPECT(not s.standard());
+    EXPECT(s.symbol_table().size() == 1);
+    EXPECT(symbol_table_roundtrips(s, {"n", "3"}));
+}
+
+TEST_CASE(symbol_table_multiple_constraints)
+{
+    auto s = migraphx::shape::make_symbolic_shape(
+        migraphx::shape::float_type, {"n"}, {{"n", {{1, 20, {4}}, {2, 10}}}});
+    EXPECT(s.symbol_table().at("n").size() == 2);
+    EXPECT(symbol_table_roundtrips(s, {"n"}));
+}
+
+// A range-based shape names no symbols.
+TEST_CASE(symbol_table_range_shape_is_empty)
+{
+    EXPECT((migraphx::shape{migraphx::shape::float_type, {{1, 4}, {3, 3}}}.symbol_table().empty()));
+    EXPECT((migraphx::shape{migraphx::shape::float_type, {2, 3}}.symbol_table().empty()));
+}
+
+TEST_CASE(make_symbolic_shape_errors)
+{
+    EXPECT(test::throws([] {
+        return migraphx::shape::make_symbolic_shape(migraphx::shape::float_type, {""}, {});
+    }));
+    // One stride per dimension or none at all.
+    EXPECT(test::throws([] {
+        return migraphx::shape::make_symbolic_shape(
+            migraphx::shape::float_type, {"n", "3"}, {"1"}, {{"n", {{1, 8}}}});
+    }));
+}
+
+TEST_CASE(value_roundtrip_tuple_of_symbolic)
 {
     auto n = var("n", {1, 8});
     migraphx::shape s0{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}};
     migraphx::shape s1{migraphx::shape::int64_type, {2, 2}};
-    EXPECT(json_shape_roundtrips(migraphx::shape{{s0, s1}}));
+    EXPECT(value_shape_roundtrips(migraphx::shape{{s0, s1}}));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/shape_test.cpp
+++ b/test/shape_test.cpp
@@ -26,6 +26,7 @@
 #include <migraphx/sym.hpp>
 #include <migraphx/common.hpp>
 #include <migraphx/serialize.hpp>
+#include <migraphx/json.hpp>
 #include <migraphx/ranges.hpp>
 #include <migraphx/permutation.hpp>
 #include <migraphx/stringutils.hpp>
@@ -2515,6 +2516,67 @@ TEST_CASE(to_symbolic_range_based_throws)
 {
     migraphx::shape s{migraphx::shape::float_type, {{1, 4}, {3, 3}, {4, 4}}};
     EXPECT(test::throws([&] { s.to_symbolic(); }));
+}
+
+static bool json_shape_roundtrips(const migraphx::shape& s)
+{
+    return migraphx::make_json_shape(migraphx::to_json_string(migraphx::to_value(s))) == s;
+}
+
+TEST_CASE(make_json_shape_static)
+{
+    EXPECT(json_shape_roundtrips({migraphx::shape::float_type, {2, 3, 4}}));
+}
+
+TEST_CASE(make_json_shape_static_non_standard_strides)
+{
+    EXPECT(json_shape_roundtrips({migraphx::shape::float_type, {2, 3, 4}, {0, 4, 1}}));
+}
+
+TEST_CASE(make_json_shape_dyn_range)
+{
+    EXPECT(json_shape_roundtrips({migraphx::shape::float_type, {{1, 4, {2, 4}}, {3, 3}}}));
+}
+
+TEST_CASE(make_json_shape_symbolic)
+{
+    auto n = var("n", {1, 8});
+    migraphx::shape s{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}};
+    EXPECT(s.symbolic());
+    EXPECT(not s.dyn_strides().empty());
+    EXPECT(json_shape_roundtrips(s));
+}
+
+TEST_CASE(make_json_shape_symbolic_compound_expr)
+{
+    auto n = var("n", {1, 8});
+    auto m = var("m", {2, 16}, {4, 8});
+    EXPECT(json_shape_roundtrips({migraphx::shape::float_type, {dd{n * 3 + 1}, dd{m}}}));
+}
+
+// A mixed shape carries no dyn_strides, so it exercises the other branch of the codec.
+TEST_CASE(make_json_shape_symbolic_mixed_with_range)
+{
+    auto n = var("n", {1, 8});
+    migraphx::shape s{migraphx::shape::float_type, {dd{n}, dd{3, 5}}};
+    EXPECT(not s.symbolic());
+    EXPECT(json_shape_roundtrips(s));
+}
+
+// The json codec is structural, so a symbol name that sym::parse would reject still round trips.
+TEST_CASE(make_json_shape_symbolic_name_not_an_identifier)
+{
+    auto n = var("input.1_d0", {1, 8});
+    migraphx::shape s{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}};
+    EXPECT(json_shape_roundtrips(s));
+}
+
+TEST_CASE(make_json_shape_tuple_of_symbolic)
+{
+    auto n = var("n", {1, 8});
+    migraphx::shape s0{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}};
+    migraphx::shape s1{migraphx::shape::int64_type, {2, 2}};
+    EXPECT(json_shape_roundtrips(migraphx::shape{{s0, s1}}));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/shape_test.cpp
+++ b/test/shape_test.cpp
@@ -2554,7 +2554,8 @@ TEST_CASE(from_json_symbolic_compound_expr)
     EXPECT(json_shape_roundtrips({migraphx::shape::float_type, {dd{n * 3 + 1}, dd{m}}}));
 }
 
-// A mixed shape carries no dyn_strides, so it exercises the other branch of the codec.
+// A partly symbolic shape is not symbolic(), so it decodes with no dyn_strides while still
+// carrying a symbolic dimension.
 TEST_CASE(from_json_symbolic_mixed_with_range)
 {
     auto n = var("n", {1, 8});

--- a/test/shape_test.cpp
+++ b/test/shape_test.cpp
@@ -2520,25 +2520,25 @@ TEST_CASE(to_symbolic_range_based_throws)
 
 static bool json_shape_roundtrips(const migraphx::shape& s)
 {
-    return migraphx::make_json_shape(migraphx::to_json_string(migraphx::to_value(s))) == s;
+    return migraphx::shape::from_json(migraphx::to_json_string(migraphx::to_value(s))) == s;
 }
 
-TEST_CASE(make_json_shape_static)
+TEST_CASE(from_json_static)
 {
     EXPECT(json_shape_roundtrips({migraphx::shape::float_type, {2, 3, 4}}));
 }
 
-TEST_CASE(make_json_shape_static_non_standard_strides)
+TEST_CASE(from_json_static_non_standard_strides)
 {
     EXPECT(json_shape_roundtrips({migraphx::shape::float_type, {2, 3, 4}, {0, 4, 1}}));
 }
 
-TEST_CASE(make_json_shape_dyn_range)
+TEST_CASE(from_json_dyn_range)
 {
     EXPECT(json_shape_roundtrips({migraphx::shape::float_type, {{1, 4, {2, 4}}, {3, 3}}}));
 }
 
-TEST_CASE(make_json_shape_symbolic)
+TEST_CASE(from_json_symbolic)
 {
     auto n = var("n", {1, 8});
     migraphx::shape s{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}};
@@ -2547,7 +2547,7 @@ TEST_CASE(make_json_shape_symbolic)
     EXPECT(json_shape_roundtrips(s));
 }
 
-TEST_CASE(make_json_shape_symbolic_compound_expr)
+TEST_CASE(from_json_symbolic_compound_expr)
 {
     auto n = var("n", {1, 8});
     auto m = var("m", {2, 16}, {4, 8});
@@ -2555,7 +2555,7 @@ TEST_CASE(make_json_shape_symbolic_compound_expr)
 }
 
 // A mixed shape carries no dyn_strides, so it exercises the other branch of the codec.
-TEST_CASE(make_json_shape_symbolic_mixed_with_range)
+TEST_CASE(from_json_symbolic_mixed_with_range)
 {
     auto n = var("n", {1, 8});
     migraphx::shape s{migraphx::shape::float_type, {dd{n}, dd{3, 5}}};
@@ -2564,14 +2564,14 @@ TEST_CASE(make_json_shape_symbolic_mixed_with_range)
 }
 
 // The json codec is structural, so a symbol name that sym::parse would reject still round trips.
-TEST_CASE(make_json_shape_symbolic_name_not_an_identifier)
+TEST_CASE(from_json_symbolic_name_not_an_identifier)
 {
     auto n = var("input.1_d0", {1, 8});
     migraphx::shape s{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}};
     EXPECT(json_shape_roundtrips(s));
 }
 
-TEST_CASE(make_json_shape_tuple_of_symbolic)
+TEST_CASE(from_json_tuple_of_symbolic)
 {
     auto n = var("n", {1, 8});
     migraphx::shape s0{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}};

--- a/test/shape_test.cpp
+++ b/test/shape_test.cpp
@@ -2574,7 +2574,7 @@ TEST_CASE(value_roundtrip_symbolic_mixed_with_range)
 TEST_CASE(make_symbolic_shape_dims)
 {
     auto s = migraphx::shape::make_symbolic_shape(
-        migraphx::shape::float_type, {"n", "3"}, {{"n", {{1, 8, {2, 4}}}}});
+        migraphx::shape::float_type, {"n(constraints={[1..8]}, optimals={2, 4})", "3"});
     EXPECT(s == (migraphx::shape{
                     migraphx::shape::float_type,
                     {dd{var("n", {1, 8}, {std::int64_t{2}, std::int64_t{4}})}, dd{lit(3)}}}));
@@ -2584,35 +2584,37 @@ TEST_CASE(make_symbolic_shape_dims)
 TEST_CASE(make_symbolic_shape_compound_expression)
 {
     auto n = var("n", {1, 8});
-    EXPECT(migraphx::shape::make_symbolic_shape(
-               migraphx::shape::float_type, {"3*n + 1"}, {{"n", {{1, 8}}}}) ==
+    EXPECT(migraphx::shape::make_symbolic_shape(migraphx::shape::float_type,
+                                                {"3*n(constraints={[1..8]}) + 1"}) ==
            (migraphx::shape{migraphx::shape::float_type, {dd{n * 3 + 1}}}));
 }
 
-// A stride resolves through the same table, so it shares the dimensions' variables.
+// A stride carries the same self-contained symbolic variable as the dimension.
 TEST_CASE(make_symbolic_shape_strides)
 {
     auto n = var("n", {1, 8});
-    auto s = migraphx::shape::make_symbolic_shape(
-        migraphx::shape::float_type, {"n", "3"}, {"1", "n"}, {{"n", {{1, 8}}}});
+    auto s = migraphx::shape::make_symbolic_shape(migraphx::shape::float_type,
+                                                  {"n(constraints={[1..8]})", "3"},
+                                                  {"1", "n(constraints={[1..8]})"});
     EXPECT(s == (migraphx::shape{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}, {lit(1), n}}));
     EXPECT(not s.standard());
 }
 
-// Several bounds for one name assert several intervals, which is what merging two differently
-// bounded same-named variables produces.
 TEST_CASE(make_symbolic_shape_multiple_constraints)
 {
     auto s = migraphx::shape::make_symbolic_shape(
-        migraphx::shape::float_type, {"n"}, {{"n", {{1, 20}, {2, 10}}}});
+        migraphx::shape::float_type, {"n(constraints={[1..20], [2..10]}, optimals={4})"});
     EXPECT(s.dyn_dims().front() ==
-           dd{var("n", std::vector<migraphx::sym::interval>{{1, 20}, {2, 10}})});
+           dd{var("n", std::vector<migraphx::sym::interval>{{1, 20}, {2, 10}}, {std::int64_t{4}})});
 }
 
-// symbol_table is the inverse of make_symbolic_shape, so a symbolic shape rebuilds from its own
-// table.
-static bool symbol_table_roundtrips(const migraphx::shape& s, const std::vector<std::string>& dims)
+static bool expression_strings_roundtrip(const migraphx::shape& s)
 {
+    std::vector<std::string> dims;
+    std::transform(s.dyn_dims().begin(),
+                   s.dyn_dims().end(),
+                   std::back_inserter(dims),
+                   [](const auto& d) { return d.sym_expr.to_string(); });
     std::vector<std::string> strides;
     std::transform(s.dyn_strides().begin(),
                    s.dyn_strides().end(),
@@ -2620,79 +2622,55 @@ static bool symbol_table_roundtrips(const migraphx::shape& s, const std::vector<
                    [](const auto& e) { return e.to_string(); });
     if(s.standard())
         strides.clear();
-    return migraphx::shape::make_symbolic_shape(s.type(), dims, strides, s.symbol_table()) == s;
+    return migraphx::shape::make_symbolic_shape(s.type(), dims, strides) == s;
 }
 
-TEST_CASE(symbol_table_dims)
+TEST_CASE(symbolic_shape_expression_strings_roundtrip)
 {
-    auto s = migraphx::shape::make_symbolic_shape(
-        migraphx::shape::float_type, {"n", "3"}, {{"n", {{1, 8, {2, 4}}}}});
-    auto table = s.symbol_table();
-    EXPECT(table.size() == 1);
-    EXPECT(table.at("n") == std::vector<dd>{{1, 8, {2, 4}}});
-    EXPECT(symbol_table_roundtrips(s, {"n", "3"}));
+    auto n = var("n", {1, 8}, {2, 4});
+    migraphx::shape s{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}};
+    EXPECT(expression_strings_roundtrip(s));
 }
 
-TEST_CASE(symbol_table_compound_expression)
+TEST_CASE(symbolic_shape_compound_expression_strings_roundtrip)
 {
-    auto s = migraphx::shape::make_symbolic_shape(
-        migraphx::shape::float_type, {"3*n + 1", "m"}, {{"n", {{1, 8}}}, {"m", {{2, 4}}}});
-    EXPECT(symbol_table_roundtrips(s, {"3*n + 1", "m"}));
+    auto n = var("n", {1, 8});
+    auto m = var("m", {2, 4});
+    migraphx::shape s{migraphx::shape::float_type, {dd{n * 3 + 1}, dd{m}}};
+    EXPECT(expression_strings_roundtrip(s));
 }
 
-// A stride's symbols are the dimensions' own, so the table covers them without duplication.
-TEST_CASE(symbol_table_strides)
-{
-    auto s = migraphx::shape::make_symbolic_shape(
-        migraphx::shape::float_type, {"n", "3"}, {"1", "n"}, {{"n", {{1, 8}}}});
-    EXPECT(not s.standard());
-    EXPECT(s.symbol_table().size() == 1);
-    EXPECT(symbol_table_roundtrips(s, {"n", "3"}));
-}
-
-TEST_CASE(symbol_table_multiple_constraints)
-{
-    auto s = migraphx::shape::make_symbolic_shape(
-        migraphx::shape::float_type, {"n"}, {{"n", {{1, 20, {4}}, {2, 10}}}});
-    EXPECT(s.symbol_table().at("n").size() == 2);
-    EXPECT(symbol_table_roundtrips(s, {"n"}));
-}
-
-// A name can be bound differently in two dimensions, so the table has to merge them rather than
-// report whichever was reached first; otherwise the shape it describes is not the shape it came
-// from.
-TEST_CASE(symbol_table_merges_across_dimensions)
-{
-    migraphx::shape s{migraphx::shape::float_type, {dd{var("n", {1, 8})}, dd{var("n", {1, 4})}}};
-    auto bounds = s.symbol_table().at("n");
-    EXPECT(bounds.size() == 2);
-    EXPECT(bounds == std::vector<dd>{{1, 4}, {1, 8}});
-}
-
-// A symbol used by a stride is already named by a dimension, so it adds no entry.
-TEST_CASE(symbol_table_merges_strides_with_dimensions)
+TEST_CASE(symbolic_shape_stride_expression_strings_roundtrip)
 {
     auto n = var("n", {1, 8});
     migraphx::shape s{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}, {lit(1), n}};
-    EXPECT(s.symbol_table().at("n") == std::vector<dd>{{1, 8}});
+    EXPECT(not s.standard());
+    EXPECT(expression_strings_roundtrip(s));
 }
 
-// A range-based shape names no symbols.
-TEST_CASE(symbol_table_range_shape_is_empty)
+TEST_CASE(symbolic_shape_multiple_constraints_expression_strings_roundtrip)
 {
-    EXPECT((migraphx::shape{migraphx::shape::float_type, {{1, 4}, {3, 3}}}.symbol_table().empty()));
-    EXPECT((migraphx::shape{migraphx::shape::float_type, {2, 3}}.symbol_table().empty()));
+    auto n = var("n", std::vector<migraphx::sym::interval>{{1, 20}, {2, 10}}, {4});
+    migraphx::shape s{migraphx::shape::float_type, {dd{n}}};
+    EXPECT(expression_strings_roundtrip(s));
+}
+
+// Same-named variables can carry different metadata in separate expressions; printing each
+// expression independently preserves that distinction.
+TEST_CASE(symbolic_shape_same_name_different_constraints_roundtrip)
+{
+    migraphx::shape s{migraphx::shape::float_type, {dd{var("n", {1, 8})}, dd{var("n", {1, 4})}}};
+    EXPECT(expression_strings_roundtrip(s));
 }
 
 TEST_CASE(make_symbolic_shape_errors)
 {
-    EXPECT(test::throws([] {
-        return migraphx::shape::make_symbolic_shape(migraphx::shape::float_type, {""}, {});
-    }));
+    EXPECT(test::throws(
+        [] { return migraphx::shape::make_symbolic_shape(migraphx::shape::float_type, {""}); }));
     // One stride per dimension or none at all.
     EXPECT(test::throws([] {
         return migraphx::shape::make_symbolic_shape(
-            migraphx::shape::float_type, {"n", "3"}, {"1"}, {{"n", {{1, 8}}}});
+            migraphx::shape::float_type, {"n(constraints={[1..8]})", "3"}, {"1"});
     }));
 }
 

--- a/test/shape_test.cpp
+++ b/test/shape_test.cpp
@@ -2658,6 +2658,25 @@ TEST_CASE(symbol_table_multiple_constraints)
     EXPECT(symbol_table_roundtrips(s, {"n"}));
 }
 
+// A name can be bound differently in two dimensions, so the table has to merge them rather than
+// report whichever was reached first; otherwise the shape it describes is not the shape it came
+// from.
+TEST_CASE(symbol_table_merges_across_dimensions)
+{
+    migraphx::shape s{migraphx::shape::float_type, {dd{var("n", {1, 8})}, dd{var("n", {1, 4})}}};
+    auto bounds = s.symbol_table().at("n");
+    EXPECT(bounds.size() == 2);
+    EXPECT(bounds == std::vector<dd>{{1, 4}, {1, 8}});
+}
+
+// A symbol used by a stride is already named by a dimension, so it adds no entry.
+TEST_CASE(symbol_table_merges_strides_with_dimensions)
+{
+    auto n = var("n", {1, 8});
+    migraphx::shape s{migraphx::shape::float_type, {dd{n}, dd{lit(3)}}, {lit(1), n}};
+    EXPECT(s.symbol_table().at("n") == std::vector<dd>{{1, 8}});
+}
+
 // A range-based shape names no symbols.
 TEST_CASE(symbol_table_range_shape_is_empty)
 {

--- a/test/sym.cpp
+++ b/test/sym.cpp
@@ -3147,6 +3147,89 @@ TEST_CASE(var_with_constraint_and_optimals)
     EXPECT(x.eval({{x, int64_t{3}}}) == scalar{int64_t{3}});
 }
 
+// A name has to round trip through parse, since that is how a symbolic shape is spelled in
+// generated code.
+TEST_CASE(var_name_must_be_an_identifier)
+{
+    EXPECT(test::throws([] { return var("input.1_d0"); }));
+    EXPECT(test::throws([] { return var("0_d0"); }));
+    EXPECT(test::throws([] { return var("has space"); }));
+    // The check applies to every overload, not just the bare one.
+    EXPECT(test::throws([] { return var("input.1", interval{int64_t{1}, int64_t{8}}); }));
+    EXPECT(test::throws(
+        [] { return var("input.1", std::vector<interval>{interval{int64_t{1}, int64_t{8}}}); }));
+    EXPECT(parse(to_string(var("_n0"))) == var("_n0"));
+}
+
+TEST_CASE(find_variable_bounds_keeps_metadata)
+{
+    auto n      = var("n", interval{int64_t{1}, int64_t{8}}, std::set<scalar>{int64_t{2}});
+    auto m      = var("m", interval{int64_t{2}, int64_t{16}});
+    auto bounds = migraphx::sym::find_variable_bounds(n * 3 + m);
+    EXPECT(bounds.size() == 2);
+    EXPECT(bounds.at("n").constraints == std::vector<interval>{{int64_t{1}, int64_t{8}}});
+    EXPECT(bounds.at("n").optimals == std::set<scalar>{int64_t{2}});
+    EXPECT(bounds.at("m").constraints == std::vector<interval>{{int64_t{2}, int64_t{16}}});
+    EXPECT(bounds.at("m").optimals.empty());
+    // A literal carries no variable.
+    EXPECT(migraphx::sym::find_variable_bounds(lit(3)).empty());
+}
+
+TEST_CASE(find_variable_bounds_merges_same_name)
+{
+    auto c1 = interval{int64_t{1}, int64_t{20}};
+    auto c2 = interval{int64_t{2}, int64_t{10}};
+    auto e  = var("x", c1) * var("y", {1, 2}) + var("x", c2);
+    auto x  = migraphx::sym::find_variable_bounds(e).at("x");
+    EXPECT(x.constraints == std::vector<interval>{c1, c2});
+}
+
+// A double has to read back as the same value, which the six significant digits a stream
+// defaults to cannot promise.
+TEST_CASE(scalar_to_string_round_trips)
+{
+    EXPECT(migraphx::sym::to_string(scalar{int64_t{42}}) == "42");
+    EXPECT(migraphx::sym::to_string(scalar{3.14}) == "3.14");
+    for(double d : {3.14, 0.1, 1.0 / 3.0, 1e-9, 1.7976931348623157e308})
+        EXPECT(parse(migraphx::sym::to_string(scalar{d})) == lit(d));
+}
+
+// Adding two same-named variables merges their metadata by unioning the constraint sets, so this
+// is the only spelling for the result.
+TEST_CASE(var_with_multiple_constraints_matches_merge)
+{
+    auto c1 = interval{int64_t{1}, int64_t{20}};
+    auto c2 = interval{int64_t{2}, int64_t{10}};
+    // x{1,20} + x{2,10} folds to 2*x, where x asserts both intervals.
+    auto merged = var("x", c1) + var("x", c2);
+    EXPECT(merged == lit(2) * var("x", std::vector<interval>{c1, c2}));
+}
+
+// The constraint set is canonicalized, so the order it is given in does not change the variable.
+TEST_CASE(var_with_multiple_constraints_normalized)
+{
+    auto c1 = interval{int64_t{1}, int64_t{20}};
+    auto c2 = interval{int64_t{2}, int64_t{10}};
+    EXPECT(var("x", std::vector<interval>{c2, c1}) == var("x", std::vector<interval>{c1, c2}));
+    // A repeated assertion is the same as stating it once.
+    EXPECT(var("x", std::vector<interval>{c1, c1}) == var("x", c1));
+}
+
+TEST_CASE(var_with_multiple_constraints_serializes)
+{
+    auto x = var(
+        "x",
+        std::vector<interval>{interval{int64_t{1}, int64_t{20}}, interval{int64_t{2}, int64_t{10}}},
+        std::set<scalar>{int64_t{4}});
+    EXPECT(migraphx::from_value<expr>(migraphx::to_value(x)) == x);
+}
+
+TEST_CASE(var_with_invalid_constraint_throws)
+{
+    EXPECT(test::throws(
+        [] { return var("x", std::vector<interval>{interval{int64_t{10}, int64_t{1}}}); }));
+}
+
 TEST_CASE(eval_optimals_literal)
 {
     auto e      = lit(42);

--- a/test/sym.cpp
+++ b/test/sym.cpp
@@ -1621,6 +1621,22 @@ TEST_CASE(to_string_literal_double)
 
 TEST_CASE(to_string_variable) { EXPECT(var("x").to_string() == "x"); }
 
+TEST_CASE(to_string_variable_metadata)
+{
+    auto n = var("n",
+                 std::vector<interval>{{int64_t{2}, int64_t{6}}, {int64_t{1}, int64_t{4}}},
+                 std::set<scalar>{int64_t{4}, int64_t{2}});
+    EXPECT(n.to_string() == "n(constraints={[1..4], [2..6]}, optimals={2, 4})");
+}
+
+TEST_CASE(to_string_variable_optional_metadata)
+{
+    EXPECT(var("n", interval{int64_t{1}, int64_t{4}}).to_string() == "n(constraints={[1..4]})");
+    EXPECT(
+        var("n", std::vector<interval>{}, std::set<scalar>{int64_t{2}, int64_t{4}}).to_string() ==
+        "n(optimals={2, 4})");
+}
+
 TEST_CASE(to_string_add)
 {
     auto x = var("x");
@@ -2811,6 +2827,58 @@ TEST_CASE(parse_variable)
     EXPECT(e == var("x"));
 }
 
+TEST_CASE(parse_variable_metadata)
+{
+    auto expected = var("n",
+                        std::vector<interval>{{int64_t{1}, int64_t{4}}, {int64_t{2}, int64_t{6}}},
+                        std::set<scalar>{int64_t{2}, int64_t{4}});
+    EXPECT(parse("n(constraints={[1..4], [2..6]}, optimals={2, 4})") == expected);
+}
+
+TEST_CASE(parse_variable_metadata_optional_and_reordered)
+{
+    EXPECT(parse("n(constraints={[1..4]})") == var("n", interval{int64_t{1}, int64_t{4}}));
+    EXPECT(parse("n(optimals={2, 4})") ==
+           var("n", std::vector<interval>{}, std::set<scalar>{int64_t{2}, int64_t{4}}));
+    EXPECT(parse("n(optimals={2, 4}, constraints={[1..4], [2..6]})") ==
+           var("n",
+               std::vector<interval>{{int64_t{1}, int64_t{4}}, {int64_t{2}, int64_t{6}}},
+               std::set<scalar>{int64_t{2}, int64_t{4}}));
+}
+
+TEST_CASE(parse_variable_metadata_scalars)
+{
+    EXPECT(parse("n(constraints={[-4..1], [2e0..6.0]}, optimals={-2, 1.5})") ==
+           var("n",
+               std::vector<interval>{{int64_t{-4}, int64_t{1}}, {2.0, 6.0}},
+               std::set<scalar>{int64_t{-2}, 1.5}));
+}
+
+TEST_CASE(parse_variable_metadata_in_expression)
+{
+    auto n = var("n",
+                 std::vector<interval>{{int64_t{1}, int64_t{4}}, {int64_t{2}, int64_t{6}}},
+                 std::set<scalar>{int64_t{2}, int64_t{4}});
+    auto e = sin(n * 3) + 1;
+    EXPECT(parse(to_string(e)) == e);
+}
+
+TEST_CASE(parse_variable_metadata_disambiguates_function_name)
+{
+    auto sin_variable = var("sin", interval{int64_t{1}, int64_t{4}});
+    EXPECT(parse(to_string(sin_variable)) == sin_variable);
+    EXPECT(parse("sin(x)") == sin(var("x")));
+}
+
+TEST_CASE(parse_variable_metadata_errors)
+{
+    EXPECT(test::throws([] { parse("n(constraints={[1..4]}, constraints={[2..6]})"); }));
+    EXPECT(test::throws([] { parse("n(optimals={2}, optimals={4})"); }));
+    EXPECT(test::throws([] { parse("n(unknown={2})"); }));
+    EXPECT(test::throws([] { parse("n(constraints={[4..1]})"); }));
+    EXPECT(test::throws([] { parse("n(constraints={[1, 4]})"); }));
+}
+
 TEST_CASE(parse_add)
 {
     auto e = parse("x + y");
@@ -3159,29 +3227,6 @@ TEST_CASE(var_name_must_be_an_identifier)
     EXPECT(test::throws(
         [] { return var("input.1", std::vector<interval>{interval{int64_t{1}, int64_t{8}}}); }));
     EXPECT(parse(to_string(var("_n0"))) == var("_n0"));
-}
-
-TEST_CASE(find_variable_bounds_keeps_metadata)
-{
-    auto n      = var("n", interval{int64_t{1}, int64_t{8}}, std::set<scalar>{int64_t{2}});
-    auto m      = var("m", interval{int64_t{2}, int64_t{16}});
-    auto bounds = migraphx::sym::find_variable_bounds(n * 3 + m);
-    EXPECT(bounds.size() == 2);
-    EXPECT(bounds.at("n").constraints == std::vector<interval>{{int64_t{1}, int64_t{8}}});
-    EXPECT(bounds.at("n").optimals == std::set<scalar>{int64_t{2}});
-    EXPECT(bounds.at("m").constraints == std::vector<interval>{{int64_t{2}, int64_t{16}}});
-    EXPECT(bounds.at("m").optimals.empty());
-    // A literal carries no variable.
-    EXPECT(migraphx::sym::find_variable_bounds(lit(3)).empty());
-}
-
-TEST_CASE(find_variable_bounds_merges_same_name)
-{
-    auto c1 = interval{int64_t{1}, int64_t{20}};
-    auto c2 = interval{int64_t{2}, int64_t{10}};
-    auto e  = var("x", c1) * var("y", {1, 2}) + var("x", c2);
-    auto x  = migraphx::sym::find_variable_bounds(e).at("x");
-    EXPECT(x.constraints == std::vector<interval>{c1, c2});
 }
 
 // A double has to read back as the same value, which the six significant digits a stream

--- a/tools/api/api.cpp
+++ b/tools/api/api.cpp
@@ -220,6 +220,24 @@ static shape::dynamic_dimension make_symbolic_dynamic_dimension(
     return shape::make_symbolic_dynamic_dimension(expression, symbols);
 }
 
+// Build a symbolic shape from expression strings. The expressions arrive as C arrays rather than
+// through a handle, because std::vector<std::string> is already claimed by
+// migraphx_quantize_op_names and registering it twice would silently rebind that handle's
+// parameters.
+static shape
+create_symbolic_shape(shape::type_t t,
+                      const char* const* dims,
+                      std::size_t ndims,
+                      const char* const* strides,
+                      std::size_t nstrides,
+                      const std::map<std::string, std::vector<shape::dynamic_dimension>>& symbols)
+{
+    return shape::make_symbolic_shape(t,
+                                      std::vector<std::string>(dims, dims + ndims),
+                                      std::vector<std::string>(strides, strides + nstrides),
+                                      symbols);
+}
+
 #ifdef MIGRAPHX_ENABLE_ONNX
 
 static void set_default_dim_value(onnx_options& options, size_t value)
@@ -509,4 +527,6 @@ run_trace(program& p, const parameter_map& params, const std::function<void(trac
 
 } // namespace migraphx
 
-<% generate_c_api_body() %>
+<%
+    generate_c_api_body()
+%>

--- a/tools/api/api.cpp
+++ b/tools/api/api.cpp
@@ -220,22 +220,32 @@ static shape::dynamic_dimension make_symbolic_dynamic_dimension(
     return shape::make_symbolic_dynamic_dimension(expression, symbols);
 }
 
-// Build a symbolic shape from expression strings. The expressions arrive as C arrays rather than
-// through a handle, because std::vector<std::string> is already claimed by
+// Build a symbolic shape from self-contained expression strings. The expressions arrive as C
+// arrays rather than through a handle, because std::vector<std::string> is already claimed by
 // migraphx_quantize_op_names and registering it twice would silently rebind that handle's
 // parameters.
-static shape
-create_symbolic_shape(shape::type_t t,
-                      const char* const* dims,
-                      std::size_t ndims,
-                      const char* const* strides,
-                      std::size_t nstrides,
-                      const std::map<std::string, std::vector<shape::dynamic_dimension>>& symbols)
+static std::vector<std::string>
+make_expression_strings(const char* const* expressions, std::size_t size, const std::string& name)
+{
+    if(size == 0)
+        return {};
+    if(expressions == nullptr or
+       std::any_of(expressions, expressions + size, [](const char* expression) {
+           return expression == nullptr;
+       }))
+        MIGRAPHX_THROW("CREATE_SYMBOLIC_SHAPE: Null " + name + " expression");
+    return {expressions, expressions + size};
+}
+
+static shape create_symbolic_shape(shape::type_t t,
+                                   const char* const* dims,
+                                   std::size_t ndims,
+                                   const char* const* strides,
+                                   std::size_t nstrides)
 {
     return shape::make_symbolic_shape(t,
-                                      std::vector<std::string>(dims, dims + ndims),
-                                      std::vector<std::string>(strides, strides + nstrides),
-                                      symbols);
+                                      make_expression_strings(dims, ndims, "dimension"),
+                                      make_expression_strings(strides, nstrides, "stride"));
 }
 
 #ifdef MIGRAPHX_ENABLE_ONNX


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
* Need the ability to print symbolic and dynamic shapes to equivalent C++ and Python API.
* Was hitting error on onnx backend tests with dynamic shapes.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
* Added `shape::make_symbolic_shape(type_t type, vector<string> dims, vector<string> strides)` such that a symbolic shape can be made from vectors of symbolic strings. The strings are parsed using `sym::parse()` to create the symbolic expressions.
* Added `sym::symbol_name_registry` to sanitize symbol names to `[A-za-z0-9_]`. Keeps a map of input variable names to their sanitized version.
* Updated APIs to create symbolic shapes. 
* Needed to print floating points to enough precision in case there are floating point symbolic variables.
* Prevent shapes with both range-based and symbolic dynamic_dimensions. It makes for very confusing shapes if we allow mixing. We're also trying to deprecate range-based dynamic_dimensions.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [x] Added: New functionality.
- - [x] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [x] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
