### PR TITLE
Rewrite broadcast reshapes

### DIFF
--- a/src/rewrite_broadcasts.cpp
+++ b/src/rewrite_broadcasts.cpp
@@ -28,6 +28,7 @@
 #include <migraphx/matcher.hpp>
 #include <migraphx/pass_manager.hpp>
 #include <migraphx/ranges.hpp>
+#include <numeric>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -40,13 +41,18 @@ struct pointwise_broadcast_op : match::supports_dynamic_shapes
     auto matcher() const
     {
         auto pointwise = match::name("pointwise")(match::used_once()).bind("x");
+        auto reshapes =
+            match::name("reshape", "squeeze", "unsqueeze", "flatten", "transpose", "contiguous")(
+                match::used_once());
+        auto reshapes_pointwise = match::skip(reshapes)(pointwise);
         auto broadcast_pointwise =
-            match::name("multibroadcast", "broadcast")(match::used_once(), match::args(pointwise))
+            match::name("multibroadcast", "broadcast")(
+                match::used_once(), match::nargs(1), match::arg(0)(reshapes_pointwise))
                 .bind("broadcast");
         auto dyn_broadcast_pointwise =
             match::name("multibroadcast", "broadcast")(match::used_once(),
                                                        match::nargs(2),
-                                                       match::arg(0)(pointwise),
+                                                       match::arg(0)(reshapes_pointwise),
                                                        match::arg(1)(match::any().bind("ref_ins")))
                 .bind("broadcast");
         return match::name(op)(match::any_of[match::inputs()](
@@ -61,8 +67,26 @@ struct pointwise_broadcast_op : match::supports_dynamic_shapes
 
         auto broadcast = broadcast_ins->get_operator();
 
+        // Reshapes between the pointwise and the broadcast apply to each input
+        // as well since every pointwise input has the same lens as its output
+        std::vector<operation> reshape_ops;
+        auto next_ins = broadcast_ins->inputs().front();
+        while(next_ins != x_ins)
+        {
+            reshape_ops.push_back(next_ins->get_operator());
+            next_ins = next_ins->inputs().front();
+        }
+        std::reverse(reshape_ops.begin(), reshape_ops.end());
+
         auto x_inputs = x_ins->inputs();
         std::transform(x_inputs.begin(), x_inputs.end(), x_inputs.begin(), [&](auto input) {
+            input =
+                std::accumulate(reshape_ops.begin(),
+                                reshape_ops.end(),
+                                input,
+                                [&](auto start, const auto& reshape_op) {
+                                    return m.insert_instruction(broadcast_ins, reshape_op, start);
+                                });
             if(is_dyn_broadcast)
             {
                 return m.insert_instruction(

--- a/test/fuse_pointwise.cpp
+++ b/test/fuse_pointwise.cpp
@@ -1201,6 +1201,86 @@ TEST_CASE(add_broadcast_axis_add)
     EXPECT(p1.sort() == p2.sort());
 }
 
+TEST_CASE(add_squeeze_broadcast_add)
+{
+    migraphx::shape s1{migraphx::shape::float_type, {1, 1, 1, 4}};
+    migraphx::shape s2{migraphx::shape::float_type, {1, 4, 3, 3}};
+    migraphx::program p1;
+    {
+        auto* mm   = p1.get_main_module();
+        auto x     = mm->add_parameter("x", s1);
+        auto y     = mm->add_parameter("y", s1);
+        auto z     = mm->add_parameter("z", s2);
+        auto add1  = mm->add_instruction(migraphx::make_op("add"), x, y);
+        auto sq    = mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {1, 2}}}), add1);
+        auto badd1 = mm->add_instruction(
+            migraphx::make_op("broadcast", {{"axis", 0}, {"out_lens", s2.lens()}}), sq);
+        auto add2 = mm->add_instruction(migraphx::make_op("add"), badd1, z);
+        mm->add_return({add2});
+    }
+    run_pass(p1, {.enable_rewrite_broadcasts = true});
+    migraphx::program p2;
+    {
+        auto* mm = p2.get_main_module();
+        auto x   = mm->add_parameter("x", s1);
+        auto y   = mm->add_parameter("y", s1);
+        auto z   = mm->add_parameter("z", s2);
+        auto sx  = mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {1, 2}}}), x);
+        auto bx  = mm->add_instruction(
+            migraphx::make_op("broadcast", {{"axis", 0}, {"out_lens", s2.lens()}}), sx);
+        auto sy = mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {1, 2}}}), y);
+        auto by = mm->add_instruction(
+            migraphx::make_op("broadcast", {{"axis", 0}, {"out_lens", s2.lens()}}), sy);
+        auto fadd =
+            add_pointwise(p2, "main:pointwise0", {bx, by, z}, [=](auto* pm, const auto& inputs) {
+                auto add1 = pm->add_instruction(migraphx::make_op("add"), inputs[0], inputs[1]);
+                return pm->add_instruction(migraphx::make_op("add"), add1, inputs[2]);
+            });
+        mm->add_return({fadd});
+    }
+    EXPECT(p1.sort() == p2.sort());
+}
+
+TEST_CASE(add_reshape_multibroadcast_add)
+{
+    migraphx::shape s1{migraphx::shape::float_type, {2, 2}};
+    migraphx::shape s2{migraphx::shape::float_type, {3, 4}};
+    migraphx::program p1;
+    {
+        auto* mm     = p1.get_main_module();
+        auto x       = mm->add_parameter("x", s1);
+        auto y       = mm->add_parameter("y", s1);
+        auto z       = mm->add_parameter("z", s2);
+        auto add1    = mm->add_instruction(migraphx::make_op("add"), x, y);
+        auto reshape = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {1, 4}}}), add1);
+        auto badd1   = mm->add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", s2.lens()}}), reshape);
+        auto add2 = mm->add_instruction(migraphx::make_op("add"), badd1, z);
+        mm->add_return({add2});
+    }
+    run_pass(p1, {.enable_rewrite_broadcasts = true});
+    migraphx::program p2;
+    {
+        auto* mm = p2.get_main_module();
+        auto x   = mm->add_parameter("x", s1);
+        auto y   = mm->add_parameter("y", s1);
+        auto z   = mm->add_parameter("z", s2);
+        auto rx  = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), x);
+        auto bx  = mm->add_instruction(
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", s2.lens()}}), rx);
+        auto ry = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), y);
+        auto by = mm->add_instruction(
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", s2.lens()}}), ry);
+        auto fadd =
+            add_pointwise(p2, "main:pointwise0", {bx, by, z}, [=](auto* pm, const auto& inputs) {
+                auto add1 = pm->add_instruction(migraphx::make_op("add"), inputs[0], inputs[1]);
+                return pm->add_instruction(migraphx::make_op("add"), add1, inputs[2]);
+            });
+        mm->add_return({fadd});
+    }
+    EXPECT(p1.sort() == p2.sort());
+}
+
 TEST_CASE(add_broadcast_add_dyn)
 {
     migraphx::shape s1{migraphx::shape::float_type, {{2, 4}, {1, 1}}};

--- a/test/verify/test_pointwise_squeeze_broadcast_pointwise.cpp
+++ b/test/verify/test_pointwise_squeeze_broadcast_pointwise.cpp
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "verify_program.hpp"
+#include <migraphx/program.hpp>
+#include <migraphx/generate.hpp>
+#include <migraphx/make_op.hpp>
+#include <migraphx/instruction.hpp>
+
+struct test_pointwise_squeeze_broadcast_pointwise
+    : verify_program<test_pointwise_squeeze_broadcast_pointwise>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::shape s1{migraphx::shape::half_type, {1, 1, 1, 8}};
+        migraphx::shape s2{migraphx::shape::half_type, {1, 8, 4, 4}};
+        migraphx::program p;
+        auto* mm  = p.get_main_module();
+        auto x    = mm->add_parameter("x", s1);
+        auto y    = mm->add_parameter("y", s1);
+        auto z    = mm->add_parameter("z", s2);
+        auto mul  = mm->add_instruction(migraphx::make_op("mul"), x, y);
+        auto add1 = mm->add_instruction(migraphx::make_op("add"), mul, x);
+        auto sq   = mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {1, 2}}}), add1);
+        auto b    = mm->add_instruction(
+            migraphx::make_op("broadcast", {{"axis", 0}, {"out_lens", s2.lens()}}), sq);
+        auto add2 = mm->add_instruction(migraphx::make_op("add"), z, b);
+        auto relu = mm->add_instruction(migraphx::make_op("leaky_relu", {{"alpha", 0.2}}), add2);
+        mm->add_return({relu});
+        return p;
+    }
+};


### PR DESCRIPTION
## Motivation

The `rewrite_broadcasts` pass moves a broadcast before a pointwise operation so that the pointwise can fuse with its consumer, but it only matched when the pointwise fed the broadcast directly. When a reshape-like operator (such as `squeeze` or `reshape`) sat between the pointwise and the broadcast — a pattern that shows up in real models — the rewrite was skipped and the pointwise chain was left unfused across the broadcast.

## Technical Details

- The `pointwise_broadcast_op` matcher now uses `match::skip` to look through a chain of shape-only operators (`reshape`, `squeeze`, `unsqueeze`, `flatten`, `transpose`, `contiguous`, each used once) between the pointwise instruction and the `broadcast`/`multibroadcast`, for both the static and dynamic-shape variants.
- In `apply`, the skipped reshape operators are collected and replayed onto each input of the pointwise instruction before inserting the broadcast. This is valid because every pointwise input has the same lens as the pointwise output, so the same reshapes apply to the inputs directly.
- Adds unit tests in `test/fuse_pointwise.cpp` covering `squeeze`+`broadcast` and `reshape`+`multibroadcast` between the two pointwise ops, and a `test/verify` end-to-end test checking numerical results for the pointwise→squeeze→broadcast→pointwise pattern.

## Changelog Category

Add a `CHANGELOG.md` entry for any option other than `Not Applicable`
- - [ ] Added: New functionality.
- - [ ] Changed: Changes to existing functionality.
- - [ ] Removed: Functionality or support that has been removed. (Compared to a previous release)
- - [ ] Optimized: Component performance that has been optimized or improved.
- - [ ] Resolved Issues: Known issues from a previous version that have been resolved.
- - [ ] Not Applicable: This PR is not to be included in the changelog.

Follow the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html) for contributions using AI.
